### PR TITLE
docs: refer to v3 for self-host availability

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -297,7 +297,11 @@ const sections = [
         name: "Prompt Experiments",
         tiers: {
           cloud: { Hobby: true, Pro: true, Team: true },
-          selfHosted: { "Open Source": false, Pro: "soon", Enterprise: "soon" },
+          selfHosted: {
+            "Open Source": false,
+            Pro: "soon (v3)",
+            Enterprise: "soon (v3)",
+          },
         },
       },
       {
@@ -311,8 +315,8 @@ const sections = [
           },
           selfHosted: {
             "Open Source": false,
-            Pro: "soon",
-            Enterprise: "soon",
+            Pro: "soon (v3)",
+            Enterprise: "soon (v3)",
           },
         },
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `Pricing.tsx` to indicate "soon (v3)" availability for certain self-hosted features.
> 
>   - **Behavior**:
>     - Update `selfHosted` Pro and Enterprise tiers in `sections` to indicate availability "soon (v3)" for `Prompt Experiments` and `LLM-as-judge evaluators`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3b3619cf0f82d64f7871c72f0a67e3b7aaa70960. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->