### PR TITLE
docs: update Otel instrumentations

### DIFF
--- a/cookbook/otel_integration_arize.ipynb
+++ b/cookbook/otel_integration_arize.ipynb
@@ -42,19 +42,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "import base64\n",
     "\n",
-    "LANGFUSE_PUBLIC_KEY=\"pk-lf-...\"\n",
-    "LANGFUSE_SECRET_KEY=\"sk-lf-...\"\n",
-    "LANGFUSE_AUTH=base64.b64encode(f\"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}\".encode()).decode()\n",
+    "LANGFUSE_PUBLIC_KEY = \"pk-lf-...\"\n",
+    "LANGFUSE_SECRET_KEY = \"sk-lf-...\"\n",
+    "LANGFUSE_AUTH = base64.b64encode(f\"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}\".encode()).decode()\n",
     "\n",
-    "# your openai key\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
+    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = \"https://cloud.langfuse.com/api/public/otel\" # 🇪🇺 EU data region\n",
+    "# os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = \"https://us.cloud.langfuse.com/api/public/otel\" # 🇺🇸 US data region\n",
+    "\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\"\n",
+    "\n",
+    "# Set your OpenAI API key.\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from opentelemetry.sdk.trace import TracerProvider\n",
+    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
+    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "\n",
+    "trace_provider = TracerProvider()\n",
+    "trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))\n",
+    "\n",
+    "# Sets the global default tracer provider\n",
+    "from opentelemetry import trace\n",
+    "trace.set_tracer_provider(trace_provider)\n",
+    "\n",
+    "# Creates a tracer from the global tracer provider\n",
+    "tracer = trace.get_tracer(__name__)"
    ]
   },
   {
@@ -63,20 +96,37 @@
    "source": [
     "## Step 3: Initialize Instrumentation\n",
     "\n",
-    "Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python) by passing in the protocol, endpoint, and headers. The use the `SmolagentsInstrumentor` to instrument your Smolagents application. (You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing))"
+    "Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python). By setting `set_global_tracer_provider = False`, we can use the OpenTelemetry tracer provider we created in the previous step. Then, we can use the `OpenAIInstrumentor` to instrument the OpenAI SDK. You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🔭 OpenTelemetry Tracing Details 🔭\n",
+      "|  Phoenix Project: default\n",
+      "|  Span Processor: SimpleSpanProcessor\n",
+      "|  Collector Endpoint: localhost:4317\n",
+      "|  Transport: gRPC\n",
+      "|  Transport Headers: {'authorization': '****', 'user-agent': '****'}\n",
+      "|  \n",
+      "|  Using a default SpanProcessor. `add_span_processor` will overwrite this default.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
+    "# from phoenix.otel import register\n",
     "from phoenix.otel import register\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
     "\n",
     "# configure the Phoenix tracer\n",
-    "register(protocol=\"http/protobuf\", endpoint=\"https://cloud.langfuse.com/api/public/otel/v1/traces\", headers={\"Authorization\": f\"Basic {LANGFUSE_AUTH}\"})\n",
+    "register(set_global_tracer_provider = False,)\n",
     "\n",
     "OpenAIInstrumentor().instrument()"
    ]
@@ -96,6 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openai\n",
     "response = openai.OpenAI().chat.completions.create(\n",
     "    messages=[\n",
     "        {\n",
@@ -112,9 +163,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Passing User and Session ID (Optional)\n",
+    "## Step 5: Pass Additional Attributes (Optional)\n",
     "\n",
-    "To pass user and session id, you can use the [using_attributes](https://docs.arize.com/arize/llm-tracing/how-to-tracing-manual/hybrid-instrumentation#using_attributes) module. This allows you to group traces into [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions) and assign [User IDs](https://langfuse.com/docs/tracing-features/users)."
+    "Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping)."
    ]
   },
   {
@@ -125,29 +176,31 @@
    "source": [
     "import openai\n",
     "\n",
-    "from openinference.instrumentation import using_attributes\n",
-    "with using_attributes(\n",
-    "    session_id = \"my-session-id\",\n",
-    "    user_id = \"my-user-name\",\n",
-    "):\n",
+    "with tracer.start_as_current_span(\"OpenAI-Trace\") as span:\n",
+    "    span.set_attribute(\"langfuse.user.id\", \"user-123\")\n",
+    "    span.set_attribute(\"langfuse.session.id\", \"123456789\")\n",
+    "    span.set_attribute(\"langfuse.tags\", [\"staging\", \"demo\"])\n",
+    "    span.set_attribute(\"langfuse.prompt.name\", \"test-1\")\n",
     "\n",
-    "  response = openai.OpenAI().chat.completions.create(\n",
-    "      messages=[\n",
-    "          {\n",
-    "              \"role\": \"user\",\n",
-    "              \"content\": \"How does enhanced LLM observability improve AI debugging?\",\n",
-    "          }\n",
-    "      ],\n",
-    "      model=\"gpt-4o-mini\",\n",
-    "  )\n",
-    "  print(response.choices[0].message.content)"
+    "    # You application code below:\n",
+    "\n",
+    "    response = openai.OpenAI().chat.completions.create(\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": \"How does enhanced LLM observability improve AI debugging?\",\n",
+    "            }\n",
+    "        ],\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "    )\n",
+    "    print(response.choices[0].message.content)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 5: View the Traces in Langfuse\n",
+    "## Step 6: View the Traces in Langfuse\n",
     "\n",
     "After running the above code, you can inspect the generated traces on your Langfuse dashboard:\n",
     "\n",

--- a/cookbook/otel_integration_openlit.ipynb
+++ b/cookbook/otel_integration_openlit.ipynb
@@ -65,7 +65,35 @@
         "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\"\n",
         "\n",
         "# Set your OpenAI API key.\n",
-        "os.environ[\"OPENAI_API_KEY\"] = \"\""
+        "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from opentelemetry.sdk.trace import TracerProvider\n",
+        "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
+        "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+        "\n",
+        "trace_provider = TracerProvider()\n",
+        "trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))\n",
+        "\n",
+        "# Sets the global default tracer provider\n",
+        "from opentelemetry import trace\n",
+        "trace.set_tracer_provider(trace_provider)\n",
+        "\n",
+        "# Creates a tracer from the global tracer provider\n",
+        "tracer = trace.get_tracer(__name__)"
       ]
     },
     {
@@ -74,9 +102,30 @@
       "source": [
         "*Explanation:* This block configures the necessary environment variables. The Langfuse keys are combined and base64 encoded to form an authentication token that is then set in the OTLP headers. Additionally, the OpenTelemetry endpoint is provided to direct trace data to Langfuse's backend.\n",
         "\n",
-        "## Step 3: Initialize Instrumentation and make a Chat Completion Request\n",
+        "## Step 3: Initialize Instrumentation\n",
         "\n",
-        "With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in Langfuse's observability dashboard."
+        "With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. We set `tracer=tracer` to use the tracer we created in the previous step."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import openlit\n",
+        "\n",
+        "# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.\n",
+        "openlit.init(tracer=tracer, disable_batch=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4: Make a Chat Completion Request\n",
+        "\n",
+        "For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in the Langfuse dashboard."
       ]
     },
     {
@@ -92,10 +141,6 @@
       "outputs": [],
       "source": [
         "from openai import OpenAI\n",
-        "import openlit\n",
-        "\n",
-        "# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.\n",
-        "openlit.init(disable_batch=True)\n",
         "\n",
         "# Create an instance of the OpenAI client.\n",
         "openai_client = OpenAI()\n",
@@ -118,7 +163,44 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Step 4: See Traces in Langfuse\n",
+        "## Step 5: Pass Additional Attributes (Optional)\n",
+        "\n",
+        "Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import openai\n",
+        "\n",
+        "with tracer.start_as_current_span(\"OpenAI-Trace\") as span:\n",
+        "    span.set_attribute(\"langfuse.user.id\", \"user-123\")\n",
+        "    span.set_attribute(\"langfuse.session.id\", \"123456789\")\n",
+        "    span.set_attribute(\"langfuse.tags\", [\"staging\", \"demo\"])\n",
+        "    span.set_attribute(\"langfuse.prompt.name\", \"test-1\")\n",
+        "\n",
+        "    # You application code below:\n",
+        "\n",
+        "    response = openai.OpenAI().chat.completions.create(\n",
+        "        messages=[\n",
+        "            {\n",
+        "                \"role\": \"user\",\n",
+        "                \"content\": \"How does enhanced LLM observability improve AI debugging?\",\n",
+        "            }\n",
+        "        ],\n",
+        "        model=\"gpt-4o-mini\",\n",
+        "    )\n",
+        "    print(response.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 6: See Traces in Langfuse\n",
         "\n",
         "You can view the generated trace data in Langfuse. You can view this [example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/64902f6a5b4f27738be939b7ad38eab3?timestamp=2025-02-02T22%3A09%3A53.053Z) in the Langfuse UI."
       ]
@@ -142,7 +224,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.1"
     }
   },
   "nbformat": 4,

