### PR TITLE
docs(changelog): any tool-calling LLM for evals

### DIFF
--- a/pages/changelog/2024-10-11-extended-eval-models.mdx
+++ b/pages/changelog/2024-10-11-extended-eval-models.mdx
@@ -1,0 +1,19 @@
+---
+date: 2024-10-11
+title: Use any tool-calling LLM for evaluations
+description: Langfuse now supports any tool-calling LLM for evaluations.
+author: Hassieb
+showOgInHeader: false
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Langfuse now supports any tool-calling capable LLM for evaluations. Prior to creating a new eval template, you can now select any model that supports tool calls for which you have an LLM API key in Langfuse.
+
+On template creation, Langfuse will test the model with a sample run to ensure it works as expected.
+
+**Learn more**
+
+- [Langfuse Evaluations](/docs/scores/model-based-evals)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for support of any tool-calling LLM in Langfuse evaluations.
> 
>   - **Documentation**:
>     - Adds `2024-10-11-extended-eval-models.mdx` to changelog, detailing support for any tool-calling LLM in Langfuse evaluations.
>     - Describes ability to select models with tool-call support using an LLM API key.
>     - Mentions automatic model testing during template creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for faca4b53a8eb0f06b6aa29826131fdb96f30ecde. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->