### PR TITLE
docs: update pydantic AI notebook

### DIFF
--- a/cookbook/integration_pydantic_ai.ipynb
+++ b/cookbook/integration_pydantic_ai.ipynb
@@ -196,7 +196,6 @@
         "\n",
         "trace_provider = TracerProvider()\n",
         "trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))\n",
-        "trace.set_tracer_provider(trace_provider)\n",
         "tracer = trace.get_tracer(\"my.tracer.name\")\n",
         "\n",
         "# Creates a new parent span and adds additional attributes\n",
@@ -209,11 +208,11 @@
         "    # Run the agent\n",
         "    success_number = 23\n",
         "    result = roulette_agent.run_sync('Put my money on square eighteen', deps=success_number)\n",
-        "    print(result.data)\n",
+        "    print(result.output)\n",
         "\n",
         "    # Optional: Add input and output values to the new parent span\n",
         "    span.set_attribute(\"input.value\", success_number)\n",
-        "    span.set_attribute(\"output.value\", result.new_messages_json())"
+        "    span.set_attribute(\"output.value\", result.output)"
       ]
     },
     {

--- a/pages/docs/integrations/openaiagentssdk/openai-agents.md
+++ b/pages/docs/integrations/openaiagentssdk/openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,7 +253,6 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
-    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(

--- a/pages/docs/integrations/pydantic-ai.md
+++ b/pages/docs/integrations/pydantic-ai.md
@@ -111,7 +111,6 @@ from opentelemetry import trace
 
 trace_provider = TracerProvider()
 trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace.set_tracer_provider(trace_provider)
 tracer = trace.get_tracer("my.tracer.name")
 
 # Creates a new parent span and adds additional attributes
@@ -124,11 +123,11 @@ with tracer.start_as_current_span("Pydantic-Ai-Trace") as span:
     # Run the agent
     success_number = 23
     result = roulette_agent.run_sync('Put my money on square eighteen', deps=success_number)
-    print(result.data)
+    print(result.output)
 
     # Optional: Add input and output values to the new parent span
     span.set_attribute("input.value", success_number)
-    span.set_attribute("output.value", result.new_messages_json())
+    span.set_attribute("output.value", result.output)
 ```
 
 ## Step 6: Explore Traces in Langfuse

--- a/pages/guides/cookbook/integration_openai-agents.md
+++ b/pages/guides/cookbook/integration_openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,7 +253,6 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
-    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(

--- a/pages/guides/cookbook/integration_pydantic_ai.md
+++ b/pages/guides/cookbook/integration_pydantic_ai.md
@@ -111,7 +111,6 @@ from opentelemetry import trace
 
 trace_provider = TracerProvider()
 trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace.set_tracer_provider(trace_provider)
 tracer = trace.get_tracer("my.tracer.name")
 
 # Creates a new parent span and adds additional attributes
@@ -124,11 +123,11 @@ with tracer.start_as_current_span("Pydantic-Ai-Trace") as span:
     # Run the agent
     success_number = 23
     result = roulette_agent.run_sync('Put my money on square eighteen', deps=success_number)
-    print(result.data)
+    print(result.output)
 
     # Optional: Add input and output values to the new parent span
     span.set_attribute("input.value", success_number)
-    span.set_attribute("output.value", result.new_messages_json())
+    span.set_attribute("output.value", result.output)
 ```
 
 ## Step 6: Explore Traces in Langfuse


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update OpenAI Agents SDK and Pydantic AI documentation by removing `environment` attribute and adjusting output handling.
> 
>   - **OpenAI Agents SDK Documentation**:
>     - Removed `langfuse.environment` attribute from span attributes in `openai-agents.md` and `integration_openai-agents.md`.
>   - **Pydantic AI Documentation**:
>     - Removed `trace.set_tracer_provider(trace_provider)` in `pydantic-ai.md` and `integration_pydantic_ai.md`.
>     - Changed `result.data` to `result.output` and `result.new_messages_json()` to `result.output` in `pydantic-ai.md` and `integration_pydantic_ai.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c0d2431bb03ab08115a8c57c54d6a280c9067f3f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->