### PR TITLE
Fix typo in vercel-ai-sdk.mdx

### DIFF
--- a/pages/docs/integrations/vercel-ai-sdk.mdx
+++ b/pages/docs/integrations/vercel-ai-sdk.mdx
@@ -78,7 +78,7 @@ new LangfuseExporter({
 </Tab>
 </Tabs>
 
-Now you need to resister this exporter via the OpenTelemetry SDK.
+Now you need to register this exporter via the OpenTelemetry SDK.
 
 <Tabs items={["NextJs","Node.js"]}>
 <Tab>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `vercel-ai-sdk.mdx`, changing "resister" to "register".
> 
>   - Fix typo in `vercel-ai-sdk.mdx`, changing "resister" to "register".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ec8da51cf443a95aae7bc7456bbed5c151d9a5a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->