### PR TITLE
chore: add note on timezone support to docs

### DIFF
--- a/pages/self-hosting/configuration.mdx
+++ b/pages/self-hosting/configuration.mdx
@@ -73,6 +73,12 @@ import SelfHostFeatures from "@/components-mdx/self-host-features.mdx";
 
 <SelfHostFeatures />
 
+## Timezones
+
+Langfuse expects that its infrastructure components default to UTC.
+Especially Postgres and ClickHouse settings that overwrite the UTC default are not supported and may lead to unexpected behavior.
+Please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046) if you would like us to consider supporting other timezones.
+
 ## Health and Readiness Check Endpoint
 
 Langfuse web includes a health check endpoint at `/api/public/health` and a readiness check endpoint at `/api/public/ready` and the

--- a/pages/self-hosting/troubleshooting.mdx
+++ b/pages/self-hosting/troubleshooting.mdx
@@ -49,6 +49,12 @@ Use the available memory in MiB as the value for `var.memory`, e.g. 4096 for 4 G
 The value should be equal or above the memory limit of the container.
 This ensures that your container orchestrator kills the pod gracefully if the memory limit is exceeded, instead of the application terminating abruptly.
 
+## Timezone Errors
+
+Langfuse is engineered to run in the UTC timezone and expects that all infrastructure components default to UTC.
+Especially Postgres and ClickHouse settings that overwrite the UTC default are not supported and may lead to unexpected behavior.
+If you would like us to consider supporting other timezones, please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046).
+
 ## FAQ
 
 import { FaqPreview } from "@/components/faq/FaqPreview";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation on timezone support, requiring UTC defaults for infrastructure components, with a link for feedback on other timezone support.
> 
>   - **Documentation**:
>     - Added a section on timezone support in `configuration.mdx` and `troubleshooting.mdx`.
>     - Langfuse requires infrastructure components to default to UTC; non-UTC settings in Postgres and ClickHouse may cause issues.
>     - Includes a link to a GitHub discussion for users to vote on supporting other timezones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 08a43926676d39337abcda498b2e13b62881fa30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->