### PR TITLE
docs(vercel): prompt mgmt interop

### DIFF
--- a/pages/docs/integrations/vercel-ai-sdk.mdx
+++ b/pages/docs/integrations/vercel-ai-sdk.mdx
@@ -178,6 +178,32 @@ We created a sample repository ([langfuse/langfuse-vercel-ai-nextjs-example](htt
 
 By default, the exporter captures the input and output of each request. You can disable this behavior by setting the `recordInputs` and `recordOutputs` options to `false`.
 
+### Link Langfuse prompts to traces
+
+You can link Langfuse prompts to Vercel AI SDK generations by setting the `langfusePrompt` property in the `metadata` field: 
+
+```typescript
+import { generateText } from "ai"
+import { Langfuse } from "langfuse"
+
+const langfuse = new Langfuse()
+
+const fetchedPrompt = await langfuse.getPrompt('my-prompt')
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  prompt: fetchedPrompt.prompt,
+  experimental_telemetry: {
+    isEnabled: true,
+    metadata: {
+      langfusePrompt: fetchedPrompt.toJSON(),
+    },
+  },
+});
+```
+
+The resulting generation will have the prompt linked to the trace in Langfuse. Learn more about prompts in the [here](/docs/prompts/get-started).
+
 ### Pass Custom Attributes
 
 All of the `metadata` fields are automatically captured by the exporter. You can also pass custom trace attributes to e.g. track users or sessions.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for linking Langfuse prompts to Vercel AI SDK traces in `vercel-ai-sdk.mdx`.
> 
>   - **Documentation**:
>     - Adds section on linking Langfuse prompts to Vercel AI SDK traces in `vercel-ai-sdk.mdx`.
>     - Provides example code for setting `langfusePrompt` in `metadata` field to associate prompts with traces.
>     - Updates include instructions on fetching prompts and linking them to trace data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 060eaaa6b84baba95d4847ccc4451f9300638229. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->