### PR TITLE
docs: add links to free trial key

### DIFF
--- a/pages/faq/all/self-hosting-langfuse.mdx
+++ b/pages/faq/all/self-hosting-langfuse.mdx
@@ -9,7 +9,7 @@ tags: [product]
 
 Langfuse is an open source project. The core of Langfuse is MIT-licensed and can easily be [self-hosted](/self-hosting).
 
-The self-hosted version of Langfuse is also available as an Enterprise Edition (EE) which is paid and includes access to certain commercially-licensed features and services that require a [license key](/self-hosting/license-key).
+The self-hosted version of Langfuse is also available as an Enterprise Edition (EE) which is paid and includes access to certain commercially-licensed features and services that require a [license key](/self-hosting/license-key) ([get trial key](/request-trial)).
 
 | Langfuse | Cloud            | Self Hosted           |
 | -------- | ---------------- | --------------------- |

--- a/pages/self-hosting/index.mdx
+++ b/pages/self-hosting/index.mdx
@@ -15,7 +15,7 @@ import { Callout } from "nextra/components";
 
 Langfuse is open source and can be self-hosted using Docker.
 This section contains guides for different deployment scenarios.
-Some add-on features require a [license key](/self-hosting/license-key).
+Some add-on features require a [license key](/self-hosting/license-key) ([get trial key](/request-trial)).
 
 When self-hosting Langfuse, you run the same infrastructure that powers Langfuse Cloud. Read ["Why Langfuse?"](/why) to learn more about why this is important to us.
 

--- a/pages/self-hosting/organization-creators.mdx
+++ b/pages/self-hosting/organization-creators.mdx
@@ -8,7 +8,7 @@ label: "Version: v3"
 
 <Callout type="info">
 
-This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) to activate it.
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
 
 </Callout>
 

--- a/pages/self-hosting/ui-customization.mdx
+++ b/pages/self-hosting/ui-customization.mdx
@@ -8,7 +8,7 @@ label: "Version: v3"
 
 <Callout type="info">
 
-This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) to activate it.
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
 
 </Callout>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add "get trial key" links in documentation to guide users on obtaining trial license keys for Enterprise Edition features.
> 
>   - **Documentation Updates**:
>     - Add "get trial key" link next to "license key" in `self-hosting-langfuse.mdx`, `index.mdx`, `organization-creators.mdx`, and `ui-customization.mdx` to guide users on obtaining a trial license key for Enterprise Edition features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e99adcb6497795d4a285fa55a39d7e2ed9c67f0f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->