### PR TITLE
added jp, kr, cn to footer

### DIFF
--- a/components/FooterMenu.tsx
+++ b/components/FooterMenu.tsx
@@ -135,6 +135,18 @@ const menuItems: {
         name: "Status",
         href: "https://status.langfuse.com",
       },
+      {
+        name: "🇯🇵 Japanese",
+        href: "/jp",
+      },
+      {
+        name: "🇰🇷 Korean",
+        href: "/kr",
+      },
+      {
+        name: "🇨🇳 Chinese",
+        href: "/cn",
+      },
     ],
   },
   {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added Japanese, Korean, and Chinese language options to the footer menu in `FooterMenu.tsx`.
> 
>   - **Behavior**:
>     - Added new language options to the footer menu in `FooterMenu.tsx`.
>     - New entries for Japanese (`/jp`), Korean (`/kr`), and Chinese (`/cn`) with respective flags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1c9524feb9f45963c1bbab8e6a3534e9c7a444c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->