### PR TITLE
chore: document failIfDatabaseUnavailable healthcheck flag

### DIFF
--- a/pages/docs/deployment/self-host.mdx
+++ b/pages/docs/deployment/self-host.mdx
@@ -200,7 +200,7 @@ The Enterprise Edition ([compare versions](/docs/deployment/feature-overview)) o
 ### Health and Readiness Check Endpoint
 
 Langfuse includes a health check endpoint at `/api/public/health` and a readiness check endpoint at `/api/public/ready`.
-The health check endpoint checks both API functionality and database connectivity and indicates if the application is alive.
+The health check endpoint checks the API functionality and indicates if the application is alive.
 The readiness check endpoint indicates if the application is ready to serve traffic.
 
 Access the health and readiness check endpoints:
@@ -221,6 +221,10 @@ The potential responses from the readiness check endpoint are:
 - `500 Internal Server Error`: The application received a SIGTERM or SIGINT and should not receive traffic.
 
 Applications and monitoring services can call this endpoint periodically for health updates.
+
+Per default, the healthcheck endpoint does not validate if the database is reachable, as there are cases where the
+database is unavailable, but the application still serves traffic.
+If you want to run database healthchecks, you can add `?failIfDatabaseUnavailable=true` to the healthcheck endpoint.
 
 ### Encryption
 

--- a/pages/docs/deployment/v3/overview.mdx
+++ b/pages/docs/deployment/v3/overview.mdx
@@ -331,6 +331,10 @@ The potential responses from the readiness check endpoint are:
 
 Applications and monitoring services can call this endpoint periodically for health updates.
 
+Per default, the Langfuse web healthcheck endpoint does not validate if the database is reachable, as there are cases where the
+database is unavailable, but the application still serves traffic.
+If you want to run database healthchecks, you can add `?failIfDatabaseUnavailable=true` to the healthcheck endpoint.
+
 ### Encryption
 
 #### Encryption in transit (HTTPS) [#https]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates documentation to clarify health check behavior and introduce a query parameter for database validation.
> 
>   - **Documentation**:
>     - Updates `self-host.mdx` and `overview.mdx` to clarify that the health check endpoint does not validate database connectivity by default.
>     - Introduces `?failIfDatabaseUnavailable=true` query parameter to enable database validation in health checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 37d9bfd496b3823a10f131b1f91273149207d224. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->