### PR TITLE
docs: add gradio notebook

### DIFF
--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -158,5 +158,9 @@
   {
     "notebook": "js_langfuse_sdk.ipynb",
     "docsPath": "docs/sdk/typescript/example-notebook"
+  },
+  {
+    "notebook": "integration_gradio_chatbot.ipynb",
+    "docsPath": "docs/integrations/other/gradio"
   }
 ]

--- a/cookbook/integration_gradio_chatbot.ipynb
+++ b/cookbook/integration_gradio_chatbot.ipynb
@@ -1,0 +1,342 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "D_XJcxqx22uj"
+      },
+      "source": [
+        "---\n",
+        "title: Open Source LLM Observability for Gradio\n",
+        "description: Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse.\n",
+        "category: Integrations\n",
+        "---\n",
+        "\n",
+        "# Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse\n",
+        "\n",
+        "This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.\n",
+        "\n",
+        "We recommend to run this notebook in Google Colab (see link above).\n",
+        "\n",
+        "## What is Gradio?\n",
+        "\n",
+        "[Gradio](https://github.com/gradio-app/gradio) is an open-source Python library that enables quick creation of web interfaces for machine learning models, APIs, and Python functions. It allows developers to wrap any Python function with an interactive UI that can be easily shared or embedded, making it ideal for demos, prototypes, and ML model deployment. See [docs](https://www.gradio.app/docs) for more details.\n",
+        "\n",
+        "## What is Langfuse?\n",
+        "\n",
+        "[Langfuse](https://github.com/langfuse/langfuse) is an open-source LLM engineering platform that helps build reliable LLM applications via LLM Application Observability, Evaluation, Experiments, and Prompt Management. See [docs](https://langfuse.com/docs) for more details.\n",
+        "\n",
+        "## Outline\n",
+        "\n",
+        "This notebook will show you how to\n",
+        "\n",
+        "1. Build a simple chat interface in Python and rendering it in a Notebook using [Gradio `Chatbot`](https://www.gradio.app/docs/gradio/chatbot)\n",
+        "2. Add [Langfuse Tracing](https://langfuse.com/docs/tracing) to the chatbot\n",
+        "3. Implement additional Langfuse tracing features used frequently in chat applications: [chat sessions](https://langfuse.com/docs/tracing-features/sessions), [user feedback](https://langfuse.com/docs/scores/user-feedback)\n",
+        "\n",
+        "---"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lsf15VGwUwq1"
+      },
+      "source": [
+        "## Setup\n",
+        "\n",
+        "Install requirements. We use OpenAI for this simple example. We could use any model here."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "collapsed": true,
+        "id": "fJUJLWQ92g6R",
+        "outputId": "f455d5ae-9d02-46b8-d3e4-3616a02acf95"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install gradio langfuse openai httpx==0.27.2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tzQeFDsvWS_C"
+      },
+      "source": [
+        "Set credentials and initialize Langfuse SDK Client used to add user feedback later on.\n",
+        "\n",
+        "You can either create a free [Langfuse Cloud](https://cloud.langfuse.com) account or [self-host Langfuse](https://langfuse.com/self-hosting) in a couple of minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "7QVSSJC0-IZy"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Get keys for your project from the project settings page\n",
+        "# https://cloud.langfuse.com\n",
+        "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"\"\n",
+        "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"\"\n",
+        "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
+        "# os.environ[\"LANGFUSE_HOST\"] = \"https://us.cloud.langfuse.com\" # 🇺🇸 US region\n",
+        "\n",
+        "# Your openai key\n",
+        "# We use OpenAI for this demo, could easily change to other models\n",
+        "os.environ[\"OPENAI_API_KEY\"] = \"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "vfKuB8ahKrQo"
+      },
+      "outputs": [],
+      "source": [
+        "import gradio as gr\n",
+        "import json\n",
+        "import uuid\n",
+        "from langfuse import Langfuse\n",
+        "\n",
+        "langfuse = Langfuse()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "s7eBUfJP-Z4m"
+      },
+      "source": [
+        "## Implementation of Chat functions\n",
+        "\n",
+        "### Sessions/Threads\n",
+        "\n",
+        "Each chat message belongs to a thread in the Gradio Chatbot which can be reset using `clear` ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)).\n",
+        "\n",
+        "We implement the following method that creates a `session_id` that is used globally and can be reset via the `set_new_session_id` method. This session_id will be used for [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "8hKfvyYDwyzZ"
+      },
+      "outputs": [],
+      "source": [
+        "session_id = None\n",
+        "def set_new_session_id():\n",
+        "    global session_id\n",
+        "    session_id = str(uuid.uuid4())\n",
+        "\n",
+        "# Initialize\n",
+        "set_new_session_id()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kAndUm6glRjc"
+      },
+      "source": [
+        "### Response handler\n",
+        "\n",
+        "When implementing the `respond` method, we use the Langfuse [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) to automatically log each response to [Langfuse Tracing](https://langfuse.com/docs/tracing).\n",
+        "\n",
+        "In addition we use the [openai integration](https://langfuse.com/docs/integrations/openai/python/get-started) as it simplifies instrumenting the LLM call to capture model parameters, token counts, and other metadata. Alternatively, we could use the integrations with [LangChain](https://langfuse.com/docs/integrations/langchain/tracing), [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started), [other frameworks](https://langfuse.com/docs/integrations/overview), or instrument the call itself with the decorator ([example](https://langfuse.com/docs/sdk/python/decorators#log-any-llm-call))."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "SPJgd02-V77j"
+      },
+      "outputs": [],
+      "source": [
+        "# Langfuse decorator\n",
+        "from langfuse.decorators import observe, langfuse_context\n",
+        "# Optional: automated instrumentation via OpenAI SDK integration\n",
+        "# See note above regarding alternative implementations\n",
+        "from langfuse.openai import openai\n",
+        "\n",
+        "# Global reference for the current trace_id which is used to later add user feedback\n",
+        "current_trace_id = None\n",
+        "\n",
+        "# Add decorator here to capture overall timings, input/output, and manipulate trace metadata via `langfuse_context`\n",
+        "@observe()\n",
+        "async def create_response(\n",
+        "    prompt: str,\n",
+        "    history,\n",
+        "):\n",
+        "    # Save trace id in global var to add feedback later\n",
+        "    global current_trace_id\n",
+        "    current_trace_id = langfuse_context.get_current_trace_id()\n",
+        "\n",
+        "    # Add session_id to Langfuse Trace to enable session tracking\n",
+        "    global session_id\n",
+        "    langfuse_context.update_current_trace(\n",
+        "        name=\"gradio_demo_chat\",\n",
+        "        session_id=session_id,\n",
+        "        input=prompt,\n",
+        "    )\n",
+        "\n",
+        "    # Add prompt to history\n",
+        "    if not history:\n",
+        "        history = [{\"role\": \"system\", \"content\": \"You are a friendly chatbot\"}]\n",
+        "    history.append({\"role\": \"user\", \"content\": prompt})\n",
+        "    yield history\n",
+        "\n",
+        "    # Get completion via OpenAI SDK\n",
+        "    # Auto-instrumented by Langfuse via the import, see alternative in note above\n",
+        "    response = {\"role\": \"assistant\", \"content\": \"\"}\n",
+        "    oai_response = openai.chat.completions.create(\n",
+        "        messages=history,\n",
+        "        model=\"gpt-4o-mini\",\n",
+        "    )\n",
+        "    response[\"content\"] = oai_response.choices[0].message.content or \"\"\n",
+        "\n",
+        "    # Customize trace ouput for better readability in Langfuse Sessions\n",
+        "    langfuse_context.update_current_trace(\n",
+        "        output=response[\"content\"],\n",
+        "    )\n",
+        "\n",
+        "    yield history + [response]\n",
+        "\n",
+        "async def respond(prompt: str, history):\n",
+        "    async for message in create_response(prompt, history):\n",
+        "        yield message"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OlIiYrjqlwKW"
+      },
+      "source": [
+        "### User feedback handler\n",
+        "\n",
+        "We implement user [feedback tracking in Langfuse](https://langfuse.com/docs/scores/user-feedback) via the `like` event for the Gradio chatbot ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This methdod reuses the current trace id available in the global state of this application."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "C1rctBvPWl1p"
+      },
+      "outputs": [],
+      "source": [
+        "def handle_like(data: gr.LikeData):\n",
+        "    global current_trace_id\n",
+        "    if data.liked:\n",
+        "        langfuse.score(value=1, name=\"user-feedback\", trace_id=current_trace_id)\n",
+        "    else:\n",
+        "        langfuse.score(value=0, name=\"user-feedback\", trace_id=current_trace_id)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zI4CINMpCmbk"
+      },
+      "source": [
+        "### Retries\n",
+        "\n",
+        "Allow to retry a completion via the Gradio Chatbot `retry` event ([docs](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This is not specific to the integration with Langfuse."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "OtMHqFEfClcw"
+      },
+      "outputs": [],
+      "source": [
+        "async def handle_retry(history, retry_data: gr.RetryData):\n",
+        "    new_history = history[: retry_data.index]\n",
+        "    previous_prompt = history[retry_data.index][\"content\"]\n",
+        "    async for message in respond(previous_prompt, new_history):\n",
+        "        yield message"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-GM54eHzmD7x"
+      },
+      "source": [
+        "# Run Gradio Chatbot\n",
+        "\n",
+        "After implementing all methods above, we can now put together the [Gradio Chatbot](https://www.gradio.app/docs/gradio/chatbot) and launch it. If run within Colab, you should see an embedded Chatbot interface."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YczZ18oTcv08"
+      },
+      "outputs": [],
+      "source": [
+        "with gr.Blocks() as demo:\n",
+        "    gr.Markdown(\"# Chatbot using 🤗 Gradio + 🪢 Langfuse\")\n",
+        "    chatbot = gr.Chatbot(\n",
+        "        label=\"Chat\",\n",
+        "        type=\"messages\",\n",
+        "        show_copy_button=True,\n",
+        "        avatar_images=(\n",
+        "            None,\n",
+        "            \"https://static.langfuse.com/cookbooks/gradio/hf-logo.png\",\n",
+        "        ),\n",
+        "    )\n",
+        "    prompt = gr.Textbox(max_lines=1, label=\"Chat Message\")\n",
+        "    prompt.submit(respond, [prompt, chatbot], [chatbot])\n",
+        "    chatbot.retry(handle_retry, chatbot, [chatbot])\n",
+        "    chatbot.like(handle_like, None, None)\n",
+        "    chatbot.clear(set_new_session_id)\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    demo.launch(share=True, debug=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bKOBm48PED57"
+      },
+      "source": [
+        "## Done\n",
+        "\n",
+        "When interacting with the Chatbot, you should see traces, sessions, and feedback scores in your Langfuse project. See video above for a walkthrough.\n",
+        "\n",
+        "If you have any questions or feedback, please join the [Langfuse Discord](https://langfuse.com/discord) or create a new thread on [GitHub Discussions](https://langfuse.com/gh-support)."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/pages/docs/integrations/other/_meta.tsx
+++ b/pages/docs/integrations/other/_meta.tsx
@@ -1,4 +1,5 @@
 export default {
+  gradio: "Gradio",
   inferable: "Inferable",
   milvus: "Milvus",
   ragas: "Ragas",

--- a/pages/docs/integrations/other/gradio.md
+++ b/pages/docs/integrations/other/gradio.md
@@ -1,0 +1,211 @@
+---
+title: Open Source LLM Observability for Gradio
+description: Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse.
+category: Integrations
+---
+
+# Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse
+
+This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.
+
+We recommend to run this notebook in Google Colab (see link above).
+
+## What is Gradio?
+
+[Gradio](https://github.com/gradio-app/gradio) is an open-source Python library that enables quick creation of web interfaces for machine learning models, APIs, and Python functions. It allows developers to wrap any Python function with an interactive UI that can be easily shared or embedded, making it ideal for demos, prototypes, and ML model deployment. See [docs](https://www.gradio.app/docs) for more details.
+
+## What is Langfuse?
+
+[Langfuse](https://github.com/langfuse/langfuse) is an open-source LLM engineering platform that helps build reliable LLM applications via LLM Application Observability, Evaluation, Experiments, and Prompt Management. See [docs](https://langfuse.com/docs) for more details.
+
+## Outline
+
+This notebook will show you how to
+
+1. Build a simple chat interface in Python and rendering it in a Notebook using [Gradio `Chatbot`](https://www.gradio.app/docs/gradio/chatbot)
+2. Add [Langfuse Tracing](https://langfuse.com/docs/tracing) to the chatbot
+3. Implement additional Langfuse tracing features used frequently in chat applications: [chat sessions](https://langfuse.com/docs/tracing-features/sessions), [user feedback](https://langfuse.com/docs/scores/user-feedback)
+
+---
+
+## Setup
+
+Install requirements. We use OpenAI for this simple example. We could use any model here.
+
+
+```
+!pip install gradio langfuse openai httpx==0.27.2
+```
+
+Set credentials and initialize Langfuse SDK Client used to add user feedback later on.
+
+You can either create a free [Langfuse Cloud](https://cloud.langfuse.com) account or [self-host Langfuse](https://langfuse.com/self-hosting) in a couple of minutes.
+
+
+```
+import os
+
+# Get keys for your project from the project settings page
+# https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = ""
+os.environ["LANGFUSE_SECRET_KEY"] = ""
+os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+# os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" # 🇺🇸 US region
+
+# Your openai key
+# We use OpenAI for this demo, could easily change to other models
+os.environ["OPENAI_API_KEY"] = ""
+```
+
+
+```
+import gradio as gr
+import json
+import uuid
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+```
+
+## Implementation of Chat functions
+
+### Sessions/Threads
+
+Each chat message belongs to a thread in the Gradio Chatbot which can be reset using `clear` ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)).
+
+We implement the following method that creates a `session_id` that is used globally and can be reset via the `set_new_session_id` method. This session_id will be used for [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions).
+
+
+```
+session_id = None
+def set_new_session_id():
+    global session_id
+    session_id = str(uuid.uuid4())
+
+# Initialize
+set_new_session_id()
+```
+
+### Response handler
+
+When implementing the `respond` method, we use the Langfuse [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) to automatically log each response to [Langfuse Tracing](https://langfuse.com/docs/tracing).
+
+In addition we use the [openai integration](https://langfuse.com/docs/integrations/openai/python/get-started) as it simplifies instrumenting the LLM call to capture model parameters, token counts, and other metadata. Alternatively, we could use the integrations with [LangChain](https://langfuse.com/docs/integrations/langchain/tracing), [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started), [other frameworks](https://langfuse.com/docs/integrations/overview), or instrument the call itself with the decorator ([example](https://langfuse.com/docs/sdk/python/decorators#log-any-llm-call)).
+
+
+```
+# Langfuse decorator
+from langfuse.decorators import observe, langfuse_context
+# Optional: automated instrumentation via OpenAI SDK integration
+# See note above regarding alternative implementations
+from langfuse.openai import openai
+
+# Global reference for the current trace_id which is used to later add user feedback
+current_trace_id = None
+
+# Add decorator here to capture overall timings, input/output, and manipulate trace metadata via `langfuse_context`
+@observe()
+async def create_response(
+    prompt: str,
+    history,
+):
+    # Save trace id in global var to add feedback later
+    global current_trace_id
+    current_trace_id = langfuse_context.get_current_trace_id()
+
+    # Add session_id to Langfuse Trace to enable session tracking
+    global session_id
+    langfuse_context.update_current_trace(
+        name="gradio_demo_chat",
+        session_id=session_id,
+        input=prompt,
+    )
+
+    # Add prompt to history
+    if not history:
+        history = [{"role": "system", "content": "You are a friendly chatbot"}]
+    history.append({"role": "user", "content": prompt})
+    yield history
+
+    # Get completion via OpenAI SDK
+    # Auto-instrumented by Langfuse via the import, see alternative in note above
+    response = {"role": "assistant", "content": ""}
+    oai_response = openai.chat.completions.create(
+        messages=history,
+        model="gpt-4o-mini",
+    )
+    response["content"] = oai_response.choices[0].message.content or ""
+
+    # Customize trace ouput for better readability in Langfuse Sessions
+    langfuse_context.update_current_trace(
+        output=response["content"],
+    )
+
+    yield history + [response]
+
+async def respond(prompt: str, history):
+    async for message in create_response(prompt, history):
+        yield message
+```
+
+### User feedback handler
+
+We implement user [feedback tracking in Langfuse](https://langfuse.com/docs/scores/user-feedback) via the `like` event for the Gradio chatbot ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This methdod reuses the current trace id available in the global state of this application.
+
+
+```
+def handle_like(data: gr.LikeData):
+    global current_trace_id
+    if data.liked:
+        langfuse.score(value=1, name="user-feedback", trace_id=current_trace_id)
+    else:
+        langfuse.score(value=0, name="user-feedback", trace_id=current_trace_id)
+
+```
+
+### Retries
+
+Allow to retry a completion via the Gradio Chatbot `retry` event ([docs](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This is not specific to the integration with Langfuse.
+
+
+```
+async def handle_retry(history, retry_data: gr.RetryData):
+    new_history = history[: retry_data.index]
+    previous_prompt = history[retry_data.index]["content"]
+    async for message in respond(previous_prompt, new_history):
+        yield message
+```
+
+# Run Gradio Chatbot
+
+After implementing all methods above, we can now put together the [Gradio Chatbot](https://www.gradio.app/docs/gradio/chatbot) and launch it. If run within Colab, you should see an embedded Chatbot interface.
+
+
+```
+with gr.Blocks() as demo:
+    gr.Markdown("# Chatbot using 🤗 Gradio + 🪢 Langfuse")
+    chatbot = gr.Chatbot(
+        label="Chat",
+        type="messages",
+        show_copy_button=True,
+        avatar_images=(
+            None,
+            "https://static.langfuse.com/cookbooks/gradio/hf-logo.png",
+        ),
+    )
+    prompt = gr.Textbox(max_lines=1, label="Chat Message")
+    prompt.submit(respond, [prompt, chatbot], [chatbot])
+    chatbot.retry(handle_retry, chatbot, [chatbot])
+    chatbot.like(handle_like, None, None)
+    chatbot.clear(set_new_session_id)
+
+
+if __name__ == "__main__":
+    demo.launch(share=True, debug=True)
+```
+
+## Done
+
+When interacting with the Chatbot, you should see traces, sessions, and feedback scores in your Langfuse project. See video above for a walkthrough.
+
+If you have any questions or feedback, please join the [Langfuse Discord](https://langfuse.com/discord) or create a new thread on [GitHub Discussions](https://langfuse.com/gh-support).

--- a/pages/docs/integrations/overview.mdx
+++ b/pages/docs/integrations/overview.mdx
@@ -42,6 +42,7 @@ Objective:
 | [LobeChat](/docs/integrations/lobechat)             | Chat/Agent&nbsp;UI | Open source chatbot platform.                                                                                           |
 | [Vapi](/docs/integrations/other/vapi)               | Platform           | Open source voice AI platform.                                                                                          |
 | [Inferable](/docs/integrations/other/inferable)     | Agents             | Open source LLM platform for building distributed agents.                                                               |
+| [Gradio](/docs/integrations/other/gradio)           | Chat/Agent&nbsp;UI | Open source Python library to build web interfaces like Chat UI.                                                        |
 
 Unsure which integration to choose? Ask us on [Discord](/discord) or in the chat.
 

--- a/pages/guides/cookbook/integration_gradio_chatbot.md
+++ b/pages/guides/cookbook/integration_gradio_chatbot.md
@@ -1,0 +1,211 @@
+---
+title: Open Source LLM Observability for Gradio
+description: Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse.
+category: Integrations
+---
+
+# Build a LLM Chat UI with 🤗 Gradio and trace it with 🪢 Langfuse
+
+This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.
+
+We recommend to run this notebook in Google Colab (see link above).
+
+## What is Gradio?
+
+[Gradio](https://github.com/gradio-app/gradio) is an open-source Python library that enables quick creation of web interfaces for machine learning models, APIs, and Python functions. It allows developers to wrap any Python function with an interactive UI that can be easily shared or embedded, making it ideal for demos, prototypes, and ML model deployment. See [docs](https://www.gradio.app/docs) for more details.
+
+## What is Langfuse?
+
+[Langfuse](https://github.com/langfuse/langfuse) is an open-source LLM engineering platform that helps build reliable LLM applications via LLM Application Observability, Evaluation, Experiments, and Prompt Management. See [docs](https://langfuse.com/docs) for more details.
+
+## Outline
+
+This notebook will show you how to
+
+1. Build a simple chat interface in Python and rendering it in a Notebook using [Gradio `Chatbot`](https://www.gradio.app/docs/gradio/chatbot)
+2. Add [Langfuse Tracing](https://langfuse.com/docs/tracing) to the chatbot
+3. Implement additional Langfuse tracing features used frequently in chat applications: [chat sessions](https://langfuse.com/docs/tracing-features/sessions), [user feedback](https://langfuse.com/docs/scores/user-feedback)
+
+---
+
+## Setup
+
+Install requirements. We use OpenAI for this simple example. We could use any model here.
+
+
+```
+!pip install gradio langfuse openai httpx==0.27.2
+```
+
+Set credentials and initialize Langfuse SDK Client used to add user feedback later on.
+
+You can either create a free [Langfuse Cloud](https://cloud.langfuse.com) account or [self-host Langfuse](https://langfuse.com/self-hosting) in a couple of minutes.
+
+
+```
+import os
+
+# Get keys for your project from the project settings page
+# https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = ""
+os.environ["LANGFUSE_SECRET_KEY"] = ""
+os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+# os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" # 🇺🇸 US region
+
+# Your openai key
+# We use OpenAI for this demo, could easily change to other models
+os.environ["OPENAI_API_KEY"] = ""
+```
+
+
+```
+import gradio as gr
+import json
+import uuid
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+```
+
+## Implementation of Chat functions
+
+### Sessions/Threads
+
+Each chat message belongs to a thread in the Gradio Chatbot which can be reset using `clear` ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)).
+
+We implement the following method that creates a `session_id` that is used globally and can be reset via the `set_new_session_id` method. This session_id will be used for [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions).
+
+
+```
+session_id = None
+def set_new_session_id():
+    global session_id
+    session_id = str(uuid.uuid4())
+
+# Initialize
+set_new_session_id()
+```
+
+### Response handler
+
+When implementing the `respond` method, we use the Langfuse [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) to automatically log each response to [Langfuse Tracing](https://langfuse.com/docs/tracing).
+
+In addition we use the [openai integration](https://langfuse.com/docs/integrations/openai/python/get-started) as it simplifies instrumenting the LLM call to capture model parameters, token counts, and other metadata. Alternatively, we could use the integrations with [LangChain](https://langfuse.com/docs/integrations/langchain/tracing), [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started), [other frameworks](https://langfuse.com/docs/integrations/overview), or instrument the call itself with the decorator ([example](https://langfuse.com/docs/sdk/python/decorators#log-any-llm-call)).
+
+
+```
+# Langfuse decorator
+from langfuse.decorators import observe, langfuse_context
+# Optional: automated instrumentation via OpenAI SDK integration
+# See note above regarding alternative implementations
+from langfuse.openai import openai
+
+# Global reference for the current trace_id which is used to later add user feedback
+current_trace_id = None
+
+# Add decorator here to capture overall timings, input/output, and manipulate trace metadata via `langfuse_context`
+@observe()
+async def create_response(
+    prompt: str,
+    history,
+):
+    # Save trace id in global var to add feedback later
+    global current_trace_id
+    current_trace_id = langfuse_context.get_current_trace_id()
+
+    # Add session_id to Langfuse Trace to enable session tracking
+    global session_id
+    langfuse_context.update_current_trace(
+        name="gradio_demo_chat",
+        session_id=session_id,
+        input=prompt,
+    )
+
+    # Add prompt to history
+    if not history:
+        history = [{"role": "system", "content": "You are a friendly chatbot"}]
+    history.append({"role": "user", "content": prompt})
+    yield history
+
+    # Get completion via OpenAI SDK
+    # Auto-instrumented by Langfuse via the import, see alternative in note above
+    response = {"role": "assistant", "content": ""}
+    oai_response = openai.chat.completions.create(
+        messages=history,
+        model="gpt-4o-mini",
+    )
+    response["content"] = oai_response.choices[0].message.content or ""
+
+    # Customize trace ouput for better readability in Langfuse Sessions
+    langfuse_context.update_current_trace(
+        output=response["content"],
+    )
+
+    yield history + [response]
+
+async def respond(prompt: str, history):
+    async for message in create_response(prompt, history):
+        yield message
+```
+
+### User feedback handler
+
+We implement user [feedback tracking in Langfuse](https://langfuse.com/docs/scores/user-feedback) via the `like` event for the Gradio chatbot ([reference](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This methdod reuses the current trace id available in the global state of this application.
+
+
+```
+def handle_like(data: gr.LikeData):
+    global current_trace_id
+    if data.liked:
+        langfuse.score(value=1, name="user-feedback", trace_id=current_trace_id)
+    else:
+        langfuse.score(value=0, name="user-feedback", trace_id=current_trace_id)
+
+```
+
+### Retries
+
+Allow to retry a completion via the Gradio Chatbot `retry` event ([docs](https://www.gradio.app/docs/gradio/chatbot#event-listeners)). This is not specific to the integration with Langfuse.
+
+
+```
+async def handle_retry(history, retry_data: gr.RetryData):
+    new_history = history[: retry_data.index]
+    previous_prompt = history[retry_data.index]["content"]
+    async for message in respond(previous_prompt, new_history):
+        yield message
+```
+
+# Run Gradio Chatbot
+
+After implementing all methods above, we can now put together the [Gradio Chatbot](https://www.gradio.app/docs/gradio/chatbot) and launch it. If run within Colab, you should see an embedded Chatbot interface.
+
+
+```
+with gr.Blocks() as demo:
+    gr.Markdown("# Chatbot using 🤗 Gradio + 🪢 Langfuse")
+    chatbot = gr.Chatbot(
+        label="Chat",
+        type="messages",
+        show_copy_button=True,
+        avatar_images=(
+            None,
+            "https://static.langfuse.com/cookbooks/gradio/hf-logo.png",
+        ),
+    )
+    prompt = gr.Textbox(max_lines=1, label="Chat Message")
+    prompt.submit(respond, [prompt, chatbot], [chatbot])
+    chatbot.retry(handle_retry, chatbot, [chatbot])
+    chatbot.like(handle_like, None, None)
+    chatbot.clear(set_new_session_id)
+
+
+if __name__ == "__main__":
+    demo.launch(share=True, debug=True)
+```
+
+## Done
+
+When interacting with the Chatbot, you should see traces, sessions, and feedback scores in your Langfuse project. See video above for a walkthrough.
+
+If you have any questions or feedback, please join the [Langfuse Discord](https://langfuse.com/discord) or create a new thread on [GitHub Discussions](https://langfuse.com/gh-support).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation and a notebook for integrating Gradio with Langfuse, including setup, chat functions, and user feedback handling.
> 
>   - **Documentation**:
>     - Adds `integration_gradio_chatbot.ipynb` to `cookbook/_routes.json` for Gradio integration.
>     - Creates `gradio.md` in `pages/docs/integrations/other/` detailing Gradio and Langfuse integration.
>     - Adds Gradio to `pages/docs/integrations/overview.mdx` and `_meta.tsx` for documentation consistency.
>   - **Content**:
>     - Provides a step-by-step guide to build a chat UI with Gradio and Langfuse.
>     - Includes setup instructions, chat function implementations, and user feedback handling.
>     - Demonstrates session management and retry functionality in Gradio chatbot.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 757a8511cc2b6c5c666074b4b99c1a01adf4e19f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->