### PR TITLE
chore: enable background migrations for pg->ch move

### DIFF
--- a/pages/docs/deployment/v3/migrate-v2-to-v3.mdx
+++ b/pages/docs/deployment/v3/migrate-v2-to-v3.mdx
@@ -118,6 +118,8 @@ As part of the v3 release, we have introduced four migrations that will run once
 Each migration has to finish, before the next one starts.
 Depending on the size of your event tables, this process may take multiple hours.
 
+You need to set `LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS=true` to enable background migrations and start the migration of data from Postgres to ClickHouse.
+
 [//]: # (TODO: Reference to new UI to monitor background migrations)
 
 #### 5. Stop the old Langfuse containers


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to guide enabling background migrations for Postgres to ClickHouse data transfer in Langfuse v3 migration.
> 
>   - **Documentation**:
>     - Update `migrate-v2-to-v3.mdx` to include instructions for enabling background migrations by setting `LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS=true` for data migration from Postgres to ClickHouse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5c6866ece264003a1e6933840c019cae796739ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->