### PR TITLE
docs: support for openai o3, o4-mini

### DIFF
--- a/pages/changelog/2025-04-16-o3-o4-mini-support.mdx
+++ b/pages/changelog/2025-04-16-o3-o4-mini-support.mdx
@@ -1,0 +1,28 @@
+---
+date: 2025-04-16
+title: OpenAI o3 and o4-mini integration for playground, evaluations and cost tracking
+description: Langfuse launches same day full compatibility with OpenAI's latest models o3 and o4-mini
+author: Marlies
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Some highlights about o3 and o4-mini from the [OpenAI release notes](https://openai.com/index/introducing-o3-and-o4-mini):
+- **Improved Instruction Following**: Both models demonstrate enhanced instruction following and provide more useful, verifiable responses than their predecessors
+- **More Natural Interaction**: Responses feel more conversational and personalized by leveraging memory and past conversation context
+
+As OpenAIs best reasoning model yet, o3:
+- **Advanced Reasoning**: o3 is OpenAI's most powerful reasoning model, setting new state-of-the-art benchmarks across coding, math, science, and visual perception
+- **Reduced Error Rate**: Makes 20 percent fewer major errors than OpenAI o1 on difficult real-world tasks, especially in programming, business consulting, and creative ideation
+
+o4-mini for cost-effective reasoning:
+- **Cost-Effective Performance**: o4-mini achieves remarkable performance for its size and cost, particularly excelling in math, coding, and visual tasks
+- **Higher Usage Capacity**: Supports significantly higher usage limits than o3, making it ideal for high-volume applications that benefit from reasoning
+
+## Learn more
+
+- [Langfuse LLM playground](/docs/playground)
+- [Langfuse model usage and cost tracking](/docs/model-usage-and-cost)
+

--- a/pages/docs/playground.mdx
+++ b/pages/docs/playground.mdx
@@ -60,6 +60,10 @@ Currently the playground supports the following models by default. You may confi
 
 export function ModelList() {
   const openAIModels = [
+    "o3",
+    "o3-2025-04-16",
+    "o4-mini",
+    "o4-mini-2025-04-16",
     "gpt-4.1",
     "gpt-4.1-2025-04-14",
     "gpt-4.1-mini-2025-04-14",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for OpenAI `o3` and `o4-mini` models in Langfuse playground and updates documentation with changelog entry.
> 
>   - **Documentation**:
>     - Adds `2025-04-16-o3-o4-mini-support.mdx` to changelog, detailing integration of OpenAI `o3` and `o4-mini` models.
>     - Highlights improved instruction following, natural interaction, advanced reasoning, and cost-effective performance of new models.
>   - **Playground Support**:
>     - Updates `playground.mdx` to include `o3`, `o3-2025-04-16`, `o4-mini`, and `o4-mini-2025-04-16` in the supported models list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1aeba0dd8e0b3fd0229e4419aae8c994bfcb1a96. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->