### PR TITLE
fix: update otel exporter docs to otlphttp

### DIFF
--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -168,9 +168,9 @@ processors:
     check_interval: 5s
 
 exporters:
-  otlp/langfuse:
-    endpoint: "cloud.langfuse.com/api/public/otel" # EU data region
-    # endpoint: "us.cloud.langfuse.com/api/public/otel" # US data region
+  otlphttp/langfuse:
+    endpoint: "https://cloud.langfuse.com/api/public/otel" # EU data region
+    # endpoint: "https://us.cloud.langfuse.com/api/public/otel" # US data region
     headers:
       Authorization: "Basic ${AUTH_STRING}" # Previously encoded API keys
 
@@ -179,7 +179,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlp/langfuse]
+      exporters: [otlphttp/langfuse]
 ```
 
 ## Property Mapping [#property-mapping]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update OpenTelemetry exporter configuration in documentation to use `otlphttp` instead of `otlp`.
> 
>   - **Documentation**:
>     - Update OpenTelemetry exporter configuration in `get-started.mdx` to use `otlphttp` instead of `otlp`.
>     - Change `exporters` from `otlp/langfuse` to `otlphttp/langfuse`.
>     - Update `service` pipelines to use `otlphttp/langfuse` exporter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 392555202858148f6142800c8750701d281ddb23. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->