### PR TITLE
docs: changelog o3-mini

### DIFF
--- a/pages/changelog/2025-01-31-o3-mini-support.mdx
+++ b/pages/changelog/2025-01-31-o3-mini-support.mdx
@@ -1,0 +1,21 @@
+---
+date: 2025-01-31
+title: OpenAI o3-mini support for playground and cost tracking
+description: Two hours ago, OpenAI released the latest version of their o3-mini model. Langfuse now supports this model in both the LLM playground and cost tracking.
+author: Marc
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Some highlights about o3-mini from the [OpenAI release notes](https://openai.com/index/openai-o3-mini/):
+
+- Performance: Matches o1 in math, coding, and science; responds 24% faster.
+- Developer Features: Supports function calling, structured outputs, and developer messages.
+- Reasoning Effort Levels: Offers low, medium, and high options to balance speed and thoroughness.
+
+## Learn more
+
+- [Langfuse LLM playground](/docs/playground)
+- [Langfuse model usage and cost tracking](/docs/model-usage-and-cost)

--- a/pages/docs/playground.mdx
+++ b/pages/docs/playground.mdx
@@ -44,7 +44,7 @@ You can either start from scratch or jump into the playground from an existing p
 
 ## Supported Models
 
-Currently the playground supports the following models by default. You may configure additional custom model names when adding your LLM API Key in the Langfuse project settings.
+Currently the playground supports the following models by default. You may configure additional custom model names when adding your LLM API Key in the Langfuse project settings, e.g. when using a custom model or proxy.
 
 export function ModelList() {
   const openAIModels = [
@@ -53,6 +53,12 @@ export function ModelList() {
     "gpt-4o-2024-05-13",
     "gpt-4o-mini",
     "gpt-4o-mini-2024-07-18",
+    "o3-mini",
+    "o3-mini-2025-01-31",
+    "o1-preview",
+    "o1-preview-2024-09-12",
+    "o1-mini",
+    "o1-mini-2024-09-12",
     "gpt-4-turbo-preview",
     "gpt-4-1106-preview",
     "gpt-4-0613",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for OpenAI o3-mini model in Langfuse playground and cost tracking, updating changelog and supported models list.
> 
>   - **Changelog**:
>     - Adds `2025-01-31-o3-mini-support.mdx` to document support for OpenAI o3-mini model in playground and cost tracking.
>     - Highlights o3-mini's performance, developer features, and reasoning effort levels.
>   - **Playground Documentation**:
>     - Updates `playground.mdx` to include `o3-mini` and `o3-mini-2025-01-31` in the list of supported models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3d741838cc284ee2d7bc3f42e3c41f72e3100df4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->