### PR TITLE
docs: remove community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  banner: {
-    key: "langfuse-community-hour",
-    dismissible: true,
-    content: (
-      <Link href="https://lu.ma/yvg9gv12">
-        {/* mobile */}
-        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
-        {/* desktop */}
-        <span className="hidden sm:inline">
-          Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
-        </span>
-      </Link>
-    ),
-  },
+  // banner: {
+  //   key: "langfuse-community-hour",
+  //   dismissible: true,
+  //   content: (
+  //     <Link href="https://lu.ma/yvg9gv12">
+  //       {/* mobile */}
+  //       <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
+  //       {/* desktop */}
+  //       <span className="hidden sm:inline">
+  //         Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
+  //       </span>
+  //     </Link>
+  //   ),
+  // },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out the Langfuse Community Hour banner in `theme.config.tsx`, removing it from the site.
> 
>   - **Behavior**:
>     - Comments out the `banner` configuration in `theme.config.tsx`, removing the Langfuse Community Hour banner.
>     - The banner was previously dismissible and linked to an external event page.
>   - **Misc**:
>     - No other changes or features are affected by this update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 87c90379271bff7a4e6e399d900b9e9f8bbe9ee8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->