### PR TITLE
fix: notebook js readme

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -13,7 +13,7 @@ The JS cookbooks are written in TypeScript and run using Deno. To install Deno a
 ```bash
 brew install deno
 poetry shell
-deno jupyter --unstable
+deno jupyter --install
 ```
 
 Start the notebook server with the following command:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `cookbook/README.md` to correct Deno Jupyter Kernel installation command.
> 
>   - **Documentation**:
>     - Update `cookbook/README.md` to change Deno Jupyter Kernel installation command from `deno jupyter --unstable` to `deno jupyter --install`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 23bf66e1b2e0a9562b079190ff0c5af24d19e1f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->