### PR TITLE
docs: add any llm to playground

### DIFF
--- a/pages/docs/playground.mdx
+++ b/pages/docs/playground.mdx
@@ -104,6 +104,12 @@ export function ModelList() {
           platform and enabled in your GCP account through the `Custom model
           names` section in the LLM API Key creation form.
         </li>
+        <li>
+          <strong>Amazon Bedrock:</strong> All Amazon Bedrock models are supported.
+        </li>
+        <li>
+          <strong>Any model that supports the OpenAI API:</strong> The Playground and LLM-as-a-Judge evaluations can be used by any framework that supports the OpenAI API schema such as Groq, OpenRouter, LiteLLM, Hugging Face, and more. Just replace the API Base URL with the appropriate endpoint for the model you want to use and add the providers API keys for authentication.
+        </li>
       </ul>
     </div>
   );
@@ -111,7 +117,6 @@ export function ModelList() {
 
 <ModelList />
 
-The playground also supports all Amazon Bedrock models.
 
 ## GitHub Discussions
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `playground.mdx` to include Amazon Bedrock and OpenAI API-compatible models, and remove redundant Amazon Bedrock support line.
> 
>   - **Documentation Update**:
>     - Adds support for Amazon Bedrock models in `playground.mdx`.
>     - Adds support for any model supporting the OpenAI API schema, including Groq, OpenRouter, LiteLLM, Hugging Face, etc., in `playground.mdx`.
>     - Removes redundant line about Amazon Bedrock support in `playground.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 557dedeea0a3e44b9da9ed35608affd15edc1d69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->