### PR TITLE
chore: add note on zero-donwtime background migrations

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
+++ b/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
@@ -180,6 +180,13 @@ Also, ensure that you run a recent version of Langfuse, ideally a version later 
 For a zero-downtime upgrade, we recommend that you provision new instances of the Langfuse web and worker containers
 and move your traffic after validating that the new instances are working as expected.
 
+<Callout type="warning">
+  If you go for the zero-downtime upgrade, we recommend to disable background migrations until you shift traffic to the new instances.
+  Otherwise, the migration may miss events that are ingested after the new instances were started.
+  Set `LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS=false` in the environment variables of the new Langfuse web and worker containers until traffic is shifted.
+  Afterwards, remove the overwrite or set to `true`.
+</Callout>
+
 ### Upgrade Steps
 
 <Steps>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a warning in `upgrade-v2-to-v3.mdx` to disable background migrations during zero-downtime upgrades and updates a URL in `next-env.d.ts`.
> 
>   - **Upgrade Guide**:
>     - Adds a warning note in `upgrade-v2-to-v3.mdx` to disable background migrations during zero-downtime upgrades to prevent missing events.
>     - Suggests setting `LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS=false` until traffic is shifted.
>   - **Documentation**:
>     - Updates URL in `next-env.d.ts` comment to new Next.js TypeScript configuration documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 76daa237402f3e271a19bd9a4369ae04b7ac0def. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->