--- a/pages/docs/integrations/smolagents.md
+++ b/pages/docs/integrations/smolagents.md
@@ -102,7 +102,7 @@ manager_agent.run(
 
 ## Step 5: Pass Additional Attributes (Optional)
 
-OpenTelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [Property Mapping Documentation](/docs/opentelemetry/get-started#property-mapping).
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
 
 ```python

--- a/pages/docs/opentelemetry/example-arize.md
+++ b/pages/docs/opentelemetry/example-arize.md
@@ -7,7 +7,7 @@ description: Example cookbook on using the Arize AI SDK to trace your applicatio
 
 Langfuse offers an [OpenTelemetry backend](https://langfuse.com/docs/opentelemetry/get-started) to ingest trace data from your LLM applications. With the Arize SDK and OpenTelemetry, you can log traces from multiple other frameworks to Langfuse. Below is an example of tracing OpenAI to Langfuse, you can find a full list of supported frameworks [here](https://docs.arize.com/phoenix/tracing/integrations-tracing). To make this example work with other frameworks, you just need to change the instrumentor to match the framework. 
 
-> **Arize AI SDK:** Arize AI provides [Openinference](https://github.com/Arize-ai/openinference), a library that is complementary to OpenTelemetry to enable tracing of AI applications. OpenInference can be used with any OpenTelemetry-compatible backend.
+> **Arize AI SDK:** Arize AI provides [Openinference](https://github.com/Arize-ai/openinference), a library that is complimentary to OpenTelemetry to enable tracing of AI applications. OpenInference can be used with any OpenTelemetry-compatible backend. 
 
 ## Step 1: Install Dependencies
 
@@ -29,28 +29,64 @@ Also, add your `OPENAI_API_KEY` as an environment variable.
 import os
 import base64
 
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_SECRET_KEY="sk-lf-..."
-LANGFUSE_AUTH=base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
+LANGFUSE_AUTH = base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
 
-# your openai key
-os.environ["OPENAI_API_KEY"] = "sk-..."
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+# os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
+
+os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+
+# Set your OpenAI API key.
+os.environ["OPENAI_API_KEY"] = "sk-proj-..."
+```
+
+Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables.
+
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+trace_provider = TracerProvider()
+trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+
+# Sets the global default tracer provider
+from opentelemetry import trace
+trace.set_tracer_provider(trace_provider)
+
+# Creates a tracer from the global tracer provider
+tracer = trace.get_tracer(__name__)
 ```
 
 ## Step 3: Initialize Instrumentation
 
-Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python) by passing in the protocol, endpoint, and headers. The use the `SmolagentsInstrumentor` to instrument your Smolagents application. (You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing))
+Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python). By setting `set_global_tracer_provider = False`, we can use the OpenTelemetry tracer provider we created in the previous step. Then, we can use the `OpenAIInstrumentor` to instrument the OpenAI SDK. You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing)
 
 
 ```python
+# from phoenix.otel import register
 from phoenix.otel import register
 from openinference.instrumentation.openai import OpenAIInstrumentor
 
 # configure the Phoenix tracer
-register(protocol="http/protobuf", endpoint="https://cloud.langfuse.com/api/public/otel/v1/traces", headers={"Authorization": f"Basic {LANGFUSE_AUTH}"})
+register(set_global_tracer_provider = False,)
 
 OpenAIInstrumentor().instrument()
 ```
+
+    🔭 OpenTelemetry Tracing Details 🔭
+    |  Phoenix Project: default
+    |  Span Processor: SimpleSpanProcessor
+    |  Collector Endpoint: localhost:4317
+    |  Transport: gRPC
+    |  Transport Headers: {'authorization': '****', 'user-agent': '****'}
+    |  
+    |  Using a default SpanProcessor. `add_span_processor` will overwrite this default.
+    
+
 
 ## Step 4: Execute a Sample LLM Request
 
@@ -58,6 +94,7 @@ With instrumentation enabled, every OpenAI API call will now be traced. The foll
 
 
 ```python
+import openai
 response = openai.OpenAI().chat.completions.create(
     messages=[
         {
@@ -70,33 +107,35 @@ response = openai.OpenAI().chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-## Passing User and Session ID (Optional)
+## Step 5: Pass Additional Attributes (Optional)
 
-To pass user and session id, you can use the [using_attributes](https://docs.arize.com/arize/llm-tracing/how-to-tracing-manual/hybrid-instrumentation#using_attributes) module. This allows you to group traces into [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions) and assign [User IDs](https://langfuse.com/docs/tracing-features/users).
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
 
 ```python
 import openai
 
-from openinference.instrumentation import using_attributes
-with using_attributes(
-    session_id = "my-session-id",
-    user_id = "my-user-name",
-):
+with tracer.start_as_current_span("OpenAI-Trace") as span:
+    span.set_attribute("langfuse.user.id", "user-123")
+    span.set_attribute("langfuse.session.id", "123456789")
+    span.set_attribute("langfuse.tags", ["staging", "demo"])
+    span.set_attribute("langfuse.prompt.name", "test-1")
 
-  response = openai.OpenAI().chat.completions.create(
-      messages=[
-          {
-              "role": "user",
-              "content": "How does enhanced LLM observability improve AI debugging?",
-          }
-      ],
-      model="gpt-4o-mini",
-  )
-  print(response.choices[0].message.content)
+    # You application code below:
+
+    response = openai.OpenAI().chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "How does enhanced LLM observability improve AI debugging?",
+            }
+        ],
+        model="gpt-4o-mini",
+    )
+    print(response.choices[0].message.content)
 ```
 
-## Step 5: View the Traces in Langfuse
+## Step 6: View the Traces in Langfuse
 
 After running the above code, you can inspect the generated traces on your Langfuse dashboard:
 

--- a/pages/docs/opentelemetry/example-openlit.md
+++ b/pages/docs/opentelemetry/example-openlit.md
@@ -36,22 +36,49 @@ os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/publ
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
 
 # Set your OpenAI API key.
-os.environ["OPENAI_API_KEY"] = ""
+os.environ["OPENAI_API_KEY"] = "sk-proj-..."
+```
+
+Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables.
+
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+trace_provider = TracerProvider()
+trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+
+# Sets the global default tracer provider
+from opentelemetry import trace
+trace.set_tracer_provider(trace_provider)
+
+# Creates a tracer from the global tracer provider
+tracer = trace.get_tracer(__name__)
 ```
 
 *Explanation:* This block configures the necessary environment variables. The Langfuse keys are combined and base64 encoded to form an authentication token that is then set in the OTLP headers. Additionally, the OpenTelemetry endpoint is provided to direct trace data to Langfuse's backend.
 
-## Step 3: Initialize Instrumentation and make a Chat Completion Request
+## Step 3: Initialize Instrumentation
 
-With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in Langfuse's observability dashboard.
+With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. We set `tracer=tracer` to use the tracer we created in the previous step.
+
+
+```python
+import openlit
+
+# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.
+openlit.init(tracer=tracer, disable_batch=True)
+```
+
+## Step 4: Make a Chat Completion Request
+
+For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in the Langfuse dashboard.
 
 
 ```python
 from openai import OpenAI
-import openlit
-
-# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.
-openlit.init(disable_batch=True)
 
 # Create an instance of the OpenAI client.
 openai_client = OpenAI()
@@ -70,7 +97,35 @@ chat_completion = openai_client.chat.completions.create(
 print(chat_completion)
 ```
 
-## Step 4: See Traces in Langfuse
+## Step 5: Pass Additional Attributes (Optional)
+
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
+
+
+```python
+import openai
+
+with tracer.start_as_current_span("OpenAI-Trace") as span:
+    span.set_attribute("langfuse.user.id", "user-123")
+    span.set_attribute("langfuse.session.id", "123456789")
+    span.set_attribute("langfuse.tags", ["staging", "demo"])
+    span.set_attribute("langfuse.prompt.name", "test-1")
+
+    # You application code below:
+
+    response = openai.OpenAI().chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "How does enhanced LLM observability improve AI debugging?",
+            }
+        ],
+        model="gpt-4o-mini",
+    )
+    print(response.choices[0].message.content)
+```
+
+## Step 6: See Traces in Langfuse
 
 You can view the generated trace data in Langfuse. You can view this [example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/64902f6a5b4f27738be939b7ad38eab3?timestamp=2025-02-02T22%3A09%3A53.053Z) in the Langfuse UI.
 

--- a/pages/docs/opentelemetry/example-python-sdk.md
+++ b/pages/docs/opentelemetry/example-python-sdk.md
@@ -45,7 +45,7 @@ tracer = trace.get_tracer(__name__)
 
 ## Flattened attributes
 
-OpenTelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span).
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span).
 
 **GenAI Semantic Convention Attributes:**
 

--- a/pages/guides/cookbook/otel_integration_arize.md
+++ b/pages/guides/cookbook/otel_integration_arize.md
@@ -29,28 +29,64 @@ Also, add your `OPENAI_API_KEY` as an environment variable.
 import os
 import base64
 
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_SECRET_KEY="sk-lf-..."
-LANGFUSE_AUTH=base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
+LANGFUSE_AUTH = base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
 
-# your openai key
-os.environ["OPENAI_API_KEY"] = "sk-..."
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+# os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
+
+os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+
+# Set your OpenAI API key.
+os.environ["OPENAI_API_KEY"] = "sk-proj-..."
+```
+
+Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables.
+
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+trace_provider = TracerProvider()
+trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+
+# Sets the global default tracer provider
+from opentelemetry import trace
+trace.set_tracer_provider(trace_provider)
+
+# Creates a tracer from the global tracer provider
+tracer = trace.get_tracer(__name__)
 ```
 
 ## Step 3: Initialize Instrumentation
 
-Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python) by passing in the protocol, endpoint, and headers. The use the `SmolagentsInstrumentor` to instrument your Smolagents application. (You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing))
+Initialize the Arize Phoenix module [`register()`](https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing-python). By setting `set_global_tracer_provider = False`, we can use the OpenTelemetry tracer provider we created in the previous step. Then, we can use the `OpenAIInstrumentor` to instrument the OpenAI SDK. You can replace this with any of the frameworks supported [here](https://docs.arize.com/phoenix/tracing/integrations-tracing)
 
 
 ```python
+# from phoenix.otel import register
 from phoenix.otel import register
 from openinference.instrumentation.openai import OpenAIInstrumentor
 
 # configure the Phoenix tracer
-register(protocol="http/protobuf", endpoint="https://cloud.langfuse.com/api/public/otel/v1/traces", headers={"Authorization": f"Basic {LANGFUSE_AUTH}"})
+register(set_global_tracer_provider = False,)
 
 OpenAIInstrumentor().instrument()
 ```
+
+    🔭 OpenTelemetry Tracing Details 🔭
+    |  Phoenix Project: default
+    |  Span Processor: SimpleSpanProcessor
+    |  Collector Endpoint: localhost:4317
+    |  Transport: gRPC
+    |  Transport Headers: {'authorization': '****', 'user-agent': '****'}
+    |  
+    |  Using a default SpanProcessor. `add_span_processor` will overwrite this default.
+    
+
 
 ## Step 4: Execute a Sample LLM Request
 
@@ -58,6 +94,7 @@ With instrumentation enabled, every OpenAI API call will now be traced. The foll
 
 
 ```python
+import openai
 response = openai.OpenAI().chat.completions.create(
     messages=[
         {
@@ -70,33 +107,35 @@ response = openai.OpenAI().chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-## Passing User and Session ID (Optional)
+## Step 5: Pass Additional Attributes (Optional)
 
-To pass user and session id, you can use the [using_attributes](https://docs.arize.com/arize/llm-tracing/how-to-tracing-manual/hybrid-instrumentation#using_attributes) module. This allows you to group traces into [Langfuse Sessions](https://langfuse.com/docs/tracing-features/sessions) and assign [User IDs](https://langfuse.com/docs/tracing-features/users).
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
 
 ```python
 import openai
 
-from openinference.instrumentation import using_attributes
-with using_attributes(
-    session_id = "my-session-id",
-    user_id = "my-user-name",
-):
+with tracer.start_as_current_span("OpenAI-Trace") as span:
+    span.set_attribute("langfuse.user.id", "user-123")
+    span.set_attribute("langfuse.session.id", "123456789")
+    span.set_attribute("langfuse.tags", ["staging", "demo"])
+    span.set_attribute("langfuse.prompt.name", "test-1")
 
-  response = openai.OpenAI().chat.completions.create(
-      messages=[
-          {
-              "role": "user",
-              "content": "How does enhanced LLM observability improve AI debugging?",
-          }
-      ],
-      model="gpt-4o-mini",
-  )
-  print(response.choices[0].message.content)
+    # You application code below:
+
+    response = openai.OpenAI().chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "How does enhanced LLM observability improve AI debugging?",
+            }
+        ],
+        model="gpt-4o-mini",
+    )
+    print(response.choices[0].message.content)
 ```
 
-## Step 5: View the Traces in Langfuse
+## Step 6: View the Traces in Langfuse
 
 After running the above code, you can inspect the generated traces on your Langfuse dashboard:
 

--- a/pages/guides/cookbook/otel_integration_openlit.md
+++ b/pages/guides/cookbook/otel_integration_openlit.md
@@ -36,22 +36,49 @@ os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/publ
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
 
 # Set your OpenAI API key.
-os.environ["OPENAI_API_KEY"] = ""
+os.environ["OPENAI_API_KEY"] = "sk-proj-..."
+```
+
+Configure `tracer_provider` and add a span processor to export traces to Langfuse. `OTLPSpanExporter()` uses the endpoint and headers from the environment variables.
+
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+trace_provider = TracerProvider()
+trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+
+# Sets the global default tracer provider
+from opentelemetry import trace
+trace.set_tracer_provider(trace_provider)
+
+# Creates a tracer from the global tracer provider
+tracer = trace.get_tracer(__name__)
 ```
 
 *Explanation:* This block configures the necessary environment variables. The Langfuse keys are combined and base64 encoded to form an authentication token that is then set in the OTLP headers. Additionally, the OpenTelemetry endpoint is provided to direct trace data to Langfuse's backend.
 
-## Step 3: Initialize Instrumentation and make a Chat Completion Request
+## Step 3: Initialize Instrumentation
 
-With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in Langfuse's observability dashboard.
+With the environment set up, import the needed libraries and initialize OpenLIT instrumentation. We set `tracer=tracer` to use the tracer we created in the previous step.
+
+
+```python
+import openlit
+
+# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.
+openlit.init(tracer=tracer, disable_batch=True)
+```
+
+## Step 4: Make a Chat Completion Request
+
+For this example, we will make a simple chat completion request to the OpenAI Chat API. This will generate trace data that you can later view in the Langfuse dashboard.
 
 
 ```python
 from openai import OpenAI
