### PR TITLE
docs: add deploy to Zeabur button

### DIFF
--- a/pages/docs/deployment/self-host.mdx
+++ b/pages/docs/deployment/self-host.mdx
@@ -245,6 +245,10 @@ If you encounter any bugs or have suggestions for improvements, please contribut
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/gmbqa_)
 
+### Zeabur
+
+[![Deploy to Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/NU78ME)
+
 ### Google Cloud Platform (Cloud Run & Cloud SQL)
 
 The simplest way to deploy Langfuse on Google Cloud Platform is to use Cloud Run for the containerized application and Cloud SQL for the database.


### PR DESCRIPTION
[Zeabur](https://zeabur.com) is a platform for hosting full stack services, and there is a template made by the community to deploy Langfuse with one click.
https://zeabur.com/templates/NU78ME