### PR TITLE
Add encryption at rest docs

### DIFF
--- a/pages/docs/data-security-privacy.mdx
+++ b/pages/docs/data-security-privacy.mdx
@@ -35,7 +35,7 @@ With Langfuse Cloud, we handle:
 
 ## Security Measures
 
-**Langfuse Cloud**
+### Langfuse Cloud
 
 - We encrypt all data at rest and in transit using TLS.
 - Our database and application run on AWS infrastructure, partly managed by Supabase and Vercel.
@@ -47,7 +47,7 @@ With Langfuse Cloud, we handle:
 - For security inquiries, please contact us at security@langfuse.com
 
 
-## Encryption at rest (databases) [#encryption-at-rest]
+#### Encryption at rest (databases) [#encryption-at-rest]
 
 Below is a list of all data stores in Langfuse Cloud and their encryption methods.
 
@@ -58,8 +58,8 @@ Below is a list of all data stores in Langfuse Cloud and their encryption method
 | Clickhouse | AES-256 |
 | S3 | AES-256 |
 
-  
-**Self-hosted Instances**
+
+### Self-hosted Instances
 
 - For installation and configuration, see: [Self-hosting guide](/self-hosting)
 - For architecture/component diagram, see: [CONTRIBUTING.md](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)

--- a/pages/docs/data-security-privacy.mdx
+++ b/pages/docs/data-security-privacy.mdx
@@ -46,6 +46,19 @@ With Langfuse Cloud, we handle:
 - We do not use any of your data for model training and treat it confidentially ([terms and conditions](/terms)).
 - For security inquiries, please contact us at security@langfuse.com
 
+
+## Encryption at rest (databases) [#encryption-at-rest]
+
+Below is a list of all data stores in Langfuse Cloud and their encryption methods.
+
+| Service | Encryption |
+| --- | --- |
+| Elasticache (Redis) | AES-256 |
+| Aurora (Postgres) | AES-256 |
+| Clickhouse | AES-256 |
+| S3 | AES-256 |
+
+  
 **Self-hosted Instances**
 
 - For installation and configuration, see: [Self-hosting guide](/self-hosting)

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -41,6 +41,14 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 
 ## Encryption at rest (database) [#encryption-at-rest]
 
+| Service | Encryption |
+| --- | --- |
+| Elasticache (Redis) | AES-256 |
+| Aurora (Postgres) | AES-256 |
+| Clickhouse | AES-256 |
+| S3 | AES-256 |
+
+
 All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
 Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -39,9 +39,11 @@ There are two main approaches to handle HTTPS for Langfuse:
 
 Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` to ensure browser only allow HTTPS connections when using Langfuse.
 
-## Encryption at rest (databases) [#encryption-at-rest]
 
-All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store. Database-level encryption is recommended for a secure production deployment and available across cloud providers.
+## Encryption at rest (database) [#encryption-at-rest]
+
+All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
+Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 
 ## Additional application-level encryption [#application-level-encryption]
 

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -39,7 +39,11 @@ There are two main approaches to handle HTTPS for Langfuse:
 
 Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` to ensure browser only allow HTTPS connections when using Langfuse.
 
-## Encryption at rest (database) [#encryption-at-rest]
+## Encryption at rest (databases) [#encryption-at-rest]
+
+
+All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
+Database-level encryption is recommended for a secure production deployment and available across cloud providers. Here is a list of the encryption methods used on Langfuse Cloud across all regions.
 
 | Service | Encryption |
 | --- | --- |
@@ -48,9 +52,6 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 | Clickhouse | AES-256 |
 | S3 | AES-256 |
 
-
-All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
-Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 
 ## Additional application-level encryption [#application-level-encryption]
 

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -42,8 +42,8 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 ## Encryption at rest (databases) [#encryption-at-rest]
 
 
-All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
-Database-level encryption is recommended for a secure production deployment and available across cloud providers. Here is a list of the encryption methods used on Langfuse Cloud across all regions.
+Langfuse stores data across multiple storage systems: PostgreSQL for relational data, ClickHouse for analytics, Redis for caching, and S3/Blob Storage for object storage. 
+For secure production deployments, we strongly recommend enabling database-level encryption, which is readily available from all major cloud providers. Below is an overview of the encryption methods implemented in Langfuse Cloud across all regions.
 
 | Service | Encryption |
 | --- | --- |

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -41,17 +41,7 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 
 ## Encryption at rest (databases) [#encryption-at-rest]
 
-
-Langfuse stores data across multiple storage systems: PostgreSQL for relational data, ClickHouse for analytics, Redis for caching, and S3/Blob Storage for object storage. 
-For secure production deployments, we strongly recommend enabling database-level encryption, which is readily available from all major cloud providers. Below is an overview of the encryption methods implemented in Langfuse Cloud across all regions.
-
-| Service | Encryption |
-| --- | --- |
-| Elasticache (Redis) | AES-256 |
-| Aurora (Postgres) | AES-256 |
-| Clickhouse | AES-256 |
-| S3 | AES-256 |
-
+All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store. Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 
 ## Additional application-level encryption [#application-level-encryption]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add documentation for encryption at rest for Langfuse Cloud and self-hosted instances, detailing encryption methods and storage options.
> 
>   - **Langfuse Cloud**:
>     - Added section on encryption at rest in `data-security-privacy.mdx`.
>     - Lists encryption methods for Elasticache (Redis), Aurora (Postgres), Clickhouse, and S3 using AES-256.
>   - **Self-hosted Instances**:
>     - Added section on encryption at rest in `encryption.mdx`.
>     - Mentions storage in Postgres, Clickhouse, Redis, or S3/Blob Store.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 55e180e6806d00c9bf14e3b752b75e7f2121d65d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->