### PR TITLE
docs: add note on encryption algo

### DIFF
--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -44,6 +44,8 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 All Langfuse data is stored in your Postgres database, Clickhouse, Redis, or S3/Blob Store.
 Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 
+On Langfuse Cloud, we use AES-256 across all databases.
+
 ## Additional application-level encryption [#application-level-encryption]
 
 In addition to in-transit and at-rest encryption, sensitive data is also encrypted or hashed at the application level.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds note in `encryption.mdx` about AES-256 encryption used in Langfuse Cloud databases.
> 
>   - **Documentation**:
>     - Adds note in `encryption.mdx` that Langfuse Cloud uses AES-256 for database encryption.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 74bb98df4a9dd874df2d7794eb3d4dec873e7389. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->