### PR TITLE
docs: datasets rate limit group

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -715,8 +715,20 @@ const sections: Section[] = [
         href: "/faq/all/api-limits",
         tiers: {
           cloud: {
-            Hobby: "10 requests / min",
+            Hobby: "30 requests / min",
             Core: "100 requests / min",
+            Pro: "1,000 requests / min",
+            Enterprise: "Custom",
+          },
+        },
+      },
+      {
+        name: "Rate limit (datasets api)",
+        href: "/faq/all/api-limits",
+        tiers: {
+          cloud: {
+            Hobby: "100 requests / min",
+            Core: "200 requests / min",
             Pro: "1,000 requests / min",
             Enterprise: "Custom",
           },

--- a/pages/faq/all/api-limits.mdx
+++ b/pages/faq/all/api-limits.mdx
@@ -28,7 +28,8 @@ Rate limits are applied per-organization.
 | **Legacy Tracing**. Legacy ingestion endpoints.                                                                  | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
 | **Prompts**. GET APIs used to fetch prompts for use in applications.                                             | No limit           | No limit           | No limit            |
 | **Metrics**. GET APIs used to fetch analytics data, e.g. [daily metrics api](/docs/analytics/daily-metrics-api). | 10&nbsp;req/day    | 20&nbsp;req/day    | 200&nbsp;req/day    |
-| **API**. All other APIs.                                                                                         | 20&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                 | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **API**. All other APIs.                                                                                         | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
 
 **Rate limit response**
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated rate limits for datasets and general API routes in `Pricing.tsx` and `api-limits.mdx`.
> 
>   - **Rate Limits Update**:
>     - In `Pricing.tsx`, updated "Rate limit (general API routes)" for Hobby from "10 requests / min" to "30 requests / min".
>     - Added "Rate limit (datasets api)" with limits: Hobby "100 requests / min", Core "200 requests / min", Pro "1,000 requests / min", Enterprise "Custom".
>   - **Documentation**:
>     - In `api-limits.mdx`, added datasets API rate limits: Hobby "100 req/min", Core "200 req/min", Pro "1,000 req/min".
>     - Updated general API rate limits for Hobby from "20 req/min" to "30 req/min".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 043ad2227cf38375f4218c0b27276acb4dc2c52c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->