### PR TITLE
ci: skip identical ci in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,24 @@ on:
   merge_group:
 
 jobs:
-  build:
+  # Add pre-job to skip duplicate actions in merge queues
+  pre-job:
     runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    timeout-minutes: 15
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          do_not_skip: '["workflow_dispatch"]'
+
+  build:
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,5 +41,4 @@ jobs:
       - run: pnpm install
 
       - name: Build next.js app
-        # change this if your site requires a custom build command
         run: pnpm build


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a pre-job to the CI workflow to skip duplicate actions in merge queues, controlling the execution of the build job.
> 
>   - **CI Workflow**:
>     - Adds `pre-job` to `.github/workflows/ci.yml` to skip duplicate actions in merge queues using `fkirc/skip-duplicate-actions@v5`.
>     - `pre-job` outputs `should_skip` to determine if `build` job should run.
>     - `build` job now depends on `pre-job` and runs only if `should_skip` is not 'true'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5caf0b6e70309e54b54d6ae62bb74c0634e13ed0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->