### PR TITLE
docs: make checks and auth method configurable across SSO providers

### DIFF
--- a/pages/self-hosting/authentication-and-sso.mdx
+++ b/pages/self-hosting/authentication-and-sso.mdx
@@ -33,7 +33,7 @@ Email/password authentication is enabled by default. Users can sign up and log i
 
 To disable email/password authentication, set `AUTH_DISABLE_USERNAME_PASSWORD=true`. In this case, you need to set up [SSO](#sso) instead.
 
-If you decide to switch from email/password to SSO on a running instance, you can enable `*_ALLOW_ACCOUNT_LINKING=true` on the SSO provider. This will automatically merge accounts with the same email address.
+If you decide to switch from email/password to SSO on a running instance, you can enable `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING=true` on the SSO provider. This will automatically merge accounts with the same email address.
 
 ### Creation of default user
 
@@ -43,7 +43,7 @@ If you want to programmatically create a default user, check out the [Headless I
 
 To enable OAuth/SSO provider sign-in for Langfuse, configure the required environment variables for the provider.
 
-Use `*_ALLOW_ACCOUNT_LINKING` to allow merging accounts with the same email address. This is useful when users sign in with different providers or email/password but have the same email address. You need to be careful with this setting as it can lead to security issues if the emails are not verified.
+Use `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING` to allow merging accounts with the same email address. This is useful when users sign in with different providers or email/password but have the same email address. You need to be careful with this setting as it can lead to security issues if the emails are not verified.
 
 Need another provider? Langfuse uses Auth.js, which integrates with [many providers](https://next-auth.js.org/providers/). Add a [feature request on GitHub](/ideas) if you want us to add support for a specific provider.
 
@@ -51,28 +51,28 @@ Need another provider? Langfuse uses Auth.js, which integrates with [many provid
 
 [NextAuth Google Provider Docs](https://next-auth.js.org/providers/google)
 
-| Configuration      | Value                                                                                                                                                                                                                                               |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Required Variables | `AUTH_GOOGLE_CLIENT_ID`<br/>`AUTH_GOOGLE_CLIENT_SECRET`                                                                                                                                                                                             |
-| Optional Variables | `AUTH_GOOGLE_ALLOW_ACCOUNT_LINKING=true`<br/>`AUTH_GOOGLE_ALLOWED_DOMAINS=langfuse.com,google.com` (list of allowed domains based on [`hd` OAuth claim](https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload)) |
-| OAuth Redirect URL | `/api/auth/callback/google`                                                                                                                                                                                                                         |
+| Configuration      | Value                                                                                                                                                                                                                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Required Variables | `AUTH_GOOGLE_CLIENT_ID`<br/>`AUTH_GOOGLE_CLIENT_SECRET`                                                                                                                                                                                                                                                   |
+| Optional Variables | `AUTH_GOOGLE_ALLOWED_DOMAINS=langfuse.com,google.com` (list of allowed domains based on [`hd` OAuth claim](https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload))<br/><br/>See [additional configuration](#additional-configuration) section below for more options. |
+| OAuth Redirect URL | `/api/auth/callback/google`                                                                                                                                                                                                                                                                               |
 
 ### GitHub
 
 [NextAuth GitHub Provider Docs](https://next-auth.js.org/providers/github)
 
-| Configuration      | Value                                                   |
-| ------------------ | ------------------------------------------------------- |
-| Required Variables | `AUTH_GITHUB_CLIENT_ID`<br/>`AUTH_GITHUB_CLIENT_SECRET` |
-| Optional Variables | `AUTH_GITHUB_ALLOW_ACCOUNT_LINKING=true`                |
-| OAuth Redirect URL | `/api/auth/callback/github`                             |
+| Configuration      | Value                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| Required Variables | `AUTH_GITHUB_CLIENT_ID`<br/>`AUTH_GITHUB_CLIENT_SECRET`                  |
+| Optional Variables | See [additional configuration](#additional-configuration) section below. |
+| OAuth Redirect URL | `/api/auth/callback/github`                                              |
 
 ### GitHub Enterprise
 
 | Configuration      | Value                                                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | Required Variables | `AUTH_GITHUB_ENTERPRISE_CLIENT_ID`<br/>`AUTH_GITHUB_ENTERPRISE_CLIENT_SECRET`<br/>`AUTH_GITHUB_ENTERPRISE_BASE_URL` |
-| Optional Variables | `AUTH_GITHUB_ENTERPRISE_ALLOW_ACCOUNT_LINKING=false`                                                                |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.                                            |
 | OAuth Redirect URL | `/api/auth/callback/github-enterprise`                                                                              |
 
 Thanks to [@jay0129](https://github.com/jay0129) for the initial contribution of GitHub Enterprise support!
@@ -81,11 +81,11 @@ Thanks to [@jay0129](https://github.com/jay0129) for the initial contribution of
 
 [NextAuth GitLab Provider Docs](https://next-auth.js.org/providers/gitlab)
 
-| Configuration      | Value                                                             |
-| ------------------ | ----------------------------------------------------------------- |
-| Required Variables | `AUTH_GITLAB_CLIENT_ID`<br/>`AUTH_GITLAB_CLIENT_SECRET`           |
-| Optional Variables | `AUTH_GITLAB_ISSUER`<br/>`AUTH_GITLAB_ALLOW_ACCOUNT_LINKING=true` |
-| OAuth Redirect URL | `/api/auth/callback/gitlab`                                       |
+| Configuration      | Value                                                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Required Variables | `AUTH_GITLAB_CLIENT_ID`<br/>`AUTH_GITLAB_CLIENT_SECRET`                                                                 |
+| Optional Variables | `AUTH_GITLAB_ISSUER`<br/><br/>See [additional configuration](#additional-configuration) section below for more options. |
+| OAuth Redirect URL | `/api/auth/callback/gitlab`                                                                                             |
 
 ### Azure AD/Entra ID
 
@@ -94,7 +94,7 @@ Thanks to [@jay0129](https://github.com/jay0129) for the initial contribution of
 | Configuration      | Value                                                                                     |
 | ------------------ | ----------------------------------------------------------------------------------------- |
 | Required Variables | `AUTH_AZURE_AD_CLIENT_ID`<br/>`AUTH_AZURE_AD_CLIENT_SECRET`<br/>`AUTH_AZURE_AD_TENANT_ID` |
-| Optional Variables | `AUTH_AZURE_ALLOW_ACCOUNT_LINKING=true`                                                   |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.                  |
 | OAuth Redirect URL | `/api/auth/callback/azure-ad`                                                             |
 
 Notes:
@@ -108,7 +108,7 @@ Notes:
 | Configuration      | Value                                                                      |
 | ------------------ | -------------------------------------------------------------------------- |
 | Required Variables | `AUTH_OKTA_CLIENT_ID`<br/>`AUTH_OKTA_CLIENT_SECRET`<br/>`AUTH_OKTA_ISSUER` |
-| Optional Variables | `AUTH_OKTA_ALLOW_ACCOUNT_LINKING=true`                                     |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.   |
 | OAuth Redirect URL | `/api/auth/callback/okta`                                                  |
 
 ### Auth0
@@ -118,7 +118,7 @@ Notes:
 | Configuration      | Value                                                                         |
 | ------------------ | ----------------------------------------------------------------------------- |
 | Required Variables | `AUTH_AUTH0_CLIENT_ID`<br/>`AUTH_AUTH0_CLIENT_SECRET`<br/>`AUTH_AUTH0_ISSUER` |
-| Optional Variables | `AUTH_AUTH0_ALLOW_ACCOUNT_LINKING=true`                                       |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.      |
 | OAuth Redirect URL | `/api/auth/callback/auth0`                                                    |
 
 ### AWS Cognito
@@ -128,7 +128,7 @@ Notes:
 | Configuration      | Value                                                                               |
 | ------------------ | ----------------------------------------------------------------------------------- |
 | Required Variables | `AUTH_COGNITO_CLIENT_ID`<br/>`AUTH_COGNITO_CLIENT_SECRET`<br/>`AUTH_COGNITO_ISSUER` |
-| Optional Variables | `AUTH_COGNITO_ALLOW_ACCOUNT_LINKING=true`                                           |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.            |
 | OAuth Redirect URL | `/api/auth/callback/cognito`                                                        |
 
 ### Keycloak
@@ -138,7 +138,7 @@ Notes:
 | Configuration      | Value                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------- |
 | Required Variables | `AUTH_KEYCLOAK_CLIENT_ID`<br/>`AUTH_KEYCLOAK_CLIENT_SECRET`<br/>`AUTH_KEYCLOAK_ISSUER` |
-| Optional Variables | `AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING=true`                                             |
+| Optional Variables | See [additional configuration](#additional-configuration) section below.               |
 | OAuth Redirect URL | `/api/auth/callback/keycloak`                                                          |
 
 Thanks to [@RTae](https://github.com/RTae) for the initial contribution of Keycloak support!
@@ -147,11 +147,11 @@ Thanks to [@RTae](https://github.com/RTae) for the initial contribution of Keycl
 
 [NextAuth Custom OAuth Provider Docs](https://next-auth.js.org/configuration/providers/oauth#using-a-custom-provider) ([source](https://github.com/langfuse/langfuse/blob/main/web/src/server/auth.ts))
 
-| Configuration      | Value                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Required Variables | `AUTH_CUSTOM_CLIENT_ID`<br/>`AUTH_CUSTOM_CLIENT_SECRET`<br/>`AUTH_CUSTOM_ISSUER`<br/>`AUTH_CUSTOM_NAME` (any, used only in UI)                                                                                                                                                                                                                                                |
-| Optional Variables | `AUTH_CUSTOM_ALLOW_ACCOUNT_LINKING=true`<br/>`AUTH_CUSTOM_SCOPE` (defaults to `"openid email profile"`)<br/>`AUTH_CUSTOM_CLIENT_AUTH_METHOD` (defaults to `"client_secret_basic"`)<br/>`AUTH_CUSTOM_ID_TOKEN` (Defaults to `true`, set to `false` if you want to make a request to the `userinfo` endpoint instead of extracting user information from the `id_token` claims) |
-| OAuth Redirect URL | `/api/auth/callback/custom`                                                                                                                                                                                                                                                                                                                                                   |
+| Configuration      | Value                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Required Variables | `AUTH_CUSTOM_CLIENT_ID`<br/>`AUTH_CUSTOM_CLIENT_SECRET`<br/>`AUTH_CUSTOM_ISSUER`<br/>`AUTH_CUSTOM_NAME` (any, used only in UI)                                                                                                                                                                                                                           |
+| Optional Variables | `AUTH_CUSTOM_SCOPE` (defaults to `"openid email profile"`)<br/>`AUTH_CUSTOM_ID_TOKEN` (Defaults to `true`, set to `false` if you want to make a request to the `userinfo` endpoint instead of extracting user information from the `id_token` claims)<br/><br/>See [additional configuration](#additional-configuration) section below for more options. |
+| OAuth Redirect URL | `/api/auth/callback/custom`                                                                                                                                                                                                                                                                                                                              |
 
 ## HTTP Proxy for SSO
 
@@ -160,23 +160,24 @@ Configure `AUTH_HTTPS_PROXY` or `AUTH_HTTP_PROXY` to use a proxy for SSO provide
 
 ## Additional configuration
 
-| Variable                            | Description                                                                                                                                                                                              |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH_DOMAINS_WITH_SSO_ENFORCEMENT` | Comma-separated list of domains that are only allowed to sign in using SSO. Email/password sign in is disabled for these domains. E.g. `domain1.com,domain2.com`                                         |
-| `AUTH_DISABLE_SIGNUP`               | Set to `true` to disable sign up for new users. Only existing users can sign in. This affects all new users that try to sign up, also those who received an invite to a project and have no account yet. |
-| `AUTH_SESSION_MAX_AGE`              | Set the maximum age of the session (JWT) in minutes. The default is 30 days (`43200`). The value must be greater than 5 minutes, as the front-end application refreshes its session every 5 minutes.     |
-| `AUTH_IGNORE_ACCOUNT_FIELDS`        | Comma-separated list of fields to ignore from the SSO IDP account when creating an account. Use this to correct errors with custom IDP providers.                                                        |
+These are additional configuration variables. Replace `<PROVIDER>` with the provider name (e.g., `GOOGLE`, `GITHUB`, `AZURE_AD`, etc., see other variables of provider above).
 
-Notes:
-
-- If you want to use PKCE code flow, set `AUTH_CUSTOM_CLIENT_AUTH_METHOD='none'`.
+| Variable                                | Description                                                                                                                                                                                                                                                                                   |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_DOMAINS_WITH_SSO_ENFORCEMENT`     | Comma-separated list of domains that are only allowed to sign in using SSO. Email/password sign in is disabled for these domains. E.g. `domain1.com,domain2.com`                                                                                                                              |
+| `AUTH_DISABLE_SIGNUP`                   | Set to `true` to disable sign up for new users. Only existing users can sign in. This affects all new users that try to sign up, also those who received an invite to a project and have no account yet.                                                                                      |
+| `AUTH_SESSION_MAX_AGE`                  | Set the maximum age of the session (JWT) in minutes. The default is 30 days (`43200`). The value must be greater than 5 minutes, as the front-end application refreshes its session every 5 minutes.                                                                                          |
+| `AUTH_IGNORE_ACCOUNT_FIELDS`            | Comma-separated list of fields to ignore from the SSO IDP account when creating an account. Use this to correct errors with custom IDP providers.                                                                                                                                             |
+| `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING` | Set to `true` to allow merging accounts with the same email address. This is useful when users sign in with different providers or email/password but have the same email address. You need to be careful with this setting as it can lead to security issues if the emails are not verified. |
+| `AUTH_<PROVIDER>_AUTH_METHOD`           | Configure the token endpoint authentication method. Supported values: `client_secret_basic` (default), `client_secret_post`, `client_secret_jwt`, `private_key_jwt`, `tls_client_auth`, `self_signed_tls_client_auth`, `none`. Use `none` for PKCE flow.                                      |
+| `AUTH_<PROVIDER>_CHECKS`                | Configure the authentication checks. Supported values: `nonce`, `none`, `pkce`, `state`. Multiple values can be provided as comma-separated list.                                                                                                                                             |
 
 ## Troubleshooting
 
 - Make sure that `NEXTAUTH_URL` environment variable is [configured correctly](/self-hosting/configuration) if you want to use any authentication method other than email/password.
-- Error: _"Please sign in with the same provider that you used to create this account"._ This error occurs when you try to sign in with a different provider than the one you used to create your account. To fix this, you need to sign in with the same provider that you used to create your account or allow for account linking/takeover by setting `*_ALLOW_ACCOUNT_LINKING=true` (env depends on the provider, see above).
+- Error: _"Please sign in with the same provider that you used to create this account"._ This error occurs when you try to sign in with a different provider than the one you used to create your account. To fix this, you need to sign in with the same provider that you used to create your account or allow for account linking/takeover by setting `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING=true` (env depends on the provider, see above).
 - For password reset, see the [Password Reset](#password-reset) section.
-- Langfuse authentication is based on emails. When using SSO, make sure that the email address is included in the profile of the user in the IDP.
+- Langfuse authentication relies on email addresses. When using SSO, ensure that the user's email address is included in their IDP profile.
 
 ## GitHub Discussions
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make SSO provider configurations more flexible by allowing provider-specific account linking, authentication methods, and checks.
> 
>   - **Configuration Changes**:
>     - Updated `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING` to be provider-specific for account merging.
>     - Introduced `AUTH_<PROVIDER>_AUTH_METHOD` to configure token endpoint authentication methods.
>     - Added `AUTH_<PROVIDER>_CHECKS` for authentication checks configuration.
>   - **Documentation**:
>     - Updated `authentication-and-sso.mdx` to reflect new configuration options for SSO providers.
>     - Removed specific `ALLOW_ACCOUNT_LINKING` options from individual provider sections, directing to a general configuration section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9d38444fd2f5602f40ce444b971eb4e1f6d3af57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->