### PR TITLE
docs: fix broken links

### DIFF
--- a/pages/blog/2024-11-most-used-oss-llmops.mdx
+++ b/pages/blog/2024-11-most-used-oss-llmops.mdx
@@ -80,8 +80,8 @@ _Numbers refresh automatically via [shields.io](https://shields.io)_
 <Steps>
   ### Large community: Langfuse has numerous actively maintained
   **integrations** with the latest LLM frameworks (such as
-  [Langchain](docs/integrations/langchain),
-  [LlamaIndex](docs/integrations/llamaindex), and
+  [Langchain](/docs/integrations/langchain/tracing),
+  [LlamaIndex](/docs/integrations/llama-index/get-started), and
   [OpenAI](docs/integrations/openai)) and a helpful community on
   [Discord](https://discord.langfuse.com) and
   [GitHub](https://github.com/orgs/langfuse/discussions). ### Battle-tested:

--- a/pages/docs/deployment/v3/migrate-v2-to-v3.mdx
+++ b/pages/docs/deployment/v3/migrate-v2-to-v3.mdx
@@ -12,7 +12,7 @@ description: A guide to upgrade a Langfuse v2 setup to v3.
   For a production-ready setup, follow the [self-hosting guide](/docs/deployment/self-host)
   or consider using [Langfuse Cloud](https://cloud.langfuse.com) maintained by the Langfuse team.
 
-  If you want to get started on v3, please follow our [v3 Self-Host Guide](/docs/deployment/self-host-v3).
+  If you want to get started on v3, please follow our [v3 Self-Host Guide](/docs/deployment/v3/overview).
 </Callout>
 
 To learn more about our reasons for the architectural changes, jump to the [Reasoning](#reasoning) section.

--- a/pages/faq/all/ai-research-assistant-monitoring.mdx
+++ b/pages/faq/all/ai-research-assistant-monitoring.mdx
@@ -52,7 +52,7 @@ Maintain logs of the AI assistant's activities.
 - **Activity Logs**: Record all queries made by the user, the AI and the sources of its information.
 - **Process Tracing**: Monitor the decision-making pathways the AI uses to generate outputs.
 
-Learn how to set up [logging and tracing](/docs/logging-and-tracing).
+Learn how to set up [logging and tracing](/docs/tracing).
 
 ### 3. Analytics Dashboards
 
@@ -97,9 +97,9 @@ Langfuse offers a range of [integrations and SDKs](/docs/integrations/get-starte
 - **Performance Maintenance**: Ensure monitoring tools scale with increased AI assistant usage.
 - **Distributed Systems Support**: Monitor AI assistants operating across various platforms.
 
-Langfuse is designed to [scale](/docs/scaling) with your needs.
+Langfuse is designed to [scale](/docs/deployment/v3/migrate-v2-to-v3) with your needs.
 
 ## Get Started
 
-To implement observability for your AI research assistant, have a look at the Langfuse quickstart [guide](/docs/get-started).
+To implement observability for your AI research assistant, have a look at the Langfuse quickstart [guide](/docs/integrations/overview).
 

--- a/pages/faq/all/best-phoenix-arize-alternatives.mdx
+++ b/pages/faq/all/best-phoenix-arize-alternatives.mdx
@@ -81,7 +81,7 @@ Langfuse is an LLM observability platform that provides a comprehensive tracing 
 
 - **Holistic Tracing and Debugging**: Effective tracking of both LLM and non-LLM actions, delivering complete context for applications.
 - **Production Environments**: Best in class for core LLM engineering features, emphasizing production-grade monitoring, debugging, and performance analytics.
-- **Prompt Management**: Provides robust [prompt management](/docs/prompt-management) solutions through client SDKs, ensuring minimal impact on application latency and uptime during prompt retrieval.
+- **Prompt Management**: Provides robust [prompt management](/docs/prompts/get-started) solutions through client SDKs, ensuring minimal impact on application latency and uptime during prompt retrieval.
 - **Integration Options**: Supports asynchronous logging and tracing SDKs with integrations for frameworks like [LangChain](/docs/integrations/langchain/tracing), [LlamaIndex](/docs/integrations/llama-index/get-started), [OpenAI SDK](/docs/integrations/openai/python/get-started), and [others](/docs/integrations/overview).
 - **Deep Evaluation**: Facilitates user feedback collection, manual reviews, annotation queues, [LLM-as-a-Judge](/docs/scores/model-based-evals) automated annotations, and [custom evaluation](/docs/scores/overview) functions.
 - **Self-Hosting**: Extensive [self-hosting documentation](/docs/deployment/feature-overview) for data security or compliance requirements.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes broken links in multiple documentation files to ensure correct navigation.
> 
>   - **Documentation**:
>     - Fix broken links in `2024-11-most-used-oss-llmops.mdx` for `Langchain` and `LlamaIndex`.
>     - Update link in `migrate-v2-to-v3.mdx` for `v3 Self-Host Guide`.
>     - Correct links in `ai-research-assistant-monitoring.mdx` for `logging and tracing`, `scale`, and `quickstart guide`.
>     - Update link in `best-phoenix-arize-alternatives.mdx` for `prompt management`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c9906ae8c12bc6ccff11015059d8a8669b6cb26e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->