### PR TITLE
docs: metadata on observations

### DIFF
--- a/pages/docs/tracing-features/metadata.mdx
+++ b/pages/docs/tracing-features/metadata.mdx
@@ -14,11 +14,23 @@ When using the [`@observe()` decorator](/docs/sdk/python/decorators):
 ```python
 from langfuse.decorators import langfuse_context, observe
 
-@observe()
-def fn():
+@observe
+def nested():
+    # Update trace metadata from anywhere inside call stack
     langfuse_context.update_current_trace(
         metadata={"key":"value"}
     )
+
+    # Update observation metadata for current observation
+    langfuse_context.update_current_observation(
+        metadata={"key": "value"}
+    )
+
+    return
+
+@observe
+def fn():
+    nested()
 
 fn()
 ```
@@ -30,6 +42,10 @@ from langfuse import Langfuse
 langfuse = Langfuse()
 
 trace = langfuse.trace(
+    metadata={"key":"value"}
+)
+
+span = trace.span(
     metadata={"key":"value"}
 )
 ```
@@ -44,6 +60,10 @@ const langfuse = new Langfuse();
 const trace = langfuse.trace({
   metadata: { key: "value" },
 });
+
+const span = trace.span({
+  metadata: { key: "value" }
+})
 ```
 
 See [JS/TS SDK docs](/docs/sdk/typescript/guide) for more details.
@@ -75,10 +95,16 @@ When using the integration with the `@observe()` decorator (see [interop docs](/
 from langfuse.decorators import langfuse_context, observe
 from langfuse.openai import openai
 
-@observe()
-def fn():
+@observe
+def nested():
+    # Update trace metadata from anywhere inside call stack
     langfuse_context.update_current_trace(
         metadata={"key":"value"}
+    )
+
+    # Update observation metadata for current observation
+    langfuse_context.update_current_observation(
+        metadata={"key": "value"}
     )
 
     completion = openai.chat.completions.create(
@@ -89,6 +115,10 @@ def fn():
         {"role": "user", "content": "1 + 1 = "}],
       temperature=0,
     )
+
+@observe
+def fn():
+    nested()
 
 fn()
 ```


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `metadata.mdx` documentation to include examples of adding metadata to traces and observations using `@observe` decorator and integrations with OpenAI, Langchain, and LlamaIndex.
> 
>   - **Documentation Updates**:
>     - Update `metadata.mdx` to demonstrate adding metadata to traces and observations using `@observe` decorator.
>     - Add examples for updating trace and observation metadata in Python and JS/TS.
>     - Include integration examples for OpenAI, Langchain, and LlamaIndex.
>   - **Code Examples**:
>     - Show usage of `langfuse_context.update_current_trace()` and `langfuse_context.update_current_observation()` in Python.
>     - Demonstrate metadata addition in JS/TS using `langfuse.trace()` and `trace.span()`.
>     - Provide OpenAI integration examples with metadata as an additional argument.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 12a308c4a7dab2cd9817a385734eb9886905eaa7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->