### PR TITLE
feat: add native environment changelog post

### DIFF
--- a/pages/changelog/2025-03-06-native-environments.mdx
+++ b/pages/changelog/2025-03-06-native-environments.mdx
@@ -1,0 +1,17 @@
+---
+date: 2025-03-06
+title: Add support for Native Environments
+description: Use native environment to separate staging, dev, and production systems within the same Langfuse project.
+author: Steffen
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+[Langfuse Native Environments](/docs/tracing-features/environments) allow you to separate your staging, development, or production systems within a single Langfuse project.
+This enables you to share prompts, datasets, and more within a project without mixing the source of your tracing data.
+
+Read our [documentation page](/docs/tracing-features/environments) to learn how to label your traces with the environment they belong to.
+
+If you have any questions or feedback, please share it in our [GitHub discussion](https://github.com/orgs/langfuse/discussions/5005) or via our usual support channels.

--- a/pages/docs/tracing-features/environments.mdx
+++ b/pages/docs/tracing-features/environments.mdx
@@ -97,7 +97,7 @@ To set an environment property globally, you can use resource attributes: `os.en
 
 Alternatively, you can set the environment on a per-span basis:
 
-  ```python
+```python
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 

--- a/pages/docs/tracing-features/environments.mdx
+++ b/pages/docs/tracing-features/environments.mdx
@@ -215,7 +215,7 @@ instrumentor = LlamaIndexInstrumentor(environment="production")
 
 ## Filtering
 
-In the Langfuse UI, you can filter events by environment using the environment filter in the navigation bar. This filter applies across all views in Langfuse (Coming soon).
+In the Langfuse UI, you can filter events by environment using the environment filter in the navigation bar. This filter applies across all views in Langfuse.
 
 See our [API Reference](/docs/api) for details on how to filter by environment on our API.
 

--- a/pages/docs/tracing-features/environments.mdx
+++ b/pages/docs/tracing-features/environments.mdx
@@ -93,7 +93,11 @@ When using [OpenTelemetry](/docs/opentelemetry/get-started), you can set the env
 - `deployment.environment.name`
 - `deployment.environment`
 
-```python
+To set an environment property globally, you can use resource attributes: `os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "langfuse.environment=staging"`.
+
+Alternatively, you can set the environment on a per-span basis:
+
+  ```python
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds changelog entry and updates documentation for new Native Environments feature in Langfuse.
> 
>   - **Changelog**:
>     - Adds `2025-03-06-native-environments.mdx` to document the addition of Native Environments.
>     - Describes the ability to separate staging, dev, and production systems within a Langfuse project.
>   - **Documentation**:
>     - Updates `environments.mdx` to include instructions for setting environments globally and per-span in OpenTelemetry.
>     - Clarifies usage of environment variables and constructor parameters for various SDKs (Python, JS/TS, OpenAI, Langchain, Vercel AI SDK, LlamaIndex).
>     - Removes "Coming soon" from the UI filtering feature description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9d891361b9ba686329ca723dacb702fc31e1003d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->