### PR TITLE
docs: removed link to deprecated llamaindex callback handler video

### DIFF
--- a/pages/docs/integrations/llama-index/get-started.mdx
+++ b/pages/docs/integrations/llama-index/get-started.mdx
@@ -27,8 +27,7 @@ If you are interested in the deprecated callback-based integration, see the [dep
   gifStyle
 />
 <span>
-  _Example LlamaIndex trace in Langfuse. See a full video demo
-  [here](/guides/videos/llama-index)._
+  _Example LlamaIndex trace in Langfuse._
 </span>
 
 ## Add Langfuse to your LlamaIndex application


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed link to deprecated LlamaIndex callback handler video in `get-started.mdx`.
> 
>   - **Documentation**:
>     - Removed link to deprecated LlamaIndex callback handler video in `get-started.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9d11c33a8252b7054712be70c1a70e966dfdbdba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->