### PR TITLE
docs: change links to api docs

### DIFF
--- a/pages/changelog/2024-02-19-metrics-api-endpoint.mdx
+++ b/pages/changelog/2024-02-19-metrics-api-endpoint.mdx
@@ -28,7 +28,7 @@ Optional filters
 - `userId` to filter by [user](/docs/tracing-features/users)
 - `tags` to filter by [tags](/docs/tracing-features/tags)
 
-See [API reference](https://api.reference.langfuse.com/#get-/api/public/metrics/daily) for more details.
+See [API reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/metrics/daily) for more details.
 
 Do you miss any other GET API routes or metrics on this one? Add them to our [idea board](/ideas)!
 

--- a/pages/cn.mdx
+++ b/pages/cn.mdx
@@ -68,7 +68,7 @@ Langfuse 提供一系列功能，可在人工智能产品的整个周期中为�
 
 - **框架支持**：与 [DeepSeek](/docs/integrations/deepseek), [LangChain](/docs/integrations/langchain/tracing)、[LlamaIndex](/docs/integrations/llama-index/get-started) 和 [AWS Bedrock](/docs/integrations/amazon-bedrock) 等流行的 LLM 框架集成。
 - **工具支持**：与 [Dify](/docs/integrations/dify) 或 [LobeChat](/docs/integrations/lobechat) 等无代码构建工具集成。
-- **应用程序接口（API**）：利用我们开放且功能强大的[应用程序接口](https://api.reference.langfuse.com/#get-/api/public/comments)进行自定义集成和工作流程自动化。
+- **应用程序接口（API**）：利用我们开放且功能强大的[应用程序接口](https://api.reference.langfuse.com/#tag/comments/GET/api/public/comments)进行自定义集成和工作流程自动化。
 
 ## **开始使用 Langfuse**
 

--- a/pages/cn.mdx
+++ b/pages/cn.mdx
@@ -68,7 +68,7 @@ Langfuse 提供一系列功能，可在人工智能产品的整个周期中为�
 
 - **框架支持**：与 [DeepSeek](/docs/integrations/deepseek), [LangChain](/docs/integrations/langchain/tracing)、[LlamaIndex](/docs/integrations/llama-index/get-started) 和 [AWS Bedrock](/docs/integrations/amazon-bedrock) 等流行的 LLM 框架集成。
 - **工具支持**：与 [Dify](/docs/integrations/dify) 或 [LobeChat](/docs/integrations/lobechat) 等无代码构建工具集成。
-- **应用程序接口（API**）：利用我们开放且功能强大的[应用程序接口](https://api.reference.langfuse.com/#tag/comments/GET/api/public/comments)进行自定义集成和工作流程自动化。
+- **应用程序接口（API**）：利用我们开放且功能强大的[应用程序接口](https://api.reference.langfuse.com/)进行自定义集成和工作流程自动化。
 
 ## **开始使用 Langfuse**
 
@@ -82,7 +82,7 @@ Langfuse 提供一系列功能，可在人工智能产品的整个周期中为�
 
 ### **探索文档：**
 
-访问我们的[文档](https://docs.langfuse.com/)，了解如何将 Langfuse 与 [OpenAI](/docs/integrations/openai/python/get-started) 或 [Langchain](/docs/integrations/langchain/tracing) 等本机集成进行设置，或使用我们的 [API](https://api.reference.langfuse.com/#get-/api/public/comments) 或[底层 SDK](/docs/sdk/python/low-level-sdk) 跟踪任何模型。
+访问我们的[文档](https://docs.langfuse.com/)，了解如何将 Langfuse 与 [OpenAI](/docs/integrations/openai/python/get-started) 或 [Langchain](/docs/integrations/langchain/tracing) 等本机集成进行设置，或使用我们的 [API](https://api.reference.langfuse.com/) 或[底层 SDK](/docs/sdk/python/low-level-sdk) 跟踪任何模型。
 
 ### **仪表您的应用程序：**
 

--- a/pages/docs/analytics/daily-metrics-api.mdx
+++ b/pages/docs/analytics/daily-metrics-api.mdx
@@ -10,7 +10,7 @@ GET /api/public/metrics/daily
 
 Via the **Daily Metrics API**, you can retrieve aggregated daily usage and cost metrics from Langfuse for downstream use, e.g., in analytics, billing, and rate-limiting. The API allows you to filter by application type, user, or tags for tailored data retrieval.
 
-See [API reference](https://api.reference.langfuse.com/#get-/api/public/metrics/daily) for more details.
+See [API reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/metrics/daily) for more details.
 
 ## Overview
 

--- a/pages/jp.mdx
+++ b/pages/jp.mdx
@@ -65,7 +65,7 @@ Langfuse は、生成 AI プロダクトの全サイクルをサポートする�
 
 - **フレームワークのサポート**：[LangChain](/docs/integrations/langchain/tracing)、[LlamaIndex](/docs/integrations/llama-index/get-started)、[AWS Bedrock など](/docs/integrations/amazon-bedrock) の一般的な LLM フレームワークと統合。
 - **ツールのサポート**：Dify や[Langflow](/docs/integrations/langflow)のようなノーコードビルダーと統合できます。
-- **API**：カスタム統合やワークフロー自動化のためのオープンで強力な[API](https://api.reference.langfuse.com/#tag/comments/GET/api/public/comments)をご利用ください。
+- **API**：カスタム統合やワークフロー自動化のためのオープンで強力な[API](https://api.reference.langfuse.com/)をご利用ください。
 
 ## **Langfuse を使い始める**
 

--- a/pages/jp.mdx
+++ b/pages/jp.mdx
@@ -65,7 +65,7 @@ Langfuse は、生成 AI プロダクトの全サイクルをサポートする�
 
 - **フレームワークのサポート**：[LangChain](/docs/integrations/langchain/tracing)、[LlamaIndex](/docs/integrations/llama-index/get-started)、[AWS Bedrock など](/docs/integrations/amazon-bedrock) の一般的な LLM フレームワークと統合。
 - **ツールのサポート**：Dify や[Langflow](/docs/integrations/langflow)のようなノーコードビルダーと統合できます。
-- **API**：カスタム統合やワークフロー自動化のためのオープンで強力な[API](https://api.reference.langfuse.com/#get-/api/public/comments)をご利用ください。
+- **API**：カスタム統合やワークフロー自動化のためのオープンで強力な[API](https://api.reference.langfuse.com/#tag/comments/GET/api/public/comments)をご利用ください。
 
 ## **Langfuse を使い始める**
 

--- a/pages/kr.mdx
+++ b/pages/kr.mdx
@@ -68,7 +68,7 @@ Langfuse는 AI 제품의 전체 주기를 지원하는 일련의 기능을 제�
 
 - **프레임워크 지원**: [LangChain](/docs/integrations/langchain/tracing), [LlamaIndex](/docs/integrations/llama-index/get-started), [AWS Bedrock과](/docs/integrations/amazon-bedrock) 같은 인기 있는 LLM 프레임워크와 통합하세요.
 - **도구 지원**: [Dify](/docs/integrations/dify) 또는 [Langflow와](/docs/integrations/langflow) 같은 노코드 빌더와 통합하세요.
-- **API**: 사용자 지정 통합 및 워크플로 자동화를 위한 개방적이고 강력한 [API를](https://api.reference.langfuse.com/#get-/api/public/comments) 활용하세요.
+- **API**: 사용자 지정 통합 및 워크플로 자동화를 위한 개방적이고 강력한 [API를](https://api.reference.langfuse.com/) 활용하세요.
 
 ## **Langfuse 시작하기**
 
@@ -82,7 +82,7 @@ Langfuse와 함께 여정을 시작하는 방법은 간단합니다:
 
 ### **문서 살펴보기:**
 
-[문서에](https://docs.langfuse.com/) 액세스하여 [OpenAI](/docs/integrations/openai/python/get-started) 또는 [Langchain과](/docs/integrations/langchain/tracing) 같은 기본 통합을 통해 Langfuse를 설정하는 방법에 대한 가이드를 확인하거나, [API](https://api.reference.langfuse.com/#get-/api/public/comments) 또는 [로우레벨 SDK를](/docs/sdk/python/low-level-sdk) 사용하여 모든 모델을 추적할 수 있습니다.
+[문서에](https://docs.langfuse.com/) 액세스하여 [OpenAI](/docs/integrations/openai/python/get-started) 또는 [Langchain과](/docs/integrations/langchain/tracing) 같은 기본 통합을 통해 Langfuse를 설정하는 방법에 대한 가이드를 확인하거나, [API](https://api.reference.langfuse.com/) 또는 [로우레벨 SDK를](/docs/sdk/python/low-level-sdk) 사용하여 모든 모델을 추적할 수 있습니다.
 
 ### **애플리케이션을 계측하세요:**
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update API documentation links across multiple language files for consistency and accuracy.
> 
>   - **Documentation Links**:
>     - Update API reference link in `2024-02-19-metrics-api-endpoint.mdx` and `daily-metrics-api.mdx` to `https://api.reference.langfuse.com/#tag/metrics/GET/api/public/metrics/daily`.
>     - Update API reference link in `cn.mdx`, `jp.mdx`, and `kr.mdx` to `https://api.reference.langfuse.com/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for dcc9c91885cd9f04b70f74b61c2936786ec93007. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->