### PR TITLE
fix: pricing page compliance link

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -582,7 +582,7 @@ const sections = [
   },
   {
     name: "Compliance",
-    href: "/docs/security",
+    href: "/security",
     features: [
       {
         name: "Data processing agreement (GDPR)",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Compliance section link in `Pricing.tsx` to correct path `/security`.
> 
>   - **Behavior**:
>     - Update `href` for Compliance section in `Pricing.tsx` from `/docs/security` to `/security`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3644b8ec4296a56b5ce333ad80051a6d294612c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->