### PR TITLE
feat: add posthog tracking to inkeep + prepare for support handover

### DIFF
--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -6,7 +6,18 @@ import type {
 } from "@inkeep/uikit";
 import { useTheme } from "nextra-theme-docs";
 import { openChat } from "../supportChat";
-import { MessageCircle } from "lucide-react";
+import { InkeepCallbackEvent } from "@inkeep/uikit";
+import { type PostHog, usePostHog } from "posthog-js/react";
+
+const customAnalyticsCallback = (
+  event: InkeepCallbackEvent,
+  posthog: PostHog
+): void => {
+  const { interactionType } = event.commonProperties;
+  posthog.capture(`inkeep:${event.eventName}`, {
+    interactionType,
+  });
+};
 
 type InkeepSharedSettings = {
   baseSettings: InkeepBaseSettings;
@@ -17,6 +28,7 @@ type InkeepSharedSettings = {
 
 const useInkeepSettings = (): InkeepSharedSettings => {
   const { resolvedTheme } = useTheme();
+  const posthog = usePostHog();
 
   const baseSettings: InkeepBaseSettings = {
     apiKey: process.env.NEXT_PUBLIC_INKEEP_API_KEY!,
@@ -28,6 +40,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     colorMode: {
       forcedColorMode: resolvedTheme, // to sync dark mode with the widget
     },
+    logEventCallback: (event) => customAnalyticsCallback(event, posthog),
     theme: {
       components: {
         SearchBarTrigger: {
@@ -52,25 +65,25 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     // optional settings
     chatSubjectName: "Langfuse",
     botAvatarSrcUrl: "/icon256.png", // use your own bot avatar
-    // includeAIAnnotations: {
-    //   shouldEscalateToSupport: true,
-    // },
-    // aiAnnotationPolicies: {
-    //   shouldEscalateToSupport: [
-    //     {
-    //       threshold: "STANDARD", // "STRICT" or "STANDARD"
-    //       action: {
-    //         type: "SHOW_SUPPORT_BUTTON",
-    //         label: "Contact Support",
-    //         icon: { builtIn: "LuUsers" },
-    //         action: {
-    //           type: "INVOKE_CALLBACK",
-    //           callback: () => openChat(),
-    //         },
-    //       },
-    //     },
-    //   ],
-    // },
+    includeAIAnnotations: {
+      shouldEscalateToSupport: true,
+    },
+    aiAnnotationPolicies: {
+      shouldEscalateToSupport: [
+        {
+          threshold: "STANDARD", // "STRICT" or "STANDARD"
+          action: {
+            type: "SHOW_SUPPORT_BUTTON",
+            label: "Contact Support",
+            icon: { builtIn: "LuUsers" },
+            action: {
+              type: "INVOKE_CALLBACK",
+              callback: () => openChat(),
+            },
+          },
+        },
+      ],
+    },
     getHelpCallToActions: [
       {
         name: "Chat with us",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds PostHog tracking and enables AI annotation support escalation in `useInkeepSettings.ts`.
> 
>   - **Analytics**:
>     - Adds `customAnalyticsCallback` function in `useInkeepSettings.ts` to capture events with PostHog.
>     - Integrates PostHog with `useInkeepSettings` using `usePostHog()`.
>   - **AI Annotations**:
>     - Enables `includeAIAnnotations` and `aiAnnotationPolicies` for support escalation in `useInkeepSettings.ts`.
>     - Configures support button with `SHOW_SUPPORT_BUTTON` action and `openChat` callback.
>   - **Misc**:
>     - Restores previously commented-out AI annotation settings in `useInkeepSettings.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7c32ea8640ba92eb6fec5f436942f36063d10bb7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->