### PR TITLE
feat: add s3 blob store docs

### DIFF
--- a/pages/docs/deployment/v3/components/_meta.tsx
+++ b/pages/docs/deployment/v3/components/_meta.tsx
@@ -1,5 +1,5 @@
 export default {
   "clickhouse": "Clickhouse",
   "redis": "Redis / Valkey",
-  "blobstorage": "S3 / Blob Storage (Coming soon)",
+  "blobstorage": "S3 / Blob Storage",
 };

--- a/pages/docs/deployment/v3/components/blobstorage.mdx
+++ b/pages/docs/deployment/v3/components/blobstorage.mdx
@@ -21,7 +21,7 @@ They need to be provided for the Langfuse Web and Langfuse Worker containers.
 
 | Variable                                     | Required / Default | Description                                                                                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LANGFUSE_S3_EVENT_UPLOAD_ENABLED`           | `true`             | Whether to enable Langfuse S3 event uploads. Thist must be set to `true` to use tracing. |
+| `LANGFUSE_S3_EVENT_UPLOAD_ENABLED`           | `true`             | Whether to enable Langfuse S3 event uploads. This must be set to `true` to use tracing. |
 | `LANGFUSE_S3_EVENT_UPLOAD_BUCKET`            | Required           | Name of the bucket in which event information should be uploaded. |
 | `LANGFUSE_S3_EVENT_UPLOAD_PREFIX`            | `""`               | Prefix to store events within a subpath of the bucket. Defaults to the bucket root. If provided, must end with a `/`. |
 | `LANGFUSE_S3_EVENT_UPLOAD_REGION`            |                    | Region in which the bucket resides. |

--- a/pages/docs/deployment/v3/components/blobstorage.mdx
+++ b/pages/docs/deployment/v3/components/blobstorage.mdx
@@ -2,6 +2,200 @@
 description: How Langfuse uses S3 / Blob Storage
 ---
 
-# S3 / Blob Storage (Coming Soon)
+# S3 / Blob Storage
 
-This page is still work in progress.
+Langfuse uses S3 or another S3-compatible blob storage (referred to as S3 going forward) to store raw events, user media, batch expors, and other files.
+We use it as a scalable and durable storage solution for large files with strong read-after-write guarantees.
+This guide covers how to configure S3 within Langfuse and how to connect your own S3-compatible storage.
+
+## Configuration
+
+Langfuse has multiple use-cases for S3 and allows you to configure them individually.
+That way, you can use separate buckets for each case, or combine information in a single bucket using prefixes.
+
+### Mandatory Configuration
+
+Langfuse needs an S3 bucket to upload raw event information.
+The following environment variables are mandatory for every deployment.
+They need to be provided for the Langfuse Web and Langfuse Worker containers.
+
+| Variable                                     | Required / Default | Description                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LANGFUSE_S3_EVENT_UPLOAD_ENABLED`           | `true`             | Whether to enable Langfuse S3 event uploads. Thist must be set to `true` to use tracing. |
+| `LANGFUSE_S3_EVENT_UPLOAD_BUCKET`            | Required           | Name of the bucket in which event information should be uploaded. |
+| `LANGFUSE_S3_EVENT_UPLOAD_PREFIX`            | `""`               | Prefix to store events within a subpath of the bucket. Defaults to the bucket root. If provided, must end with a `/`. |
+| `LANGFUSE_S3_EVENT_UPLOAD_REGION`            |                    | Region in which the bucket resides. |
+| `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT`          |                    | Endpoint to use to upload events. |
+| `LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID`     |                    | Access key for the bucket. Must have List, Get, and Put permissions. |
+| `LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY` |                    | Secret access key for the bucket. |
+| `LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE`  |                    | Whether to force path style on requests. Required for MinIO. |
+
+### Optional Configuration
+
+Langfuse also uses S3 for batch exports and for multi-modal tracing.
+Those use-cases are opt-in and can be configured separately.
+Use the following information to enable them.
+
+#### Multi-Modal Tracing
+
+| Variable                                     | Required / Default | Description                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LANGFUSE_S3_MEDIA_UPLOAD_ENABLED`           | `false`            | Whether to enable Langfuse S3 media uploads. Thist must be set to `true` to use multi-modal tracing. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_BUCKET`            | Required           | Name of the bucket in which media files should be uploaded. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_PREFIX`            | `""`               | Prefix to store media within a subpath of the bucket. Defaults to the bucket root. If provided, must end with a `/`. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_REGION`            |                    | Region in which the bucket resides. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT`          |                    | Endpoint to use to upload media files. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID`     |                    | Access key for the bucket. Must have List, Get, and Put permissions. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY` |                    | Secret access key for the bucket. |
+| `LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE`  |                    | Whether to force path style on requests. Required for MinIO. |
+
+#### Batch Exports
+
+These variables where introduced before additional use-cases for S3 arose and, therefore, use a different naming scheme.
+This is likely to change soon.
+Please monitor this page to stay up-to-date.
+
+| Variable               | Required / Default | Description                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `S3_ENDPOINT`          |                    | Endpoint to use to upload batch exports. |
+| `S3_ACCESS_KEY_ID`     |                    | Access key for the bucket. Must have List, Get, and Put permissions. |
+| `S3_SECRET_ACCESS_KEY` |                    | Secret access key for the bucket. |
+| `S3_BUCKET_NAME`       |                    | Name of the bucket in which to upload batch exports. |
+| `S3_REGION`            |                    | Region in which the bucket resides. |
+| `S3_FORCE_PATH_STYLE`  |                    | Whether to force path style on requests. Required for MinIO. |
+
+## Deployment Options
+
+This section covers different deployment options and provides example environment variables.
+We will focus on the EVENT_UPLOAD case, as the other cases are similar.
+
+### Amazon S3
+
+[Amazon S3](https://aws.amazon.com/s3/) is a globally available object storage.
+Langfuse uses the AWS SDK internally to connect to blob storages, as most providers provide an S3-compatible interface.
+
+If Langfuse is running on an AWS instance, we recommend to use an IAM role on the Langfuse container to access S3.
+Otherwise, create an IAM user and generate an Access Key pair for Langfuse.
+Ensure that both entities have the necessary permissions to access the bucket:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:PutObject",
+                "s3:ListBucket",
+                "s3:GetObject"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::<my-bucket-name>/*",
+                "arn:aws:s3:::<my-bucket-name>"
+            ],
+            "Sid": "EventBucketAccess"
+        }
+    ]
+}
+```
+
+#### Example Configuration
+
+Set the following environment variables if you authenticate using an IAM role:
+```yaml
+LANGFUSE_S3_EVENT_UPLOAD_ENABLED=true
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=my-bucket-name
+```
+
+If you authenticate using an Access Key pair:
+```yaml
+LANGFUSE_S3_EVENT_UPLOAD_ENABLED=true
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=my-bucket-name
+LANGFUSE_S3_EVENT_UPLOAD_REGION=my-bucket-region
+LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+### MinIO
+
+[MinIO](https://min.io/) is an open-source object storage server that is compatible with the S3 API.
+It is a popular choice for on-premise deployments and local development.
+Langfuse uses it for local development and as a default in our [Docker Compose](/docs/deployment/v3/guides/docker-compose) and [Kubernetes (Helm)](/docs/deployment/v3/guides/kubernetes-helm) deployment options.
+
+#### Example Configuration
+
+Start a local MinIO container with Docker using:
+```bash
+docker run --name minio \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -e MINIO_ROOT_USER=minio \
+  -e MINIO_ROOT_PASSWORD=miniosecret \
+  minio/minio server /data --console-address ":9001"
+```
+
+Navigate to `http://localhost:9001` to access the MinIO console and create a bucket named `langfuse`.
+Now, you can start Langfuse using the following environment variables:
+
+```yaml
+LANGFUSE_S3_EVENT_UPLOAD_ENABLED=true
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse
+LANGFUSE_S3_EVENT_UPLOAD_REGION=us-east-1
+LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=minio
+LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=miniosecret
+LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://minio:9000
+LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
+LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
+```
+
+This example setup uses an ephemeral volume, i.e. on restarts MinIO will discard all event data.
+Please follow the MinIO documentation or use a cloud provider managed blob store for persistent data storage.
+
+### Cloudflare R2
+
+[Cloudflare R2](https://www.cloudflare.com/developer-platform/products/r2/) is globally available, S3 compatible object storage by Cloudflare.
+Create a new bucket within the Cloudflare UI and generate an Access Key pair.
+Ensure that the Access Key pair has the necessary permissions to access the bucket.
+
+#### Example Configuration
+
+Set the following environment variables to connect Langfuse with your Cloudflare R2 bucket:
+
+```yaml
+LANGFUSE_S3_EVENT_UPLOAD_ENABLED=true
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=my-bucket-name
+LANGFUSE_S3_EVENT_UPLOAD_REGION=auto
+LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=<access-key-id>
+LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=<secret-access-key>
+LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=https://${ACCOUNT_ID}.r2.cloudflarestorage.com
+```
+
+### Google Cloud Storage
+
+[Google Cloud Storage](https://cloud.google.com/storage) is a globally available object storage by Google Cloud.
+It offers S3-compatibility through its interoperability interface.
+To get started, create a new bucket within Google Cloud Storage.
+Navigate to `Settings > Interoperability` to create a service account HMAC key.
+Ensure that the HMAC key has the necessary permissions to access the bucket.
+
+#### Example Configuration
+
+Set the following environment variables to connect Langfuse with your Google Cloud Storage bucket:
+
+```yaml
+LANGFUSE_S3_EVENT_UPLOAD_ENABLED=true
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=my-bucket-name
+LANGFUSE_S3_EVENT_UPLOAD_REGION=auto
+LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=<HMAC Access Key>
+LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=<HMAC Secret Key>
+LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=https://storage.googleapis.com
+LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
+LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
+```
+
+### Other Providers
+
+Langfuse supports any S3-compatible storage provider.
+Please refer to the provider's documentation on how to create a bucket and generate Access Key pairs.
+Ensure that the Access Key pair has the necessary permissions to access the bucket.
+If you believe that other providers should be documented here, please open an [issue](https://github.com/langfuse/langfuse-docs/issues)
+or a [pull request](https://github.com/langfuse/langfuse-docs/pulls) to contribute to this documentation.

--- a/pages/docs/deployment/v3/components/clickhouse.mdx
+++ b/pages/docs/deployment/v3/components/clickhouse.mdx
@@ -18,7 +18,7 @@ They need to be provided for the Langfuse Web and Langfuse Worker containers.
 | `CLICKHOUSE_MIGRATION_URL`                    | Required           | Migration URL (TCP protocol) for the ClickHouse instance. Pattern: `clickhouse://<hostname>:(9000/9440)` |
 | `CLICKHOUSE_MIGRATION_SSL`                    | `false`            | Set to true to establish an SSL connection to ClickHouse for the database migration. |
 | `CLICKHOUSE_URL`                              | Required           | Hostname of the ClickHouse instance. Pattern: `http(s)://<hostname>:(8123/8443)` |
-| `CLICKHOUSE_USER`                             | Required           | Username of the ClickHouse database. Needs SELECT, INSERT, CREATE, DELETE grants.   |
+| `CLICKHOUSE_USER`                             | Required           | Username of the ClickHouse database. Needs SELECT, ALTER, INSERT, CREATE, DELETE grants.   |
 | `CLICKHOUSE_PASSWORD`                         | Required           | Password of the ClickHouse user. |
 | `CLICKHOUSE_MIGRATION_CLUSTER_DISABLED`       | `false`            | Whether to disable the automatic ClickHouse migrations during server start. |
 | `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED` | `false`            | Whether to disable automatic ClickHouse migrations. |

--- a/pages/docs/deployment/v3/overview.mdx
+++ b/pages/docs/deployment/v3/overview.mdx
@@ -191,7 +191,7 @@ You can use the same environment variables for the Langfuse Web and Langfuse Wor
 | `CLICKHOUSE_MIGRATION_URL`                                                                           | Required           | Migration URL (TCP protocol) for the clickhouse instance. Pattern: `clickhouse://<hostname>:(9000/9440)` |
 | `CLICKHOUSE_MIGRATION_SSL`                                                                           | `false`            | Set to true to establish an SSL connection to Clickhouse for the database migration. |
 | `CLICKHOUSE_URL`                                                                                     | Required           | Hostname of the clickhouse instance. Pattern: `http(s)://<hostname>:8123` |
-| `CLICKHOUSE_USER`                                                                                    | Required           | Username of the clickhouse database. Needs SELECT, INSERT, CREATE, DELETE grants.   |
+| `CLICKHOUSE_USER`                                                                                    | Required           | Username of the clickhouse database. Needs SELECT, ALTER, INSERT, CREATE, DELETE grants.   |
 | `CLICKHOUSE_PASSWORD`                                                                                | Required           | Password of the clickhouse user. |
 | `CLICKHOUSE_MIGRATION_CLUSTER_DISABLED`                                                              | `false`            | Whether to disable the automatic ClickHouse migrations during server start. |
 | `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED`                                                        | `false`            | Whether to disable the cluster mode in ClickHouse migrations. |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds S3 blob storage configuration documentation and updates ClickHouse user permissions in Langfuse docs.
> 
>   - **S3 Blob Storage Documentation**:
>     - Adds detailed configuration guide for S3 blob storage in `blobstorage.mdx`, including mandatory and optional configurations.
>     - Provides deployment options and example configurations for Amazon S3, MinIO, Cloudflare R2, Google Cloud Storage, and other providers.
>   - **Meta Update**:
>     - Updates `blobstorage` label in `_meta.tsx` to remove "(Coming soon)".
>   - **ClickHouse Documentation**:
>     - Updates `CLICKHOUSE_USER` permissions in `clickhouse.mdx` and `overview.mdx` to include `ALTER` grant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4c5f500e760bb8d349025c2b3555cd3d886c8498. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->