### PR TITLE
docs: reference cloud sso docs in self-hosting docs

### DIFF
--- a/pages/security/auth.mdx
+++ b/pages/security/auth.mdx
@@ -1,4 +1,5 @@
 ---
+title: Authentication & Authorization (Langfuse Cloud)
 description: Overview of authentication and authorization methods in Langfuse, including social logins, SSO, and RBAC.
 ---
 
@@ -28,7 +29,7 @@ For simplified access, users can sign in using their existing social accounts:
 
 By default, Langfuse does not support switching between social logins or signing up with a social login after signing up with email/password. Please reach out to [support](/support) if you need help.
 
-### Enterprise SSO & SSO Enforcement
+### Enterprise SSO & SSO Enforcement [#sso]
 
 <AvailabilityBanner
   availability={{

--- a/pages/self-hosting/authentication-and-sso.mdx
+++ b/pages/self-hosting/authentication-and-sso.mdx
@@ -4,7 +4,7 @@ description: Langfuse supports both email/password and SSO authentication. Follo
 label: "Version: v3"
 ---
 
-# Authentication and SSO
+# Authentication and SSO (self-hosted)
 
 <Callout>
   Make sure that `NEXTAUTH_URL` environment variable is [configured
@@ -13,6 +13,8 @@ label: "Version: v3"
 </Callout>
 
 Langfuse supports both email/password and SSO authentication.
+
+If you use Langfuse Cloud, please refer to the [Cloud Authentication and SSO](/security/auth) documentation.
 
 ## Email/Password [#auth-email-password]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update authentication docs to reference cloud and self-hosted guides appropriately.
> 
>   - **Documentation Updates**:
>     - In `pages/security/auth.mdx`, added a title for Langfuse Cloud and a reference to the self-hosted guide for authentication.
>     - In `pages/self-hosting/authentication-and-sso.mdx`, added a reference to the Cloud Authentication and SSO documentation for users of Langfuse Cloud.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 18a8809c6ddb9f069fc70f49d6a4fe6c4ac8757e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->