### PR TITLE
Add missing import for python langchain integration

### DIFF
--- a/pages/docs/sdk/python/decorators.mdx
+++ b/pages/docs/sdk/python/decorators.mdx
@@ -424,7 +424,7 @@ from operator import itemgetter
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema import StrOutputParser
-from langfuse.decorators import observe
+from langfuse.decorators import langfuse_context, observe
 
 prompt = ChatPromptTemplate.from_template("what is the city {person} is from?")
 model = ChatOpenAI()


### PR DESCRIPTION
Adds missing import
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing import `langfuse_context` in `decorators.mdx` for Python Langchain integration example.
> 
>   - **Imports**:
>     - Add missing import `langfuse_context` in `decorators.mdx` for Python Langchain integration example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4cd6d07c734d5041b4bdce7c84376c5829256b10. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->