### PR TITLE
chore: mark custom dashboards as beta on self-hosted

### DIFF
--- a/pages/docs/analytics/custom-dashboards.mdx
+++ b/pages/docs/analytics/custom-dashboards.mdx
@@ -10,7 +10,7 @@ description: Create self-service dashboards to visualize, monitor, and share ins
     core: "public-beta",
     pro: "public-beta",
     enterprise: "public-beta",
-    selfHosted: "not-available",
+    selfHosted: "public-beta",
   }}
 />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Marks custom dashboards as 'public-beta' for self-hosted environments in `custom-dashboards.mdx`.
> 
>   - **Documentation**:
>     - Updates `custom-dashboards.mdx` to mark custom dashboards as `public-beta` for `selfHosted` environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f9f551fb4e9bf5d3ecf32bf213775e486ac883a2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->