### PR TITLE
docs: edit VAPI page

### DIFF
--- a/pages/docs/integrations/vapi.mdx
+++ b/pages/docs/integrations/vapi.mdx
@@ -60,6 +60,12 @@ Click **Save** to update your credentials.
 
 Once you've added your credentials, you should start seeing traces in your Langfuse dashboard for every conversation your agents have.
 
+<Callout type="info" emoji="💡">
+
+The content of the `Generation` type Spans in Langfuse is the text model output directly (not the transcription of the text-to-speech model).
+
+</Callout>
+
 <Frame border>
   ![Example trace of Vapi conversation in
   Langfuse](/images/docs/vapi-integration-example-trace.png)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a callout in `vapi.mdx` about `Generation` type Spans content in Langfuse.
> 
>   - **Documentation**:
>     - Adds a callout in `vapi.mdx` explaining that `Generation` type Spans in Langfuse contain the text model output directly, not the transcription of the text-to-speech model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a38c1b1957d29b635364dca458097fddf1d2bf58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->