### PR TITLE
feat: add docker compose upgrade guide

### DIFF
--- a/pages/self-hosting/docker-compose.mdx
+++ b/pages/self-hosting/docker-compose.mdx
@@ -14,6 +14,10 @@ If you use a cloud provider like AWS, GCP, or Azure, you will need permissions t
 For high-availability and high-throughput, we recommend using Kubernetes ([deployment guide](/self-hosting/kubernetes-helm)).
 The docker compose setup lacks high-availability, scaling capabilities, and backup functionality.
 
+<Callout type="info">
+  Coming from docker-compose v2? See our upgrade guide for [docker compose](/self-hosting/upgrade-guides/upgrade-v2-to-v3#docker-compose).
+</Callout>
+
 ## Get Started
 
 <Steps>

--- a/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
+++ b/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
@@ -254,6 +254,47 @@ After you have verified that new events are being stored in Clickhouse and are s
 
 </Steps>
 
+## Deployment Specific Guides
+
+In this section, we collect deployment-specific guides to help you with the upgrade process.
+Feel free to contribute guides or create GitHub issues if you encounter any issues or are missing guidelines.
+
+### Docker Compose
+
+For the docker compose upgrade we assume that a short downtime is acceptable while services are restarting.
+If you want to perform a zero-downtime upgrade, you can follow the steps outlined in the general upgrade guide.
+In case you use an external Postgres instance, you should follow the general guide as well and just start a new v3 deployment which points to your Postgres instance.
+
+<Steps>
+  #### 1. Note the volume name for the Postgres instance
+
+  We assume that you have deployed Langfuse v2 using the docker-compose.yml from the [Langfuse repository](https://github.com/langfuse/langfuse/blob/v2/docker-compose.yml).
+  Take a note of the volume configuration for your database, e.g. `database_data` in the example below.
+  ```yaml
+  volumes:
+    database_data:
+      driver: local
+  ```
+
+  #### 2. Create a copy of the docker-compose.yml from v3
+
+  Create a copy of the Langfuse v3 [docker-compose file](https://github.com/langfuse/langfuse/blob/main/docker-compose.yml) on your local machine.
+  Replace the `langfuse_postgres_data` volume name with the one you noted in step 1.
+  Make sure to update the `volumes` and the `postgres` section.
+
+  #### 3. Stop the Langfuse v2 deployment (Beginning of downtime)
+
+  Run `docker compose down` to stop your Langfuse v2 deployment.
+  Make sure to _not_ add `-v` as we want to retain all volumes.
+
+  #### 4. Start the Langfuse v3 deployment (End of downtime)
+
+  Run `docker compose -f docker-compose.v3.yml up -d` to start the Langfuse v3 deployment.
+  Make sure to replace `docker-compose.v3.yml` with the name of the file you created in step 2.
+  You can start to ingest traces and use other features as soon as the new containers are up and running.
+  The deployment will migrate data from your v2 deployment in the background, so you may see some data missing in the UI for a while.
+</Steps>
+
 ## Support
 
 If you experience any issues, please create an [issue on GitHub](/issues) or contact the maintainers ([support](/support)).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds Docker Compose upgrade guide for transitioning from v2 to v3 with detailed steps and documentation updates.
> 
>   - **Upgrade Guide**:
>     - Adds Docker Compose upgrade guide in `upgrade-v2-to-v3.mdx` with steps for transitioning from v2 to v3.
>     - Steps include noting Postgres volume, copying v3 `docker-compose.yml`, stopping v2 deployment, and starting v3 deployment.
>   - **Documentation**:
>     - Adds callout in `docker-compose.mdx` linking to the new Docker Compose upgrade guide.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5a63f78e7ca4346091fbfe428b3b086c7ede5928. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->