### PR TITLE
docs: update Vercel AI SDK instrumentation setup for Next.js 15

### DIFF
--- a/pages/docs/integrations/vercel-ai-sdk.mdx
+++ b/pages/docs/integrations/vercel-ai-sdk.mdx
@@ -83,25 +83,12 @@ Now you need to register this exporter via the OpenTelemetry SDK.
 <Tabs items={["NextJs","Node.js"]}>
 <Tab>
 
-NextJS has experimental support for OpenTelemetry instrumentation on the framework level. Learn more about it in the [Next.js OpenTelemetry guide](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry).
+NextJS has support for OpenTelemetry instrumentation on the framework level. Learn more about it in the [Next.js OpenTelemetry guide](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry).
 
 Install dependencies:
 
 ```bash
 npm install @vercel/otel langfuse-vercel @opentelemetry/api-logs @opentelemetry/instrumentation @opentelemetry/sdk-logs
-```
-
-Enable the `instrumentationHook` in your `next.config.js`:
-
-```ts filename="next.config.js" {4}
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    instrumentationHook: true,
-  },
-};
-
-module.exports = nextConfig;
 ```
 
 Add `LangfuseExporter` to your instrumentation:

--- a/pages/docs/integrations/vercel-ai-sdk.mdx
+++ b/pages/docs/integrations/vercel-ai-sdk.mdx
@@ -91,6 +91,24 @@ Install dependencies:
 npm install @vercel/otel langfuse-vercel @opentelemetry/api-logs @opentelemetry/instrumentation @opentelemetry/sdk-logs
 ```
 
+<details>
+<summary>Next.js &lt;15: enable OpenTelemetry instrumentation hook</summary>
+
+Enable the `instrumentationHook` in your `next.config.js`:
+
+```ts filename="next.config.js" {4}
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+};
+
+module.exports = nextConfig;
+```
+
+</details>
+
 Add `LangfuseExporter` to your instrumentation:
 
 ```ts filename="instrumentation.ts" {7}


### PR DESCRIPTION
As of Next.js 15, `instrumentation.js` is stable, so this PR updates the Vercel AI SDK integration page to remove the experimental wording and `experimental.instrumentationHook` requirement.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Vercel AI SDK documentation for Next.js 15, removing experimental wording and `instrumentationHook` requirement.
> 
>   - **Documentation Update**:
>     - Removes experimental wording for OpenTelemetry instrumentation in `vercel-ai-sdk.mdx`.
>     - Deletes `experimental.instrumentationHook` requirement from `next.config.js` setup instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 886d1e58a397e437b527b5d22168b3ca8e2d8005. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->