### PR TITLE
docs: add Quarkus LangChain4j integration

### DIFF
--- a/pages/docs/integrations/_meta.tsx
+++ b/pages/docs/integrations/_meta.tsx
@@ -31,5 +31,6 @@ export default {
   smolagents: "Smolagents",
   crewai: "CrewAI",
   "spring-ai": "Spring AI",
+  "quarkus-langchain4j": "Quarkus LangChain4j",
   other: "More Ways to Integrate",
 };

--- a/pages/docs/integrations/overview.mdx
+++ b/pages/docs/integrations/overview.mdx
@@ -50,6 +50,7 @@ Objective:
 | [smolagents](/docs/integrations/smolagents)         | Agents             | Open source AI agents framework.                                                                                        |
 | [CrewAI](/docs/integrations/crewai)                 | Agents             | Multi agent framework for agent collaboration and tool use.                                                             |
 | [Spring AI](/docs/integrations/spring-ai)           | Library             | Spring-based framework for AI development with built-in OTel tracing for AI calls. |
+| [Quarkus LangChain4j](/docs/integrations/quarkus-langchain4j)           | Library             | A Quarkus based integration of LangChain4j for AI development with built-in OTel tracing for AI calls |
 | [Firecrawl](/docs/integrations/other/firecrawl)     | Web Scraping       | Web scraper that allows you to turn entire websites into LLM-ready markdown. |
 | [OpenRouter](/docs/integrations/other/openrouter)   | Framework          | OpenAI-compatible completion API to +280 language models |
 | [xAI / Grok](/docs/integrations/other/xai)         | Model              | xAI's Grok models |

--- a/pages/docs/integrations/quarkus-langchain4j.mdx
+++ b/pages/docs/integrations/quarkus-langchain4j.mdx
@@ -1,0 +1,102 @@
+---
+title: Integrating Langfuse with Quarkus LangChain4j Using OpenTelemetry
+description: Learn how to integrate Langfuse with Quarkus LangChain4j using OpenTelemetry for enhanced observability and performance monitoring in your AI applications.
+---
+
+# Integrating Langfuse with Quarkus LangChain4j
+
+This guide shows how to integrate [Langfuse](/) with [Quarkus LangChain4j](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) using OpenTelemetry.
+
+**Quarkus LangChain4j**: A [Quarkus](https://quarkus.io/) based integration of [LangChain4j](https://docs.langchain4j.dev/) for AI development with built-in OTel tracing for AI calls.
+
+**Langfuse**: Open source LLM engineering platform for observability, evals and prompt management.
+
+<Callout type="info" emoji="🐞">
+Please raise an Issue on [GitHub](/issues) if you face any issues with this integration.
+</Callout>
+
+## Step 1: Enable OpenTelemetry in Quarkus LangChain4j
+
+**Add Quarkus OpenTelemetry Dependency** (Maven):
+
+For Maven, add the following to your `pom.xml` (Gradle users can include equivalent coordinates in Gradle):
+
+```xml
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-opentelemetry</artifactId>
+</dependency>
+```
+
+**Configure OpenTelemetry exporter** (`application.properties`):
+
+```properties
+quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+```
+
+With these configurations and dependencies in place, your Quarkus application is ready to produce OpenTelemetry traces. Quarkus LangChain4j internal calls (e.g. when you invoke a chat model) will be recorded as spans.
+
+Each span will carry attributes like `gen_ai.operation.name`, `gen_ai.system` (the provider, e.g. “openai”), model names, token usage, etc., and – since we enabled them – events for the prompt and response content
+
+## Step 2: Configure Langfuse
+
+Now that your Quarkus application is emitting OpenTelemetry trace data, the next step is to direct that data to Langfuse.
+
+Langfuse will act as the “backend” for OpenTelemetry in this setup – essentially replacing a typical Jaeger/Zipkin/OTel-Collector with Langfuse’s trace ingestion API.
+
+
+**Langfuse Setup**
+   - Sign up for [Langfuse Cloud](https://cloud.langfuse.com/) or [self-hosted Langfuse](https://langfuse.com/self-hosting).
+   - Set the OTLP endpoint (e.g. `https://cloud.langfuse.com/api/public/otel`) and API keys.
+
+Configure these via environment variables:
+
+```bash
+QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: set this to the Langfuse OTLP URL (e.g. https://cloud.langfuse.com/api/public/otel).
+QUARKUS_OTEL_EXPORTER_OTLP_HEADERS: set this to Authorization=Basic <base64 public:secret>.
+```
+
+<Callout type="info">
+You can find more on authentication via Basic Auth [here](/docs/opentelemetry/get-started).
+</Callout>
+
+## Step 3: Run a Test AI Operation
+
+Start your Quarkus application. Trigger an AI operation that Quarkus LangChain4j handles – for example, call a service or controller that uses a `ChatModel` to generate a completion.
+
+**Note**: A complete example can be found [here](https://github.com/langfuse/langfuse-examples/tree/main/applications/quarkus-langchain4j-demo)
+
+```java
+@RegisterAiService(tools = EmailService.class)
+public interface MyAiService {
+
+    /**
+     * Ask the LLM to create a poem about the given topic.
+     *
+     * @param topic the topic of the poem
+     * @param lines the number of line of the poem
+     * @return the poem
+     */
+    @SystemMessage("You are a professional poet")
+    @UserMessage("""
+            Write a single poem about {topic}. The poem should be {lines} lines long and your response should only include the poem itself, nothing else.
+            Then send this poem by email. Your response should include the poem.
+            """)
+    String writeAPoem(String topic, int lines);
+
+}
+
+@Singleton
+public class Startup {
+
+    public void writeAPoem(@Observes StartupEvent event, MyAiService service) {
+        System.out.println(service.writeAPoem("LangFuse", 4));
+    }
+}
+```
+
+## Troubleshooting
+
+**No Traces:**
+  - Check the logs of the application for potential clues
+  - Check [Troubleshooting](https://langfuse.com/self-hosting/troubleshooting#missing-events-after-post-apipublicingestion) page


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for integrating Langfuse with Quarkus LangChain4j using OpenTelemetry, including a new guide and updates to integration overview and metadata.
> 
>   - **Documentation**:
>     - Adds `quarkus-langchain4j.mdx` for integrating Langfuse with Quarkus LangChain4j using OpenTelemetry.
>     - Provides step-by-step guide for enabling OpenTelemetry, configuring Langfuse, and running a test AI operation.
>   - **Integration Overview**:
>     - Updates `overview.mdx` to include Quarkus LangChain4j in the list of integrations.
>   - **Metadata**:
>     - Updates `_meta.tsx` to add "Quarkus LangChain4j" entry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ba6dee70ee5ab4dbafdec05ff088da1add6b9fd4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->