### PR TITLE
feat: update kubernetes helm to released version

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/self-hosting/kubernetes-helm.mdx
+++ b/pages/self-hosting/kubernetes-helm.mdx
@@ -10,7 +10,9 @@ This guide will walk you through the steps to deploy Langfuse on Kubernetes usin
 You will need access to a Kubernetes cluster and Helm installed on your local machine.
 For the purposes of this guide, we will use a local minikube instance, but each step should extend to a managed Kubernetes service like GKE, EKS, or AKS.
 
-By default, the chart will deploy the Langfuse application containers and data stores ([architecture overview](/self-hosting#architecture)). You can optionally point to an existing PostgreSQL, Clickhouse and Redis instance. See [Readme](https://github.com/langfuse/langfuse-k8s/blob/lfe-1348-v3-chart/README.md) for more details.
+By default, the chart will deploy the Langfuse application containers and data stores ([architecture overview](/self-hosting#architecture)).
+You can optionally point to an existing PostgreSQL, Clickhouse and Redis instance.
+See [Readme](https://github.com/langfuse/langfuse-k8s) for more details.
 
 <Callout type="info">
   If you are interested in contributing to our Kubernetes deployment guide or
@@ -19,61 +21,36 @@ By default, the chart will deploy the Langfuse application containers and data s
   Discussion](https://github.com/orgs/langfuse/discussions/1902).
 </Callout>
 
-<Callout type="info">
-  This guide references the `lfe-1348-v3-chart` branch and v3-preview. It will
-  be updated to `v3.0.0` on Dec 9, 2024.
-</Callout>
-
 Planned: Cloud-specific deployment guides, please upvote and comment on the following threads: [AWS](https://github.com/orgs/langfuse/discussions/4645), [Google Cloud](https://github.com/orgs/langfuse/discussions/4646),[Azure](https://github.com/orgs/langfuse/discussions/4647).
 
 ## Fetch the Helm chart and customize values
 
-Fetch the `langfuse-k8s` GitHub repository to your local machine to install using Helm.
+Fetch the `langfuse-k8s` Helm chart.
 
 ```bash
-git clone https://github.com/langfuse/langfuse-k8s.git
-
-cd langfuse-k8s/charts/langfuse
-```
-
-Checkout the `lfe-1348-v3-chart` branch. This will be merged on Dec 9, 2024.
-
-```bash
-git checkout lfe-1348-v3-chart
+helm repo add langfuse https://langfuse.github.io/langfuse-k8s
+helm repo update
 ```
 
 For local experimentation, the pre-configured variables in the values.yaml file are usually sufficient.
 
 If you send _any_ kind of sensitive data to the application or intend to keep it up for longer, we recommend that
-you modify the values.yaml file and overwrite the following environment variables using the `additionalEnv` field:
-
-- `SALT`: A random string used to hash passwords. It should be at least 32 characters long.
-- `ENCRYPTION_KEY`: Generate this via `openssl rand -base64 32`.
-- `NEXTAUTH_SECRET`: A random string used to sign JWT tokens.
-- `NEXTAUTH_URL`: The URL where the application is hosted. Used for redirects after signup.
-
-In addition, you can change the database and storage credentials to be more secure.
+you modify the values.yaml file according to your needs
 
 For a comprehensive overview of all available environment variables and configuration options, please refer to the [configuration guide](/self-hosting/configuration).
 
 ## Deploy the helm chart
 
-Create a new namespace for the Langfuse deployment, e.g.:
+Create a new namespace for the Langfuse deployment (optional), e.g.:
 
 ```bash
-kubectl create namespace langfuse-v3-preview
+kubectl create namespace langfuse
 ```
 
-Download the Helm chart dependencies:
+Install the Helm chart into your namespace:
 
 ```bash
-helm dependency update
-```
-
-Install the Helm chart to our demo namespace:
-
-```bash
-helm install langfuse . -n langfuse-v3-preview
+helm install langfuse langfuse/langfuse -n langfuse
 ```
 
 Our chart assumes that it's installed as `langfuse`.
@@ -81,14 +58,14 @@ If you want to install it with a different name, you will have to adjust the Red
 
 At this point, Kubernetes will start to deploy the Langfuse application and its dependencies.
 This can take up to 5 minutes.
-You can monitor the progress by checking `kubectl get pods -n langfuse-v3-preview` - we expect all pods to be running eventually.
+You can monitor the progress by checking `kubectl get pods -n langfuse` - we expect all pods to be running eventually.
 The langfuse-web and langfuse-worker container will restart a couple of times while the databases are being provisioned.
 
 ## Smoke test UI
 
-The Langfuse UI will be served on a NodePort service.
-Use `kubectl get services -n langfuse-v3-preview` and search for `langfuse-web` to see the port mapping.
-You can access the Langfuse UI by visiting `http://<minikube-ip>:<nodeport>` in your browser.
+The Langfuse UI will be served on a ClusterIP service by default.
+Use `kubectl get services -n langfuse` and search for `langfuse-web` to see the port mapping.
+Create a port-forward via `kubectl port-forward svc/langfuse-web -n langfuse <local-port>:<nodeport>` and access the UI via `http://localhost:<local-port>` in your browser.
 Go ahead and register, create a new organization, project, and explore Langfuse.
 
 ## Features
@@ -105,8 +82,8 @@ import SelfHostFeatures from "@/components-mdx/self-host-features.mdx";
 You can delete the Helm release and the namespace to clean up the resources:
 
 ```bash
-helm uninstall langfuse -n langfuse-v3-preview
-kubectl delete namespace langfuse-v3-preview
+helm uninstall langfuse -n langfuse
+kubectl delete namespace langfuse
 ```
 
 ## How to Upgrade
@@ -114,8 +91,8 @@ kubectl delete namespace langfuse-v3-preview
 Run the following commands to upgrade the Helm chart to the latest version:
 
 ```bash
-helm dependency update
-helm upgrade langfuse . -n langfuse-v3-preview
+helm repo update
+helm upgrade langfuse langfuse/langfuse -n langfuse
 ```
 
 For more details on upgrading, please refer to the [upgrade guide](/self-hosting/upgrade).

--- a/pages/self-hosting/kubernetes-helm.mdx
+++ b/pages/self-hosting/kubernetes-helm.mdx
@@ -21,7 +21,7 @@ See [Readme](https://github.com/langfuse/langfuse-k8s) for more details.
   Discussion](https://github.com/orgs/langfuse/discussions/1902).
 </Callout>
 
-Planned: Cloud-specific deployment guides, please upvote and comment on the following threads: [AWS](https://github.com/orgs/langfuse/discussions/4645), [Google Cloud](https://github.com/orgs/langfuse/discussions/4646),[Azure](https://github.com/orgs/langfuse/discussions/4647).
+Planned: Cloud-specific deployment guides, please upvote and comment on the following threads: [AWS](https://github.com/orgs/langfuse/discussions/4645), [Google Cloud](https://github.com/orgs/langfuse/discussions/4646), [Azure](https://github.com/orgs/langfuse/discussions/4647).
 
 ## Fetch the Helm chart and customize values
 

--- a/pages/self-hosting/kubernetes-helm.mdx
+++ b/pages/self-hosting/kubernetes-helm.mdx
@@ -12,7 +12,7 @@ For the purposes of this guide, we will use a local minikube instance, but each 
 
 By default, the chart will deploy the Langfuse application containers and data stores ([architecture overview](/self-hosting#architecture)).
 You can optionally point to an existing PostgreSQL, Clickhouse and Redis instance.
-See [Readme](https://github.com/langfuse/langfuse-k8s) for more details.
+See [Readme](https://github.com/langfuse/langfuse-k8s/blob/main/README.md) for more details.
 
 <Callout type="info">
   If you are interested in contributing to our Kubernetes deployment guide or
@@ -37,7 +37,7 @@ For local experimentation, the pre-configured variables in the values.yaml file 
 If you send _any_ kind of sensitive data to the application or intend to keep it up for longer, we recommend that
 you modify the values.yaml file according to your needs
 
-For a comprehensive overview of all available environment variables and configuration options, please refer to the [configuration guide](/self-hosting/configuration).
+For a comprehensive overview of all available environment variables and configuration options, please refer to the [configuration guide](/self-hosting/configuration) and the [Readme](https://github.com/langfuse/langfuse-k8s/blob/main/README.md).
 
 ## Deploy the helm chart
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Kubernetes Helm guide to use released chart version and adjust TypeScript config for Next.js documentation changes.
> 
>   - **Kubernetes Helm Guide**:
>     - Update `kubernetes-helm.mdx` to use released Helm chart version from `langfuse` repo.
>     - Remove references to `lfe-1348-v3-chart` branch.
>     - Change deployment instructions to use `helm repo add` and `helm install` with `langfuse/langfuse`.
>     - Update instructions for accessing Langfuse UI via port-forwarding.
>   - **TypeScript Configuration**:
>     - Remove `next/navigation-types/compat/navigation` reference in `next-env.d.ts`.
>     - Update Next.js documentation URL in `next-env.d.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 0de085573c5ed2eb9121100178c5c1ea6f34d326. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->