### PR TITLE
chore: add index pages to videos and cookbook

### DIFF
--- a/components/CookbookIndex.tsx
+++ b/components/CookbookIndex.tsx
@@ -12,6 +12,7 @@ export const CookbookIndex = ({ categories }: { categories?: string[] }) => (
         >
       )
         .filter((page) => page.route !== "/cookbook")
+        .filter((page) => page.route !== "/guides/cookbook")
         .reduce((acc, page) => {
           const category = page.frontMatter?.category || "Other";
           if (!acc[category]) acc[category] = [];

--- a/components/VideoIndex.tsx
+++ b/components/VideoIndex.tsx
@@ -8,40 +8,42 @@ export const VideoIndex = () => (
   <Cards num={3}>
     {(
       getPagesUnderRoute("/guides/videos") as Array<Page & { frontMatter: any }>
-    ).map((page, i) => (
-      <Cards.Card
-        href={page.route}
-        key={page.route}
-        title={
-          page.frontMatter?.title ||
-          page.name
-            .split("_")
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(" ")
-        }
-        icon={<Video />}
-        arrow
-      >
-        {page.frontMatter.ogImage ? (
-          <div className="relative aspect-video">
-            <Image
-              src={page.frontMatter.ogImage}
-              alt={
-                page.frontMatter?.title ||
-                page.name
-                  .split("_")
-                  .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-                  .join(" ")
-              }
-              objectFit="cover"
-              fill
-              sizes="(max-width: 560px) 100vw, (max-width: 1350px) 50vw, 33vw"
-            />
-          </div>
-        ) : (
-          ""
-        )}
-      </Cards.Card>
-    ))}
+    )
+      .filter((page) => page.route !== "/guides/videos")
+      .map((page, i) => (
+        <Cards.Card
+          href={page.route}
+          key={page.route}
+          title={
+            page.frontMatter?.title ||
+            page.name
+              .split("_")
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(" ")
+          }
+          icon={<Video />}
+          arrow
+        >
+          {page.frontMatter.ogImage ? (
+            <div className="relative aspect-video">
+              <Image
+                src={page.frontMatter.ogImage}
+                alt={
+                  page.frontMatter?.title ||
+                  page.name
+                    .split("_")
+                    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join(" ")
+                }
+                objectFit="cover"
+                fill
+                sizes="(max-width: 560px) 100vw, (max-width: 1350px) 50vw, 33vw"
+              />
+            </div>
+          ) : (
+            ""
+          )}
+        </Cards.Card>
+      ))}
   </Cards>
 );

--- a/pages/guides/cookbook/_meta.tsx
+++ b/pages/guides/cookbook/_meta.tsx
@@ -1,0 +1,3 @@
+export default {
+  index: "Overview",
+};

--- a/pages/guides/cookbook/index.mdx
+++ b/pages/guides/cookbook/index.mdx
@@ -1,0 +1,11 @@
+---
+description: A collection of notebooks and examples to help you get started with Langfuse.
+---
+
+# Langfuse Cookbook
+
+You can find the `ipynb` files in the [`cookbook`](https://github.com/langfuse/langfuse-docs/tree/main/cookbook) directory of the repository.
+
+import { CookbookIndex } from "@/components/CookbookIndex";
+
+<CookbookIndex />

--- a/pages/guides/videos/_meta.tsx
+++ b/pages/guides/videos/_meta.tsx
@@ -1,0 +1,3 @@
+export default {
+  index: "Overview",
+};

--- a/pages/guides/videos/index.mdx
+++ b/pages/guides/videos/index.mdx
@@ -1,0 +1,9 @@
+---
+description: A collection of videos and tutorials to help you get started with Langfuse.
+---
+
+# Langfuse Videos
+
+import { VideoIndex } from "@/components/VideoIndex";
+
+<VideoIndex />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add index pages for cookbook and videos, filtering main routes and introducing new meta and index files.
> 
>   - **Components**:
>     - `CookbookIndex.tsx`: Filters out `/cookbook` and `/guides/cookbook` routes.
>     - `VideoIndex.tsx`: Filters out `/guides/videos` route.
>   - **Pages**:
>     - Adds `index.mdx` and `_meta.tsx` for `cookbook` and `videos` under `pages/guides/`.
>     - `index.mdx` files import and render respective index components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 210a37d6996b88a3adff6698aa01dfcabfdeab9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->