### PR TITLE
docs: move minio media upload troubleshooting to s3 guide

### DIFF
--- a/pages/self-hosting/docker-compose.mdx
+++ b/pages/self-hosting/docker-compose.mdx
@@ -127,13 +127,7 @@ Ensure to stop the VM instance in your cloud provider interface to avoid unneces
 
 ## Troubleshooting
 
-### Configuring Minio for Media Uploads
-
-To enable multimodal tracing, presigned URLs allow SDK clients and browsers outside the Docker network to directly upload and download media assets. Therefore, the `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` must resolve to the Docker host's address.
-
-**Development Environment:** When running `docker compose` locally, set `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` to `http://localhost:9090` to ensure presigned URLs correctly loop back to the local instance.
-
-**Production Environment:** In a production environment, configure `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` with a publicly accessible hostname or IP address that is reachable by your SDK clients and browsers.
+- Multimodal tracing is not working: This docker compose setup by default uses MinIO for blob storage which is not accessible from outside the Docker network for direct uploads. Please refer to the [blob storage guide](/self-hosting/infrastructure/blobstorage#minio-media-uploads) for more details on how to configure MinIO for media uploads.
 
 ## How to Upgrade
 

--- a/pages/self-hosting/infrastructure/blobstorage.mdx
+++ b/pages/self-hosting/infrastructure/blobstorage.mdx
@@ -158,6 +158,14 @@ LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
 This example setup uses an ephemeral volume, i.e. on restarts MinIO will discard all event data.
 Please follow the MinIO documentation or use a cloud provider managed blob store for persistent data storage.
 
+#### Configuring Minio for Media Uploads [#minio-media-uploads]
+
+To enable multimodal tracing, presigned URLs allow SDK clients and browsers outside the Docker network to directly upload and download media assets. Therefore, the `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` must resolve to the Docker host's address.
+
+**Development Environment:** When running `docker compose` locally, set `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` to `http://localhost:9090` to ensure presigned URLs correctly loop back to the local instance.
+
+**Production Environment:** In a production environment, configure `LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT` with a publicly accessible hostname or IP address that is reachable by your SDK clients and browsers.
+
 ### Cloudflare R2
 
 [Cloudflare R2](https://www.cloudflare.com/developer-platform/products/r2/) is globally available, S3 compatible object storage by Cloudflare.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Moved Minio media upload troubleshooting from `docker-compose.mdx` to `blobstorage.mdx` for better organization.
> 
>   - **Documentation Changes**:
>     - Moved Minio media upload troubleshooting section from `docker-compose.mdx` to `blobstorage.mdx`.
>     - Updated `docker-compose.mdx` to refer users to the blob storage guide for Minio configuration details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for dbd3ad9580a124c56de3942c27962cf0ecacb5e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->