### PR TITLE
chore: add hiring badge to logo on desktop

### DIFF
--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 
 const ContextMenu = dynamic(() => import("./LogoContextMenu"), {
   ssr: false,
@@ -10,43 +11,53 @@ export function Logo() {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
     <>
-      <div
-        className="flex gap-2 items-center cursor-pointer -mr-4 md:-mr-0"
-        onContextMenu={(e) => {
-          e.preventDefault();
-          setMenuOpen(true);
-        }}
-      >
-        <Image
-          src="/langfuse_logo_white.svg"
-          alt="Langfuse Logo"
-          width={120}
-          height={20}
-          className="hidden dark:block max-w-28 sm:max-w-none"
-        />
-        <Image
-          src="/langfuse_logo.svg"
-          alt="Langfuse Logo"
-          width={120}
-          height={20}
-          className="block dark:hidden max-w-28 sm:max-w-none"
-        />
-        <style jsx>{`
-          div {
-            mask-image: linear-gradient(
-              60deg,
-              #bba0ff 25%,
-              rgba(187, 160, 255, 0.2) 50%,
-              #bba0ff 75%
-            );
-            mask-size: 400%;
-            mask-position: 0%;
-          }
-          div:hover {
-            mask-position: 100%;
-            transition: mask-position 1s ease, -webkit-mask-position 1s ease;
-          }
-        `}</style>
+      <div className="flex items-center gap-2">
+        <Link
+          href="/"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setMenuOpen(true);
+          }}
+        >
+          <div className="flex gap-2 items-center cursor-pointer -mr-4 md:-mr-0">
+            <Image
+              src="/langfuse_logo_white.svg"
+              alt="Langfuse Logo"
+              width={120}
+              height={20}
+              className="hidden dark:block max-w-28 sm:max-w-none"
+            />
+            <Image
+              src="/langfuse_logo.svg"
+              alt="Langfuse Logo"
+              width={120}
+              height={20}
+              className="block dark:hidden max-w-28 sm:max-w-none"
+            />
+            <style jsx>{`
+              div {
+                mask-image: linear-gradient(
+                  60deg,
+                  #bba0ff 25%,
+                  rgba(187, 160, 255, 0.2) 50%,
+                  #bba0ff 75%
+                );
+                mask-size: 400%;
+                mask-position: 0%;
+              }
+              div:hover {
+                mask-position: 100%;
+                transition: mask-position 1s ease, -webkit-mask-position 1s ease;
+              }
+            `}</style>
+          </div>
+        </Link>
+        <Link
+          href="/careers"
+          className="ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-900 border transition-colors hidden lg:block"
+        >
+          HIRING
+        </Link>
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}
     </>

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -19,6 +19,7 @@ import InkeepSearchBar from "./components/inkeep/InkeepSearchBar";
 
 const config: DocsThemeConfig = {
   logo: <Logo />,
+  logoLink: false,
   main: MainContentWrapper,
   search: {
     // placeholder: "Search...",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 'HIRING' badge linking to the careers page next to the logo on desktop in `Logo` component and updates `theme.config.tsx`.
> 
>   - **Behavior**:
>     - Adds a 'HIRING' badge next to the logo in `Logo` component in `components/logo.tsx` for desktop view.
>     - Badge links to `/careers` and is styled for visibility on large screens.
>   - **Configuration**:
>     - Sets `logoLink` to `false` in `theme.config.tsx` to disable default logo linking behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e90e9ee1118ef0736421c058df6505e18177714b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->