### PR TITLE
feat: document public metrics api

### DIFF
--- a/pages/changelog/2025-05-12-custom-metrics-api.mdx
+++ b/pages/changelog/2025-05-12-custom-metrics-api.mdx
@@ -1,0 +1,58 @@
+---
+date: 2025-05-12
+title: "Metrics API for custom analytics"
+description: Build custom reports and dashboards with our flexible Metrics API. Query traces, observations, and scores with custom dimensions, metrics, and time granularity.
+author: Steffen
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+## Overview
+
+We're excited to announce our new Metrics API, which allows you to build custom analytics dashboards and reports from your Langfuse data.
+This flexible API enables you to construct queries with:
+
+- Customizable dimensions and metrics
+- Flexible time granularity (hourly, daily, weekly, monthly)
+- Advanced filtering capabilities including metadata filtering
+- Support for both traces and observations views
+
+## Key Features
+
+- **Multiple Dimensions**: Group your data by any available dimension like name, model, or user ID
+- **Flexible Metrics**: Select and aggregate metrics like count, latency (with various aggregations like p95, avg)
+- **Time-Based Analysis**: Apply time dimensions with different granularities
+- **Rich Filtering**: Filter by metadata, timestamps, and other properties
+- **JSON-Based Query Format**: Intuitive query structure for complex analytics needs
+
+## Example
+
+Here's an example of querying the number of traces grouped by name:
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  -G \
+  --data-urlencode 'query={
+    "view": "traces",
+    "metrics": [{"measure": "count", "aggregation": "count"}],
+    "dimensions": [{"field": "name"}],
+    "filters": [],
+    "fromTimestamp": "2025-05-01T00:00:00Z",
+    "toTimestamp": "2025-05-13T00:00:00Z"
+  }' \
+  https://cloud.langfuse.com:3000/api/public/metrics
+```
+
+Response:
+
+```json
+{"data":[{"name":"trace-test-2","count_count":"10"},{"name":"trace-test-3","count_count":"10"},{"name":"trace-test-1","count_count":"10"}]}
+```
+
+## Learn more
+
+- [Metrics API](/docs/analytics/metrics-api)
+- [API Reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/metrics)

--- a/pages/docs/analytics/metrics-api.mdx
+++ b/pages/docs/analytics/metrics-api.mdx
@@ -40,7 +40,7 @@ The API accepts a JSON query object passed as a URL-encoded parameter:
 | `timeDimension` | object | No       | Configuration for time-based analysis, e.g. `{ "granularity": "day" }`                                                                                                   |
 | `fromTimestamp` | string | Yes      | ISO timestamp for the start of the query period                                                                                                                          |
 | `toTimestamp`   | string | Yes      | ISO timestamp for the end of the query period                                                                                                                            |
-| `orderBy`       | object | No       | Specification for result ordering, e.g. `[{ "field": "name", "direction": "asc" }]`                                                                                      |
+| `orderBy`       | array  | No       | Specification for result ordering, e.g. `[{ "field": "name", "direction": "asc" }]`                                                                                      |
 
 ### Dimension Object Structure
 

--- a/pages/docs/analytics/metrics-api.mdx
+++ b/pages/docs/analytics/metrics-api.mdx
@@ -124,109 +124,109 @@ The Metrics API provides access to several data views, each with its own set of 
 
 ### Available Views
 
-| View | Description |
-|------|-------------|
-| `traces` | Query data at the trace level |
-| `observations` | Query data at the observation level |
-| `scores-numeric` | Query numeric and boolean scores |
-| `scores-categorical` | Query categorical (string) scores |
+| View                 | Description                         |
+|----------------------|-------------------------------------|
+| `traces`             | Query data at the trace level       |
+| `observations`       | Query data at the observation level |
+| `scores-numeric`     | Query numeric and boolean scores    |
+| `scores-categorical` | Query categorical (string) scores   |
 
 ### Trace Dimensions
 
-| Dimension | Type | Description |
-|-----------|------|-------------|
-| `id` | string | Trace ID |
-| `name` | string | Trace name |
-| `tags` | string[] | Trace tags |
-| `userId` | string | User ID associated with the trace |
-| `sessionId` | string | Session ID associated with the trace |
-| `release` | string | Release tag |
-| `version` | string | Version tag |
-| `environment` | string | Environment (e.g., production, staging) |
-| `observationName` | string | Name of related observations |
-| `scoreName` | string | Name of related scores |
+| Dimension         | Type     | Description                             |
+|-------------------|----------|-----------------------------------------|
+| `id`              | string   | Trace ID                                |
+| `name`            | string   | Trace name                              |
+| `tags`            | string[] | Trace tags                              |
+| `userId`          | string   | User ID associated with the trace       |
+| `sessionId`       | string   | Session ID associated with the trace    |
+| `release`         | string   | Release tag                             |
+| `version`         | string   | Version tag                             |
+| `environment`     | string   | Environment (e.g., production, staging) |
+| `observationName` | string   | Name of related observations            |
+| `scoreName`       | string   | Name of related scores                  |
 
 ### Trace Metrics
 
-| Metric | Aggregations | Description |
-|--------|-------------|-------------|
-| `count` | count | Count of traces |
-| `observationsCount` | count | Count of observations within traces |
-| `scoresCount` | count | Count of scores within traces |
-| `latency` | sum, avg, min, max, p95 | Trace duration in milliseconds |
-| `totalTokens` | sum, avg | Total tokens used in the trace |
-| `totalCost` | sum, avg | Total cost of the trace |
+| Metric              | Description                         |
+|---------------------|-------------------------------------|
+| `count`             | Count of traces                     |
+| `observationsCount` | Count of observations within traces |
+| `scoresCount`       | Count of scores within traces       |
+| `latency`           | Trace duration in milliseconds      |
+| `totalTokens`       | Total tokens used in the trace      |
+| `totalCost`         | Total cost of the trace             |
 
 ### Observation Dimensions
 
-| Dimension | Type | Description |
-|-----------|------|-------------|
-| `id` | string | Observation ID |
-| `traceId` | string | Associated trace ID |
-| `traceName` | string | Name of the parent trace |
-| `environment` | string | Environment (e.g., production, staging) |
-| `parentObservationId` | string | ID of parent observation |
-| `type` | string | Observation type |
-| `name` | string | Observation name |
-| `level` | string | Log level |
-| `version` | string | Version |
-| `providedModelName` | string | Model name |
-| `promptName` | string | Prompt name |
-| `promptVersion` | string | Prompt version |
-| `userId` | string | User ID from parent trace |
-| `sessionId` | string | Session ID from parent trace |
-| `traceRelease` | string | Release from parent trace |
-| `traceVersion` | string | Version from parent trace |
-| `scoreName` | string | Related score name |
+| Dimension             | Type   | Description                             |
+|-----------------------|--------|-----------------------------------------|
+| `id`                  | string | Observation ID                          |
+| `traceId`             | string | Associated trace ID                     |
+| `traceName`           | string | Name of the parent trace                |
+| `environment`         | string | Environment (e.g., production, staging) |
+| `parentObservationId` | string | ID of parent observation                |
+| `type`                | string | Observation type                        |
+| `name`                | string | Observation name                        |
+| `level`               | string | Log level                               |
+| `version`             | string | Version                                 |
+| `providedModelName`   | string | Model name                              |
+| `promptName`          | string | Prompt name                             |
+| `promptVersion`       | string | Prompt version                          |
+| `userId`              | string | User ID from parent trace               |
+| `sessionId`           | string | Session ID from parent trace            |
+| `traceRelease`        | string | Release from parent trace               |
+| `traceVersion`        | string | Version from parent trace               |
+| `scoreName`           | string | Related score name                      |
 
 ### Observation Metrics
 
-| Metric | Aggregations | Description |
-|--------|-------------|-------------|
-| `count` | count | Count of observations |
-| `latency` | sum, avg, min, max, p95 | Observation duration in milliseconds |
-| `totalTokens` | sum, avg | Total tokens used |
-| `totalCost` | sum, avg | Total cost |
-| `timeToFirstToken` | sum, avg, min, max, p95 | Time to first token in milliseconds |
-| `countScores` | count | Count of related scores |
+| Metric             | Description                          |
+|--------------------|--------------------------------------|
+| `count`            | Count of observations                |
+| `latency`          | Observation duration in milliseconds |
+| `totalTokens`      | Total tokens used                    |
+| `totalCost`        | Total cost                           |
+| `timeToFirstToken` | Time to first token in milliseconds  |
+| `countScores`      | Count of related scores              |
 
 ### Score Dimensions (Common)
 
-| Dimension | Type | Description |
-|-----------|------|-------------|
-| `id` | string | Score ID |
-| `name` | string | Score name |
-| `environment` | string | Environment |
-| `source` | string | Score source |
-| `dataType` | string | Data type |
-| `traceId` | string | Related trace ID |
-| `traceName` | string | Related trace name |
-| `userId` | string | User ID from trace |
-| `sessionId` | string | Session ID from trace |
-| `observationId` | string | Related observation ID |
-| `observationName` | string | Related observation name |
-| `observationModelName` | string | Model used in related observation |
-| `observationPromptName` | string | Prompt name used in related observation |
+| Dimension                  | Type   | Description                                |
+|----------------------------|--------|--------------------------------------------|
+| `id`                       | string | Score ID                                   |
+| `name`                     | string | Score name                                 |
+| `environment`              | string | Environment                                |
+| `source`                   | string | Score source                               |
+| `dataType`                 | string | Data type                                  |
+| `traceId`                  | string | Related trace ID                           |
+| `traceName`                | string | Related trace name                         |
+| `userId`                   | string | User ID from trace                         |
+| `sessionId`                | string | Session ID from trace                      |
+| `observationId`            | string | Related observation ID                     |
+| `observationName`          | string | Related observation name                   |
+| `observationModelName`     | string | Model used in related observation          |
+| `observationPromptName`    | string | Prompt name used in related observation    |
 | `observationPromptVersion` | string | Prompt version used in related observation |
-| `configId` | string | Configuration ID |
+| `configId`                 | string | Configuration ID                           |
 
 ### Score Metrics
 
 #### Numeric Scores
 
-| Metric | Aggregations | Description |
-|--------|-------------|-------------|
-| `count` | count | Count of scores |
-| `value` | avg, min, max, p95 | Numeric score value |
+| Metric  | Description         |
+|---------|---------------------|
+| `count` | Count of scores     |
+| `value` | Numeric score value |
 
 #### Categorical Scores
 
-| Metric | Aggregations | Description |
-|--------|-------------|-------------|
-| `count` | count | Count of scores |
+| Metric  | Description     |
+|---------|-----------------|
+| `count` | Count of scores |
 
 Categorical scores have an additional dimension:
 
-| Dimension | Type | Description |
-|-----------|------|-------------|
+| Dimension     | Type   | Description                           |
+|---------------|--------|---------------------------------------|
 | `stringValue` | string | String value of the categorical score |

--- a/pages/docs/analytics/metrics-api.mdx
+++ b/pages/docs/analytics/metrics-api.mdx
@@ -1,0 +1,113 @@
+---
+description: Retrieve custom metrics from Langfuse for flexible analytics and reporting.
+---
+
+# Metrics API
+
+```
+GET /api/public/metrics
+```
+
+The **Metrics API** enables you to retrieve customized analytics from your Langfuse data.
+This endpoint allows you to specify dimensions, metrics, filters, and time granularity to build powerful custom reports and dashboards for your LLM applications.
+
+## Overview
+
+The Metrics API supports querying across different views (traces, observations, scores) and allows you to:
+
+- Select specific dimensions to group your data
+- Apply multiple metrics with different aggregation methods
+- Filter data based on metadata, timestamps, and other properties
+- Analyze data across time with customizable granularity
+- Order results according to your needs
+
+## Query Parameters
+
+The API accepts a JSON query object passed as a URL-encoded parameter:
+
+| Parameter | Type        | Description                                                |
+|-----------|-------------|------------------------------------------------------------|
+| `query`   | JSON string | The encoded query object defining what metrics to retrieve |
+
+### Query Object Structure
+
+| Field           | Type   | Required | Description                                                                                                                                                              |
+|-----------------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `view`          | string | Yes      | The data view to query: `"traces"`, `"observations"`, `"scores-numeric"`, or `"scores-categorical"`                                                                      |
+| `dimensions`    | array  | No       | Array of dimension objects to group by, e.g. `[{ "field": "name" }]`                                                                                                     |
+| `metrics`       | array  | Yes      | Array of metric objects to calculate, e.g. `[{ "measure": "latency", "aggregation": "p95" }]`                                                                            |
+| `filters`       | array  | No       | Array of filter objects to narrow results, e.g. `[{ "column": "metadata", "operator": "contains", "key": "customKey", "value": "customValue", "type": "stringObject" }]` |
+| `timeDimension` | object | No       | Configuration for time-based analysis, e.g. `{ "granularity": "day" }`                                                                                                   |
+| `fromTimestamp` | string | Yes      | ISO timestamp for the start of the query period                                                                                                                          |
+| `toTimestamp`   | string | Yes      | ISO timestamp for the end of the query period                                                                                                                            |
+| `orderBy`       | object | No       | Specification for result ordering, e.g. `[{ "field": "name", "direction": "asc" }]`                                                                                      |
+
+### Dimension Object Structure
+
+```json
+{ "field": "name" }
+```
+
+### Metric Object Structure
+
+```json
+{ "measure": "count", "aggregation": "count" }
+```
+
+Common measure types include:
+- `count` - Count of records
+- `latency` - Duration/latency metrics
+
+Aggregation types include:
+- `count` - Count records
+- `p95` - 95th percentile
+- Other standard aggregations (sum, avg, min, max, etc.)
+
+### Filter Object Structure
+
+```json
+{
+  "column": "metadata",
+  "operator": "contains",
+  "key": "customKey",
+  "value": "customValue",
+  "type": "stringObject"
+}
+```
+
+### Time Dimension Object
+
+```json
+{
+  "granularity": "day"
+}
+```
+
+Supported granularities include: `hour`, `day`, `week`, `month`, and `auto`.
+
+## Example
+
+Here's an example of querying the number of traces grouped by name:
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  -G \
+  --data-urlencode 'query={
+    "view": "traces",
+    "metrics": [{"measure": "count", "aggregation": "count"}],
+    "dimensions": [{"field": "name"}],
+    "filters": [],
+    "fromTimestamp": "2025-05-01T00:00:00Z",
+    "toTimestamp": "2025-05-13T00:00:00Z"
+  }' \
+  https://cloud.langfuse.com:3000/api/public/metrics
+```
+
+Response:
+
+```json
+{"data":[{"name":"trace-test-2","count_count":"10"},{"name":"trace-test-3","count_count":"5"},{"name":"trace-test-1","count_count":"3"}]}
+```
+
+## Data Model

