### PR TITLE
chore: add timezone note to CH and PG component docs

### DIFF
--- a/pages/self-hosting/infrastructure/clickhouse.mdx
+++ b/pages/self-hosting/infrastructure/clickhouse.mdx
@@ -41,6 +41,12 @@ You must set `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED = false` and run Click
 Clone the Langfuse repository, adjust the cluster name in `./packages/shared/clickhouse/migrations/clustered/*.sql` and run `cd ./packages/shared && sh ./clickhouse/scripts/up.sh`
 to manually apply the migrations.
 
+### Timezones
+
+Langfuse expects that its infrastructure components default to UTC.
+Especially Postgres and ClickHouse settings that overwrite the UTC default are not supported and may lead to unexpected behavior.
+Please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046) if you would like us to consider supporting other timezones.
+
 ## Deployment Options
 
 This section covers different deployment options and provides example environment variables.

--- a/pages/self-hosting/infrastructure/postgres.mdx
+++ b/pages/self-hosting/infrastructure/postgres.mdx
@@ -27,3 +27,12 @@ Postgres is used for all transactional data, including:
 - Datasets
 - Encrypted API keys
 - Settings
+
+## Configuration
+
+### Timezones
+
+Langfuse expects that its infrastructure components default to UTC.
+Especially Postgres and ClickHouse settings that overwrite the UTC default are not supported and may lead to unexpected behavior.
+Please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046) if you would like us to consider supporting other timezones.
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timezone note to ClickHouse and Postgres documentation, emphasizing UTC default and potential issues with non-UTC settings.
> 
>   - **Documentation**:
>     - Added a timezone note to `clickhouse.mdx` and `postgres.mdx` stating that Langfuse expects infrastructure components to default to UTC.
>     - Mentioned that non-UTC settings for Postgres and ClickHouse are not supported and may cause unexpected behavior.
>     - Included a link to a GitHub discussion for users interested in other timezone support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a9be6f4db197aa7bfcbbc3e1af7430d6485979eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->