### PR TITLE
feat: add clickhouse and s3 backup context

### DIFF
--- a/pages/docs/deployment/v3/components/blobstorage.mdx
+++ b/pages/docs/deployment/v3/components/blobstorage.mdx
@@ -218,3 +218,9 @@ Please refer to the provider's documentation on how to create a bucket and gener
 Ensure that the Access Key pair has the necessary permissions to access the bucket.
 If you believe that other providers should be documented here, please open an [issue](https://github.com/langfuse/langfuse-docs/issues)
 or a [pull request](https://github.com/langfuse/langfuse-docs/pulls) to contribute to this documentation.
+
+## Backups
+
+Langfuse does not manage backups for S3.
+We recommend that you create a backup strategy for your buckets.
+Those may involve versioning, cross-region replication, or regular exports to another storage provider.

--- a/pages/docs/deployment/v3/components/clickhouse.mdx
+++ b/pages/docs/deployment/v3/components/clickhouse.mdx
@@ -148,3 +148,11 @@ CLICKHOUSE_USER=clickhouse
 CLICKHOUSE_PASSWORD=clickhouse
 CLICKHOUSE_CLUSTER_ENABLED=false
 ```
+
+## Backups
+
+ClickHouse Cloud manages backups automatically for you.
+For self-hosted ClickHouse instances, you need to create backups on your own.
+We recommend following the [ClickHouse backup guide](https://clickhouse.com/docs/en/operations/backup) for more details.
+In addition, the ClickHouse state can be restored based on the data in S3.
+While this is computationally expensive and may take a long time, it is an alternative safety measure to prevent data loss.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds backup recommendations for S3 and ClickHouse in the documentation, advising users on strategies and resources.
> 
>   - **Blob Storage Backups**:
>     - Added a section on backups in `blobstorage.mdx`.
>     - States Langfuse does not manage S3 backups.
>     - Recommends users create a backup strategy, suggesting versioning, cross-region replication, or exports.
>   - **ClickHouse Backups**:
>     - Added a section on backups in `clickhouse.mdx`.
>     - Notes ClickHouse Cloud manages backups automatically.
>     - Advises self-hosted users to follow the ClickHouse backup guide.
>     - Mentions restoring ClickHouse state from S3 as an alternative.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 883fa6c6c5a22ac998c290e57929d27b04acf4b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->