### PR TITLE
docs: add banner re sf event

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  // banner: {
-  //   key: "langfuse-community-hour",
-  //   dismissible: true,
-  //   content: (
-  //     <Link href="https://lu.ma/4a4kae7p">
-  //       {/* mobile */}
-  //       <span className="sm:hidden">Wednesday: Langfuse Community Hour →</span>
-  //       {/* desktop */}
-  //       <span className="hidden sm:inline">
-  //         Wednesday: Langfuse Community Hour, 10am PT / 7pm CET →
-  //       </span>
-  //     </Link>
-  //   ),
-  // },
+  banner: {
+    key: "langfuse-sf-meetup",
+    dismissible: true,
+    content: (
+      <Link href="https://lu.ma/eydxi5ry">
+        {/* mobile */}
+        <span className="sm:hidden">Monday in SF: Event w/ Samsara & Langfuse →</span>
+        {/* desktop */}
+        <span className="hidden sm:inline">
+        Monday in SF: Bringing agents to production with Samsara and Langfuse →
+        </span>
+      </Link>
+    ),
+  },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates banner in `theme.config.tsx` to announce the `langfuse-sf-meetup` event.
> 
>   - **Banner Update**:
>     - Replaces commented-out `langfuse-community-hour` banner with new `langfuse-sf-meetup` banner in `theme.config.tsx`.
>     - New banner links to `https://lu.ma/eydxi5ry` and displays different text for mobile and desktop views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c13531159be928bb97b080ec7bb74896cf1b5ead. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->