### PR TITLE
feat: document new langfuse.metadata behaviour

### DIFF
--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -260,23 +260,25 @@ Attributes in the Langfuse namespace take precedence over the generic mapping we
 Some of the attributes are only taken into consideration if they are set on the root span. We mark those in the table below.
 The following Langfuse specific properties are supported:
 
-| OpenTelemetry Attribute   | Langfuse Property | Type       | Root Span only | Description                                                                                                                          |
-| ------------------------- | ----------------- | ---------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `langfuse.session.id`     | `sessionId`       | `string`   | `true`         | The [session ID](/docs/tracing-features/sessions) for the request.                                                                   |
-| `langfuse.user.id`        | `userId`          | `string`   | `true`         | The [user ID](/docs/tracing-features/users) for the request.                                                                         |
-| `langfuse.public`         | `public`          | `boolean`  | `true`         | Mark the trace as public to be able to [share it via url](/docs/tracing-features/url). This can be changed later in the Langfuse UI. |
-| `langfuse.release`        | `release`         | `string`   | `true`         | The [release](/docs/tracing-features/releases-and-versioning) for the request.                                                       |
-| `langfuse.version`        | `version`         | `string`   | `true`         | The [version](/docs/tracing-features/releases-and-versioning) for the request.                                                       |
-| `langfuse.tags`           | `tags`            | `string[]` | `true`         | The [tags](/docs/tracing-features/tags) for the request.                                                                             |
-| `langfuse.prompt.name`    | `promptName`      | `string`   | `false`        | The [prompt name](/docs/prompts/get-started) for the request.                                                                        |
-| `langfuse.prompt.version` | `promptVersion`   | `int`      | `false`        | The [prompt version](/docs/prompts/get-started) for the request.                                                                     |
-| `langfuse.environment`    | `environment`     | `string`   | `false`        | The environment for the request.                                                                                                     |
+| OpenTelemetry Attribute   | Langfuse Property | Type       | Root Span only | Description                                                                                                                                                |
+|---------------------------|-------------------|------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `langfuse.session.id`     | `sessionId`       | `string`   | `true`         | The [session ID](/docs/tracing-features/sessions) for the request.                                                                                         |
+| `langfuse.user.id`        | `userId`          | `string`   | `true`         | The [user ID](/docs/tracing-features/users) for the request.                                                                                               |
+| `langfuse.public`         | `public`          | `boolean`  | `true`         | Mark the trace as public to be able to [share it via url](/docs/tracing-features/url). This can be changed later in the Langfuse UI.                       |
+| `langfuse.release`        | `release`         | `string`   | `true`         | The [release](/docs/tracing-features/releases-and-versioning) for the request.                                                                             |
+| `langfuse.version`        | `version`         | `string`   | `true`         | The [version](/docs/tracing-features/releases-and-versioning) for the request.                                                                             |
+| `langfuse.tags`           | `tags`            | `string[]` | `true`         | The [tags](/docs/tracing-features/tags) for the request.                                                                                                   |
+| `langfuse.prompt.name`    | `promptName`      | `string`   | `false`        | The [prompt name](/docs/prompts/get-started) for the request.                                                                                              |
+| `langfuse.prompt.version` | `promptVersion`   | `int`      | `false`        | The [prompt version](/docs/prompts/get-started) for the request.                                                                                           |
+| `langfuse.environment`    | `environment`     | `string`   | `false`        | The environment for the request.                                                                                                                           |
+| `langfuse.metadata`       | `metadata`        | `object`   | `false`        | All keys within the `langfuse.metadata` object on attributes or resourceAttributes are mapped to the top-level metadata object on traces and observations. |
+| `langfuse.metadata.*`     | `metadata`        | `string`   | `false`        | All keys prefixed with `langfuse.metadata` on attributes or resourceAttributes are mapped to the top-level metadata object on traces and observations.     |
 
 Below, we present a non-exhaustive list of additional mappings that Langfuse applies.
 These mappings are based on OTel GenAI semantic conventions and vendor-specific implementations that deviate from these conventions:
 
 | OpenTelemetry Attribute       | Langfuse Property   | Description                                                                                                                                                      |
-| ----------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `gen_ai.usage.cost`           | `costDetails.total` | The total [cost](/docs/model-usage-and-cost) of the request.                                                                                                     |
 | `gen_ai.usage.*`              | `usageDetails.*`    | Maps all keys within [usage](/docs/model-usage-and-cost) aside from `cost` to `usageDetails`. Token properties are simplified to `input`, `output`, and `total`. |
 | `llm.token_count.*`           | `usageDetails.*`    | Maps all keys within [usage](/docs/model-usage-and-cost) to `usageDetails`. Token properties are simplified to `input`, `output`, and `total`.                   |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Documents new `langfuse.metadata` behavior in OpenTelemetry integration, updating `get-started.mdx` with new attribute mappings.
> 
>   - **Documentation Update**:
>     - Adds `langfuse.metadata` and `langfuse.metadata.*` to the Langfuse-specific properties table in `get-started.mdx`.
>     - Describes mapping of `langfuse.metadata` keys to top-level metadata object on traces and observations.
>   - **Formatting**:
>     - Adjusts table formatting for better readability in `get-started.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 45b32d5af8c33916c56e8c707bc72d8ec9b37c99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->