### PR TITLE
fix: fix broken link to upgrade guides

### DIFF
--- a/pages/self-hosting/v2/index.mdx
+++ b/pages/self-hosting/v2/index.mdx
@@ -10,7 +10,7 @@ label: "Version: v2"
   This guide covers Langfuse v2. For Langfuse v3, see the [v3
   documentation](/self-hosting). Langfuse v2 receives security updates until end
   of Q1 2025. If you have any questions while upgrading, please refer to the [v3
-  upgrade guide](/self-hosting/upgrade-v2-to-v3) or open a thread on [GitHub
+  upgrade guide](/self-hosting/upgrade-guides/upgrade-v2-to-v3) or open a thread on [GitHub
   Discussions](/gh-support).
 </Callout>
 


### PR DESCRIPTION
Fixes #1104

Update the link to the v3 upgrade guide on the self-hosting v2 page.

* Change the link in the `Callout` section of `pages/self-hosting/v2/index.mdx` from `/self-hosting/upgrade-v2-to-v3` to `/self-hosting/upgrade-guides/upgrade-v2-to-v3`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/langfuse/langfuse-docs/pull/1105?shareId=fd3f7ce6-e931-45bf-83e4-c7c436ace5c0).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `pages/self-hosting/v2/index.mdx` to the v3 upgrade guide.
> 
>   - **Documentation**:
>     - Fix broken link in `pages/self-hosting/v2/index.mdx` `Callout` section from `/self-hosting/upgrade-v2-to-v3` to `/self-hosting/upgrade-guides/upgrade-v2-to-v3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2f12a69ed8083541869e679d0a6cfcbc3c1e835e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->