### PR TITLE
docs: add trace linking note in openai functions example

### DIFF
--- a/cookbook/prompt_management_openai_functions.ipynb
+++ b/cookbook/prompt_management_openai_functions.ipynb
@@ -254,7 +254,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Use Langfuse prompt to construct the `summarize_story` example function."
+        "Use Langfuse prompt to construct the `summarize_story` example function.\n",
+        "\n",
+        "**Note:** You can link the generation in Langfuse Tracing to the prompt version by passing the `langfuse_prompt` parameter to the `create` method. Have a look at our [prompt management docs](https://langfuse.com/docs/prompts/get-started#link-with-langfuse-tracing-optional) to learn how to link prompt and generation with other integrations and SDKs."
       ]
     },
     {

--- a/pages/guides/cookbook/prompt_management_openai_functions.md
+++ b/pages/guides/cookbook/prompt_management_openai_functions.md
@@ -129,6 +129,8 @@ client = OpenAI()
 
 Use Langfuse prompt to construct the `summarize_story` example function.
 
+**Note:** You can link the generation in Langfuse Tracing to the prompt version by passing the `langfuse_prompt` parameter to the `create` method. Have a look at our [prompt management docs](https://langfuse.com/docs/prompts/get-started#link-with-langfuse-tracing-optional) to learn how to link prompt and generation with other integrations and SDKs.
+
 
 ```python
 import json


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in the OpenAI functions example about linking prompt generation with Langfuse Tracing.
> 
>   - **Documentation**:
>     - Adds a note in `prompt_management_openai_functions.md` about linking prompt generation with Langfuse Tracing using the `langfuse_prompt` parameter in the `create` method.
>     - Provides a link to the prompt management docs for further details on linking prompts and generations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4d90aeb3d6a62a8eb504a34a3d8ab3ec6bdbe4b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->