### PR TITLE
docs: improve environment variable generation methods for docker compose

### DIFF
--- a/pages/self-hosting/docker-compose.mdx
+++ b/pages/self-hosting/docker-compose.mdx
@@ -79,8 +79,8 @@ For testing purposes, the pre-configured variables in the docker-compose file ar
 If you send _any_ kind of sensitive data to the application or intend to keep it up for longer, we recommend that you modify the docker-compose file and overwrite the following environment variables:
 
 - `SALT`: A random string used to hash passwords. It should be at least 32 characters long.
-- `ENCRYPTION_KEY`: Generate this via `openssl rand -base64 32`.
-- `NEXTAUTH_SECRET`: A random string used to sign JWT tokens.
+- `ENCRYPTION_KEY`: Generate this via `openssl rand -hex 32`.
+- `NEXTAUTH_SECRET`: A random string used to sign JWT tokens (Generate this via `openssl rand -base64 32`).
 - `NEXTAUTH_URL`: The URL where the application is hosted. Used for redirects after signup.
 
 In addition, you can change the database and storage credentials to be more secure.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update environment variable generation methods in `docker-compose.mdx` for `ENCRYPTION_KEY` and `NEXTAUTH_SECRET`.
> 
>   - **Environment Variables**:
>     - Change `ENCRYPTION_KEY` generation method to `openssl rand -hex 32` in `docker-compose.mdx`.
>     - Add generation method for `NEXTAUTH_SECRET` using `openssl rand -base64 32` in `docker-compose.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a82d832f0033e321b24d4bf3fcbdb515a0e1730d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->