### PR TITLE
docs: add note - numerical scores at llm-as-a-judge

### DIFF
--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -97,6 +97,12 @@ Prompt templates contain **`{{variables}}`** that are substituted with actual da
 
 Langfuse uses function/tool calling to extract the evaluation output. At the bottom of the form, you can configure `score` and `reasoning` variables which will be used to instruct the LLM on how to score and reason about the evaluation.
 
+<Callout type="info">
+
+Currently, LLM-as-a-judge templates only support `numeric` scores. Support for `categorical` and `boolean` scores is on our roadmap. ([GitHub Issue](https://github.com/orgs/langfuse/discussions/4965))
+
+</Callout>
+
 <Frame border>![Langfuse](/images/docs/eval-hallucination-template.png)</Frame>
 
 ### Set up an evaluator


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `model-based-evals.mdx` about LLM-as-a-judge templates only supporting numeric scores, with future plans for categorical and boolean scores.
> 
>   - **Documentation**:
>     - Adds a note in `model-based-evals.mdx` indicating that LLM-as-a-judge templates currently support only `numeric` scores.
>     - Mentions that support for `categorical` and `boolean` scores is planned, with a link to the relevant GitHub issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 790100b1cb53e32d974549a1b439fbfe3440894a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->