### PR TITLE
docs: add video api keys

### DIFF
--- a/pages/faq/all/where-are-langfuse-api-keys.mdx
+++ b/pages/faq/all/where-are-langfuse-api-keys.mdx
@@ -5,6 +5,12 @@ tags: [help, setup]
 
 # Where are my Langfuse API keys?
 
+<CloudflareVideo
+  videoId="b3885f0e784c61526c0701f790608acd"
+  aspectRatio={16 / 9}
+  title="Where are my Langfuse API keys?"
+/>
+
 You can always look up your API keys or create new ones by navigating to **Project --> Settings** within Langfuse.
 
 You will also receive Langfuse API keys when you create a new project.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a video guide to `where-are-langfuse-api-keys.mdx` for locating Langfuse API keys.
> 
>   - **Documentation**:
>     - Adds a `CloudflareVideo` component to `where-are-langfuse-api-keys.mdx` to visually guide users on finding Langfuse API keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f6aeb68e1929934a38a88d536a91ca8e96b0a254. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->