### PR TITLE
docs: fix typos in example doc (misspelled `anthropic`)

### DIFF
--- a/pages/docs/sdk/python/example.md
+++ b/pages/docs/sdk/python/example.md
@@ -138,7 +138,7 @@ This works with any LLM provider/SDK. In this example, we'll use Anthropic.
 os.environ["ANTHROPIC_API_KEY"] = ""
 
 import anthropic
-anthopic_client = anthropic.Anthropic()
+anthropic_client = anthropic.Anthropic()
 ```
 
 
@@ -156,7 +156,7 @@ def anthropic_completion(**kwargs):
       metadata=kwargs_clone
   )
   
-  response = anthopic_client.messages.create(**kwargs)
+  response = anthropic_client.messages.create(**kwargs)
 
   # See docs for more details on token counts and usd cost in Langfuse
   # https://langfuse.com/docs/model-usage-and-cost


### PR DESCRIPTION
`anthopic` instead of `anthropic` (can probably be caught with pre-commit hooks and codespell or similar?)

https://langfuse.com/docs/sdk/python/example#log-an-llm-call-using-as_typegeneration


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typos in `example.md` by correcting `anthopic` to `anthropic`.
> 
>   - Fix typos in `example.md` by correcting `anthopic` to `anthropic` in two instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 420ebb39982ddeebc8df8cb6e591ac3bb940bfcc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->