### PR TITLE
docs: fixed spelling mistake on /why

### DIFF
--- a/pages/why.mdx
+++ b/pages/why.mdx
@@ -16,8 +16,8 @@
 
 ### Reliable Partner
 
-- All changes to the Langfuse API and intgerations are covered by [semantic versioning](https://semver.org), we test public interfaces to ensure backwards compatibility, and run end-to-end integration tests for the most common use cases in CI.
-- Raised a [$4M seed round](/blog/announcing-our-seed-round) from Lightspeed Ventures, General Catalyst, Y Combinator and angel investors.
+- All changes to the Langfuse API and integrations are covered by [semantic versioning](https://semver.org); we test public interfaces to ensure backward compatibility and run end-to-end integration tests for the most common use cases in CI.
+- Raised a [$4M seed round](/blog/announcing-our-seed-round) from Lightspeed Ventures, General Catalyst, Y Combinator, and angel investors.
 - Strong adoption and community growth ([see metrics](#metrics)).
 - [Learn more](/about) about us as a team.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix spelling and punctuation in `pages/why.mdx`.
> 
>   - **Spelling Correction**:
>     - Corrected 'intgerations' to 'integrations' in `pages/why.mdx`.
>   - **Punctuation**:
>     - Added a comma after 'Y Combinator' in `pages/why.mdx` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8f049ccc09a36ca75ca4eaff9fe29fe356c506a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->