### PR TITLE
docs: use new terminology for Langfuse evals

### DIFF
--- a/components/home/FeatAnalytics.tsx
+++ b/components/home/FeatAnalytics.tsx
@@ -11,7 +11,7 @@ const features = [
   {
     name: "Quality.",
     description:
-      "Add scores to each trace. Can be model-based evaluation, user feedback, or manual labeling in the Langfuse UI.",
+      "Add scores to each trace. Langfuse supports LLM-as-a-judge evaluators, user feedback, or human annotation in the Langfuse UI.",
     icon: Check,
   },
   {

--- a/pages/changelog/2024-10-11-extended-eval-models.mdx
+++ b/pages/changelog/2024-10-11-extended-eval-models.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2024-10-11
-title: Langfuse Evals now supports any (tool-calling) LLM
-description: Tool calling makes Langfuse Evals reliable. Previously, only OpenAI models were supported. With this update, you can use any tool-calling LLM for evaluations.
+title: Langfuse LLM-as-a-judge now supports any (tool-calling) LLM
+description: Tool calling makes Langfuse Evals reliable. Previously, only OpenAI models were supported. With this update, you can use any tool-calling LLM when setting up an LLM-as-a-judge evaluator.
 author: Hassieb
 showOgInHeader: false
 ---
@@ -10,7 +10,7 @@ import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
 
 <ChangelogHeader />
 
-Prior to creating a new eval template, you can now select any model that supports tool calls for which you have an LLM API key in Langfuse. On template creation, Langfuse will test the model with a sample run to ensure it works as expected.
+Prior to creating an evaluator, you can now select any model that supports tool calls for which you have an LLM API key in Langfuse. On evaluator creation, Langfuse will test the model with a sample run to ensure it works as expected.
 
 **Learn more**
 

--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -4,7 +4,7 @@ description: Langfuse (open source) helps run model-based evaluations (llm-as-a-
 
 # LLM-as-a-judge in Langfuse
 
-Using LLM-as-a-judge (aka model-based evaluations) has proven as a powerful evaluation tool next to human annotation. Via Langfuse, we support setting up LLM-evaluators to evaluate your LLM applications integrated with Langfuse. These evaluators are used to score a specific session/trace/LLM-call in Langfuse on criteria such as correctness, toxicity, or hallucinations.
+Using LLM-as-a-judge (model-based evaluations) has proven as a powerful evaluation tool next to human annotation. Via Langfuse, we support setting up LLM-evaluators to evaluate your LLM applications integrated with Langfuse. These evaluators are used to score a specific session/trace/LLM-call in Langfuse on criteria such as correctness, toxicity, or hallucinations.
 
 There are two ways to run LLM-as-a-judge in Langfuse:
 
@@ -52,7 +52,7 @@ Second, we need to specify on which `traces` Langfuse should run the evaluator.
 
 - Specify the name of the `scores` which will be created as a result of the evaluation.
 - Filter which newly ingested traces should be evaluated. (Coming soon: select existing traces)
-- Specify how Langfuse should fill the variables in the template. Langfuse can extract data from `trace`, `generations`, `spans`, or `event` objects which belong to a trace. You can choose to take `Input`, `Output` or `metadata` form each of these objects. For `generations`, `spans`, or `events`, you also have to specify the name of the object. We will always take the latest object that matches the name.
+- Specify how Langfuse should fill the variables in the template. Langfuse can extract data from `trace`, `generations`, `spans`, or `event` objects which belong to a trace. You can choose to take `Input`, `Output` or `metadata` from each of these objects. For `generations`, `spans`, or `events`, you also have to specify the name of the object. We will always take the latest object that matches the name.
 - Reduce the sampling to not run evaluations on each trace. This helps to save LLM API cost.
 - Add a delay to the evaluation execution. This is how you can ensure all data arrived at Langfuse servers before evaluation is executed.
 
@@ -101,7 +101,7 @@ Pipeline ->> Langfuse: Add score to trace via SDK/API
 Langfuse ->> User: Analyze evaluation scores via UI & API
 ```
 
-You can run your own automatic evaluations on data in Langfuse by fetching traces from Langfuse (e.g. via the Python SDK) and then adding evaluation results as [`scores`](/docs/scores) back to the traces in Langfuse. This gives you full flexibility to run various eval libraries on your production data and discover which work well for your use case.
+You can run your own model-based evals on data in Langfuse by fetching traces from Langfuse (e.g. via the Python SDK) and then adding evaluation results as [`scores`](/docs/scores) back to the traces in Langfuse. This gives you full flexibility to run various eval libraries on your production data and discover which work well for your use case.
 
 The example notebook is a good template to get started with building your own evaluation pipeline.
 

--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -6,12 +6,12 @@ description: Langfuse (open source) helps run model-based evaluations (llm-as-a-
 
 Using LLM-as-a-judge (model-based evaluations) has proven as a powerful evaluation tool next to human annotation. Via Langfuse, we support setting up LLM-evaluators to evaluate your LLM applications integrated with Langfuse. These evaluators are used to score a specific session/trace/LLM-call in Langfuse on criteria such as correctness, toxicity, or hallucinations.
 
-There are two ways to run LLM-as-a-judge in Langfuse:
+Langfuse supports two types of model-based evaluations:
 
-1. [Via the Langfuse UI (beta)](#ui)
-1. [Via external evaluation pipeline](#evaluation-pipeline)
+1. [LLM-as-a-judge via the Langfuse UI (beta)](#ui)
+1. [Custom evaluators via external evaluation pipeline](#evaluation-pipeline)
 
-## Via Langfuse UI (beta) [#ui]
+## LLM-as-a-judge via the Langfuse UI (beta) [#ui]
 
 <AvailabilityBanner
   availability={{
@@ -76,7 +76,7 @@ Upon receiving new traces, navigate to the trace detail view to see the associat
 
 </Steps>
 
-## Via External Evaluation Pipeline [#evaluation-pipeline]
+## Custom evaluators via external evaluation pipeline [#evaluation-pipeline]
 
 <AvailabilityBanner
   availability={{

--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -2,11 +2,11 @@
 description: Langfuse (open source) helps run model-based evaluations (llm-as-a-judge) on production data to monitor and improve LLMs applications.
 ---
 
-# Model-based Evaluations in Langfuse
+# LLM-as-a-judge in Langfuse
 
-Model-based evaluations (_LLM-as-a-judge_) are a powerful tool to automate the evaluation of LLM applications integrated with Langfuse. With model-based evalutions, LLMs are used to score a specific session/trace/LLM-call in Langfuse on criteria such as correctness, toxicity, or hallucinations.
+Using LLM-as-a-judge (aka model-based evaluations) has proven as a powerful evaluation tool next to human annotation. Via Langfuse, we support setting up LLM-evaluators to evaluate your LLM applications integrated with Langfuse. These evaluators are used to score a specific session/trace/LLM-call in Langfuse on criteria such as correctness, toxicity, or hallucinations.
 
-There are two ways to run model-based evaluations in Langfuse:
+There are two ways to run LLM-as-a-judge in Langfuse:
 
 1. [Via the Langfuse UI (beta)](#ui)
 1. [Via external evaluation pipeline](#evaluation-pipeline)
@@ -34,34 +34,33 @@ There are two ways to run model-based evaluations in Langfuse:
 
 ### Store an API key
 
-To use evals, you have to bring your own LLM API keys. To do so, navigate to the settings page and insert your API key. We store them encrypted on our servers.
+To use Langfuse LLM-as-a-judge, you have to bring your own LLM API keys. To do so, navigate to the settings page and insert your API key. We store them encrypted on our servers.
 
-### Create an eval template
+### Create an evaluator
 
-First, we need to specify the evaluation template:
+To set up an evaluator, we first need to configure the following:
 
 - Select the model and its parameters.
-- Customise one of the Langfuse managed prompt templates or write your own.
+- Select the evaluation prompt. Langfuse offers a set of managed prompts, but you can also write your own.
 - We use function calling to extract the evaluation output. Specify the descriptions for the function parameters `score` and `reasoning`. This is how you can direct the LLM to score on a specific range and provide specific reasoning for the score.
+
+We store this information in an so-called evaluator template, so you can reuse it for multiple evaluators.
 
 <Frame border>![Langfuse](/images/docs/eval-hallucination-template.png)</Frame>
 
-### Create an eval config
+Second, we need to specify on which `traces` Langfuse should run the evaluator.
 
-Second, we need to specify on which `traces` Langfuse should run the template we created above.
-
-- Select the evaluation template to run.
 - Specify the name of the `scores` which will be created as a result of the evaluation.
 - Filter which newly ingested traces should be evaluated. (Coming soon: select existing traces)
 - Specify how Langfuse should fill the variables in the template. Langfuse can extract data from `trace`, `generations`, `spans`, or `event` objects which belong to a trace. You can choose to take `Input`, `Output` or `metadata` form each of these objects. For `generations`, `spans`, or `events`, you also have to specify the name of the object. We will always take the latest object that matches the name.
-- Reduce the sampling to not run evals on each trace. This helps to save LLM API cost.
-- Add a delay to the evaluation execution. This is how you can ensure all data arrived at Langfuse servers before evaluation is exeucted.
+- Reduce the sampling to not run evaluations on each trace. This helps to save LLM API cost.
+- Add a delay to the evaluation execution. This is how you can ensure all data arrived at Langfuse servers before evaluation is executed.
 
 <Frame border>![Langfuse](/images/docs/eval-config.png)</Frame>
 
 ### See the progress
 
-Once the configuration is saved, Langfuse will start running the evals on the traces that match the filter. You can see the progress on the config page or the log table.
+Once the evaluator is saved, Langfuse will start running evaluations on the traces that match the filter. You can view logs on the log page, or view each evaluator to see configuration and logs.
 
 <Frame border className="max-w-lg">
   ![Langfuse](/images/docs/evals-log.png)
@@ -102,7 +101,7 @@ Pipeline ->> Langfuse: Add score to trace via SDK/API
 Langfuse ->> User: Analyze evaluation scores via UI & API
 ```
 
-You can run your own model-based evals on data in Langfuse by fetching traces from Langfuse (e.g. via the Python SDK) and then adding evaluation results as [`scores`](/docs/scores) back to the traces in Langfuse. This gives you full flexibility to run various eval libraries on your production data and discover which work well for your use case.
+You can run your own automatic evaluations on data in Langfuse by fetching traces from Langfuse (e.g. via the Python SDK) and then adding evaluation results as [`scores`](/docs/scores) back to the traces in Langfuse. This gives you full flexibility to run various eval libraries on your production data and discover which work well for your use case.
 
 The example notebook is a good template to get started with building your own evaluation pipeline.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Langfuse documentation and components to use 'LLM-as-a-judge' terminology for evaluations.
> 
>   - **Terminology Update**:
>     - Change 'model-based evaluations' to 'LLM-as-a-judge' in `FeatAnalytics.tsx`, `2024-10-11-extended-eval-models.mdx`, and `model-based-evals.mdx`.
>     - Update descriptions and instructions to reflect new terminology in `model-based-evals.mdx`.
>   - **Documentation**:
>     - Update `2024-10-11-extended-eval-models.mdx` to reflect support for any tool-calling LLM in LLM-as-a-judge evaluators.
>     - Modify `model-based-evals.mdx` to describe setting up and using LLM-as-a-judge evaluators.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2f4e1eadbbadae85092f68c8526020fd2350b7e0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->