### PR TITLE
feat: document OTEL support for self-hosters

### DIFF
--- a/pages/self-hosting/configuration.mdx
+++ b/pages/self-hosting/configuration.mdx
@@ -16,8 +16,8 @@ You can use the same environment variables for the Langfuse Web and Langfuse Wor
 ### Core Infrastructure Settings
 
 | Variable                                        | Required / Default | Description                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                                  | Required           | Connection string of your Postgres database. Instead of `DATABASE_URL`, you can also use `DATABASE_HOST`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_NAME`, and `DATABASE_ARGS`.                                                                                                                                                                                                      |
+|-------------------------------------------------|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DATABASE_URL`                                  | Required           | Connection string of your Postgres database. Instead of `DATABASE_URL`, you can also use `DATABASE_HOST`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_NAME`, and `DATABASE_ARGS`.                                                                                                                                                                                                             |
 | `DIRECT_URL`                                    | `DATABASE_URL`     | Connection string of your Postgres database used for database migrations. Use this if you want to use a different user for migrations or use connection pooling on `DATABASE_URL`. **For large deployments**, configure the database user with long timeouts as migrations might need a while to complete.                                                                                            |
 | `SHADOW_DATABASE_URL`                           |                    | If your database user lacks the `CREATE DATABASE` permission, you must create a shadow database and configure the "SHADOW_DATABASE_URL". This is often the case if you use a Cloud database. Refer to the [Prisma docs](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually) for detailed instructions. |
 | `CLICKHOUSE_MIGRATION_URL`                      | Required           | Migration URL (TCP protocol) for the clickhouse instance. Pattern: `clickhouse://<hostname>:(9000/9440)`                                                                                                                                                                                                                                                                                              |
@@ -71,7 +71,7 @@ There are additional features that can be enabled and configured via environment
 
 import SelfHostFeatures from "@/components-mdx/self-host-features.mdx";
 
-<SelfHostFeatures />
+<SelfHostFeatures/>
 
 ## Timezones
 
@@ -108,3 +108,14 @@ Applications and monitoring services can call this endpoint periodically for hea
 Per default, the Langfuse web healthcheck endpoint does not validate if the database is reachable, as there are cases where the
 database is unavailable, but the application still serves traffic.
 If you want to run database healthchecks, you can add `?failIfDatabaseUnavailable=true` to the healthcheck endpoint.
+
+## OpenTelemetry
+
+Langfuse uses OpenTelemetry to provide observability into the application.
+If you want to include Langfuse into your own tracing setup, you can configure the following environment variables to send spans to your own collector:
+
+| Variable                      | Required / Default      | Description                                                                                       |
+|-------------------------------|-------------------------|---------------------------------------------------------------------------------------------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | The OTLP collector endpoint Langfuse should send traces to. Path is /v1/traces.                   |
+| `OTEL_SERVICE_NAME`           | `web/worker`            | Name of the service within your APM tool.                                                         |
+| `OTEL_TRACE_SAMPLING_RATIO`   | `1`                     | The sampling ratio for traces. A value of `1` means all traces are sent. Must be between 0 and 1. |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds OpenTelemetry documentation for self-hosters in `configuration.mdx`, detailing environment variables for tracing setup.
> 
>   - **Documentation**:
>     - Adds OpenTelemetry section to `configuration.mdx` for self-hosters.
>     - Documents `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, and `OTEL_TRACE_SAMPLING_RATIO` environment variables for tracing setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for b8d0b036ff7768503b881edd89023c64679ea833. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->