### PR TITLE
docs: add note to openai agents sdk docs

### DIFF
--- a/cookbook/example_evaluating_openai_agents.ipynb
+++ b/cookbook/example_evaluating_openai_agents.ipynb
@@ -161,6 +161,13 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Note:** `nest_asyncio.apply()` is not compatible with `uvloop`, which is commonly used with FastAPI to manage the event loop. If your application uses `uvloop` and you require nest_asyncio (e.g., for certain instrumentation or tracing libraries), you'll need to disable `uvloop` in the affected parts of your codebase and fall back to Python’s standard asyncio event loop."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {

--- a/pages/docs/integrations/langchain/example-python.md
+++ b/pages/docs/integrations/langchain/example-python.md
@@ -535,7 +535,7 @@ langfuse.score(
     name="user-feedback",
     value=1,
     comment="This was correct, thank you"
-);
+)
 ```
 
 Example trace: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/08bb7cf3-87c6-4a78-a3fc-72af8959a106

--- a/pages/docs/integrations/openaiagentssdk/example-evaluating-openai-agents.md
+++ b/pages/docs/integrations/openaiagentssdk/example-evaluating-openai-agents.md
@@ -94,6 +94,8 @@ import nest_asyncio
 nest_asyncio.apply()
 ```
 
+**Note:** `nest_asyncio.apply()` is not compatible with `uvloop`, which is commonly used with FastAPI to manage the event loop. If your application uses `uvloop` and you require nest_asyncio (e.g., for certain instrumentation or tracing libraries), you'll need to disable `uvloop` in the affected parts of your codebase and fall back to Python’s standard asyncio event loop.
+
 
 ```python
 import logfire

--- a/pages/docs/integrations/openaiagentssdk/openai-agents.md
+++ b/pages/docs/integrations/openaiagentssdk/openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,6 +253,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
+    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(

--- a/pages/guides/cookbook/example_evaluating_openai_agents.md
+++ b/pages/guides/cookbook/example_evaluating_openai_agents.md
@@ -94,6 +94,8 @@ import nest_asyncio
 nest_asyncio.apply()
 ```
 
+**Note:** `nest_asyncio.apply()` is not compatible with `uvloop`, which is commonly used with FastAPI to manage the event loop. If your application uses `uvloop` and you require nest_asyncio (e.g., for certain instrumentation or tracing libraries), you'll need to disable `uvloop` in the affected parts of your codebase and fall back to Python’s standard asyncio event loop.
+
 
 ```python
 import logfire

--- a/pages/guides/cookbook/integration_langchain.md
+++ b/pages/guides/cookbook/integration_langchain.md
@@ -535,7 +535,7 @@ langfuse.score(
     name="user-feedback",
     value=1,
     comment="This was correct, thank you"
-);
+)
 ```
 
 Example trace: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/08bb7cf3-87c6-4a78-a3fc-72af8959a106

--- a/pages/guides/cookbook/integration_openai-agents.md
+++ b/pages/guides/cookbook/integration_openai-agents.md
@@ -226,7 +226,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 Opentelemetry lets you attach a set of attributes to all spans by setting [`set_attribute`](https://opentelemetry.io/docs/languages/python/instrumentation/#add-attributes-to-a-span). This allows you to set properties like a Langfuse Session ID, to group traces into Langfuse Sessions or a User ID, to assign traces to a specific user. You can find a list of all supported attributes in the [here](/docs/opentelemetry/get-started#property-mapping).
 
-In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions) and [trace_tags](https://langfuse.com/docs/tracing-features/tags) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
+In this example, we pass a [user_id](https://langfuse.com/docs/tracing-features/users), [session_id](https://langfuse.com/docs/tracing-features/sessions), [trace_tags](https://langfuse.com/docs/tracing-features/tags) and [environment](https://langfuse.com/docs/tracing-features/environments) to Langfuse. You can also use the span attribute `input.value` and `output.value` to set the trace level input and output.
 
 
 ```python
@@ -253,6 +253,7 @@ with tracer.start_as_current_span("OpenAI-Agent-Trace") as span:
     span.set_attribute("langfuse.user.id", "user-12345")
     span.set_attribute("langfuse.session.id", "my-agent-session")
     span.set_attribute("langfuse.tags", ["staging", "demo", "OpenAI Agent SDK"])
+    span.set_attribute("langfuse.environment", "local-dev")
  
     async def main(input_query):
         agent = Agent(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add note on `nest_asyncio` and `uvloop` incompatibility, and update Langfuse trace attributes in documentation.
> 
>   - **Documentation Updates**:
>     - Add note in `example-evaluating-openai-agents.md` and `example_evaluating_openai_agents.md` about `nest_asyncio.apply()` incompatibility with `uvloop` in FastAPI applications.
>     - Update `openai-agents.md` and `integration_openai-agents.md` to include `langfuse.environment` attribute in Langfuse traces.
>   - **Code Style**:
>     - Remove semicolons from Python code blocks in `example-python.md` and `integration_langchain.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8a746065ba40888b1b64ec0fc615cf7369f928f5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->