### PR TITLE
fix: python shutdown for langchain

### DIFF
--- a/pages/docs/integrations/langchain/tracing.mdx
+++ b/pages/docs/integrations/langchain/tracing.mdx
@@ -212,7 +212,7 @@ If you are running a short-lived application, you need to shutdown Langfuse to e
 {/* Python */}
 
 ```python
-langfuse_handler.shutdown_async()
+langfuse_handler.shutdown()
 ```
 
 </Tab>


### PR DESCRIPTION
Correct shutdown method for python is `shutdown` not `shutdown_async`.