### PR TITLE
docs: add sticker link to asian pages

### DIFF
--- a/pages/cn.mdx
+++ b/pages/cn.mdx
@@ -107,3 +107,4 @@ Langfuse 提供一系列功能，可在人工智能产品的整个周期中为�
   * [推特](https://x.com/langfuse)  
   * [纪和声](https://discord.langfuse.com/)  
   * [LinkedIn](https://www.linkedin.com/company/langfuse)
+* 🖼️ [接收朗富斯贴纸](https://langfuse.com/stickers)

--- a/pages/jp.mdx
+++ b/pages/jp.mdx
@@ -115,3 +115,4 @@ Langfuseは[インテグレーションやSDKを通して](/docs/integrations/ov
   * [Twitter](https://x.com/langfuse)
   * [Discord](https://discord.langfuse.com/)  
   * [LinkedIn](https://www.linkedin.com/company/langfuse)
+* 🖼️ [ラングフューズのステッカーを受け取る](https://langfuse.com/stickers)

--- a/pages/kr.mdx
+++ b/pages/kr.mdx
@@ -113,3 +113,4 @@ Langfuse와 함께 여정을 시작하는 방법은 간단합니다:
   * [트위터](https://x.com/langfuse)  
   * [디스코드](https://discord.langfuse.com/)  
   * [LinkedIn](https://www.linkedin.com/company/langfuse)
+* 🖼️ [랑퓨즈 스티커 받기](https://langfuse.com/stickers)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added a link to receive Langfuse stickers in the community sections of the Chinese, Japanese, and Korean pages.
> 
>   - **Content Update**:
>     - Added a link to receive Langfuse stickers in the community sections of `cn.mdx`, `jp.mdx`, and `kr.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2cfc94965d998f5066954ad64b1f3a6cd5bf7808. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->