### PR TITLE
docs: add link to otel docs to otel blog post

### DIFF
--- a/pages/blog/2024-10-opentelemetry-for-llm-observability.mdx
+++ b/pages/blog/2024-10-opentelemetry-for-llm-observability.mdx
@@ -18,6 +18,12 @@ import { BlogHeader } from "@/components/blog/BlogHeader";
 
 import Image from "next/image";
 
+<Callout type="info">
+
+**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to icnrease compatibility with emerging OTel-based instrumentation libraries.
+
+</Callout>
+
 ## Introduction to <Image src="/images/blog/2024-10-opentelemetry-for-llms/opentelemetry-logo.svg" alt="OpenTelemetry Logo" width={140} height={30} className="inline-block" />
 
 [OpenTelemetry](https://opentelemetry.io/) is an open-source observability framework designed to handle the instrumentation of applications for collecting traces, metrics, and logs. It helps developers monitor and troubleshoot complex systems by providing standardized tools and practices for data collection and analysis.
@@ -127,6 +133,12 @@ We are committed to OTel and are happy to contribute to the SIG. We will continu
 <Callout>
   If you are interested in contributing to our OTel efforts, join the [GitHub
   Discussion thread](https://github.com/orgs/langfuse/discussions/2509).
+</Callout>
+
+<Callout type="info">
+
+**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to icnrease compatibility with emerging OTel-based instrumentation libraries.
+
 </Callout>
 
 ## Get Started

--- a/pages/blog/2024-10-opentelemetry-for-llm-observability.mdx
+++ b/pages/blog/2024-10-opentelemetry-for-llm-observability.mdx
@@ -20,7 +20,7 @@ import Image from "next/image";
 
 <Callout type="info">
 
-**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to icnrease compatibility with emerging OTel-based instrumentation libraries.
+**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to increase compatibility with emerging OTel-based instrumentation libraries.
 
 </Callout>
 
@@ -137,7 +137,7 @@ We are committed to OTel and are happy to contribute to the SIG. We will continu
 
 <Callout type="info">
 
-**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to icnrease compatibility with emerging OTel-based instrumentation libraries.
+**Update**: We have released a [Langfuse OTel Collector](/docs/opentelemetry/get-started) to increase compatibility with emerging OTel-based instrumentation libraries.
 
 </Callout>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds informational callouts to a blog post about the release of a Langfuse OTel Collector.
> 
>   - **Content Update**:
>     - Adds informational callouts in `2024-10-opentelemetry-for-llm-observability.mdx` about the release of a [Langfuse OTel Collector](/docs/opentelemetry/get-started).
>     - Callouts are placed after the introduction and before the 'Get Started' section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ef0d58c7e82e6572b3a43b6cce50fa44a734b8b8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->