### PR TITLE
fix: overflowing nextra tabs should wrap

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -67,3 +67,9 @@ svg .edgeLabel {
 .nextra-callout ul {
     margin-top: 0;
 }
+
+/* Overflowing nextra tabs should wrap */
+[role="tablist"] {
+    flex-wrap: wrap;
+    row-gap: 0.2rem;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add CSS rules in `overrides.css` to wrap overflowing tabs in a tablist.
> 
>   - **CSS Changes**:
>     - In `overrides.css`, added `flex-wrap: wrap;` and `row-gap: 0.2rem;` to `[role="tablist"]` to ensure overflowing tabs wrap.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e6a741fcb5718fe7bd4d1dc164fa44b7e4025d72. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->