### PR TITLE
docs: add changelog for in-product onboarding

### DIFF
--- a/pages/changelog/2025-02-26-in-product-onboarding-screens.mdx
+++ b/pages/changelog/2025-02-26-in-product-onboarding-screens.mdx
@@ -1,0 +1,13 @@
+---
+date: 2025-02-26
+title: Improved In-Product Onboarding
+description: New onboarding screens that introduce the capabilities of Langfuse features that are not yet used within a project.
+author: Marc
+ogCloudflareVideo: f7f06203fc902f6538d0f7688f17ab1c
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+We've added new in-product onboarding screens that highlight features and capabilities that aren't yet being used in your project. These contextual guides help you discover all Langfuse features without needing to read the entire documentation.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for new in-product onboarding screens highlighting unused Langfuse features.
> 
>   - **Changelog**:
>     - Adds `2025-02-26-in-product-onboarding-screens.mdx` to document new in-product onboarding screens.
>     - Describes new screens that highlight unused Langfuse features in projects.
>     - Includes author `Marc` and a video reference `f7f06203fc902f6538d0f7688f17ab1c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c9d64cf4610984ea11f295f525c58f5f1c64c342. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->