### PR TITLE
feat: cron job to trigger indexing of knowledge docs

### DIFF
--- a/.github/workflows/plain-sync-knowledge-docs.yml
+++ b/.github/workflows/plain-sync-knowledge-docs.yml
@@ -1,0 +1,30 @@
+name: Index Plain Knowledge Docs
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 3am every day
+  workflow_dispatch:
+
+jobs:
+  index-plain-knowledge-docs:
+    name: Index Plain Knowledge Docs
+    environment: "main"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install CLI
+        run: npm install -g @team-plain/cli@latest
+
+      - name: Index Langfuse.com
+        run: plain index-sitemap https://langfuse.com/sitemap-0.xml
+        env:
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY_WRITE_INDEXED_DOCUMENTS }}
+
+      - name: Index GH Discussions
+        run: plain index-sitemap https://langfuse.com/github-discussions-sitemap.xml
+        env:
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY_WRITE_INDEXED_DOCUMENTS }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a GitHub Actions workflow to index knowledge documents daily at 3am using a CLI tool and Node.js.
> 
>   - **Workflow**:
>     - Adds `plain-sync-knowledge-docs.yml` to automate indexing of knowledge docs.
>     - Scheduled to run daily at 3am and supports manual dispatch.
>   - **Setup**:
>     - Uses `actions/checkout@v4` and `actions/setup-node@v4` with Node.js version 22.
>     - Installs `@team-plain/cli@latest` globally via npm.
>   - **Indexing**:
>     - Indexes `https://langfuse.com/sitemap-0.xml` and `https://langfuse.com/github-discussions-sitemap.xml` using `plain index-sitemap`.
>     - Requires `PLAIN_API_KEY_WRITE_INDEXED_DOCUMENTS` secret for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d78de32be5a7b59a226e42671d92e0c63d97378e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->