### PR TITLE
chore: bump langufse

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "framer-motion": "^11.12.0",
     "geist": "^1.3.1",
     "gpt3-tokenizer": "^1.1.5",
-    "langfuse": "^3.31.0",
+    "langfuse": "^3.31.1",
     "lucide-react": "^0.462.0",
     "next": "^15.0.3",
     "next-sitemap": "^4.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^1.1.5
         version: 1.1.5
       langfuse:
-        specifier: ^3.31.0
-        version: 3.31.0
+        specifier: ^3.31.1
+        version: 3.31.1
       lucide-react:
         specifier: ^0.462.0
         version: 0.462.0(react@18.3.1)
@@ -3092,12 +3092,12 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  langfuse-core@3.31.0:
-    resolution: {integrity: sha512-aJ8dNp1Oh8e+XLJb5M+1lzluqi4oLBFxuSh56e8852WOifPs4Q3HPVblvf2YtyhpYqj0x+0cwhVP+iO2AAsh6Q==}
+  langfuse-core@3.31.1:
+    resolution: {integrity: sha512-mLFya8KJhCeqBlUy5iNzHoorOTb05Y/Oa9lfcI7PBH+RBmtLB7+QyYyTaP7EmVRkK21uRhn0U/BU0oN8UKxdYQ==}
     engines: {node: '>=18'}
 
-  langfuse@3.31.0:
-    resolution: {integrity: sha512-Qk2P4dNfiDGjbIjxBsurkRoyBUm5P4KdaeKdM65+IZosZ45TwOgv3AetmXbg+6bKIHbjkJZvOz+KFUmQ3I0AOg==}
+  langfuse@3.31.1:
+    resolution: {integrity: sha512-V74AWfB3aLz2Z0TiuIgXK7uG5eMYE20qfp5zYyKAS4DvQSAiSqC9Sgg3xm6OG8Jc1pK/X7s5WeLvswWn7PwfOA==}
     engines: {node: '>=18'}
 
   langium@3.0.0:
@@ -8480,13 +8480,13 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langfuse-core@3.31.0:
+  langfuse-core@3.31.1:
     dependencies:
       mustache: 4.2.0
 
-  langfuse@3.31.0:
+  langfuse@3.31.1:
     dependencies:
-      langfuse-core: 3.31.0
+      langfuse-core: 3.31.1
 
   langium@3.0.0:
     dependencies:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `langfuse` version from `^3.31.0` to `^3.31.1` in `package.json`.
> 
>   - **Dependencies**:
>     - Bump `langfuse` version from `^3.31.0` to `^3.31.1` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 48fe8f74abfaef66fe5654491093614fa5fc8365. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->