### PR TITLE
docs: add otel example using the python sdk

### DIFF
--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -202,5 +202,9 @@
   {
     "notebook": "integration_crewai.ipynb",
     "docsPath": "docs/integrations/crewai"
+  },
+  {
+    "notebook": "otel_integration_python_sdk.ipynb",
+    "docsPath": "docs/opentelemetry/example-python-sdk"
   }
 ]

--- a/cookbook/otel_integration_python_sdk.ipynb
+++ b/cookbook/otel_integration_python_sdk.ipynb
@@ -1,0 +1,176 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kMEC0LbPyAdh"
+      },
+      "source": [
+        "# Example: Using OpenTelemetry SDK with Langfuse OTel API\n",
+        "\n",
+        "This notebook demonstrates how to use any OpenTelemetry SDK to send traces to Langfuse. [OpenTelemetry](https://opentelemetry.io/) is a CNCF project that provides a standard way to collect distributed traces and metrics from applications.\n",
+        "\n",
+        "Langfuse operates as an [OpenTelemetry Backend](/docs/opentelemetry/get-started) and maps the received traces to the Langfuse data model according to the OpenTelemetry Gen AI Conventions. See the [property mapping documentation](/docs/opentelemetry/get-started#property-mapping) for details on how attributes are parsed.\n",
+        "\n",
+        "In this example, we'll use the [Python OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/) to send traces with GenAI attributes to Langfuse.\n",
+        "\n",
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "blZJc8AEw-QD"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-api"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Y4_CLoWNr-4B"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import base64\n",
+        "\n",
+        "from opentelemetry import trace\n",
+        "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
+        "from opentelemetry.sdk.trace import TracerProvider\n",
+        "from opentelemetry.sdk.trace.export import BatchSpanProcessor\n",
+        "\n",
+        "LANGFUSE_OTEL_API = \"https://cloud.langfuse.com/api/public/otel\" # EU Data Region\n",
+        "# LANGFUSE_OTEL_API = \"https://us.cloud.langfuse.com/api/public/otel\" # US Data Region\n",
+        "\n",
+        "LANGFUSE_PUBLIC_KEY=\"pk-lf-xxx\"\n",
+        "LANGFUSE_SECRET_KEY=\"sk-lf-xxx\"\n",
+        "\n",
+        "\n",
+        "LANGFUSE_AUTH = base64.b64encode(f\"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}\".encode()).decode()\n",
+        "provider = TracerProvider()\n",
+        "processor = BatchSpanProcessor(\n",
+        "    OTLPSpanExporter(\n",
+        "        endpoint=f\"{LANGFUSE_OTEL_API}/v1/traces\",\n",
+        "        headers={\"Authorization\": f\"Basic {LANGFUSE_AUTH}\"},\n",
+        "    )\n",
+        ")\n",
+        "provider.add_span_processor(processor)\n",
+        "trace.set_tracer_provider(provider)\n",
+        "tracer = trace.get_tracer(__name__)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bGnKN6iN3I87"
+      },
+      "source": [
+        "## Flattened attributes\n",
+        "\n",
+        "Export a span with flattened attribute names following the GenAI semantic conventions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "tGh1O4C1xUEZ"
+      },
+      "outputs": [],
+      "source": [
+        "with tracer.start_as_current_span(\"GenAI Attributes\") as span:\n",
+        "    span.set_attribute(\"gen_ai.prompt.0.role\", \"system\")\n",
+        "    span.set_attribute(\"gen_ai.prompt.0.content\", \"You are a coding assistant that helps write Python code.\")\n",
+        "    span.set_attribute(\"gen_ai.prompt.1.role\", \"user\") \n",
+        "    span.set_attribute(\"gen_ai.prompt.1.content\", \"Write a function that calculates the factorial of a number.\")\n",
+        "\n",
+        "    span.set_attribute(\"gen_ai.completion.0.role\", \"assistant\")\n",
+        "    span.set_attribute(\"gen_ai.completion.0.content\", \"\"\"def factorial(n):\n",
+        "    if n == 0:\n",
+        "        return 1\n",
+        "    return n * factorial(n-1)\"\"\")\n",
+        "\n",
+        "    span.set_attribute(\"gen_ai.request.model\", \"gpt-4\")\n",
+        "    span.set_attribute(\"gen_ai.request.temperature\", 0.7)\n",
+        "    span.set_attribute(\"gen_ai.usage.prompt_tokens\", 25)\n",
+        "    span.set_attribute(\"gen_ai.usage.completion_tokens\", 45)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "P9JE4GFb4GfW"
+      },
+      "source": [
+        "[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/226b5e5ea844788de7bced27fc475c62?timestamp=2025-02-06T10%3A57%3A11.141Z&observation=db79c5e1372feffc)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GZflRTLi3K2w"
+      },
+      "source": [
+        "## JSON-serialized attributes\n",
+        "\n",
+        "Export a span using JSON-serialized attributes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "HIrRPcYt2-ij"
+      },
+      "outputs": [],
+      "source": [
+        "with tracer.start_as_current_span(\"GenAI JSON-Serialized Attributes\") as span:\n",
+        "    span.set_attribute(\n",
+        "        \"gen_ai.prompt_json\",\n",
+        "        json.dumps(\n",
+        "            [\n",
+        "                {\"role\": \"system\", \"content\": \"You are an expert art historian and critic.\"},\n",
+        "                {\"role\": \"user\", \"content\": \"Describe Vincent van Gogh's 'The Starry Night' painting in detail.\"},\n",
+        "            ]\n",
+        "        ),\n",
+        "    )\n",
+        "    span.set_attribute(\n",
+        "        \"gen_ai.completion_json\",\n",
+        "        json.dumps(\n",
+        "            [\n",
+        "                {\"role\": \"assistant\", \"content\": \"The Starry Night (1889) is one of Van Gogh's most famous works, painted during his stay at the Saint-Paul-de-Mausole asylum. The painting depicts a night scene with a swirling sky filled with stars and a crescent moon over a village. The sky is dominated by luminous yellow stars and a spiral pattern of blue clouds. In the foreground, a dark cypress tree reaches toward the sky like a flame. The village below is quiet and peaceful, with a prominent church spire piercing the night. The brushwork is bold and expressive, with thick impasto strokes creating a sense of movement and energy throughout the composition.\"},\n",
+        "            ]\n",
+        "        ),\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Aou_RE774CNG"
+      },
+      "source": [
+        "[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019440a211c0ee6739d0be1f9101ac3f?timestamp=2025-02-06T10%3A57%3A44.540Z&observation=a09151c5814c1803)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/pages/docs/opentelemetry/_meta.tsx
+++ b/pages/docs/opentelemetry/_meta.tsx
@@ -1,5 +1,6 @@
 export default {
   "get-started": "Overview",
+  "example-python-sdk": "Example: OTel Python SDK",
   "example-openlit": "Example: OpenLIT",
   "example-openllmetry": "Example: OpenLLMetry",
 };

--- a/pages/docs/opentelemetry/example-python-sdk.md
+++ b/pages/docs/opentelemetry/example-python-sdk.md
@@ -1,0 +1,98 @@
+# Example: Using OpenTelemetry SDK with Langfuse OTel API
+
+This notebook demonstrates how to use any OpenTelemetry SDK to send traces to Langfuse. [OpenTelemetry](https://opentelemetry.io/) is a CNCF project that provides a standard way to collect distributed traces and metrics from applications.
+
+Langfuse operates as an [OpenTelemetry Backend](/docs/opentelemetry/get-started) and maps the received traces to the Langfuse data model according to the OpenTelemetry Gen AI Conventions. See the [property mapping documentation](/docs/opentelemetry/get-started#property-mapping) for details on how attributes are parsed.
+
+In this example, we'll use the [Python OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/) to send traces with GenAI attributes to Langfuse.
+
+## Setup
+
+
+```python
+%pip install opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-api
+```
+
+
+```python
+import json
+import base64
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+LANGFUSE_OTEL_API = "https://cloud.langfuse.com/api/public/otel" # EU Data Region
+# LANGFUSE_OTEL_API = "https://us.cloud.langfuse.com/api/public/otel" # US Data Region
+
+LANGFUSE_PUBLIC_KEY="pk-lf-xxx"
+LANGFUSE_SECRET_KEY="sk-lf-xxx"
+
+
+LANGFUSE_AUTH = base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
+provider = TracerProvider()
+processor = BatchSpanProcessor(
+    OTLPSpanExporter(
+        endpoint=f"{LANGFUSE_OTEL_API}/v1/traces",
+        headers={"Authorization": f"Basic {LANGFUSE_AUTH}"},
+    )
+)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer(__name__)
+```
+
+## Flattened attributes
+
+Export a span with flattened attribute names following the GenAI semantic conventions
+
+
+```python
+with tracer.start_as_current_span("GenAI Attributes") as span:
+    span.set_attribute("gen_ai.prompt.0.role", "system")
+    span.set_attribute("gen_ai.prompt.0.content", "You are a coding assistant that helps write Python code.")
+    span.set_attribute("gen_ai.prompt.1.role", "user") 
+    span.set_attribute("gen_ai.prompt.1.content", "Write a function that calculates the factorial of a number.")
+
+    span.set_attribute("gen_ai.completion.0.role", "assistant")
+    span.set_attribute("gen_ai.completion.0.content", """def factorial(n):
+    if n == 0:
+        return 1
+    return n * factorial(n-1)""")
+
+    span.set_attribute("gen_ai.request.model", "gpt-4")
+    span.set_attribute("gen_ai.request.temperature", 0.7)
+    span.set_attribute("gen_ai.usage.prompt_tokens", 25)
+    span.set_attribute("gen_ai.usage.completion_tokens", 45)
+```
+
+[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/226b5e5ea844788de7bced27fc475c62?timestamp=2025-02-06T10%3A57%3A11.141Z&observation=db79c5e1372feffc)
+
+## JSON-serialized attributes
+
+Export a span using JSON-serialized attributes
+
+
+```python
+with tracer.start_as_current_span("GenAI JSON-Serialized Attributes") as span:
+    span.set_attribute(
+        "gen_ai.prompt_json",
+        json.dumps(
+            [
+                {"role": "system", "content": "You are an expert art historian and critic."},
+                {"role": "user", "content": "Describe Vincent van Gogh's 'The Starry Night' painting in detail."},
+            ]
+        ),
+    )
+    span.set_attribute(
+        "gen_ai.completion_json",
+        json.dumps(
+            [
+                {"role": "assistant", "content": "The Starry Night (1889) is one of Van Gogh's most famous works, painted during his stay at the Saint-Paul-de-Mausole asylum. The painting depicts a night scene with a swirling sky filled with stars and a crescent moon over a village. The sky is dominated by luminous yellow stars and a spiral pattern of blue clouds. In the foreground, a dark cypress tree reaches toward the sky like a flame. The village below is quiet and peaceful, with a prominent church spire piercing the night. The brushwork is bold and expressive, with thick impasto strokes creating a sense of movement and energy throughout the composition."},
+            ]
+        ),
+    )
+```
+
+[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019440a211c0ee6739d0be1f9101ac3f?timestamp=2025-02-06T10%3A57%3A44.540Z&observation=a09151c5814c1803)

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -61,9 +61,7 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://cloud.langfuse.com/api/public/otel/v
 
 ## Custom via OpenTelemetry SDKs
 
-You can use the OpenTelemetry SDKs to directly export traces to Langfuse with the configuration mentioned above.
-
-Thereby, Language support of Langfuse is extended to other languages than the ones supported by the [Langfuse SDKs](/docs/sdk/overview) (Python and JS/TS).
+You can use the OpenTelemetry SDKs to directly export traces to Langfuse with the configuration mentioned above. Thereby, Language support of Langfuse is extended to other languages than the ones supported by the [Langfuse SDKs](/docs/sdk/overview) (Python and JS/TS).
 
 As a reference, see [this example notebook](/docs/opentelemetry/example-python-sdk) on how to use the OpenTelemetry Python SDK to export traces to Langfuse.
 

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -59,6 +59,14 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://cloud.langfuse.com/api/public/otel/v
 
 </Callout>
 
+## Custom via OpenTelemetry SDKs
+
+You can use the OpenTelemetry SDKs to directly export traces to Langfuse with the configuration mentioned above.
+
+Thereby, Language support of Langfuse is extended to other languages than the ones supported by the [Langfuse SDKs](/docs/sdk/overview) (Python and JS/TS).
+
+As a reference, see [this example notebook](/docs/opentelemetry/example-python-sdk) on how to use the OpenTelemetry Python SDK to export traces to Langfuse.
+
 ## Use OpenTelemetry GenAI Instrumentation Libraries
 
 Any OpenTelemetry compatible instrumentation can be used to export traces to Langfuse. Check out the following end-to-end examples of popular instrumentation SDKs to get started:

--- a/pages/docs/sdk/python/low-level-sdk.md
+++ b/pages/docs/sdk/python/low-level-sdk.md
@@ -64,8 +64,7 @@ langfuse = Langfuse()
 | `LANGFUSE_MAX_RETRIES`, `max_retries` | Specifies the number of times the SDK should retry network requests for tracing. | 3
 | `LANGFUSE_TIMEOUT`, `timeout` | Timeout in seonds for network requests | 20
 | `LANGFUSE_SAMPLE_RATE`, `sample_rate` | [Sample rate](/docs/tracing-features/sampling) for tracing. | 1.0
-| `LANGFUSE_MAX_EVENT_SIZE_BYTES`, | Configure max event size before input / output / metadata is truncated. Please use in self-hosted environments only.| 1_000_000
-| `LANGFUSE_MAX_BATCH_SIZE_BYTES`, | Configure max batch size per ingestion request. Please use in self-hosted environments only.| 2_500_000
+
 
 ## Tracing
 

--- a/pages/guides/cookbook/otel_integration_python_sdk.md
+++ b/pages/guides/cookbook/otel_integration_python_sdk.md
@@ -1,0 +1,98 @@
+# Example: Using OpenTelemetry SDK with Langfuse OTel API
+
+This notebook demonstrates how to use any OpenTelemetry SDK to send traces to Langfuse. [OpenTelemetry](https://opentelemetry.io/) is a CNCF project that provides a standard way to collect distributed traces and metrics from applications.
+
+Langfuse operates as an [OpenTelemetry Backend](/docs/opentelemetry/get-started) and maps the received traces to the Langfuse data model according to the OpenTelemetry Gen AI Conventions. See the [property mapping documentation](/docs/opentelemetry/get-started#property-mapping) for details on how attributes are parsed.
+
+In this example, we'll use the [Python OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/) to send traces with GenAI attributes to Langfuse.
+
+## Setup
+
+
+```python
+%pip install opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-api
+```
+
+
+```python
+import json
+import base64
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+LANGFUSE_OTEL_API = "https://cloud.langfuse.com/api/public/otel" # EU Data Region
+# LANGFUSE_OTEL_API = "https://us.cloud.langfuse.com/api/public/otel" # US Data Region
+
+LANGFUSE_PUBLIC_KEY="pk-lf-xxx"
+LANGFUSE_SECRET_KEY="sk-lf-xxx"
+
+
+LANGFUSE_AUTH = base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
+provider = TracerProvider()
+processor = BatchSpanProcessor(
+    OTLPSpanExporter(
+        endpoint=f"{LANGFUSE_OTEL_API}/v1/traces",
+        headers={"Authorization": f"Basic {LANGFUSE_AUTH}"},
+    )
+)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer(__name__)
+```
+
+## Flattened attributes
+
+Export a span with flattened attribute names following the GenAI semantic conventions
+
+
+```python
+with tracer.start_as_current_span("GenAI Attributes") as span:
+    span.set_attribute("gen_ai.prompt.0.role", "system")
+    span.set_attribute("gen_ai.prompt.0.content", "You are a coding assistant that helps write Python code.")
+    span.set_attribute("gen_ai.prompt.1.role", "user") 
+    span.set_attribute("gen_ai.prompt.1.content", "Write a function that calculates the factorial of a number.")
+
+    span.set_attribute("gen_ai.completion.0.role", "assistant")
+    span.set_attribute("gen_ai.completion.0.content", """def factorial(n):
+    if n == 0:
+        return 1
+    return n * factorial(n-1)""")
+
+    span.set_attribute("gen_ai.request.model", "gpt-4")
+    span.set_attribute("gen_ai.request.temperature", 0.7)
+    span.set_attribute("gen_ai.usage.prompt_tokens", 25)
+    span.set_attribute("gen_ai.usage.completion_tokens", 45)
+```
+
+[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/226b5e5ea844788de7bced27fc475c62?timestamp=2025-02-06T10%3A57%3A11.141Z&observation=db79c5e1372feffc)
+
+## JSON-serialized attributes
+
+Export a span using JSON-serialized attributes
+
+
+```python
+with tracer.start_as_current_span("GenAI JSON-Serialized Attributes") as span:
+    span.set_attribute(
+        "gen_ai.prompt_json",
+        json.dumps(
+            [
+                {"role": "system", "content": "You are an expert art historian and critic."},
+                {"role": "user", "content": "Describe Vincent van Gogh's 'The Starry Night' painting in detail."},
+            ]
+        ),
+    )
+    span.set_attribute(
+        "gen_ai.completion_json",
+        json.dumps(
+            [
+                {"role": "assistant", "content": "The Starry Night (1889) is one of Van Gogh's most famous works, painted during his stay at the Saint-Paul-de-Mausole asylum. The painting depicts a night scene with a swirling sky filled with stars and a crescent moon over a village. The sky is dominated by luminous yellow stars and a spiral pattern of blue clouds. In the foreground, a dark cypress tree reaches toward the sky like a flame. The village below is quiet and peaceful, with a prominent church spire piercing the night. The brushwork is bold and expressive, with thick impasto strokes creating a sense of movement and energy throughout the composition."},
+            ]
+        ),
+    )
+```
+
+[Example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019440a211c0ee6739d0be1f9101ac3f?timestamp=2025-02-06T10%3A57%3A44.540Z&observation=a09151c5814c1803)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for using OpenTelemetry Python SDK with Langfuse, including setup and trace export examples.
> 
>   - **Documentation**:
>     - Adds `example-python-sdk.md` to provide a guide on using OpenTelemetry SDK with Langfuse, including setup and examples of exporting traces with GenAI attributes.
>     - Adds `otel_integration_python_sdk.md` with similar content for the cookbook section.
>   - **Routing and Metadata**:
>     - Updates `_routes.json` to include `otel_integration_python_sdk.ipynb`.
>     - Updates `_meta.tsx` to include "Example: OTel Python SDK".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 638d55a6f73f6d22e51c27d54222973bf30f4252. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->