### PR TITLE
chore: add note on redis permissions

### DIFF
--- a/pages/self-hosting/infrastructure/cache.mdx
+++ b/pages/self-hosting/infrastructure/cache.mdx
@@ -115,6 +115,11 @@ Langfuse uses Redis mainly for queuing event metadata that should be processed b
 In most cases, the worker can process the queue quickly to keep events from piling up.
 For every ~100000 events per minute we recommend about 1GB of memory for the Redis instance.
 
+## Redis Permissions
+
+Redis allows users to restrict the keys and commands that a given user can access [Redis ACL Docs](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).
+Langfuse expects that the provided user has access to all keys and commands within the given database, i.e. the access control should be defined as `on ~* +@all`.
+
 ## Valkey vs Redis
 
 [Valkey](https://github.com/valkey-io/valkey) was created as an open source (BSD) alternative to Redis.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Redis permissions section to `cache.mdx`, specifying required access control settings for Langfuse.
> 
>   - **Documentation**:
>     - Adds a new section "Redis Permissions" in `cache.mdx`.
>     - Specifies that Langfuse requires Redis user access control to be set as `on ~* +@all` for full key and command access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d981a6a52cec0c47369da60720e5ceeac735f7d4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->