### PR TITLE
docs: add hugging face gradio template link to docs

### DIFF
--- a/cookbook/integration_gradio_chatbot.ipynb
+++ b/cookbook/integration_gradio_chatbot.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.\n",
         "\n",
-        "We recommend to run this notebook in Google Colab (see link above).\n",
+        "**Note:** We recommend to run this notebook in Google Colab (see link above). This notebook is also avaliable as Hugging Face Space template [here](https://huggingface.co/spaces/langfuse/langfuse-gradio-example-template).\n",
         "\n",
         "Thank you to [@tkmamidi](https://github.com/tkmamidi) for the original implementation and contributions to this notebook.\n",
         "\n",

--- a/pages/docs/integrations/other/gradio.md
+++ b/pages/docs/integrations/other/gradio.md
@@ -8,7 +8,7 @@ category: Integrations
 
 This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.
 
-We recommend to run this notebook in Google Colab (see link above).
+**Note:** We recommend to run this notebook in Google Colab (see link above). This notebook is also avaliable as Hugging Face Space template [here](https://huggingface.co/spaces/langfuse/langfuse-gradio-example-template).
 
 Thank you to [@tkmamidi](https://github.com/tkmamidi) for the original implementation and contributions to this notebook.
 

--- a/pages/docs/integrations/other/gradio.md
+++ b/pages/docs/integrations/other/gradio.md
@@ -8,7 +8,7 @@ category: Integrations
 
 This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.
 
-**Note:** We recommend to run this notebook in Google Colab (see link above). This notebook is also avaliable as Hugging Face Space template [here](https://huggingface.co/spaces/langfuse/langfuse-gradio-example-template).
+**Note:** We recommend to run this notebook in Google Colab (see link above).This notebook is also avaliable as Hugging Face Space template [here](https://huggingface.co/spaces/langfuse/langfuse-gradio-example-template).
 
 Thank you to [@tkmamidi](https://github.com/tkmamidi) for the original implementation and contributions to this notebook.
 

--- a/pages/guides/cookbook/integration_gradio_chatbot.md
+++ b/pages/guides/cookbook/integration_gradio_chatbot.md
@@ -8,7 +8,7 @@ category: Integrations
 
 This is a simple end-to-end example notebook which showcases how to integrate a Gradio application with Langfuse for LLM Observability and Evaluation.
 
-We recommend to run this notebook in Google Colab (see link above).
+**Note:** We recommend to run this notebook in Google Colab (see link above). This notebook is also avaliable as Hugging Face Space template [here](https://huggingface.co/spaces/langfuse/langfuse-gradio-example-template).
 
 Thank you to [@tkmamidi](https://github.com/tkmamidi) for the original implementation and contributions to this notebook.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add note about Hugging Face Space template availability in Gradio integration documentation.
> 
>   - **Documentation**:
>     - Added note in `gradio.md` and `integration_gradio_chatbot.md` about the availability of the notebook as a Hugging Face Space template.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7cf7c008210b57e56db070e879c53e01fbe780cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->