### PR TITLE
feat: update docs for posthog integration

### DIFF
--- a/pages/docs/analytics/posthog.mdx
+++ b/pages/docs/analytics/posthog.mdx
@@ -14,7 +14,7 @@ availability.selfHosted: not-available
     hobby: "public-beta",
     pro: "public-beta",
     team: "public-beta",
-    selfHosted: "not-available",
+    selfHosted: "ee",
   }}
 />
 
@@ -104,7 +104,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_release`: Information relating to the event release.
 - `langfuse_version`: The version of the event.
 - `langfuse_tags`: Any tags associated with the event.
-- `langfuse_integration_version`: The integration version of LangFuse.
+- `langfuse_event_version`: The integration version of LangFuse.
 
 #### Event: `langfuse generation`
 
@@ -117,7 +117,6 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_input_units`: Number of tokens utilized in prompting the generation.
 - `langfuse_output_units`: Number of tokens produced by the generation.
 - `langfuse_total_units`: Total number of tokens consumed in the generation process.
-- `langfuse_unit`: The units used for the generation (likely tokens).
 - `langfuse_session_id`: The session ID associated with the trace of the generation.
 - `langfuse_project_id`: The project identification where the generation happened.
 - `langfuse_user_id`: The user ID that started the trace linked to the generation. In case it's unavailable, it defaults to `langfuse_unknown_user`.
@@ -128,7 +127,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_model`: The model used during this generation's process.
 - `langfuse_level`: The level associated with the generation.
 - `langfuse_tags`: Any tags attached to the trace of the generation.
-- `langfuse_integration_version`: The integration version with LangFuse.
+- `langfuse_event_version`: The integration version with LangFuse.
 
 #### Event `langfuse score`
 
@@ -143,7 +142,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_user_id`: The user ID that triggered the trace tied with the score. If not available, defaults to `langfuse_unknown_user`.
 - `langfuse_release`: The release information of the trace associated with the score.
 - `langfuse_tags`: Any tags related to the trace of the score.
-- `langfuse_integration_version`: The integration version with LangFuse.
+- `langfuse_event_version`: The integration version with LangFuse.
 
 ## Troubleshooting
 

--- a/pages/docs/analytics/posthog.mdx
+++ b/pages/docs/analytics/posthog.mdx
@@ -65,7 +65,7 @@ Once integrated, you can build a dashboard in PostHog to visualize your Langfuse
 
 ## Integration details [#details]
 
-On a daily schedule Langfuse batches aggregated events and metrics to your PostHog instance.
+On an hourly schedule Langfuse batches aggregated events and metrics to your PostHog instance.
 
 ### Metadata matching
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update PostHog integration docs: change self-hosted availability, rename metadata field, and remove redundant event detail.
> 
>   - **Availability**:
>     - Update `selfHosted` availability from `not-available` to `ee` in `posthog.mdx`.
>   - **Metadata**:
>     - Rename `langfuse_integration_version` to `langfuse_event_version` in event details.
>   - **Event Details**:
>     - Remove `langfuse_unit` from `langfuse generation` event details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for faf24115f8e802f1f72a21df3d7ac59932fbd88e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->