### PR TITLE
feat: add inkeep chat to faq overview page

### DIFF
--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -55,6 +55,11 @@ const useInkeepSettings = (): InkeepSharedSettings => {
             variant: "subtle", // 'emphasized' 'subtle',
           },
         },
+        AIChatPageWrapper: {
+          defaultProps: {
+            size: "shrink-vertically",
+          },
+        },
       },
     },
   };

--- a/pages/faq/index.mdx
+++ b/pages/faq/index.mdx
@@ -6,6 +6,15 @@ description: Collection of frequently asked questions about Langfuse.
 
 These FAQs are the most common questions we receive. If your question is not answered below, please open a new discussion on [GitHub Discussions](#github-discussions).
 
+## Ask AI
+
+The Langfuse AI assistant helps you find answers about Langfuse's features, integrations, and best practices. It's trained on our documentation, GitHub discussions/issues, and API.
+
+import InkeepEmbeddedChat from "@/components/inkeep/InkeepEmbeddedChat";
+
+<div className="h-10" />
+<InkeepEmbeddedChat />
+
 ## Categories
 
 import { FaqIndex } from "@/components/faq/FaqIndex";

--- a/pages/support.mdx
+++ b/pages/support.mdx
@@ -17,7 +17,7 @@ description: "The Langfuse team and community can help you with questions and is
 
 - Our [documentation](/docs) is the best place to start looking for answers. It is comprehensive, and we invest significant time into maintaining it. You can also suggest edits to the docs via GitHub.
 - [Langfuse FAQs](/faq) where the most common questions are answered.
-- Use the "Ask AI" chat `widget` to get instant answers to your questions:
+- Use "Ask AI" to get instant answers to your questions:
 
 import InkeepEmbeddedChat from "@/components/inkeep/InkeepEmbeddedChat";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds AI chat feature to the FAQ page and updates settings in `useInkeepSettings.ts`.
> 
>   - **Behavior**:
>     - Adds `InkeepEmbeddedChat` to `index.mdx` in the FAQ page to provide AI chat functionality.
>     - Updates `useInkeepSettings.ts` to include `AIChatPageWrapper` with default size `shrink-vertically`.
>   - **Documentation**:
>     - Updates `support.mdx` to reflect the new "Ask AI" feature for instant answers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 828aa9072f96c2ace85bcc3a06ab9d568429291d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->