### PR TITLE
docs: fix grammar for clarity in self-hosting section

### DIFF
--- a/pages/faq/all/langsmith-alternative.mdx
+++ b/pages/faq/all/langsmith-alternative.mdx
@@ -47,7 +47,7 @@ LangSmith is a closed source product. It is developed by the Langchain team whic
 
 LangSmith can be self-hosted but it requires [a paid Enterprise License](https://www.langchain.com/pricing) to do so. It is a closed source project.
 
-Langfuse can be freely [self-hosted](/self-hosting) and is open source. Users can self-host Langfuse for in a FOSS (Free and Open Source) version while a paid Enterprise Edition with some additional features is also available.
+Langfuse can be freely [self-hosted](/self-hosting) and is open source. Users can self-host the FOSS (Free and Open Source) version of Langfuse, while a paid Enterprise Edition with some additional features is also available.
 
 ## Langfuse and LangSmith Comparisons
 


### PR DESCRIPTION
Hello,

Noticed a small wording issue in the self-hosting section and made a minimal fix to improve clarity.

It looks like the intent was to say that users can self-host the FOSS version of Langfuse while also mentioning the separate paid Enterprise Edition. I adjusted the wording slightly to better reflect that.

Let me know if this aligns with what was meant!


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarified wording in `langsmith-alternative.mdx` about self-hosting options for Langfuse, specifying the FOSS version and paid Enterprise Edition.
> 
>   - **Documentation**:
>     - In `langsmith-alternative.mdx`, clarified wording about self-hosting options for Langfuse, specifying the FOSS version and the availability of a paid Enterprise Edition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 18efa9f77f9c574709bf8e13492a69dd0e359673. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->