### PR TITLE
docs: add env example

### DIFF
--- a/cookbook/integration_openai-agents.ipynb
+++ b/cookbook/integration_openai-agents.ipynb
@@ -325,7 +325,7 @@
         "\n",
         "Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).\n",
         "\n",
-        "In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output."
+        "In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output."
       ]
     },
     {
@@ -361,6 +361,7 @@
         "    span.set_attribute(\"langfuse.user.id\", \"user-12345\")\n",
         "    span.set_attribute(\"langfuse.session.id\", \"my-agent-session\")\n",
         "    span.set_attribute(\"langfuse.tags\", [\"staging\", \"demo\", \"OpenAI Agent SDK\"])\n",
+        "    span.set_attribute(\"langfuse.environment\", \"local-dev\")\n",
         " \n",
         "    async def main(input_query):\n",
         "        agent = Agent(\n",

--- a/pages/docs/integrations/openaiagentssdk/openai-agents.md
+++ b/pages/docs/integrations/openaiagentssdk/openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,6 +253,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
+    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(

--- a/pages/guides/cookbook/integration_openai-agents.md
+++ b/pages/guides/cookbook/integration_openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,6 +253,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
+    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `environment` attribute example to OpenTelemetry spans in OpenAI Agents SDK documentation for better trace categorization.
> 
>   - **Documentation**:
>     - Add `environment` attribute example to OpenTelemetry spans in `openai-agents.md` and `integration_openai-agents.md`.
>     - Update examples to include `span.set_attribute("langfuse.environment", "local-dev")` for better trace categorization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 81114c73ea3ead5f28c74f3c46b3fe93de4f2f48. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->