### PR TITLE
docs: add blog post to /jp

### DIFF
--- a/pages/jp.mdx
+++ b/pages/jp.mdx
@@ -96,6 +96,7 @@ Langfuse は[インテグレーションや SDK を通して](/docs/integrations
 - [書籍:俺たちと探究する LLM アプリケーションのオブザーバビリティ](https://techbookfest.org/product/mn0L7GEm3s8Vhmxq971HEi?productVariantID=myG2YLxFNAEVkRf2dipG8f)
 - [Blog 記事: 生成 AI アプリの出力を Ragas で評価して、Langfuse で GUI 監視しよう！](https://qiita.com/minorun365/items/70ad2f5a0afaac6e5cb9)
 - [Blog 記事: Google Cloud で LLM アプリ監視ツール Langfuse をセルフホスティングする方法](https://zenn.dev/cloud_ace/articles/2a3668221e9c90)
+- [Blog 記事: ペアーズにおける評価ドリブンなリリースサイクル：Langfuseをフル活用したLLMOps基盤](https://medium.com/eureka-engineering/ペアーズにおける評価ドリブンなリリースサイクル-langfuseをフル活用したllmops基盤-957986e3dcb2)
 
 _リソースを追加したい場合は、[プルリクエストを上げて](https://github.com/langfuse/langfuse-docs)ください。_
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a new blog post link to the Japanese documentation page.
> 
>   - **Documentation**:
>     - Added a new blog post link to `pages/jp.mdx` under the Japanese external resources section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 65756515d062b690f740e789497b0f72230820d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->