### PR TITLE
docs: add audit logs to plan comparisons

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -539,6 +539,13 @@ const sections = [
         },
       },
       {
+        name: "Audit Logs",
+        tiers: {
+          cloud: { Hobby: false, Pro: false, Team: true },
+          selfHosted: { "Open Source": false, Pro: false, Enterprise: true },
+        },
+      },
+      {
         name: "Data retention management",
         tiers: {
           cloud: {

--- a/pages/self-hosting/license-key.mdx
+++ b/pages/self-hosting/license-key.mdx
@@ -45,6 +45,7 @@ There are some commercially licensed peripheral features:
 | SSO Enforcement                                                | 🛑             | 🛑            | ✅             | 🛑                  | 🛑                  | ✅                         |
 | [Project-level RBAC roles](/docs/rbac)                         | 🛑             | 🛑            | ✅             | 🛑                  | 🛑                  | ✅                         |
 | Data Retention Policies                                        | 🛑             | 🛑            | ✅             | 🛑                  | 🛑                  | soon                       |
+| Audit Logs                                                     | 🛑             | 🛑            | ✅             | 🛑                  | 🛑                  | ✅                         |
 | [UI Customization](/self-hosting/ui-customization)             | 🛑             | 🛑            | 🛑             | 🛑                  | 🛑                  | ✅                         |
 | [Organization Creators](/self-hosting/organization-creators)   | 🛑             | 🛑            | 🛑             | 🛑                  | 🛑                  | ✅                         |
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'Audit Logs' to plan comparison tables in `Pricing.tsx` and `license-key.mdx`.
> 
>   - **Documentation**:
>     - Add 'Audit Logs' feature to plan comparison in `Pricing.tsx` and `license-key.mdx`.
>     - 'Audit Logs' available for 'Team' in cloud and 'Enterprise' in self-hosted plans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7bf579d41835f14b5bed2a2c5a498129ff17606b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->