### PR TITLE
chore: default to ai chat in inkeep

### DIFF
--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -42,6 +42,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
 
   const modalSettings: InkeepModalSettings = {
     // optional settings
+    defaultView: "AI_CHAT", // chat should also be the default for the regular search
   };
 
   const searchSettings: InkeepSearchSettings = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets `defaultView` to `AI_CHAT` in `modalSettings` in `useInkeepSettings.ts`.
> 
>   - **Behavior**:
>     - Sets `defaultView` to `AI_CHAT` in `modalSettings` in `useInkeepSettings.ts`, making AI chat the default view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 72e89f7d511e92d1a88dfcaf1cd8b8f26a2cf700. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->