### PR TITLE
docs: change time of town hall

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -204,7 +204,7 @@ const config: DocsThemeConfig = {
         <span className="sm:hidden">Wednesday: Langfuse Town Hall →</span>
         {/* desktop */}
         <span className="hidden sm:inline">
-        Wednesday: Langfuse Town Hall, 10am PT / 7pm CET →
+        Wednesday: Langfuse Town Hall, 11am PT / 8pm CET →
         </span>
       </Link>
     ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Langfuse Town Hall time in `theme.config.tsx` from `10am PT / 7pm CET` to `11am PT / 8pm CET`.
> 
>   - **Docs**:
>     - Update Langfuse Town Hall time from `10am PT / 7pm CET` to `11am PT / 8pm CET` in `theme.config.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 678f0238ecbb88a0afd6b1cde118d03cde75c71d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->