### PR TITLE
chore: add deletion disclaimer for GCS

### DIFF
--- a/pages/self-hosting/infrastructure/blobstorage.mdx
+++ b/pages/self-hosting/infrastructure/blobstorage.mdx
@@ -201,6 +201,10 @@ To get started, create a new bucket within Google Cloud Storage.
 Navigate to `Settings > Interoperability` to create a service account HMAC key.
 Ensure that the HMAC key has the necessary permissions to access the bucket.
 
+Please note that GCS does not implement all functions of the S3 API.
+We are aware of issues around DeleteObject requests that may cause errors in your application.
+This will have no effect on normal operations within Langfuse, but may limit your ability to delete data.
+
 #### Example Configuration
 
 Set the following environment variables to connect Langfuse with your Google Cloud Storage bucket:


### PR DESCRIPTION
Document behaviour on deletion issues raised in https://github.com/langfuse/langfuse/issues/6172#event-16951310528.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a disclaimer in `blobstorage.mdx` about GCS's limitations with DeleteObject requests in the S3 API.
> 
>   - **Documentation**:
>     - Adds a disclaimer in `blobstorage.mdx` about GCS not fully supporting the S3 API, specifically DeleteObject requests.
>     - Notes that this limitation may cause errors but does not affect normal Langfuse operations, only data deletion capabilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d038f952874f5d6d22264ad23da32be5e10b51e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->