### PR TITLE
chore: remove note on strict otel ratelimits

### DIFF
--- a/pages/docs/opentelemetry/example-openllmetry.md
+++ b/pages/docs/opentelemetry/example-openllmetry.md
@@ -19,8 +19,8 @@ LANGFUSE_PUBLIC_KEY=""
 LANGFUSE_SECRET_KEY=""
 LANGFUSE_AUTH=base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
 
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel" # EU data region
-# os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel" # US data region
+os.environ["TRACELOOP_BASE_URL"] = "https://cloud.langfuse.com/api/public/otel" # EU data region
+# os.environ["TRACELOOP_BASE_URL"] = "https://us.cloud.langfuse.com/api/public/otel" # US data region
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
 
 # your openai key

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -18,7 +18,6 @@ description: How to connect Langfuse with Opentelemetry.
 
 OpenTelemetry support in Langfuse is experimental.
 All APIs may change at any point in time without prior notice.
-On Langfuse Cloud, we have strict rate-limits in place for OpenTelemetry span ingestion.
 
 The public beta is intended to gather feedback and improve the integration based on your needs.
 Please share all feedback in the [OpenTelemetry Support GitHub Discussion](https://github.com/orgs/langfuse/discussions/2509).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes note on strict OpenTelemetry rate limits and updates environment variable names in documentation.
> 
>   - **Documentation**:
>     - Removes note on strict rate-limits for OpenTelemetry span ingestion in `get-started.mdx`.
>     - Updates environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` to `TRACELOOP_BASE_URL` in `example-openllmetry.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for afcaa90767808efe8d1081d89dc6b72d73159f77. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->