### PR TITLE
Fix docs h1 title casing

### DIFF
--- a/pages/docs/fine-tuning.mdx
+++ b/pages/docs/fine-tuning.mdx
@@ -2,7 +2,7 @@
 description: You can export your Langfuse observability data to easily train or fine-tune models.
 ---
 
-# Fine-tuning
+# Fine-Tuning
 
 Langfuse is [open-source](/open-source) and data tracked with Langfuse is open. You can easily [trace](/docs/tracing) your application, collect user feedback, and then use the data to fine-tune a model for your specific use case.
 

--- a/pages/docs/integrations/dify.mdx
+++ b/pages/docs/integrations/dify.mdx
@@ -3,7 +3,7 @@ title: Observability and tracing for Dify.AI
 description: Open source observability for Dify applications. Automatically capture detailed traces and metrics for every request.
 ---
 
-# Dify - Observability & Metrics for your LLM apps
+# Dify - Observability & Metrics for Your LLM Apps
 
 **Dify** ([GitHub](https://github.com/langgenius/dify)) is an open-source LLM app development platform which is natively integrated with Langfuse. With the native integration, you can use Dify to quickly create complex LLM applications and then use Langfuse to monitor and improve them.
 

--- a/pages/docs/integrations/llama-index/deprecated-llama-index-callback.mdx
+++ b/pages/docs/integrations/llama-index/deprecated-llama-index-callback.mdx
@@ -3,7 +3,7 @@ title: (Deprecated) Callback-based LlamaIndex Integration
 description: Open source observability for LlamaIndex. Automatically capture detailed traces and metrics for every request of your RAG application.
 ---
 
-# (Deprecated) Callback-based LlamaIndex Integration
+# (Deprecated) Callback-Based LlamaIndex Integration
 
 <Callout type="warning">
   This integration is deprecated. We recommend using the new

--- a/pages/docs/integrations/mastra.mdx
+++ b/pages/docs/integrations/mastra.mdx
@@ -3,7 +3,7 @@ title: Observability for Mastra with Langfuse
 description: Learn how to integrate Langfuse with Mastra, a TypeScript agent framework, to monitor, debug, and analyze your AI applications.
 ---
 
-#  Observability for Mastra with Langfuse
+#  Observability for Mastra With Langfuse
 
 This guide shows you how to integrate **Langfuse** with **Mastra** for observability and tracing. By following these steps, you'll be able to monitor and debug your Mastra agents in the Langfuse dashboard.
 

--- a/pages/docs/integrations/mirascope/tracing.mdx
+++ b/pages/docs/integrations/mirascope/tracing.mdx
@@ -3,7 +3,7 @@ title: Open Source Observability & Monitoring for Mirascope
 description: Open source observability for Mirascope applications. Automatically capture detailed traces of how users interact with your application.
 ---
 
-# Monitor Mirascope applications with Langfuse
+# Monitor Mirascope Applications with Langfuse
 
 This guide shows you how to use Langfuse to track and debug Mirascope applications.
 

--- a/pages/docs/integrations/openai/python/track-errors.mdx
+++ b/pages/docs/integrations/openai/python/track-errors.mdx
@@ -2,7 +2,7 @@
 description: Langfuse automatically tracks and monitors OpenAI API errors if you use the native integration.
 ---
 
-# Tracking of OpenAI API errors
+# Tracking of OpenAI API Errors
 
 Langfuse Langfuse automatically tracks and monitors OpenAI API errors if you use the native integration. They are captured via the `level` and `statusMessage` fields (see [docs](/docs/tracing-features/log-levels)).
 

--- a/pages/docs/integrations/other/ragas.mdx
+++ b/pages/docs/integrations/other/ragas.mdx
@@ -3,7 +3,7 @@ title: "Langfuse Integration with Ragas"
 description: "Optimize your RAG pipelines with Langfuse and Ragas integration for efficient evaluation, monitoring, and performance enhancement."
 ---
 
-# RAG pipeline evaluation with Ragas and Langfuse
+# RAG Pipeline Evaluation with Ragas and Langfuse
 
 Ragas and Langfuse is a powerful combination that can help you evaluate and monitor your Retrieval-Augmented Generation (RAG) pipelines.
 

--- a/pages/docs/rbac.mdx
+++ b/pages/docs/rbac.mdx
@@ -2,7 +2,7 @@
 description: Langfuse offers extensive RBAC capabilities to manage project sharing and permissions across different organizations and projects.
 ---
 
-# Role-based Access Controls in Langfuse
+# Role-Based Access Controls in Langfuse
 
 The role-based access control (RBAC) in Langfuse is based on organizations, projects, and roles:
 

--- a/pages/docs/scores/model-based-evals.mdx
+++ b/pages/docs/scores/model-based-evals.mdx
@@ -3,7 +3,7 @@ title: Fully managed LLM-as-a-judge evaluation
 description: Langfuse (open source) helps run model-based evaluations (llm-as-a-judge) on production data to monitor and improve LLMs applications.
 ---
 
-# Fully managed LLM-as-a-judge evaluation
+# Fully Managed LLM-As-a-Judge Evaluation
 
 <AvailabilityBanner
   availability={{

--- a/pages/docs/sdk/python/decorators.mdx
+++ b/pages/docs/sdk/python/decorators.mdx
@@ -2,7 +2,7 @@
 description: A decorator-based integration to give you powerful tracing, evals, and analytics for your LLM application
 ---
 
-# Decorator-based Python Integration
+# Decorator-Based Python Integration
 
 Integrate [Langfuse Tracing](/docs/tracing) into your LLM applications with the Langfuse Python SDK using the `@observe()` decorator.
 

--- a/pages/docs/tracing-features/masking.mdx
+++ b/pages/docs/tracing-features/masking.mdx
@@ -2,7 +2,7 @@
 description: Configure masking to redact sensitive information from inputs and outputs sent to the Langfuse server.
 ---
 
-# Masking of sensitive LLM data
+# Masking of Sensitive LLM Data
 
 Masking is a feature that allows precise control over the [tracing](/docs/tracing/overview) data sent to the Langfuse server. With custom masking functions, you can control and sanitize the data that gets traced and sent to the server. Whether it's for **compliance reasons** or to protect **user privacy**, masking sensitive data is a crucial step in responsible application development. It enables you to:
 

--- a/pages/docs/tracing-features/tags.mdx
+++ b/pages/docs/tracing-features/tags.mdx
@@ -2,7 +2,7 @@
 description: Tags help to filter and organize traces in Langfuse based on use case, functions/apis used, environment and other criteria.
 ---
 
-# Tagging traces
+# Tagging Traces
 
 Tags allow you to categorize and filter traces. You can tag traces (1) when they are created using the Langfuse SDKs and integrations or (2) from the Langfuse UI. To tag a trace, add a list of tags to the tags field of the trace object. Tags are strings and a trace may have multiple tags.
 

--- a/scripts/fix_titlecase.py
+++ b/scripts/fix_titlecase.py
@@ -1,0 +1,69 @@
+import os
+import re
+
+SMALL_WORDS = {
+    'a', 'an', 'the', 'and', 'but', 'or', 'nor', 'for', 'so', 'yet', 'at', 'by',
+    'in', 'of', 'on', 'to', 'up', 'via', 'with', 'from', 'into', 'onto', 'off', 'per'
+}
+
+
+def title_case(text: str) -> str:
+    words = re.split(r'(\s+|-)', text)
+    # Count real words (exclude spaces/hyphens)
+    real_words = [w for w in words if w and not re.match(r'(\s+|-)', w)]
+    total = len(real_words)
+    result = []
+    index = 0
+    for part in words:
+        if re.match(r'(\s+|-)', part):
+            result.append(part)
+            continue
+        word = part
+        is_first = index == 0
+        is_last = index == total - 1
+        lower = word.lower()
+        if word.isupper() or any(c.isupper() for c in word[1:]):
+            result.append(word)
+        elif not is_first and not is_last and lower in SMALL_WORDS:
+            result.append(lower)
+        else:
+            result.append(word.capitalize())
+        index += 1
+    return ''.join(result)
+
+
+def fix_file(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    in_code = False
+    changed = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith('```') or stripped.startswith('~~~'):
+            in_code = not in_code
+            continue
+        if not in_code and line.startswith('# '):
+            title = line[2:].rstrip('\n')
+            new_title = title_case(title)
+            if new_title != title:
+                lines[i] = '# ' + new_title + '\n'
+                changed = True
+            break
+
+    if changed:
+        with open(path, 'w', encoding='utf-8') as f:
+            f.writelines(lines)
+        print(f'Updated {path}')
+
+
+def main():
+    root = 'pages/docs'
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith('.mdx'):
+                fix_file(os.path.join(dirpath, name))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add helper script to convert h1 headings to Title Case
- update h1 titles across documentation

## Testing
- `node scripts/check-h1-headings.js`
- *(link-check failed: missing dependencies and network access)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates documentation H1 titles to Title Case using a new script `fix_titlecase.py`.
> 
>   - **Behavior**:
>     - Updates H1 titles across documentation to Title Case.
>     - Introduces `fix_titlecase.py` script to automate title casing of H1 headings.
>   - **Scripts**:
>     - Adds `fix_titlecase.py` to convert H1 headings to Title Case in `.mdx` files under `pages/docs`.
>     - Script skips code blocks and only modifies the first H1 heading in each file.
>   - **Testing**:
>     - Run `node scripts/check-h1-headings.js` to verify changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 70019d5d3858286e44ba8e8ae34e290457f2a31f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->