### PR TITLE
chore: document environment in otel docs

### DIFF
--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -266,6 +266,7 @@ The following Langfuse specific properties are supported:
 | `langfuse.tags`           | `tags`            | `string[]` | `true`         | The [tags](/docs/tracing-features/tags) for the request.                                                                             |
 | `langfuse.prompt.name`    | `promptName`      | `string`   | `false`        | The [prompt name](/docs/prompts/get-started) for the request.                                                                        |
 | `langfuse.prompt.version` | `promptVersion`   | `int`      | `false`        | The [prompt version](/docs/prompts/get-started) for the request.                                                                     |
+| `langfuse.environment`    | `environment`     | `string`   | `false`        | The environment for the request.                                                                                                     |
 
 Below, we present a non-exhaustive list of additional mappings that Langfuse applies.
 These mappings are based on OTel GenAI semantic conventions and vendor-specific implementations that deviate from these conventions:
@@ -289,6 +290,8 @@ These mappings are based on OTel GenAI semantic conventions and vendor-specific 
 | `output.value`                | `output`            | Output field. Used by OpenInference based traces.                                                                                                                |
 | `mlflow.spanInputs`           | `input`             | Input field. Used by MLflow based traces.                                                                                                                        |
 | `mlflow.spanOutputs`          | `output`            | Output field. Used by MLflow based traces.                                                                                                                       |
+| `deployment.environment.name` | `environment`       | The environment for the request.                                                                                                                                 |
+| `deployment.environment`      | `environment`       | The environment for the request.                                                                                                                                 |
 
 ## Troubleshooting
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for `environment` property mapping in OpenTelemetry integration with Langfuse.
> 
>   - **Documentation**:
>     - Adds `langfuse.environment` to the Langfuse specific properties table in `get-started.mdx`.
>     - Adds `deployment.environment.name` and `deployment.environment` to the additional mappings table in `get-started.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 192357a8115cbb061936198808f45a01f6258f54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->