### PR TITLE
docs: add prompt diff feature

### DIFF
--- a/components-mdx/prompt-overview-gifs.mdx
+++ b/components-mdx/prompt-overview-gifs.mdx
@@ -1,6 +1,6 @@
 import { CloudflareVideo } from "@/components/Video";
 
-<Tabs items={["Version Control", "Deploy", "Metrics", "Test in Playground", "Link with Traces"]}>
+<Tabs items={["Version Control", "Deploy", "Metrics", "Test in Playground", "Link with Traces", "Track changes"]}>
 <Tab>
 
 Collaboratively version and edit prompts via UI, API, or SDKs.
@@ -54,5 +54,16 @@ Link prompts with traces to understand how they perform in the context of your L
   aspectRatio={1696 / 1080}
   gifStyle
 />
+</Tab>
+<Tab>
+
+Track changes to your prompts to understand how they evolve over time.
+
+<CloudflareVideo
+  videoId="003505c095576d070cd1520178eb564c"
+  aspectRatio={1728 / 1080}
+  gifStyle
+/>
+
 </Tab>
 </Tabs>

--- a/pages/changelog/2025-01-22-track-changes-between-prompt-versions.mdx
+++ b/pages/changelog/2025-01-22-track-changes-between-prompt-versions.mdx
@@ -1,0 +1,15 @@
+---
+date: 2025-01-22
+title: Track changes between prompt versions
+description: See a detailed comparison of changes between prompt versions. Optionally, you can also review changes before creating a new prompt version.
+author: Hassieb
+ogCloudflareVideo: 80d49e04116c4683448b16866f4b6358
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+[Langfuse Prompt Management](/docs/prompts/get-started) now includes a detailed comparison of changes between prompt versions. This has been a [long-awaited](https://github.com/orgs/langfuse/discussions/1105) feature and we are excited to finally release it based on an initial contribution from [@chrispe](https://github.com/chrispe).
+
+These comparisons/diffs are especially helpful when making lots of changes in a larger team in order to understand what has actually changed between versions.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation and changelog entry for tracking changes between prompt versions.
> 
>   - **Documentation**:
>     - Adds a new tab "Track changes" in `prompt-overview-gifs.mdx` to describe tracking changes in prompts.
>     - Includes a `CloudflareVideo` with `videoId="003505c095576d070cd1520178eb564c"` to demonstrate the feature.
>   - **Changelog**:
>     - New changelog entry `2025-01-22-track-changes-between-prompt-versions.mdx` to announce the feature.
>     - Describes the ability to compare changes between prompt versions and review changes before creating new versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 91b6d539737b0607b8be4bb6fbfef4b29086a140. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->