### PR TITLE
docs: add prompt commit changelog; add datasets csv upload gif

### DIFF
--- a/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
+++ b/pages/changelog/2025-01-27-Dataset-Items-csv-upload.mdx
@@ -3,7 +3,7 @@ date: 2025-01-27
 title: Dataset CSV upload
 description: Create your Datasets in seconds
 author: Marlies
-# ogCloudflareVideo: xxx
+ogCloudflareVideo: b5c2ebab7e4f65ca6b4809b8ca03a185
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";

--- a/pages/changelog/2025-01-28-prompt-commit-messages.mdx
+++ b/pages/changelog/2025-01-28-prompt-commit-messages.mdx
@@ -1,0 +1,25 @@
+---
+date: 2025-01-28
+title: Commit Messages on Prompt Versions
+description: Document your updates to prompts  
+author: Marlies
+ogCloudflareVideo: 2b1ce8c01198efb773d5d084c723e050
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { FileCode, BookOpen, GitCommit } from "lucide-react"
+
+<ChangelogHeader />
+
+When creating a new version of a prompt, you can now add a commit message to document your changes. This makes it easier to track the evolution of your prompts and understand why specific changes were made while maintaining a clear history of prompt iterations and the reasoning behind each update.
+
+**Learn more**
+
+<Cards num={2}>
+  <Card title="Prompts" href="/docs/prompts/get-started" icon={<GitCommit />} />
+  <Card
+    title="API Reference"
+    href="https://api.reference.langfuse.com"
+    icon={<BookOpen />}
+  />
+</Cards>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for prompt commit messages and updates dataset CSV upload entry with a video link.
> 
>   - **Changelog Updates**:
>     - Adds `2025-01-28-prompt-commit-messages.mdx` to document the ability to add commit messages when creating new prompt versions.
>     - Updates `2025-01-27-Dataset-Items-csv-upload.mdx` to include a video link for CSV upload feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2e66bce35efa6c0e24cb7e53ee0153d6eccad589. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->