### PR TITLE
docs(api): access via sdks

### DIFF
--- a/pages/docs/api.mdx
+++ b/pages/docs/api.mdx
@@ -50,3 +50,50 @@ Example:
 ```bash
 curl -u public-key:secret-key https://cloud.langfuse.com/api/public/projects
 ```
+
+## Access via SDKs
+
+Both the Langfuse [Python SDK](/docs/sdk/python/decorators) and the [JS/TS SDK](/docs/sdk/typescript/guide) provide a strongly-typed wrapper around our public REST API for your convenience. The API methods are accessible via the `api` property on the Langfuse client instance in both SDKs.
+
+<Callout type="info">When fetching [prompts](/docs/prompts/get-started#use-prompt), please use the `get_prompt` (Python) / `getPrompt` (JS/TS) methods on the Langfuse client to benefit from client-side caching, automatic retries, and fallbacks</Callout>
+
+<Tabs items={["Python SDK", "JS/TS SDK"]}>
+<Tab>
+When using the [decorator-based integration](/docs/sdk/python/decorators):
+
+```python
+from langfuse.decorators import langfuse_context
+
+# fetch a trace
+langfuse_context.client_instance.api.trace.get(trace_id)
+
+# async client via asyncio
+await langfuse_context.client_instance.async_api.trace(trace_id)
+```
+
+When using the [low-level SDK](/docs/sdk/python/low-level-sdk):
+
+```python
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+...
+# fetch a trace
+langfuse.api.trace.get(trace_id)
+
+# async client via asyncio
+await langfuse.async_api.trace(trace_id)
+```
+</Tab>
+
+<Tab>
+```ts
+import { Langfuse } from "langfuse"
+
+const langfuse = new Langfuse()
+...
+// fetch a trace
+await langfuse.api.traceGet(traceId)
+```
+</Tab>
+</Tabs>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for accessing Langfuse API via Python and JS/TS SDKs in `api.mdx`.
> 
>   - **Documentation**:
>     - Adds section "Access via SDKs" in `api.mdx`.
>     - Provides examples for using Langfuse API with Python SDK (decorator-based and low-level) and JS/TS SDK.
>     - Includes info on using `get_prompt`/`getPrompt` methods for client-side caching, retries, and fallbacks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for caed1e96ec647771e0e4cbde98a3cc909280547e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->