### PR TITLE
docs: add serveless faq

### DIFF
--- a/pages/faq/all/aws-lambda-and-serverless-functions.mdx
+++ b/pages/faq/all/aws-lambda-and-serverless-functions.mdx
@@ -1,0 +1,26 @@
+---
+title: How to use Langfuse Tracing in Serverless Functions (AWS Lambda, Vercel, Cloudflare Workers, etc.)
+tags: [setup, tracing]
+---
+
+# How to use Langfuse Tracing in Serverless Functions (AWS Lambda, Vercel, Cloudflare Workers, etc.)
+
+Langfuse Tracing is optimized to run in the background in order to avoid adding latency to an application. This can cause some difficulties when tracing in serverless environments like AWS Lambda, Vercel Functions, Google Cloud Functions, etc.
+
+The behavior of the Langfuse clients is outlined [here](/docs/tracing).
+
+## What is the root cause of this issue?
+
+The root cause of this issue is that serverless functions are typically short-lived and terminate after execution. This means that the Langfuse agent, which runs in the background, may not have enough time to complete its work before the function exits. Thereby, events might not be sent to Langfuse.
+
+## Use `flush` to ensure events are sent before the function exits
+
+To solve this issue, you can manually flush the events before the function exits. This can be done by calling the `flush` method of the Langfuse client. The flush method is supported across all Langfuse SDKs and integrations.
+
+## Alternative: waitUntil
+
+Vercel and Cloudflare Workers support the [`waitUntil`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil) method, which allows you to wait for a promise (`flush`) to resolve before the function exits. Thereby you can return a value from your function and still ensure that events are sent to Langfuse.
+
+## Alternative: flushAt
+
+Alternatively, you can configure Langfuse to flush events individually. This can be done by setting the `flushAt` option to a specific number of events.


### PR DESCRIPTION
Fixes LFE-2089
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds FAQ document on using Langfuse Tracing in serverless functions, providing solutions for event sending issues.
> 
>   - **Documentation**:
>     - Adds `aws-lambda-and-serverless-functions.mdx` to provide guidance on using Langfuse Tracing in serverless environments.
>     - Explains the issue of short-lived serverless functions causing incomplete event sending.
>     - Suggests using `flush` method to ensure events are sent before function exits.
>     - Describes `waitUntil` method for Vercel and Cloudflare Workers to wait for `flush` to resolve.
>     - Mentions `flushAt` option to configure individual event flushing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 0aa753306427ba9f483b27661f04c6fb04f90f0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->