### PR TITLE
docs(tracing): add masking

### DIFF
--- a/pages/changelog/2024-10-25-input-output-masking.mdx
+++ b/pages/changelog/2024-10-25-input-output-masking.mdx
@@ -1,0 +1,29 @@
+---
+date: 2024-10-25
+title: Event input and output masking
+description: Configure SDK-side masking to redact sensitive information from inputs and outputs sent to the Langfuse server.
+author: Hassieb
+showOgInHeader: false
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+SDK-side masking enables you to:
+
+1. Redact sensitive information from trace or observation inputs and outputs.
+2. Customize the content of events before transmission.
+3. Implement fine-grained data filtering based on your specific requirements.
+
+The process works as follows:
+
+1. You define a custom masking function and pass it to the Langfuse client constructor.
+2. All event inputs and outputs are processed through this function.
+3. The masked eventdata is then sent to the Langfuse server.
+
+This approach ensures that you have complete control over the event input and output data traced by your application.
+
+**Learn more**
+
+- [Input and Output Masking](/docs/tracing-features/masking)

--- a/pages/docs/tracing-features/masking.mdx
+++ b/pages/docs/tracing-features/masking.mdx
@@ -1,0 +1,265 @@
+---
+description: Configure masking to redact sensitive information from inputs and outputs sent to the Langfuse server.
+---
+
+# Masking
+
+Masking is a feature that allows precise control over the data sent to the Langfuse server. It enables you to:
+
+1. Redact sensitive information from trace or observation inputs and outputs.
+2. Customize the content of events before transmission.
+3. Implement fine-grained data filtering based on your specific requirements.
+
+The process works as follows:
+1. You define a custom masking function and pass it to the Langfuse client constructor.
+2. All event inputs and outputs are processed through this function.
+3. The masked data is then sent to the Langfuse server.
+
+This approach ensures that you have complete control over the event input and output data traced by your application.
+
+
+<Tabs items={["Python", "JS/TS", "OpenAI", "Langchain (Python)", "Langchain (JS/TS)", "LlamaIndex (instrumentor)" ]}>
+<Tab>
+
+Define a masking function:
+
+```python
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+```
+
+Use with the [`@observe()` decorator](/docs/sdk/python/decorators):
+
+```python
+from langfuse.decorators import langfuse_context, observe
+
+langfuse_context.configure(mask=masking_function)
+
+@observe()
+def fn():
+    return "SECRET_DATA"
+
+fn()
+
+langfuse_context.flush()
+
+# The trace output in Langfuse will have the output masked as "REDACTED".
+```
+
+Use with the [low-level SDK](/docs/sdk/python/low-level-sdk):
+
+```python
+from langfuse import Langfuse
+
+langfuse = Langfuse(mask=masking_function)
+
+trace = langfuse.trace(output="SECRET_DATA")
+
+langfuse.flush()
+
+# The trace output in Langfuse will have the output masked as "REDACTED".
+```
+
+</Tab>
+<Tab>
+```typescript
+import { Langfuse } from "langfuse";
+
+function maskingFunction(params: { data: any }) {
+  if (typeof params.data === "string" && params.data.startsWith("SECRET_")) {
+    return "REDACTED";
+  }
+
+  return params.data;
+}
+
+const langfuse = new Langfuse({ mask: maskingFunction });
+
+const trace = langfuse.trace({
+  output: "SECRET_DATA",
+});
+
+await langfuse.flushAsync();
+
+// The trace output in Langfuse will have the output masked as "REDACTED".
+```
+
+See [JS/TS SDK docs](/docs/sdk/typescript/guide) for more details.
+
+</Tab>
+<Tab>
+
+When using the [OpenAI SDK Integration](/docs/integrations/openai), set `openai.langfuse_mask` to the masking function:
+
+```python
+from langfuse.openai import openai
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+
+openai.langfuse_mask = masking_function
+
+completion = openai.chat.completions.create(
+  name="test-chat",
+  model="gpt-3.5-turbo",
+  messages=[
+    {"role": "system", "content": "You are a bot."},
+    {"role": "user", "content": "1 + 1 = "}],
+  temperature=0,
+)
+
+openai.flush_langfuse()
+```
+
+When using the integration with the `@observe()` decorator (see [interop docs](/docs/integrations/openai/get-started#use-traces)), set masking function via the `langfuse_context`:
+
+```python
+from langfuse.decorators import langfuse_context, observe
+from langfuse.openai import openai
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+
+langfuse_context.configure(mask=masking_function)
+
+@observe()
+def fn():
+    completion = openai.chat.completions.create(
+      name="test-chat",
+      model="gpt-3.5-turbo",
+      messages=[
+        {"role": "system", "content": "You are a calculator."},
+        {"role": "user", "content": "1 + 1 = "}],
+      temperature=0,
+    )
+
+fn()
+```
+
+</Tab>
+<Tab>
+
+When using the [CallbackHandler](/docs/integrations/langchain/tracing), you can pass `mask` as a keyword argument:
+
+```python
+from langfuse.callback import CallbackHandler
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+
+handler = CallbackHandler(
+  mask=masking_function
+)
+```
+
+When using the integration with the `@observe()` decorator (see [interop docs](/docs/integrations/langchain/tracing#interoperability)), set `mask` via the `langfuse_context`:
+
+```python
+from langfuse.decorators import langfuse_context, observe
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data 
+
+langfuse_context.configure(mask=masking_function)
+
+@observe()
+def fn():
+    langfuse_handler = langfuse_context.get_current_langchain_handler()
+
+    # Pass handler to invoke of your langchain chain/agent
+    chain.invoke({"person": person}, config={"callbacks":[langfuse_handler]})
+
+fn()
+```
+
+</Tab>
+<Tab>
+
+When using the [CallbackHandler](/docs/integrations/langchain/tracing), you can pass `mask` to the constructor:
+
+```ts
+const handler = new CallbackHandler({
+  mask: maskingFunction,
+});
+```
+</Tab>
+
+<Tab>
+
+When using the [LlamaIndex Integration](/docs/integrations/llama-index/get-started), set the `mask` via the `instrumentor.observe()` context manager:
+
+```python
+from langfuse.llama_index import LlamaIndexInstrumentor
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+
+instrumentor = LlamaIndexInstrumentor(mask=masking_function)
+
+with instrumentor.observe():
+    # ... your LlamaIndex index creation ...
+
+    index.as_query_engine().query("What is the capital of France?")
+
+instrumentor.flush()
+```
+
+When using the integration with the `@observe()` decorator (see [interop docs](/docs/integrations/llama-index/get-started#interoperability-with-langfuse-sdk)), set the `mask` via the `langfuse_context`:
+
+```python
+from langfuse.decorators import langfuse_context, observe
+from langfuse.llama_index import LlamaIndexInstrumentor
+
+def masking_function(data):
+  if isinstance(data, str) and data.startswith("SECRET_"):
+    return "REDACTED"
+
+  return data
+
+langfuse_context.configure(mask=masking_function)
+
+@observe()
+def llama_index_fn(question: str):
+    # Get IDs
+    current_trace_id = langfuse_context.get_current_trace_id()
+    current_observation_id = langfuse_context.get_current_observation_id()
+
+    # Pass to instrumentor
+    with instrumentor.observe(
+        trace_id=current_trace_id,
+        parent_observation_id=current_observation_id,
+        update_parent=False
+    ) as trace:
+        # ... your LlamaIndex index creation ...
+
+        index.as_query_engine().query("What is the capital of France?")
+
+        # Run application
+        index = VectorStoreIndex.from_documents([doc1, doc2])
+        response = index.as_query_engine().query(question)
+
+        return response
+```
+
+
+</Tab>
+
+</Tabs>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for SDK-side masking feature in Langfuse, enabling sensitive data redaction across multiple integrations.
> 
>   - **Documentation**:
>     - Adds `2024-10-25-input-output-masking.mdx` to `pages/changelog` to announce SDK-side masking feature.
>     - Adds `masking.mdx` to `pages/docs/tracing-features` detailing how to configure masking to redact sensitive information.
>   - **Features**:
>     - Introduces SDK-side masking to redact sensitive information from event inputs and outputs.
>     - Allows customization of event content before transmission to Langfuse server.
>     - Supports fine-grained data filtering via custom masking functions.
>   - **Integrations**:
>     - Provides examples for Python, JS/TS, OpenAI, Langchain (Python and JS/TS), and LlamaIndex integrations.
>     - Demonstrates usage with `@observe()` decorator, low-level SDK, and various integration-specific handlers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 16b04143aca701bed04b6e5ca7ee1aaaed7dae25. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->