### PR TITLE
Update langflow integration with version hint

### DIFF
--- a/pages/docs/integrations/langflow.mdx
+++ b/pages/docs/integrations/langflow.mdx
@@ -6,7 +6,7 @@ description: Open source observability for Langflow applications. Automatically 
 
 **Langflow** ([GitHub](https://github.com/logspace-ai/langflow)) is a UI for LangChain, designed with react-flow to provide an effortless way to experiment and prototype flows.
 
-With the native integration, you can use Langflow to quickly create complex LLM applications in no-code and then use Langfuse to monitor and improve them.
+With the native integration (since langflow v1.0.17), you can use Langflow to quickly create complex LLM applications in no-code and then use Langfuse to monitor and improve them.
 
 ## Integration
 


### PR DESCRIPTION
Since the langfuse tracer plugin in langflow is just available in versions >= v1.0.17 (see: https://github.com/langflow-ai/langflow/compare/v1.0.16...v1.0.17), a version hint was added.