### PR TITLE
feat: log inkeep question content

### DIFF
--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -18,6 +18,10 @@ const customAnalyticsCallback = (
   const { interactionType } = event.commonProperties;
   posthog.capture(`inkeep:${event.eventName}`, {
     interactionType,
+    content:
+      event.eventName === "chat_message_submitted"
+        ? event.properties.content
+        : undefined,
   });
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `customAnalyticsCallback` in `useInkeepSettings.ts` to log `content` for `chat_message_submitted` events.
> 
>   - **Behavior**:
>     - In `useInkeepSettings.ts`, `customAnalyticsCallback` now logs `content` for `chat_message_submitted` events.
>     - If the event is not `chat_message_submitted`, `content` is logged as `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c40fa227efafeeb8c5920ce9b0216a8f0f7af41f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->