### PR TITLE
docs: add self-serve security reports

### DIFF
--- a/pages/changelog/2024-04-30-SOC-2-Type-2-certification.mdx
+++ b/pages/changelog/2024-04-30-SOC-2-Type-2-certification.mdx
@@ -18,4 +18,6 @@ As of now, Langfuse is compliant with the following frameworks:
 - SOC 2 Type II
 - GDPR
 
+You can request access to the reports [here](https://forms.gle/o5JE7vWtX7Qk2syc8).
+
 If you are an enterprise and want to learn how Langfuse can help you meet your security and compliance requirements, review our [Enterprise FAQ](/enterprise) or contact us at enterprise@langfuse.com.

--- a/pages/docs/data-security-privacy.mdx
+++ b/pages/docs/data-security-privacy.mdx
@@ -6,7 +6,7 @@ description: Langfuse is enterprise-ready with its data privacy and security mea
 
 **At Langfuse, we prioritize data privacy and security.** We understand that the data you entrust to us is a vital asset to your business, and we treat it with the utmost care.
 
-We take active steps to demonstrate our commitment to data security and privacy such as annual SOC2 Type 2 and ISO27001 audits.
+We take active steps to demonstrate our commitment to data security and privacy such as annual SOC2 Type 2 and ISO27001 audits. You can request access to the reports [here](https://forms.gle/o5JE7vWtX7Qk2syc8).
 
 With Langfuse Cloud, we handle:
 
@@ -78,8 +78,8 @@ Below is a list of all data stores in Langfuse Cloud and their encryption method
 | Framework     | Status (Langfuse Cloud)                                                                                        |
 | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | GDPR          | Compliant. DPA available upon request on Pro and Team plan.                                                    |
-| SOC 2 Type II | Certified. Report available upon request on Team plan.                                                         |
-| ISO 27001     | Certified. Certificate available upon request on Team plan.                                                    |
+| SOC 2 Type II | Certified. Report available [upon request](https://forms.gle/o5JE7vWtX7Qk2syc8) on Pro and Enterprise plan.                                                         |
+| ISO 27001     | Certified. Certificate available [upon request](https://forms.gle/o5JE7vWtX7Qk2syc8) on Pro and Enterprise plan.                                                    |
 | HIPAA         | Not compliant. However, compliance can be attained by [self-hosting](/self-hosting) on own infrastructure/VPC. |
 
 For specific compliance requirements or questions, please contact us at compliance@langfuse.com

--- a/pages/faq/all/fifteen-questions-langfuse-answered.mdx
+++ b/pages/faq/all/fifteen-questions-langfuse-answered.mdx
@@ -67,7 +67,7 @@ As a fallback, you can always use [our API](/docs/api) to ingest data into Langf
 
 ## 8. Is Langfuse SOC2 Type2 certified?
 
-**The answer is yes, Langfuse is SOC2 Type2 certified.** The audit report is available upon request from the Langfuse Team. Please navigate to our [Security Center](/security) to learn more.
+**The answer is yes, Langfuse is SOC2 Type2 certified.** The audit report is available [upon request](https://forms.gle/o5JE7vWtX7Qk2syc8) from the Langfuse Team. Please navigate to our [Security Center](/security) to learn more.
 
 ## 9. Is Langfuse ISO27001 audited?
 

--- a/pages/faq/all/ten-reasons-to-use-langfuse.mdx
+++ b/pages/faq/all/ten-reasons-to-use-langfuse.mdx
@@ -21,7 +21,7 @@ Langfuse is a powerful tool designed to enhance LLM observability, evaluations, 
 
 6. **Scalable**: Built to scale with your projects, Langfuse handles projects of all sizes: from small to enterprise-level needs.
 
-7. **Compliance Ready**: Langfuse is ISO27001 and SOC2 Type 2 certified as well as GDPR compliant.
+7. **Compliance Ready**: Langfuse is ISO27001 and SOC2 Type 2 certified as well as GDPR compliant. (request reports [here](https://forms.gle/o5JE7vWtX7Qk2syc8))
 
 8. **Customizable Dashboards**: Langfuse lets you create dashboards that suit your requirements.
 

--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -8,7 +8,7 @@ label: "Version: v3"
 
 <Callout type="info">
 
-Security and privacy are core design objectives at Langfuse. The Langfuse Team runs Langfuse in production on Langfuse Cloud which is ISO27001, SOC2 Type 2 and GDPR compliant ([Langfuse Cloud security page](/security)).
+Security and privacy are core design objectives at Langfuse. The Langfuse Team runs Langfuse in production on Langfuse Cloud which is ISO27001, SOC2 Type 2 and GDPR compliant ([Langfuse Cloud security page](/security), [Form to request reports](https://forms.gle/o5JE7vWtX7Qk2syc8)).
 
 </Callout>
 

--- a/pages/self-hosting/v2/deployment-guide.mdx
+++ b/pages/self-hosting/v2/deployment-guide.mdx
@@ -246,7 +246,7 @@ Once HTTPS is enabled, you can configure add `LANGFUSE_CSP_ENFORCE_HTTPS=true` t
 
 All Langfuse data is stored in your Postgres database. Database-level encryption is recommended for a secure production deployment and available across cloud providers.
 
-The Langfuse team has implemented this for Langfuse Cloud and it is fully ISO27001, SOC2 Type 2 and GDPR compliant ([security page](/docs/security)).
+The Langfuse team has implemented this for Langfuse Cloud and it is fully ISO27001, SOC2 Type 2 and GDPR compliant ([security page](/docs/security), [request reports](https://forms.gle/o5JE7vWtX7Qk2syc8)).
 
 #### Additional application-level encryption [#application-level-encryption]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added links to request SOC 2 Type II and ISO 27001 security reports across multiple documentation files.
> 
>   - **Documentation Updates**:
>     - Added link to request security reports in `2024-04-30-SOC-2-Type-2-certification.mdx`, `data-security-privacy.mdx`, `fifteen-questions-langfuse-answered.mdx`, `ten-reasons-to-use-langfuse.mdx`, `encryption.mdx`, and `deployment-guide.mdx`.
>     - Updated compliance information to reflect availability of SOC 2 Type II and ISO 27001 reports upon request in `data-security-privacy.mdx` and `fifteen-questions-langfuse-answered.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a5514765eadbb268a74602bf94c1e3884acac6f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->