### PR TITLE
enable banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -199,22 +199,22 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  //  banner: {
-  //    key: "community-hour",
-  //    dismissible: true,
-  //    content: (
-  //      <Link href="https://lu.ma/5szapn5d">
-  //        {/* mobile */}
-  //        <span className="sm:hidden">
-  //           Today: Langfuse Community Hour →
-  //        </span>
-  //        {/* desktop */}
-  //        <span className="hidden sm:inline">
-  //          Today: Langfuse Community Hour, 9-10am PT, 6-7pm CEST →
-  //        </span>
-  //      </Link>
-  //    ),
-  //  },
+   banner: {
+     key: "hn-launch-2024-12-17",
+     dismissible: true,
+     content: (
+       <Link href="https://news.ycombinator.com">
+         {/* mobile */}
+         <span className="sm:hidden">
+          Langfuse V3 on Hacker News →
+         </span>
+         {/* desktop */}
+         <span className="hidden sm:inline">
+         Langfuse V3 on Hacker News →
+         </span>
+       </Link>
+     ),
+   },
 };
 
 export default config;

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -206,11 +206,11 @@ const config: DocsThemeConfig = {
        <Link href="https://news.ycombinator.com">
          {/* mobile */}
          <span className="sm:hidden">
-          Langfuse V3 on Hacker News →
+         Launch HN: Langfuse V3 is GA →
          </span>
          {/* desktop */}
          <span className="hidden sm:inline">
-         Langfuse V3 on Hacker News →
+         Launch HN: Langfuse V3 is GA →
          </span>
        </Link>
      ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enables a dismissible banner in `theme.config.tsx` for "Langfuse V3 on Hacker News" event with mobile and desktop views.
> 
>   - **Behavior**:
>     - Enables a dismissible banner in `theme.config.tsx` for "Langfuse V3 on Hacker News" event.
>     - Banner links to Hacker News and displays different text for mobile and desktop views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 926c1dedba809d02e22f05851921e96cd6aa980a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->