### PR TITLE
chore(deps): bump deps of gh actions for bundlesize workflow

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -61,13 +61,13 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: .next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v8
         if: success() && github.event.number
         with:
           workflow: nextjs_bundle_analysis.yml


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump dependencies in `nextjs_bundle_analysis.yml` for `actions/upload-artifact` to v4 and `dawidd6/action-download-artifact` to v8.
> 
>   - **Dependencies**:
>     - Bump `actions/upload-artifact` from v3 to v4 in `nextjs_bundle_analysis.yml`.
>     - Bump `dawidd6/action-download-artifact` from v6 to v8 in `nextjs_bundle_analysis.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1da91e968f45cb013ea2011c4f83138fbb78d1bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->