### PR TITLE
docs: add community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "town-hall",
-  //   dismissible: true,
-  //   content: (
-  //     <Link href="https://lu.ma/ov28jfk3">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">Wednesday: Langfuse Town Hall →</span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //       Wednesday: Langfuse Town Hall, 10am PT / 7pm CET →
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+  banner: {
+    key: "community-hour",
+    dismissible: true,
+    content: (
+      <Link href="https://lu.ma/f4v0qo34">
+        {/* mobile */}
+        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
+        {/* desktop */}
+        <span className="hidden sm:inline">
+        Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
+        </span>
+      </Link>
+    ),
+  },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a dismissible community hour banner in `theme.config.tsx` linking to an external event page.
> 
>   - **Banner**:
>     - Adds a new banner with key `community-hour` in `theme.config.tsx`.
>     - Banner is dismissible and links to `https://lu.ma/f4v0qo34`.
>     - Displays different text for mobile and desktop: "Wednesday: Langfuse Community Hour" with time details for desktop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e4b454e9dc495e8280fc53ad068d1a3da938124b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->