### PR TITLE
docs: add community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "town-hall",
-  //   dismissible: true,
-  //   content: (
-  //     <Link href="https://lu.ma/s22z25ed">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //         Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+  banner: {
+    key: "langfuse-community-hour",
+    dismissible: true,
+    content: (
+      <Link href="https://lu.ma/by4k3643">
+        {/* mobile */}
+        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
+        {/* desktop */}
+        <span className="hidden sm:inline">
+          Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
+        </span>
+      </Link>
+    ),
+  },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a dismissible community hour banner to `theme.config.tsx` with mobile and desktop text variations.
> 
>   - **Banner Addition**:
>     - Adds a new banner in `theme.config.tsx` with key `langfuse-community-hour`.
>     - Banner is dismissible and links to `https://lu.ma/by4k3643`.
>     - Displays different text for mobile and desktop views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7ffd834724664c5af30b9ba077b7584234ca67c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->