### PR TITLE
feat: generate llms.txt based on sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 # next sitemap
 public/robots.txt
 public/sitemap*.xml
+public/llms.txt
 
 # we use pnpm
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "dev": "next dev -p 3333",
     "build": "next build",
-    "postbuild": "next-sitemap && echo 'Removing .next/cache to resolve Nextra caching bug' && rm -rf .next/cache",
+    "postbuild": "pnpm run postbuild:sitemap && pnpm run postbuild:cleanup && pnpm run postbuild:llms-txt",
     "start": "next start -p 3333",
-    "analyze": "cross-env ANALYZE=true next build"
+    "analyze": "cross-env ANALYZE=true next build",
+    "postbuild:sitemap": "next-sitemap",
+    "postbuild:cleanup": "echo 'Removing .next/cache to resolve Nextra caching bug' && rm -rf .next/cache",
+    "postbuild:llms-txt": "node scripts/generate_llms_txt.js"
   },
   "engines": {
     "node": "20"
@@ -63,7 +66,8 @@
     "@next/bundle-analyzer": "^14.2.15",
     "@types/node": "20.11.1",
     "cross-env": "^7.0.3",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "xml2js": "^0.6.2"
   },
   "optionalDependencies": {
     "crisp-sdk-web": "^1.0.25"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
 
 packages:
 
@@ -2940,6 +2943,9 @@ packages:
     resolution: {integrity: sha512-XU9EELUEZuioT4acLIpCXxHcFzrsC8muvg0MY28d+TlqwxbkTzBmWbw+3+hnCzXT7YZ0Qm8k3eXktDaEu+qmEw==}
     engines: {node: '>=16'}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -3407,6 +3413,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   xmldom-sre@0.1.31:
     resolution: {integrity: sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==}
@@ -6738,6 +6752,8 @@ snapshots:
       postcss-value-parser: 4.2.0
       yoga-wasm-web: 0.3.3
 
+  sax@1.4.1: {}
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -7276,6 +7292,13 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.18.0: {}
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   xmldom-sre@0.1.31: {}
 

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const xml2js = require('xml2js');
+const path = require('path');
+
+const SITEMAP_PATH = 'public/sitemap-0.xml';
+const TITLE = 'Langfuse';
+const INTRO_DESCRIPTION = 'Langfuse is an **open-source LLM engineering platform** ([GitHub](https://github.com/langfuse/langfuse)) that helps teams collaboratively debug, analyze, and iterate on their LLM applications. All platform features are natively integrated to accelerate the development workflow.';
+const MAIN_SECTIONS = [
+    'docs',
+];
+const OPTIONAL_SECTIONS = [
+    'guides',
+    'changelog',
+    'blog',
+    'faq'
+];
+
+async function generateLLMsList() {
+    try {
+        const sitemapContent = fs.readFileSync(SITEMAP_PATH, 'utf-8');
+
+        const parser = new xml2js.Parser();
+        const result = await parser.parseStringPromise(sitemapContent);
+
+        // Start building markdown content with the title and blockquote
+        let markdownContent = `# ${TITLE}\n\n`;
+        markdownContent += `> ${INTRO_DESCRIPTION}\n\n`;
+
+        // Create a map to store URLs by section
+        const urlsBySection = {
+            other: [],
+            optional: []
+        };
+        MAIN_SECTIONS.forEach(section => {
+            urlsBySection[section] = [];
+        });
+
+        // Sort URLs into sections
+        const urls = result.urlset.url.map(url => url.loc[0]);
+        urls.forEach(url => {
+            const urlPath = new URL(url).pathname.split('/')[1]; // Get first part of path
+
+            if (MAIN_SECTIONS.includes(urlPath)) {
+                urlsBySection[urlPath].push({
+                    title: url.split('/').pop().replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+                    url: url
+                });
+            } else if (OPTIONAL_SECTIONS.includes(urlPath)) {
+                urlsBySection.optional.push({
+                    title: url.split('/').pop().replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+                    url: url
+                });
+            } else {
+                urlsBySection.other.push({
+                    title: url.split('/').pop().replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+                    url: url
+                });
+            }
+        });
+
+        // Generate markdown for main sections
+        MAIN_SECTIONS.forEach(section => {
+            if (urlsBySection[section].length > 0) {
+                markdownContent += `## ${section.charAt(0).toUpperCase() + section.slice(1)}\n\n`;
+                urlsBySection[section].forEach(({ title, url }) => {
+                    markdownContent += `- [${title}](${url})\n`;
+                });
+                markdownContent += '\n';
+            }
+        });
+
+        // Add other section
+        if (urlsBySection.other.length > 0) {
+            markdownContent += '## Other\n\n';
+            urlsBySection.other.forEach(({ title, url }) => {
+                markdownContent += `- [${title}](${url})\n`;
+            });
+            markdownContent += '\n';
+        }
+
+        // Add optional integrations section at the end
+        if (urlsBySection.optional.length > 0) {
+            markdownContent += '## Optional\n\n';
+            urlsBySection.optional.forEach(({ title, url }) => {
+                markdownContent += `- [${title}](${url})\n`;
+            });
+        }
+
+        // Write to llms.txt
+        const outputPath = path.join(process.cwd(), 'public', 'llms.txt');
+        fs.writeFileSync(outputPath, markdownContent);
+
+        console.log('Successfully generated llms.txt');
+    } catch (error) {
+        console.error('Error generating llms.txt:', error);
+    }
+}
+
+generateLLMsList(); 


### PR DESCRIPTION
credits: cursor / anthropic


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add script to generate `llms.txt` from sitemap XML, categorizing URLs into sections, and update build process to include this script.
> 
>   - **Scripts**:
>     - Add `generate_llms_txt.js` to generate `llms.txt` from `public/sitemap-0.xml`.
>     - Categorizes URLs into main (`docs`), optional (`guides`, `changelog`, `blog`, `faq`), and other sections.
>     - Outputs markdown content to `public/llms.txt`.
>   - **package.json**:
>     - Add `postbuild:llms-txt` script to run `generate_llms_txt.js`.
>     - Modify `postbuild` script to include `postbuild:llms-txt`.
>     - Add `xml2js` as a dependency for XML parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 86e8d967355a9c53ac1e8076b1a950475a5d1aca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->