### PR TITLE
docs: add community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "langfuse-community-hour",
-  //   dismissible: true,
-  //   content: (
-  //     <Link href="https://lu.ma/by4k3643">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //         Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+  banner: {
+    key: "langfuse-community-hour",
+    dismissible: true,
+    content: (
+      <Link href="https://lu.ma/yvg9gv12">
+        {/* mobile */}
+        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
+        {/* desktop */}
+        <span className="hidden sm:inline">
+          Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
+        </span>
+      </Link>
+    ),
+  },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables and updates the Langfuse Community Hour banner in `theme.config.tsx`.
> 
>   - **Banner**:
>     - Re-enables the `langfuse-community-hour` banner in `theme.config.tsx`.
>     - Updates the link in the banner content to `https://lu.ma/yvg9gv12`.
>     - Banner is dismissible and displays different text for mobile and desktop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 37fc5468f2284c5f045d720f84f8ffc7bafede81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->