### PR TITLE
docs: update community hour banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -196,17 +196,15 @@ const config: DocsThemeConfig = {
     Video,
   },
   banner: {
-    key: "townhall-q2-roadmap-recording",
+    key: "langfuse-community-hour",
     dismissible: true,
     content: (
-      <Link href="https://www.youtube.com/watch?v=uDsnMaaFzho">
+      <Link href="https://lu.ma/4a4kae7p">
         {/* mobile */}
-        <span className="sm:hidden">
-          Watch Town Hall: Demos & Q2 Roadmap →
-        </span>
+        <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
         {/* desktop */}
         <span className="hidden sm:inline">
-          Watch Town Hall: Demos of latest features and discussion of Q2 Roadmap →
+          Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
         </span>
       </Link>
     ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates community hour banner in `theme.config.tsx` with new key, link, and text.
> 
>   - **Banner Update**:
>     - Changes `banner.key` from `townhall-q2-roadmap-recording` to `langfuse-community-hour` in `theme.config.tsx`.
>     - Updates `banner.content` link to `https://lu.ma/4a4kae7p`.
>     - Modifies banner text for mobile and desktop to "Wednesday: Langfuse Community Hour" with time details for desktop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9f3f5ef1717236d4de5851d4f20c08d818f0d48e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->