### PR TITLE
chore: add note on parallel v2 and v3 operations

### DIFF
--- a/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
+++ b/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
@@ -197,7 +197,7 @@ and move your traffic after validating that the new instances are working as exp
   variables of the new Langfuse web and worker containers until traffic is
   shifted. Afterwards, remove the overwrite or set to `true`.
 
-  In addition, the upgrade is known to work well between v2.92.0 and v.3.29.0.
+  In addition, the upgrade is known to work well between v2.92.0 and v3.29.0.
   Newer versions of v3 remove database entities that v2 still depends on.
   Therefore, we recommend to use v3.29.0 for parallel operations and upgrade to the latest v3 once the migration is complete.
 </Callout>

--- a/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
+++ b/pages/self-hosting/upgrade-guides/upgrade-v2-to-v3.mdx
@@ -196,6 +196,10 @@ and move your traffic after validating that the new instances are working as exp
   started. Set `LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS=false` in the environment
   variables of the new Langfuse web and worker containers until traffic is
   shifted. Afterwards, remove the overwrite or set to `true`.
+
+  In addition, the upgrade is known to work well between v2.92.0 and v.3.29.0.
+  Newer versions of v3 remove database entities that v2 still depends on.
+  Therefore, we recommend to use v3.29.0 for parallel operations and upgrade to the latest v3 once the migration is complete.
 </Callout>
 
 ### Upgrade Steps


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in the upgrade guide about using Langfuse v3.29.0 for parallel operations with v2.92.0 to avoid database entity issues.
> 
>   - **Documentation Update**:
>     - Adds a note in `upgrade-v2-to-v3.mdx` about compatibility between Langfuse v2.92.0 and v3.29.0 for parallel operations.
>     - Recommends using v3.29.0 during migration to avoid issues with database entities removed in later v3 versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 475f20a70adc639c7a0d7019dffc6a15973152db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->