### PR TITLE
fix: add git checkout v2 to local run docs

### DIFF
--- a/pages/docs/deployment/local.mdx
+++ b/pages/docs/deployment/local.mdx
@@ -30,6 +30,9 @@ for Mac or Windows users.
 git clone https://github.com/langfuse/langfuse.git
 cd langfuse
 
+# Checkout V2 branch
+git checkout v2
+
 # Start the database and langfuse server
 docker compose up
 ```
@@ -40,6 +43,7 @@ Langfuse is now running on your local machine:
 - Integrations: set the `HOST`/`BASEURL` of the SDKs to `http://localhost:3000`
 
 Langfuse is very configurable, see [self-hosting (docker) guide](/docs/deployment/self-host) for more details on configuration options.
+Checkout the [docker-compose.yml](https://github.com/langfuse/langfuse/blob/v2/docker-compose.yml) file for more details.
 
 ### Create an Account
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add step to checkout `v2` branch in local deployment docs and link to `docker-compose.yml`.
> 
>   - **Documentation**:
>     - Add step to checkout `v2` branch in `pages/docs/deployment/local.mdx` before starting the server with `docker compose up`.
>     - Add link to `docker-compose.yml` in `pages/docs/deployment/local.mdx` for more details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ddfdbb41843d9817eff7692a0aa442618e97cca0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->