### PR TITLE
docs(openai): token usage streamed responses

### DIFF
--- a/pages/docs/integrations/openai/python/get-started.mdx
+++ b/pages/docs/integrations/openai/python/get-started.mdx
@@ -471,6 +471,10 @@ _Note that you need to provide `trace_id` and `parent_observation_id` to each ge
 
 OpenAI returns the token usage on streamed responses only when in `stream_options` the `include_usage` parameter is set to `True`. This integration automatically sets this parameter to `True` when streaming is detected to track accurate token usage. If you would like to disable this for any reason (not recommended), you can set `include_usage=False` in the `stream_options` parameter.
 
+<Callout type="info">
+  When using streaming responses with `include_usage=True`, OpenAI returns token usage information in a final chunk that has an empty `choices` list. Make sure your application properly handles these empty `choices` chunks to ensure accurate token usage tracking by not trying to access some index in the `choices` list without checking if it is non-empty.
+</Callout>
+
 ### OpenAI Beta APIs
 
 Since OpenAI beta APIs are changing frequently across versions, we fully support only the stable APIs in the OpenAI SDK. If you are using a beta API, you can still use the Langfuse SDK by wrapping the OpenAI SDK manually with the `@observe()` [decorator](/docs/sdk/python/decorators).

--- a/pages/docs/integrations/openai/python/get-started.mdx
+++ b/pages/docs/integrations/openai/python/get-started.mdx
@@ -467,6 +467,10 @@ _Note that you need to provide `trace_id` and `parent_observation_id` to each ge
 </Tab>
 </Tabs>
 
+### OpenAI token usage on streamed responses
+
+OpenAI returns the token usage on streamed responses only when in `stream_options` the `include_usage` parameter is set to `True`. This integration automatically sets this parameter to `True` when streaming is detected to track accurate token usage. If you would like to disable this for any reason (not recommended), you can set `include_usage=False` in the `stream_options` parameter.
+
 ### OpenAI Beta APIs
 
 Since OpenAI beta APIs are changing frequently across versions, we fully support only the stable APIs in the OpenAI SDK. If you are using a beta API, you can still use the Langfuse SDK by wrapping the OpenAI SDK manually with the `@observe()` [decorator](/docs/sdk/python/decorators).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds documentation for OpenAI token usage in streamed responses, detailing the `include_usage` parameter in `stream_options`.
> 
>   - **Documentation**:
>     - Adds section on OpenAI token usage in streamed responses in `get-started.mdx`.
>     - Describes `include_usage` parameter in `stream_options` for tracking token usage.
>     - Notes automatic setting of `include_usage=True` when streaming is detected, with option to disable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 09b68f56986017cb45e6346caf589dc501444032. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->