### PR TITLE
docs: add link to oai agents overview

### DIFF
--- a/cookbook/integration_openai-agents.ipynb
+++ b/cookbook/integration_openai-agents.ipynb
@@ -387,6 +387,15 @@
         "\n",
         "**Example**: [Langfuse Trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019593d79e1efd7d7542e76c15a81bdb?timestamp=2025-03-14T08%3A48%3A56.349Z&view=preview)"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Evaluating OpenAI Agents\n",
+        "\n",
+        "Once you instrumented your agent it is time to systematically evaluate the agent to make it ready for use in production. For this, check out our [example notebook on evaluating agents](https://langfuse.com/docs/integrations/openaiagentssdk/example-evaluating-openai-agents) with Langfuse. "
+      ]
     }
   ],
   "metadata": {

--- a/pages/docs/integrations/openaiagentssdk/openai-agents.md
+++ b/pages/docs/integrations/openaiagentssdk/openai-agents.md
@@ -274,3 +274,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
 ![Example trace in Langfuse](https://langfuse.com/images/cookbook/integration_openai-agents/openai-agent-sdk-custom-attributes.png)
 
 **Example**: [Langfuse Trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019593d79e1efd7d7542e76c15a81bdb?timestamp=2025-03-14T08%3A48%3A56.349Z&view=preview)
+
+## Evaluating OpenAI Agents
+
+Once you instrumented your agent it is time to systematically evaluate the agent to make it ready for use in production. For this, check out our [example notebook on evaluating agents](https://langfuse.com/docs/integrations/openaiagentssdk/example-evaluating-openai-agents) with Langfuse. 

--- a/pages/guides/cookbook/integration_openai-agents.md
+++ b/pages/guides/cookbook/integration_openai-agents.md
@@ -274,3 +274,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
 ![Example trace in Langfuse](https://langfuse.com/images/cookbook/integration_openai-agents/openai-agent-sdk-custom-attributes.png)
 
 **Example**: [Langfuse Trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019593d79e1efd7d7542e76c15a81bdb?timestamp=2025-03-14T08%3A48%3A56.349Z&view=preview)
+
+## Evaluating OpenAI Agents
+
+Once you instrumented your agent it is time to systematically evaluate the agent to make it ready for use in production. For this, check out our [example notebook on evaluating agents](https://langfuse.com/docs/integrations/openaiagentssdk/example-evaluating-openai-agents) with Langfuse. 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a section on evaluating OpenAI agents with a link to an example notebook in `openai-agents.md` and `integration_openai-agents.md`.
> 
>   - **Documentation**:
>     - Adds a new section "Evaluating OpenAI Agents" to `openai-agents.md` and `integration_openai-agents.md`.
>     - Includes a link to an example notebook for evaluating agents with Langfuse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 88ade10236d97e8a376b187902c9176652c63c20. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->