### PR TITLE
docs(changelog): add google ai studio support

### DIFF
--- a/pages/changelog/2025-02-25-google-ai-studio-support.mdx
+++ b/pages/changelog/2025-02-25-google-ai-studio-support.mdx
@@ -1,0 +1,18 @@
+---
+date: 2025-02-25
+title: Google AI Studio support
+description: Langfuse now supports access to Gemini models via Google AI Studio.
+author: Hassieb
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Google has recently released the production ready version of the Gemini 2 models. While access to Gemini models in Langfuse was previously available via Google Vertex AI, users can now directly access Gemini models from Google AI Studio without a GCP account simply by providing their API key from the Google AI Studio settings page.
+
+## Try it out
+
+- [Langfuse LLM playground](/docs/playground)
+- [Langfuse LLM-as-a-judge](/docs/scores/model-based-evals)
+- [Langfuse model usage and cost tracking](/docs/model-usage-and-cost)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for Google AI Studio support, enabling direct Gemini model access without GCP account.
> 
>   - **Documentation**:
>     - Adds `2025-02-25-google-ai-studio-support.mdx` to changelog for Google AI Studio support.
>     - Describes direct access to Gemini models via Google AI Studio without GCP account.
>     - Includes links to Langfuse LLM playground, LLM-as-a-judge, and model usage and cost tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 436c60b62cee3749290e1135fb42cf9e71c68612. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->