### PR TITLE
fix: change getting started example for openai python client

### DIFF
--- a/pages/docs/integrations/openai/python/get-started.mdx
+++ b/pages/docs/integrations/openai/python/get-started.mdx
@@ -93,10 +93,23 @@ openai.langfuse_host="https://cloud.langfuse.com" # 🇪🇺 EU region
 
 </Tabs>
 
-Optional, checks the SDK connection with the server. Not recommended for production usage.
+Call the OpenAI SDK to test your connection.
 
 ```python
-openai.auth_check()
+client = openai.OpenAI(
+    # This is the default and can be omitted
+    api_key=os.environ.get("OPENAI_API_KEY"),
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Say this is a test",
+        }
+    ],
+    model="gpt-3.5-turbo",
+)
 ```
 
 ### Use OpenAI SDK as usual


### PR DESCRIPTION
### What

The current documentation prompts the user to use `openai.auth_check()` to validate the openai setup. In my reproduction this fails with
```
python main.py
Traceback (most recent call last):
  File "/Users/steffen/Documents/langfuse-test/main.py", line 7, in <module>
    openai.auth_check()
    ^^^^^^^^^^^^^^^^^
AttributeError: module 'openai' has no attribute 'auth_check'
```

I propose to use the getting started example from https://github.com/openai/openai-python which leads to the following full test case.
```python
import os
from langfuse.openai import openai
from dotenv import load_dotenv

load_dotenv()

client = openai.OpenAI(
    # This is the default and can be omitted
    api_key=os.environ.get("OPENAI_API_KEY"),
)

chat_completion = client.chat.completions.create(
    messages=[
        {
            "role": "user",
            "content": "Say this is a test",
        }
    ],
    model="gpt-4o-mini",
)

print(chat_completion)
```