### PR TITLE
fix: add redirect for /docs/integrations/vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -166,6 +166,7 @@ const nonPermanentRedirects = [
   ["/docs/langchain", "/docs/integrations/langchain/tracing"],
   ["/docs/langchain/python", "/docs/integrations/langchain/tracing"],
   ["/docs/langchain/typescript", "/docs/integrations/langchain/tracing"],
+  ["/docs/integrations/vercel", "/docs/integrations/vercel-ai-sdk"],
   ["/docs/integrations/langchain", "/docs/integrations/langchain/tracing"],
   ["/docs/integrations/langchain/python", "/docs/integrations/langchain/tracing"],
   ["/docs/integrations/langchain/typescript", "/docs/integrations/langchain/tracing"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add non-permanent redirect from `/docs/integrations/vercel` to `/docs/integrations/vercel-ai-sdk` in `next.config.mjs`.
> 
>   - **Redirects**:
>     - Add non-permanent redirect from `/docs/integrations/vercel` to `/docs/integrations/vercel-ai-sdk` in `next.config.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 53929e7bebc490a0308b4f293e6a6698f4e48b26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->