### PR TITLE
fix: add redirect for selfhosting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -230,6 +230,7 @@ const nonPermanentRedirects = [
   ["/docs/deployment/v3", "/docs/deployment/v3/overview"],
 
   // new self-hosting section
+  ["/docs/self-hosting", "/self-hosting"],
   ["/docs/deployment/feature-overview", "/self-hosting/license-key"],
   ["/docs/deployment/local", "/self-hosting/local"],
   ["/docs/deployment/self-host", "/self-hosting"],


### PR DESCRIPTION
Fixes #1252
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add redirect from `/docs/self-hosting` to `/self-hosting` in `next.config.mjs`.
> 
>   - **Redirects**:
>     - Add redirect from `/docs/self-hosting` to `/self-hosting` in `next.config.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f7340823ac0a8b701cede18457654b3deddcf676. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->