--- a/pages/docs/analytics/metrics-api.mdx
+++ b/pages/docs/analytics/metrics-api.mdx
@@ -59,9 +59,17 @@ Common measure types include:
 - `latency` - Duration/latency metrics
 
 Aggregation types include:
-- `count` - Count records
+
+- `sum` - Sum of values
+- `avg` - Average of values
+- `count` - Count of records
+- `max` - Maximum value
+- `min` - Minimum value
+- `p50` - 50th percentile
+- `p75` - 75th percentile
+- `p90` - 90th percentile
 - `p95` - 95th percentile
-- Other standard aggregations (sum, avg, min, max, etc.)
+- `p99` - 99th percentile
 
 ### Filter Object Structure
 
@@ -111,3 +119,114 @@ Response:
 ```
 
 ## Data Model
+
+The Metrics API provides access to several data views, each with its own set of dimensions and metrics you can query. This section outlines the available options for each view.
+
+### Available Views
+
+| View | Description |
+|------|-------------|
+| `traces` | Query data at the trace level |
+| `observations` | Query data at the observation level |
+| `scores-numeric` | Query numeric and boolean scores |
+| `scores-categorical` | Query categorical (string) scores |
+
+### Trace Dimensions
+
+| Dimension | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Trace ID |
+| `name` | string | Trace name |
+| `tags` | string[] | Trace tags |
+| `userId` | string | User ID associated with the trace |
+| `sessionId` | string | Session ID associated with the trace |
+| `release` | string | Release tag |
+| `version` | string | Version tag |
+| `environment` | string | Environment (e.g., production, staging) |
+| `observationName` | string | Name of related observations |
+| `scoreName` | string | Name of related scores |
+
+### Trace Metrics
+
+| Metric | Aggregations | Description |
+|--------|-------------|-------------|
+| `count` | count | Count of traces |
+| `observationsCount` | count | Count of observations within traces |
+| `scoresCount` | count | Count of scores within traces |
+| `latency` | sum, avg, min, max, p95 | Trace duration in milliseconds |
+| `totalTokens` | sum, avg | Total tokens used in the trace |
+| `totalCost` | sum, avg | Total cost of the trace |
+
+### Observation Dimensions
+
+| Dimension | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Observation ID |
+| `traceId` | string | Associated trace ID |
+| `traceName` | string | Name of the parent trace |
+| `environment` | string | Environment (e.g., production, staging) |
+| `parentObservationId` | string | ID of parent observation |
+| `type` | string | Observation type |
+| `name` | string | Observation name |
+| `level` | string | Log level |
+| `version` | string | Version |
+| `providedModelName` | string | Model name |
+| `promptName` | string | Prompt name |
+| `promptVersion` | string | Prompt version |
+| `userId` | string | User ID from parent trace |
+| `sessionId` | string | Session ID from parent trace |
+| `traceRelease` | string | Release from parent trace |
+| `traceVersion` | string | Version from parent trace |
+| `scoreName` | string | Related score name |
+
+### Observation Metrics
+
+| Metric | Aggregations | Description |
+|--------|-------------|-------------|
+| `count` | count | Count of observations |
+| `latency` | sum, avg, min, max, p95 | Observation duration in milliseconds |
+| `totalTokens` | sum, avg | Total tokens used |
+| `totalCost` | sum, avg | Total cost |
+| `timeToFirstToken` | sum, avg, min, max, p95 | Time to first token in milliseconds |
+| `countScores` | count | Count of related scores |
+
+### Score Dimensions (Common)
+
+| Dimension | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Score ID |
+| `name` | string | Score name |
+| `environment` | string | Environment |
+| `source` | string | Score source |
+| `dataType` | string | Data type |
+| `traceId` | string | Related trace ID |
+| `traceName` | string | Related trace name |
+| `userId` | string | User ID from trace |
+| `sessionId` | string | Session ID from trace |
+| `observationId` | string | Related observation ID |
+| `observationName` | string | Related observation name |
+| `observationModelName` | string | Model used in related observation |
+| `observationPromptName` | string | Prompt name used in related observation |
+| `observationPromptVersion` | string | Prompt version used in related observation |
+| `configId` | string | Configuration ID |
+
+### Score Metrics
+
+#### Numeric Scores
+
+| Metric | Aggregations | Description |
+|--------|-------------|-------------|
+| `count` | count | Count of scores |
+| `value` | avg, min, max, p95 | Numeric score value |
+
+#### Categorical Scores
+
+| Metric | Aggregations | Description |
+|--------|-------------|-------------|
+| `count` | count | Count of scores |
+
+Categorical scores have an additional dimension:
+
+| Dimension | Type | Description |
+|-----------|------|-------------|
+| `stringValue` | string | String value of the categorical score |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Documents the new Metrics API for custom analytics, detailing its features, usage, and data model.
> 
>   - **New Documentation**:
>     - Adds `2025-05-12-custom-metrics-api.mdx` to `changelog` for announcing the Metrics API.
>     - Adds `metrics-api.mdx` to `docs/analytics` for detailed API usage.
>   - **API Features**:
>     - Supports querying with customizable dimensions, metrics, and time granularity.
>     - Allows filtering by metadata and timestamps.
>     - Provides JSON-based query format.
>   - **Data Views**:
>     - Supports `traces`, `observations`, `scores-numeric`, and `scores-categorical` views.
>   - **Example Usage**:
>     - Includes example of querying trace counts grouped by name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ca1f24823beda49be8b11bf6c2a2bfc7cc97ecc6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->