### PR TITLE
docs: remove star cta form faq page

### DIFF
--- a/pages/faq/all/api-authentication.mdx
+++ b/pages/faq/all/api-authentication.mdx
@@ -15,9 +15,3 @@ You need to authenticate with the API using [Basic Auth](https://en.wikipedia.or
 ```bash
 curl -u "<public_key>:secret_key" https://cloud.langfuse.com/api/public/projects
 ```
-
-
-
-import GitHubStarCTA from "@/components-mdx/github-cta.mdx";
-
-<GitHubStarCTA />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `GitHubStarCTA` component from `api-authentication.mdx` in the FAQ section.
> 
>   - **Documentation**:
>     - Remove `GitHubStarCTA` component from `api-authentication.mdx` in the FAQ section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e7f0a53683e08c736e8645700e948b339f5f5e67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->