### PR TITLE
chore: add /request-security-docs redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -147,6 +147,7 @@ const nonPermanentRedirects = [
   ["/discussions", "https://github.com/orgs/langfuse/discussions"],
   ["/gh-discussions", "/discussions"],
   ["/docs/analytics", "/docs/analytics/overview"],
+  ["/request-security-docs", "https://forms.gle/o5JE7vWtX7Qk2syc8"],
 
   ["/public-metrics-dashboard", "https://lookerstudio.google.com/reporting/5198bcda-7d3d-447d-b596-ebe778c5fe99"],
   ["/join-us", "/careers"],

--- a/pages/docs/data-security-privacy.mdx
+++ b/pages/docs/data-security-privacy.mdx
@@ -6,7 +6,7 @@ description: Langfuse is enterprise-ready with its data privacy and security mea
 
 **At Langfuse, we prioritize data privacy and security.** We understand that the data you entrust to us is a vital asset to your business, and we treat it with the utmost care.
 
-We take active steps to demonstrate our commitment to data security and privacy such as annual SOC2 Type 2 and ISO27001 audits. You can request access to the reports [here](https://forms.gle/o5JE7vWtX7Qk2syc8).
+We take active steps to demonstrate our commitment to data security and privacy such as annual SOC2 Type 2 and ISO27001 audits. You can request access to the reports [here](/request-security-docs).
 
 With Langfuse Cloud, we handle:
 
@@ -46,18 +46,16 @@ With Langfuse Cloud, we handle:
 - We do not use any of your data for model training and treat it confidentially ([terms and conditions](/terms)).
 - For security inquiries, please contact us at security@langfuse.com
 
-
 #### Encryption at rest (databases) [#encryption-at-rest]
 
 Below is a list of all data stores in Langfuse Cloud and their encryption methods.
 
-| Service | Encryption |
-| --- | --- |
-| Elasticache (Redis) | AES-256 |
-| Aurora (Postgres) | AES-256 |
-| Clickhouse | AES-256 |
-| S3 | AES-256 |
-
+| Service             | Encryption |
+| ------------------- | ---------- |
+| Elasticache (Redis) | AES-256    |
+| Aurora (Postgres)   | AES-256    |
+| Clickhouse          | AES-256    |
+| S3                  | AES-256    |
 
 ### Self-hosted Instances
 
@@ -78,8 +76,8 @@ Below is a list of all data stores in Langfuse Cloud and their encryption method
 | Framework     | Status (Langfuse Cloud)                                                                                        |
 | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | GDPR          | Compliant. DPA available upon request on Pro and Team plan.                                                    |
-| SOC 2 Type II | Certified. Report available [upon request](https://forms.gle/o5JE7vWtX7Qk2syc8) on Pro and Enterprise plan.                                                         |
-| ISO 27001     | Certified. Certificate available [upon request](https://forms.gle/o5JE7vWtX7Qk2syc8) on Pro and Enterprise plan.                                                    |
+| SOC 2 Type II | Certified. Report available [upon request](/request-security-docs) on Pro and Enterprise plan.                 |
+| ISO 27001     | Certified. Certificate available [upon request](/request-security-docs) on Pro and Enterprise plan.            |
 | HIPAA         | Not compliant. However, compliance can be attained by [self-hosting](/self-hosting) on own infrastructure/VPC. |
 
 For specific compliance requirements or questions, please contact us at compliance@langfuse.com


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `/request-security-docs` redirect and updates documentation links to use it.
> 
>   - **Redirects**:
>     - Adds `/request-security-docs` redirect to `https://forms.gle/o5JE7vWtX7Qk2syc8` in `next.config.mjs`.
>   - **Documentation**:
>     - Updates links in `data-security-privacy.mdx` to use `/request-security-docs` instead of the direct Google Forms link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for cb9aad1970834a411bcc042c82293ab74b217c01. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->