### PR TITLE
docs: changelog new api reference

### DIFF
--- a/pages/changelog/2025-01-30-new-api-reference.mdx
+++ b/pages/changelog/2025-01-30-new-api-reference.mdx
@@ -11,6 +11,6 @@ import { FileCode, BookOpen, GitCommit } from "lucide-react";
 
 <ChangelogHeader />
 
-The Langfuse API is important to power customized use cases (see [Why langfuse?](/why)). With the new API Reference, it is now easier to get started and explore the API.
+The Langfuse API is important to power customized use cases (see [Why langfuse?](/why)). The new API Reference makes it easier to get started and explore the API.
 
 [api.reference.langfuse.com](https://api.reference.langfuse.com)

--- a/pages/changelog/2025-01-30-new-api-reference.mdx
+++ b/pages/changelog/2025-01-30-new-api-reference.mdx
@@ -1,0 +1,16 @@
+---
+date: 2025-01-30
+title: New API Reference
+description: Langfuse now has a new API Reference with interactive examples.
+author: Marc
+ogCloudflareVideo: 3fd29aa7787e2999e32ec5e3b09144c2
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { FileCode, BookOpen, GitCommit } from "lucide-react";
+
+<ChangelogHeader />
+
+The Langfuse API is important to power customized use cases (see [Why langfuse?](/why)). With the new API Reference, it is now easier to get started and explore the API.
+
+[api.reference.langfuse.com](https://api.reference.langfuse.com)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a changelog entry for the new API Reference with interactive examples in `2025-01-30-new-api-reference.mdx`.
> 
>   - **Documentation**:
>     - Adds `2025-01-30-new-api-reference.mdx` to `pages/changelog` for the new API Reference.
>     - Highlights interactive examples and ease of use for Langfuse API.
>     - Includes a link to the new API Reference site.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1fe105e0e8de987babacf2d2e982587ad714237e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->