### PR TITLE
chore: clarify media and batch export S3 credential usage

### DIFF
--- a/pages/self-hosting/infrastructure/blobstorage.mdx
+++ b/pages/self-hosting/infrastructure/blobstorage.mdx
@@ -43,7 +43,8 @@ They need to be provided for the Langfuse Web and Langfuse Worker containers.
 
 Langfuse also uses S3 for batch exports and for multi-modal tracing.
 Those use-cases are opt-in and can be configured separately.
-Use the following information to enable them. Every potential user who uploads media or downloads exports need rights on these buckets.
+Use the following information to enable them.
+Langfuse uses the credentials to generate short-lived, pre-signed URLs that allow SDKs to upload media assets or to download batch exports.
 
 #### Multi-Modal Tracing
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies S3 credential usage in `blobstorage.mdx` for generating pre-signed URLs for media uploads and batch exports.
> 
>   - **Documentation**:
>     - Clarifies S3 credential usage in `blobstorage.mdx` for media and batch exports.
>     - Specifies that credentials generate pre-signed URLs for SDKs to upload media or download exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5e2085ecf8f061af7147502d55d1bc52f6e1a98c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->