### PR TITLE
Fix environment variables setup for langflow

### DIFF
--- a/pages/docs/integrations/langflow.mdx
+++ b/pages/docs/integrations/langflow.mdx
@@ -40,11 +40,11 @@ With the native integration (since langflow v1.0.17), you can use Langflow to qu
 
 ```sh
 # API keys from project settings in Langfuse
-export LANGFLOW_LANGFUSE_SECRET_KEY=secret_key
-export LANGFLOW_LANGFUSE_PUBLIC_KEY=public_key
+export LANGFUSE_PUBLIC_KEY=secret_key
+export LANGFUSE_SECRET_KEY=public_key
 
 # Optionally, set the host, defaults to Langfuse Cloud
-# LANGFLOW_LANGFUSE_HOST=http://localhost:3000
+# LANGFUSE_HOST=http://localhost:3000
 
 # Install Langflow
 pip install langflow
@@ -56,7 +56,7 @@ langflow run
 Alternatively, you can run the Langflow CLI command with the environment variables set:
 
 ```
-LANGFLOW_LANGFUSE_SECRET_KEY=secret_key LANGFLOW_LANGFUSE_PUBLIC_KEY=public_key langflow
+LANGFUSE_SECRET_KEY=secret_key LANGFUSE_PUBLIC_KEY=public_key langflow
 ```
 
 </Tab>
@@ -82,8 +82,8 @@ services:
     ports:
       - "7860:7860"
     environment:
-+     - LANGFLOW_LANGFUSE_SECRET_KEY=secret_key
-+     - LANGFLOW_LANGFUSE_PUBLIC_KEY=public_key
++     - LANGFUSE_SECRET_KEY=secret_key
++     - LANGFUSE_PUBLIC_KEY=public_key
     command: langflow run --host 0.0.0.0
 ```
 
@@ -120,9 +120,9 @@ services:
       - "7860:7860"
     environment:
 +     # Tokens are to be created in Langfuse, then copy-pasted here. Then restart docker-compose.
-+     - LANGFLOW_LANGFUSE_SECRET_KEY=sk-lf-...
-+     - LANGFLOW_LANGFUSE_PUBLIC_KEY=pk-lf-...
-+     - LANGFLOW_LANGFUSE_HOST=http://langfuse-server:3000
++     - LANGFUSE_SECRET_KEY=sk-lf-...
++     - LANGFUSE_PUBLIC_KEY=pk-lf-...
++     - LANGFUSE_HOST=http://langfuse-server:3000
     command: langflow run --host 0.0.0.0
 
   # https://github.com/langfuse/langfuse/blob/main/docker-compose.yml
@@ -159,7 +159,7 @@ volumes:
 To test the connectivity between Langflow and Langfuse, run the following command:
 
 ```sh
-docker compose exec langflow python -c "import requests, os; addr = os.environ.get('LANGFLOW_LANGFUSE_HOST'); print(addr); res = requests.get(addr, timeout=5); print(res.status_code)"
+docker compose exec langflow python -c "import requests, os; addr = os.environ.get('LANGFUSE_HOST'); print(addr); res = requests.get(addr, timeout=5); print(res.status_code)"
 
 # which should output the following:
 # http://langfuse-server:3000


### PR DESCRIPTION
This PR provides some documentation update:

* Removes the old `LANGFLOW_` prefix of the environment variables in the Langflow setup instructions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes outdated `LANGFLOW_` prefix from environment variables in Langflow setup documentation.
> 
>   - **Documentation Update**:
>     - Removes `LANGFLOW_` prefix from environment variables in `langflow.mdx` setup instructions.
>     - Updates examples to use `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` without the prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4ff83ee26920c79e26c2c9743ba64a3832afc31d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->