### PR TITLE
docs: remove banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -195,20 +195,20 @@ const config: DocsThemeConfig = {
     CloudflareVideo,
     Video,
   },
-  banner: {
-    key: "langfuse-sf-meetup",
-    dismissible: true,
-    content: (
-      <Link href="https://lu.ma/eydxi5ry">
-        {/* mobile */}
-        <span className="sm:hidden">Monday in SF: Event w/ Samsara & Langfuse →</span>
-        {/* desktop */}
-        <span className="hidden sm:inline">
-        Monday in SF: Bringing agents to production with Samsara and Langfuse →
-        </span>
-      </Link>
-    ),
-  },
+  // banner: {
+  //   key: "langfuse-sf-meetup",
+  //   dismissible: true,
+  //   content: (
+  //     <Link href="https://lu.ma/eydxi5ry">
+  //       {/* mobile */}
+  //       <span className="sm:hidden">Monday in SF: Event w/ Samsara & Langfuse →</span>
+  //       {/* desktop */}
+  //       <span className="hidden sm:inline">
+  //       Monday in SF: Bringing agents to production with Samsara and Langfuse →
+  //       </span>
+  //     </Link>
+  //   ),
+  // },
 };
 
 export default config;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out the `banner` configuration in `theme.config.tsx`, removing the event banner from the website.
> 
>   - **Behavior**:
>     - Comments out the `banner` configuration in `theme.config.tsx`, effectively removing the banner from the website.
>     - The banner was previously displaying an event link for "Monday in SF: Event w/ Samsara & Langfuse".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3dc7de3812e3336c5f3311d1edca289aa499dbf2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->