### PR TITLE
docs: add community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DocsThemeConfig, useConfig } from "nextra-theme-docs";
+import { DocsThemeConfig, Link, useConfig } from "nextra-theme-docs";
 import { Cards, Steps, Tabs, Callout } from "nextra/components";
 import { Logo } from "@/components/logo";
 import { useRouter } from "next/router";
@@ -191,37 +191,22 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "ph-prompt-experiments",
-  //   dismissible: false,
-  //   content: (
-  //     <Link href="/ph">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">
-  //         ✨ Today: Support us on{" "}
-  //         <Image
-  //           src={ProductHuntWhiteImage}
-  //           alt="Product Hunt"
-  //           height={25}
-  //           className="inline mx-1"
-  //         />{" "}
-  //         ✨
-  //       </span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //         ✨ Today: Support{" "}
-  //         <span className="font-bold">Langfuse Prompt Experimentation</span> on{" "}
-  //         <Image
-  //           src={ProductHuntWhiteImage}
-  //           alt="Product Hunt"
-  //           height={25}
-  //           className="inline mx-1"
-  //         />{" "}
-  //         ✨
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+   banner: {
+     key: "community-hour",
+     dismissible: true,
+     content: (
+       <Link href="https://lu.ma/5szapn5d">
+         {/* mobile */}
+         <span className="sm:hidden">
+            Today: Langfuse Community Hour →
+         </span>
+         {/* desktop */}
+         <span className="hidden sm:inline">
+           Today: Langfuse Community Hour, 9-10am PT, 6-7pm CEST →
+         </span>
+       </Link>
+     ),
+   },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a dismissible banner for "Langfuse Community Hour" in `theme.config.tsx`, linking to an external event page.
> 
>   - **Banner**:
>     - Adds a new banner for "Langfuse Community Hour" in `theme.config.tsx`.
>     - Banner is dismissible and links to `https://lu.ma/5szapn5d`.
>     - Displays different text for mobile and desktop views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 89f96b81941022db349c80df7661e157a6585eca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->