### PR TITLE
feat: add search via inkeep in addition to ask ai, default for search bar

### DIFF
--- a/components/inkeep/InkeepSearchBar.tsx
+++ b/components/inkeep/InkeepSearchBar.tsx
@@ -15,7 +15,7 @@ export default function InkeepSearchBar() {
     baseSettings,
     aiChatSettings,
     searchSettings,
-    modalSettings,
+    modalSettings: { ...modalSettings, isShortcutKeyEnabled: true },
   };
 
   return (

--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -61,7 +61,9 @@ const useInkeepSettings = (): InkeepSharedSettings => {
 
   const modalSettings: InkeepModalSettings = {
     // optional settings
-    defaultView: "AI_CHAT", // chat should also be the default for the regular search
+
+    // deactivate by default, only activated for search bar
+    isShortcutKeyEnabled: false,
   };
 
   const searchSettings: InkeepSearchSettings = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable shortcut key for search bar in `InkeepSearchBar.tsx`, while keeping it disabled by default in `useInkeepSettings.ts`.
> 
>   - **Behavior**:
>     - Enables `isShortcutKeyEnabled` for the search bar in `InkeepSearchBar.tsx`.
>     - Keeps `isShortcutKeyEnabled` disabled by default in `useInkeepSettings.ts`.
>   - **Settings**:
>     - Modifies `modalSettings` in `InkeepSearchBar.tsx` to enable shortcut keys specifically for the search bar.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c730261ebdf3615151c57c77cd0c5f4b5ee8c939. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->