### PR TITLE
fix: PaginationEllipsis has no size

### DIFF
--- a/components/changelog/ChangelogIndex.tsx
+++ b/components/changelog/ChangelogIndex.tsx
@@ -97,7 +97,7 @@ export const ChangelogIndex = ({
             {pageNumbers.map((pageNumber, index) =>
               pageNumber === null ? (
                 <PaginationItem key={`ellipsis-${index}`}>
-                  <PaginationEllipsis size="sm" />
+                  <PaginationEllipsis />
                 </PaginationItem>
               ) : (
                 <PaginationItem key={pageNumber}>

--- a/components/gh-discussions/GhDiscussionsPreviewInternal.tsx
+++ b/components/gh-discussions/GhDiscussionsPreviewInternal.tsx
@@ -200,7 +200,7 @@ const GhDiscussionsPreviewInternal = ({
             {pageNumbers.map((pageNumber, index) =>
               pageNumber === null ? (
                 <PaginationItem key={`ellipsis-${index}`}>
-                  <PaginationEllipsis size="xs" />
+                  <PaginationEllipsis />
                 </PaginationItem>
               ) : (
                 <PaginationItem key={pageNumber}>


### PR DESCRIPTION
Fixes #865
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `size` attribute from `PaginationEllipsis` in `ChangelogIndex.tsx` and `GhDiscussionsPreviewInternal.tsx`.
> 
>   - **Behavior**:
>     - Removes `size` attribute from `PaginationEllipsis` in `ChangelogIndex.tsx` and `GhDiscussionsPreviewInternal.tsx`.
>   - **Files**:
>     - `ChangelogIndex.tsx`: Removed `size="sm"` from `PaginationEllipsis`.
>     - `GhDiscussionsPreviewInternal.tsx`: Removed `size="xs"` from `PaginationEllipsis`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 151383a8f9028832b3dabe87535d41b2500fb6ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->