### PR TITLE
Fix build caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3333",
     "build": "next build",
-    "postbuild": "next-sitemap",
+    "postbuild": "next-sitemap && rm -rf .next/cache",
     "start": "next start -p 3333"
   },
   "homepage": "https://docs.langfuse.com",

--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -22,8 +22,8 @@
     "type": "separator",
     "title": "Features"
   },
-  "analytics": "Analytics (alpha)",
-  "tracing": "Nested traces",
+  "analytics": "Analytics",
+  "tracing": "Tracing",
   "user-explorer": "Users",
   "token-usage": "Token usage",
   "scores": "Scores",


### PR DESCRIPTION
Goal
- Nextra caching problems
- Currently fixed it using VERCEL_FORCE_NO_BUILD_CACHE=1
- This also disables caching of dependencies leading to long build times >3 minutes

Idea
- Postbuild, remove `.next/cache` to not cache build outputs but still have dependency caching