### PR TITLE
chore: skip vercel build in merge queue and add vercel.json

### DIFF
--- a/scripts/vercel_ignore_build_check.sh
+++ b/scripts/vercel_ignore_build_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "gh-readonly-queue/"* ]] ; then
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+
+else
+  # Proceed with the build
+    echo "✅ - Build can proceed"
+  exit 1;
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "bash scripts/vercel_ignore_build_check.sh"
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add script to skip Vercel builds for specific branches and configure it in `vercel.json`.
> 
>   - **Build Process**:
>     - Add `vercel_ignore_build_check.sh` to skip Vercel builds for branches starting with `gh-readonly-queue/`.
>     - Update `vercel.json` to use `vercel_ignore_build_check.sh` as `ignoreCommand`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 37c8407a73061a7be5e485e82f30960751b9756e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->