### PR TITLE
docs: update crewai docs

### DIFF
--- a/cookbook/integration_crewai.ipynb
+++ b/cookbook/integration_crewai.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install langfuse opnelit crewai crewai_tools"
+    "%pip install langfuse openlit crewai crewai_tools"
    ]
   },
   {

--- a/pages/docs/integrations/crewai.md
+++ b/pages/docs/integrations/crewai.md
@@ -19,7 +19,7 @@ We'll walk through a simple example of using CrewAI and integrating it with Lang
 
 
 ```python
-%pip install langfuse opnelit crewai crewai_tools
+%pip install langfuse openlit crewai crewai_tools
 ```
 
 ### Step 2: Set Up Environment Variables

--- a/pages/guides/cookbook/integration_crewai.md
+++ b/pages/guides/cookbook/integration_crewai.md
@@ -19,7 +19,7 @@ We'll walk through a simple example of using CrewAI and integrating it with Lang
 
 
 ```python
-%pip install langfuse opnelit crewai crewai_tools
+%pip install langfuse openlit crewai crewai_tools
 ```
 
 ### Step 2: Set Up Environment Variables


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in package name from `opnelit` to `openlit` in CrewAI documentation.
> 
>   - **Docs**:
>     - Fix typo in package name from `opnelit` to `openlit` in `crewai.md` and `integration_crewai.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 38c7406d2ace6836cf3e34696217d7195aa24328. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->