### PR TITLE
docs: add run-level-scores changelog

### DIFF
--- a/pages/changelog/2025-05-07-run-level-scores.mdx
+++ b/pages/changelog/2025-05-07-run-level-scores.mdx
@@ -1,0 +1,37 @@
+---
+title: Dataset Run Level Scores
+description: Score dataset runs to assess the overall quality of each run
+date: 2025-05-07
+author: Marlies
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Langfuse now supports dataset-experiment-run-level scores, enabling comprehensive evaluation of experiment runs.
+
+## What's New
+
+- **Run-Level Scoring**: Create and manage scores at the run level for holistic evaluation of experiment runs
+- **Experiment Metrics Support**: Easily ingest overall experiment metrics such as precision, recall, and F1-scores
+- **Flexible API Design**: Updated APIs to accommodate both trace-level and dataset-experiment-run-level scoring needs
+- **UI Enhancements**: Visual indicators and aggregates for run scores throughout the interface
+
+## API Updates
+
+We have extended our new v2 api and will continue to support the v1 api for the foreseeable future.
+POST and DELETE APIs will support both trace and dataset-experiment-run level scores across v1 and v2.
+
+For GET APIs:
+
+- **V1 API**: Only supports trace level scores, therefore requires `traceId` - to remain backwards compatible
+- **V2 API**: One and one only of `traceId`, `sessionId` or `datasetRunId` is now required when creating scores
+
+## Why Run-Level Scores Matter
+
+Run-level scores are particularly valuable for applications where you need to evaluate experiment performance across multiple custom test cases to find an overall metric or passing score. This enables more accurate evaluation of:
+
+- Overall system performance across dataset runs 
+- Aggregate performance metrics like precision, recall, and F1-scores
+- Comparative analysis between different model versions or parameters


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for run-level scores, detailing new features, API updates, and their importance.
> 
>   - **Changelog Addition**: Adds `2025-05-07-run-level-scores.mdx` to document new run-level scoring feature.
>   - **New Features**:
>     - Run-level scoring for holistic evaluation of experiment runs.
>     - Support for experiment metrics like precision, recall, and F1-scores.
>     - UI enhancements for visual indicators and aggregates of run scores.
>   - **API Updates**:
>     - V2 API supports `traceId`, `sessionId`, or `datasetRunId` for score creation.
>     - V1 API remains trace-level only, requiring `traceId`.
>     - POST and DELETE APIs support both trace and dataset-experiment-run level scores.
>   - **Importance**:
>     - Enables evaluation of system performance across dataset runs.
>     - Facilitates comparative analysis between model versions or parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 327bc28ef81681de890db5be474d124c8605d281. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->