### PR TITLE
chore: increase rate-limits

### DIFF
--- a/pages/faq/all/api-limits.mdx
+++ b/pages/faq/all/api-limits.mdx
@@ -22,7 +22,7 @@ While the [Langfuse API](https://api.reference.langfuse.com) is extremely open a
 
 | Resource                                                                                                                                                                | Hobby/Pro             | Team                  |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
-| **Tracing**. Batched `/ingestion` endpoint used by SDKs to ingest traces.                                                                                               | 1000&nbsp;batches/min | 5000&nbsp;batches/min |
+| **Tracing**. Batched `/ingestion` endpoint used by SDKs to ingest traces.                                                                                               | 4000&nbsp;batches/min | 20000&nbsp;batches/min |
 | **Tracing (legacy)**. Deprecated POST APIs used by V1 SDKs. Support for these APIs will be removed in [Langfuse v3](https://github.com/orgs/langfuse/discussions/1902). | 400&nbsp;req/min      | 400&nbsp;req/min      |
 | **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                                                    | No limit              | No limit              |
 | **Metrics**. GET APIs used to fetch analytics data, e.g. daily metrics api.                                                                                             | 10&nbsp;req/min       | 10&nbsp;req/min       |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased rate limits for `/ingestion` endpoint in `api-limits.mdx` for Hobby/Pro and Team tiers.
> 
>   - **Rate Limits**:
>     - Increased rate limits for `/ingestion` endpoint in `api-limits.mdx`:
>       - Hobby/Pro: from 1000 to 4000 batches/min.
>       - Team: from 5000 to 20000 batches/min.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 428a9e3a67e1a905ea6c3a680d6b3b4aff9be954. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->