### PR TITLE
docs: add link to llm-as-a-judge page

### DIFF
--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -123,7 +123,7 @@ Here we need to configure the following aspects:
 - Specify how Langfuse should fill the **`{{variables}}`** in the template.
   - Langfuse traces can be deeply nested (see [conceptual overview](/docs/tracing)). You can query from the trace directly, or from any nested observation via its name.
   - Select whether to use the `Input`, `Output`, or `Metadata` value.
-  - Optional: Provide a [JsonPath expression](https://github.com/JSONPath-Plus/JSONPath?tab=readme-ov-file#syntax-through-examples) to extract a specific value from the `Input`, `Output`, or `Metadata` value. If this is not provided, the entire value will be used.
+  - Optional: Provide a [JsonPath expression](https://github.com/JSONPath-Plus/JSONPath?tab=readme-ov-file#syntax-through-examples) to extract a specific value from the `Input`, `Output`, or `Metadata` value. If this is not provided, the entire value will be used. [This free online tool](https://jsonpathfinder.com/) is useful to determine the JSONPath of your input or output object.
 - Optional: Add **sampling** to reduce costs when running evaluations on a large volume of production data.
 - Optional: Configure **custom delay**. This is how you can ensure all data arrived at Langfuse servers before evaluation is executed. The time starts when the trace is first added to Langfuse while it might be still in progress. This is especially important for long-running agent executions.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a link to a free JSONPath tool in `model-based-evals.mdx` documentation.
> 
>   - **Documentation**:
>     - Adds a link to a free online JSONPath tool in `model-based-evals.mdx` to help users determine JSONPath of input/output objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ebb96738840c4024e03766bb0333f9cd45e92411. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->