### PR TITLE
Fix Academy module text errors

### DIFF
--- a/components/InteractiveQuiz.tsx
+++ b/components/InteractiveQuiz.tsx
@@ -60,7 +60,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 5,
-    chapter: "Module 3",
+    chapter: "Module 2",
     text: "Within a trace, which observation type extends span semantics with model-specific attributes such as prompt, completion, and token usage?",
     options: [
       { id: "A", text: "Event" },
@@ -72,7 +72,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 6,
-    chapter: "Module 3",
+    chapter: "Module 2",
     text: "Recording the p99 latency at the LLM layer primarily helps answer which of the following questions?",
     options: [
       { id: "A", text: "Which sessions hit the cost guard-rail?" },
@@ -84,7 +84,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 7,
-    chapter: "Module 4",
+    chapter: "Module 3",
     text: "In the continuous evaluation loop, what is the step that follows the creation or curation of test datasets?",
     options: [
       { id: "A", text: "Deploy changes directly to production" },
@@ -96,7 +96,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 8,
-    chapter: "Module 4",
+    chapter: "Module 3",
     text: "Which of the following is an example of implicit user feedback that can be used for online evaluation?",
     options: [
       { id: "A", text: "Thumbs-up / thumbs-down rating" },
@@ -108,7 +108,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 9,
-    chapter: "Module 5",
+    chapter: "Module 4",
     text: "Which prompting strategy intentionally includes 1-5 example interactions to guide the model's style or structure?",
     options: [
       { id: "A", text: "Zero-shot" },
@@ -120,7 +120,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 10,
-    chapter: "Module 5",
+    chapter: "Module 4",
     text: "What is the PRIMARY reason for versioning prompts in production environments?",
     options: [
       { id: "A", text: "To reduce token usage through compression" },
@@ -132,7 +132,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 11,
-    chapter: "Module 4",
+    chapter: "Module 3",
     text: "Why must automated evaluators powered by smaller LLMs be periodically calibrated against human-annotated samples?",
     options: [
       { id: "A", text: "They are deterministic and never change" },
@@ -144,7 +144,7 @@ const quizQuestions: Question[] = [
   },
   {
     id: 12,
-    chapter: "Module 3",
+    chapter: "Module 2",
     text: "In a multi-step LLM pipeline, which layer is MOST likely to dominate end-to-end latency if not instrumented properly?",
     options: [
       { id: "A", text: "LLM token generation" },

--- a/pages/academy/02-tracing.mdx
+++ b/pages/academy/02-tracing.mdx
@@ -5,7 +5,7 @@ description: Overview of tracing in LLM applications, why this is important and 
 
 # Module 2: Tracing
 
-Having introduced LLMOps and the importance of monitoring in Module 1, and different architectural patterns in Module 2, let's take a **closer look at tracing** and how it helps you manage multi-step LLM applications.
+Having introduced common architecture patterns in Module 1, let's take a **closer look at tracing** and how it helps you manage multi-step LLM applications.
 
 <Frame className="my-10" fullWidth>
   ![Tracing](/images/academy/m3-tracing.png)


### PR DESCRIPTION
## Summary
- fix intro line in tracing module
- correct module labels in the interactive quiz

## Testing
- `pnpm run link-check` *(fails: Connect Timeout Error)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes text errors in the Academy module by correcting module labels in the interactive quiz and the introductory line in the tracing module.
> 
>   - **Interactive Quiz**:
>     - Corrects module labels in `InteractiveQuiz.tsx` for questions 5, 6, 7, 8, 9, 10, 11, and 12 to reflect accurate module numbers.
>   - **Tracing Module**:
>     - Fixes introductory line in `02-tracing.mdx` to correctly reference Module 1 for common architecture patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e0b4d3387d9a8de4200256e61257f356936c7b3f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->