-import openlit
-
-# Initialize OpenLIT instrumentation. The disable_batch flag is set to true to process traces immediately.
-openlit.init(disable_batch=True)
 
 # Create an instance of the OpenAI client.
 openai_client = OpenAI()
@@ -70,7 +97,35 @@ chat_completion = openai_client.chat.completions.create(
 print(chat_completion)
 ```
 
-## Step 4: See Traces in Langfuse
+## Step 5: Pass Additional Attributes (Optional)
+
+Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
+
+
+```python
+import openai
+
+with tracer.start_as_current_span("OpenAI-Trace") as span:
+    span.set_attribute("langfuse.user.id", "user-123")
+    span.set_attribute("langfuse.session.id", "123456789")
+    span.set_attribute("langfuse.tags", ["staging", "demo"])
+    span.set_attribute("langfuse.prompt.name", "test-1")
+
+    # You application code below:
+
+    response = openai.OpenAI().chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "How does enhanced LLM observability improve AI debugging?",
+            }
+        ],
+        model="gpt-4o-mini",
+    )
+    print(response.choices[0].message.content)
+```
+
+## Step 6: See Traces in Langfuse
 
 You can view the generated trace data in Langfuse. You can view this [example trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/64902f6a5b4f27738be939b7ad38eab3?timestamp=2025-02-02T22%3A09%3A53.053Z) in the Langfuse UI.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This pull request updates documentation for OpenTelemetry instrumentations, including setup and usage examples for Langfuse integration with various SDKs.
> 
>   - **Documentation Updates**:
>     - Updated OpenTelemetry setup and usage examples in `smolagents.md`, `example-arize.md`, and `example-openlit.md`.
>     - Added configuration for `tracer_provider` and span processor using `OTLPSpanExporter` in `example-arize.md` and `example-openlit.md`.
>     - Updated examples to include setting environment variables for Langfuse API keys and OpenAI API key.
>   - **Code Examples**:
>     - Added code snippets for initializing `TracerProvider` and setting up `OTLPSpanExporter`.
>     - Updated examples to demonstrate passing additional attributes to spans using `set_attribute`.
>     - Included examples of making chat completion requests with OpenAI SDK and tracing them using OpenTelemetry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d2482105ed265ed395a4789266a40fa25877ca06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->