### PR TITLE
feat(datasets): changelog CSV upload

### DIFF
--- a/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
+++ b/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
@@ -3,6 +3,7 @@ date: 2025-01-27
 title: Dataset CSV upload
 description: Create your Datasets in seconds
 author: Marlies
+# ogCloudflareVideo: xxx
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";

--- a/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
+++ b/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
@@ -1,6 +1,6 @@
 ---
 date: 2025-01-27
-title: CSV upload for Datasets
+title: Dataset Items CSV upload
 description: Create your Datasets in seconds with CSV upload.
 author: Marlies
 ---

--- a/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
+++ b/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
@@ -1,0 +1,19 @@
+---
+date: 2025-01-27
+title: CSV upload for Datasets
+description: Create your Datasets in seconds with CSV upload.
+author: Marlies
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+You can now upload CSV files to create Dataset Items in Langfuse. 
+
+Simply drag and drop your CSV columns to map them to "input", "expected output", or "metadata" fields. Multiple columns can be combined into a single field - simply drag and drop all CSV columns you want to combine into the same field, which will automatically create a structured JSON object. Any columns that are not mapped will be ignored. The CSV should contain a header row with your column names. All schema types are supported, including nested JSON objects.
+
+**Learn more**
+
+- [Datasets overview](/docs/datasets/overview)
+- [Create Dataset and run experiments](/docs/datasets/get-started)

--- a/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
+++ b/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2025-01-27
-title: Dataset Items CSV upload
-description: Create your Datasets in seconds with CSV upload.
+title: Dataset CSV upload
+description: Create your Datasets in seconds
 author: Marlies
 ---
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds changelog entry for new CSV upload feature to create Dataset Items in Langfuse with drag-and-drop column mapping.
> 
>   - **Changelog**:
>     - Adds `2025-01-27-Dataset-Items-csv-upload.mdx` to document the new CSV upload feature for creating Dataset Items in Langfuse.
>     - Describes drag-and-drop mapping of CSV columns to "input", "expected output", or "metadata" fields.
>     - Supports combining multiple columns into a single JSON object and ignoring unmapped columns.
>     - Supports all schema types, including nested JSON objects.
>     - Provides links to [Datasets overview](/docs/datasets/overview) and [Create Dataset and run experiments](/docs/datasets/get-started).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f0cfd55486c1523f6a3041887b92b3a4a2642b9f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->