### PR TITLE
docs: fixed bug in prompt mngt docs

### DIFF
--- a/pages/docs/prompts/get-started.mdx
+++ b/pages/docs/prompts/get-started.mdx
@@ -585,7 +585,7 @@ const langfuseChatPrompt = await langfuse.getPrompt(
 const langchainChatPrompt = ChatPromptTemplate.fromMessages(
   langfuseChatPrompt.getLangchainPrompt().map((m) => [m.role, m.content])
 ).withConfig({
-  metadata: { langfusePrompt: langfuseTextPrompt },
+  metadata: { langfusePrompt: langfuseChatPrompt },
 });
 
 const chatModel = new ChatOpenAI();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes metadata reference in chat prompt configuration example in `get-started.mdx`.
> 
>   - **Bug Fix**:
>     - Corrects metadata reference from `langfuseTextPrompt` to `langfuseChatPrompt` in `get-started.mdx` for chat prompt configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for aa9f0d2808ac5569c7c289f2cd252c366d7a083b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->