### PR TITLE
docs: add notebook querying via sdks

### DIFF
--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -146,5 +146,9 @@
   {
     "notebook": "example_multi_modal_traces.ipynb",
     "docsPath": null
+  },
+  {
+    "notebook": "example_query_data_via_sdk.ipynb",
+    "docsPath": null
   }
 ]

--- a/cookbook/example_query_data_via_sdk.ipynb
+++ b/cookbook/example_query_data_via_sdk.ipynb
@@ -1,0 +1,402 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_acndviOrOXi"
+      },
+      "source": [
+        "---\n",
+        "title: Query Data in Langfuse via the SDK\n",
+        "description: All data in Langfuse is available via API. This Python notebook includes a number of examples of how to use the Langfuse SDK to query data.\n",
+        "category: Examples\n",
+        "---\n",
+        "\n",
+        "# Example: Query Data in Langfuse via the SDK\n",
+        "\n",
+        "This notebook demonstrates how to programmatically access your LLM observability data from Langfuse using the Python SDK. As outlined in our [documentation](https://langfuse.com/docs/query-traces), Langfuse provides several methods to fetch traces, observations, and sessions for various use cases like collecting few-shot examples, creating datasets, or preparing training data for fine-tuning.\n",
+        "\n",
+        "We'll explore the main query functions and show practical examples of filtering and processing the returned data.\n",
+        "\n",
+        "**This notebook is work-in-progress, feel free to contribute additional examples that you find useful.**\n",
+        "\n",
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yDQgzAOnr5q8"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install langfuse --upgrade"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "PHtGGXC8rN4B"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Get keys for your project from the project settings page\n",
+        "# https://cloud.langfuse.com\n",
+        "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"\"\n",
+        "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"\"\n",
+        "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
+        "# os.environ[\"LANGFUSE_HOST\"] = \"https://us.cloud.langfuse.com\" # 🇺🇸 US region\n",
+        "\n",
+        "# Your openai key\n",
+        "os.environ[\"OPENAI_API_KEY\"] = \"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "8z776XxDr4m0"
+      },
+      "outputs": [],
+      "source": [
+        "from langfuse import Langfuse\n",
+        "\n",
+        "langfuse = Langfuse()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "GX4fhu2Zwl7d"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "# helper function\n",
+        "def pydantic_list_to_dataframe(pydantic_list):\n",
+        "    \"\"\"\n",
+        "    Convert a list of pydantic objects to a pandas dataframe.\n",
+        "    \"\"\"\n",
+        "    data = []\n",
+        "    for item in pydantic_list:\n",
+        "        data.append(item.dict())\n",
+        "    return pd.DataFrame(data)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1m-JB4xssPhh"
+      },
+      "source": [
+        "## `fetch_traces`\n",
+        "\n",
+        "SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_traces"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g6vg-2UV3pvO"
+      },
+      "source": [
+        "Default: get the last 50 traces"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 199
+        },
+        "id": "Nq4_mDSVsPCL",
+        "outputId": "58eaa4e0-9ac7-4b48-f3f5-9b26ee99f1fc"
+      },
+      "outputs": [],
+      "source": [
+        "traces = langfuse.fetch_traces(limit=50)\n",
+        "# pydantic_list_to_dataframe(traces.data).head(1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tK3hvMev3mpR"
+      },
+      "source": [
+        "Get traces created by a specific user"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 501
+        },
+        "id": "3d-oWa6Qx9yU",
+        "outputId": "8856c1f7-f1df-450e-970e-54fd30b33680"
+      },
+      "outputs": [],
+      "source": [
+        "traces = langfuse.fetch_traces(user_id=\"u-svQKrql\")\n",
+        "# pydantic_list_to_dataframe(traces.data).head(4)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ekHYSYP03h8Y"
+      },
+      "source": [
+        "Fetch many traces via pagination:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "k5blf8PB1r1n",
+        "outputId": "9c19a28b-e5cd-4943-cb5c-c807c26e27c7"
+      },
+      "outputs": [],
+      "source": [
+        "all_traces = []\n",
+        "limit = 50  # Adjust as needed to balance performance and data retrieval.\n",
+        "page = 1\n",
+        "while True:\n",
+        "    traces = langfuse.fetch_traces(limit=limit, page=page)\n",
+        "    all_traces.extend(traces.data)\n",
+        "    if len(traces.data) < limit or len(all_traces) >= 1000:\n",
+        "        break\n",
+        "    page += 1\n",
+        "\n",
+        "print(f\"Retrieved {len(all_traces)} traces.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "icxMC8-jx84D"
+      },
+      "source": [
+        "## `fetch_trace`\n",
+        "\n",
+        "SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_trace"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EIsUnpFq4X9S"
+      },
+      "source": [
+        "Simple example: fetch and render as json -> get the full traces including evals, observation inputs/outputs, timings and costs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "yH4-MbUFwtYY",
+        "outputId": "77626204-50a8-4d26-8b96-251a0f76959d"
+      },
+      "outputs": [],
+      "source": [
+        "trace = langfuse.fetch_trace(\"4e915ff9-2a60-4035-a744-859a9db7ec1b\")\n",
+        "# print(trace.data.json(indent=1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Gy-tJ85X48XY"
+      },
+      "source": [
+        "Summarize cost by model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "Ov8X9MZv4ewU"
+      },
+      "outputs": [],
+      "source": [
+        "trace = langfuse.fetch_trace(\"4e915ff9-2a60-4035-a744-859a9db7ec1b\")\n",
+        "observations = trace.data.observations"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 143
+        },
+        "id": "ItvrU7f15B-f",
+        "outputId": "9a905682-d9ea-496e-b56d-8d765190a691"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "def summarize_usage(observations):\n",
+        "    \"\"\"Summarizes usage data grouped by model.\"\"\"\n",
+        "\n",
+        "    usage_data = []\n",
+        "    for obs in observations:\n",
+        "        usage = obs.usage\n",
+        "        if usage:\n",
+        "            usage_data.append({\n",
+        "                'model': obs.model,\n",
+        "                'input': usage.input,\n",
+        "                'output': usage.output,\n",
+        "                'total': usage.total,\n",
+        "            })\n",
+        "\n",
+        "    df = pd.DataFrame(usage_data)\n",
+        "    if df.empty:\n",
+        "      return pd.DataFrame()\n",
+        "\n",
+        "    summary = df.groupby('model').sum()\n",
+        "    return summary\n",
+        "\n",
+        "# Example usage (assuming 'observations' is defined as in the provided code):\n",
+        "summary_df = summarize_usage(observations)\n",
+        "summary_df"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ISpZeONm6w1F"
+      },
+      "source": [
+        "## `fetch_observations`\n",
+        "\n",
+        "SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_observations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lUKW1qnX7S2A"
+      },
+      "source": [
+        "Simple example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 199
+        },
+        "id": "K9osjsU55ZoR",
+        "outputId": "a01b3496-be21-4ebd-e0dc-1c7892c42132"
+      },
+      "outputs": [],
+      "source": [
+        "observations = langfuse.fetch_observations(limit=50)\n",
+        "# pydantic_list_to_dataframe(observations.data).head(1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SSDLt-7z8rvC"
+      },
+      "source": [
+        "## `fetch_observation`\n",
+        "\n",
+        "SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_observation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "p49VH27b8rS_",
+        "outputId": "67b314e4-9d21-4dbe-8d63-e308cd3fc90f"
+      },
+      "outputs": [],
+      "source": [
+        "observation = langfuse.fetch_observation(\"e2dc8fcf-1cf7-47d6-b7b0-a3b727332f17\")\n",
+        "# print(observation.data.json(indent=1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1vztqWLz85WG"
+      },
+      "source": [
+        "## `fetch_sessions`\n",
+        "\n",
+        "SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_sessions"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OApAjQPt9FBC"
+      },
+      "source": [
+        "Simple example"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 80
+        },
+        "id": "IZon_rre80Iw",
+        "outputId": "886cd143-d6c5-44bd-c904-94f715a93e68"
+      },
+      "outputs": [],
+      "source": [
+        "sessions = langfuse.fetch_sessions(limit=50)\n",
+        "# pydantic_list_to_dataframe(sessions.data).head(1)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/pages/docs/query-traces.mdx
+++ b/pages/docs/query-traces.mdx
@@ -58,6 +58,8 @@ Python SDK reference including all available filters:
 - [`fetch_observation()`](https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_observation)
 - [`fetch_sessions()`](https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_sessions)
 
+[This notebook](/guides/cookbook/example_query_data_via_sdk) includes a number of examples of how to use the Langfuse SDK to query data.
+
 </Tab>
 <Tab>
 

--- a/pages/guides/cookbook/example_query_data_via_sdk.md
+++ b/pages/guides/cookbook/example_query_data_via_sdk.md
@@ -1,0 +1,177 @@
+---
+title: Query Data in Langfuse via the SDK
+description: All data in Langfuse is available via API. This Python notebook includes a number of examples of how to use the Langfuse SDK to query data.
+category: Examples
+---
+
+# Example: Query Data in Langfuse via the SDK
+
+This notebook demonstrates how to programmatically access your LLM observability data from Langfuse using the Python SDK. As outlined in our [documentation](https://langfuse.com/docs/query-traces), Langfuse provides several methods to fetch traces, observations, and sessions for various use cases like collecting few-shot examples, creating datasets, or preparing training data for fine-tuning.
+
+We'll explore the main query functions and show practical examples of filtering and processing the returned data.
+
+**This notebook is work-in-progress, feel free to contribute additional examples that you find useful.**
+
+## Setup
+
+
+```python
+!pip install langfuse --upgrade
+```
+
+
+```python
+import os
+
+# Get keys for your project from the project settings page
+# https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = ""
+os.environ["LANGFUSE_SECRET_KEY"] = ""
+os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+# os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" # 🇺🇸 US region
+
+# Your openai key
+os.environ["OPENAI_API_KEY"] = ""
+```
+
+
+```python
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+```
+
+
+```python
+import pandas as pd
+# helper function
+def pydantic_list_to_dataframe(pydantic_list):
+    """
+    Convert a list of pydantic objects to a pandas dataframe.
+    """
+    data = []
+    for item in pydantic_list:
+        data.append(item.dict())
+    return pd.DataFrame(data)
+```
+
+## `fetch_traces`
+
+SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_traces
+
+Default: get the last 50 traces
+
+
+```python
+traces = langfuse.fetch_traces(limit=50)
+# pydantic_list_to_dataframe(traces.data).head(1)
+```
+
+Get traces created by a specific user
+
+
+```python
+traces = langfuse.fetch_traces(user_id="u-svQKrql")
+# pydantic_list_to_dataframe(traces.data).head(4)
+```
+
+Fetch many traces via pagination:
+
+
+```python
+all_traces = []
+limit = 50  # Adjust as needed to balance performance and data retrieval.
+page = 1
+while True:
+    traces = langfuse.fetch_traces(limit=limit, page=page)
+    all_traces.extend(traces.data)
+    if len(traces.data) < limit or len(all_traces) >= 1000:
+        break
+    page += 1
+
+print(f"Retrieved {len(all_traces)} traces.")
+```
+
+## `fetch_trace`
+
+SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_trace
+
+Simple example: fetch and render as json -> get the full traces including evals, observation inputs/outputs, timings and costs
+
+
+```python
+trace = langfuse.fetch_trace("4e915ff9-2a60-4035-a744-859a9db7ec1b")
+# print(trace.data.json(indent=1))
+```
+
+Summarize cost by model
+
+
+```python
+trace = langfuse.fetch_trace("4e915ff9-2a60-4035-a744-859a9db7ec1b")
+observations = trace.data.observations
+```
+
+
+```python
+import pandas as pd
+
+def summarize_usage(observations):
+    """Summarizes usage data grouped by model."""
+
+    usage_data = []
+    for obs in observations:
+        usage = obs.usage
+        if usage:
+            usage_data.append({
+                'model': obs.model,
+                'input': usage.input,
+                'output': usage.output,
+                'total': usage.total,
+            })
+
+    df = pd.DataFrame(usage_data)
+    if df.empty:
+      return pd.DataFrame()
+
+    summary = df.groupby('model').sum()
+    return summary
+
+# Example usage (assuming 'observations' is defined as in the provided code):
+summary_df = summarize_usage(observations)
+summary_df
+```
+
+## `fetch_observations`
+
+SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_observations
+
+Simple example:
+
+
+```python
+observations = langfuse.fetch_observations(limit=50)
+# pydantic_list_to_dataframe(observations.data).head(1)
+```
+
+## `fetch_observation`
+
+SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_observation
+
+
+```python
+observation = langfuse.fetch_observation("e2dc8fcf-1cf7-47d6-b7b0-a3b727332f17")
+# print(observation.data.json(indent=1))
+```
+
+## `fetch_sessions`
+
+SDK reference: https://python.reference.langfuse.com/langfuse/client#Langfuse.fetch_sessions
+
+Simple example
+
+
+```python
+sessions = langfuse.fetch_sessions(limit=50)
+# pydantic_list_to_dataframe(sessions.data).head(1)
+```


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new notebook for querying data via the Langfuse SDK and updates documentation and routes accordingly.
> 
>   - **New Notebook**:
>     - Adds `example_query_data_via_sdk.ipynb` to demonstrate querying data using the Langfuse SDK.
>     - Includes examples for `fetch_traces`, `fetch_trace`, `fetch_observations`, `fetch_observation`, and `fetch_sessions`.
>   - **Documentation**:
>     - Updates `query-traces.mdx` to reference the new notebook for SDK usage examples.
>   - **Routes**:
>     - Adds entry for `example_query_data_via_sdk.ipynb` in `_routes.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 74fa8005ed87034f99b1139c9e4d6c90454b6573. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->