### PR TITLE
fix: show controls for gif in docs

### DIFF
--- a/components/Video.tsx
+++ b/components/Video.tsx
@@ -105,7 +105,7 @@ export const Video = ({
       <MediaPlayer
         ref={mediaPlayerRef}
         src={src}
-        controls={!gifStyle && panelDismissed}
+        controls={gifStyle || panelDismissed}
         autoplay={false} // We'll handle autoplay ourselves
         muted={gifStyle}
         loop={gifStyle}
@@ -117,9 +117,7 @@ export const Video = ({
           className
         )}
       >
-        {gifStyle ? (
-          <div className="absolute inset-0 z-10" />
-        ) : !panelDismissed ? (
+        {!gifStyle && !panelDismissed ? (
           <div
             className="group cursor-pointer absolute inset-0 z-10 flex flex-col justify-center items-center bg-cover"
             style={{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `Video.tsx` to show controls for GIFs by adjusting `MediaPlayer` `controls` condition.
> 
>   - **Behavior**:
>     - In `Video.tsx`, change `controls` condition in `MediaPlayer` to `gifStyle || panelDismissed` to show controls for GIFs.
>     - Remove unnecessary overlay div when `gifStyle` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for b3fc8af81552c97cbc5add10ed5de1ac25dbe46e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->