### PR TITLE
chore: document the used postgres schema

### DIFF
--- a/pages/self-hosting/infrastructure/postgres.mdx
+++ b/pages/self-hosting/infrastructure/postgres.mdx
@@ -15,7 +15,7 @@ Follow one of the [deployment guides](/self-hosting#deployment-options) to get s
 Langfuse requires a persistent Postgres database to store its state.
 You can use a managed service on AWS, Azure, or GCP, or host it yourself.
 
-Langfuse supports Postgres versions >= 12.
+Langfuse supports Postgres versions >= 12 and uses the `public` schema in the selected database.
 
 ## Use Cases
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `postgres.mdx` to specify Langfuse uses the `public` schema in Postgres databases.
> 
>   - **Documentation**:
>     - Update `postgres.mdx` to specify that Langfuse uses the `public` schema in Postgres databases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 71068b4168c9a7da81091f691bea20a579d7fded. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->