### PR TITLE
docs: add community hou banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "town-hall",
-  //   dismissible: true,
-  //   content: (
-  //     <Link href="https://lu.ma/ov28jfk3">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">Wednesday: Langfuse Town Hall →</span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //       Wednesday: Langfuse Town Hall, 10am PT / 7pm CET →
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+  banner: {
+    key: "town-hall",
+    dismissible: true,
+    content: (
+      <Link href="https://lu.ma/s22z25ed">
+        {/* mobile */}
+        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
+        {/* desktop */}
+        <span className="hidden sm:inline">
+        Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
+        </span>
+      </Link>
+    ),
+  },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a dismissible banner for "Langfuse Community Hour" in `theme.config.tsx`, linking to the event page.
> 
>   - **Banner Addition**:
>     - Adds a new banner for "Langfuse Community Hour" in `theme.config.tsx`.
>     - Banner is dismissible and links to `https://lu.ma/s22z25ed`.
>     - Displays different text for mobile and desktop views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 98d15d4cf5b4e8e71ab86a1179f95af4f73764e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->