### PR TITLE
Add title casing check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,23 @@ jobs:
       - name: Run H1 heading check
         run: node scripts/check-h1-headings.js
 
+  check_title_case:
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run title case check
+        run: python scripts/check_titlecase.py
+
   build-and-check-links:
     needs:
       - pre-job

--- a/scripts/check_titlecase.py
+++ b/scripts/check_titlecase.py
@@ -1,0 +1,65 @@
+import os
+import re
+import sys
+
+SMALL_WORDS = {
+    'a', 'an', 'the', 'and', 'but', 'or', 'nor', 'for', 'so', 'yet', 'at', 'by',
+    'in', 'of', 'on', 'to', 'up', 'via', 'with', 'from', 'into', 'onto', 'off', 'per'
+}
+
+def title_case(text: str) -> str:
+    words = re.split(r'(\s+|-)', text)
+    real_words = [w for w in words if w and not re.match(r'(\s+|-)', w)]
+    total = len(real_words)
+    result = []
+    index = 0
+    for part in words:
+        if re.match(r'(\s+|-)', part):
+            result.append(part)
+            continue
+        word = part
+        is_first = index == 0
+        is_last = index == total - 1
+        lower = word.lower()
+        if word.isupper() or any(c.isupper() for c in word[1:]):
+            result.append(word)
+        elif not is_first and not is_last and lower in SMALL_WORDS:
+            result.append(lower)
+        else:
+            result.append(word.capitalize())
+        index += 1
+    return ''.join(result)
+
+def check_file(path: str) -> bool:
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    in_code = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('```') or stripped.startswith('~~~'):
+            in_code = not in_code
+            continue
+        if not in_code and line.startswith('# '):
+            title = line[2:].rstrip('\n')
+            expected = title_case(title)
+            if expected != title:
+                print(f'Incorrect title case in {path}: "{title}" -> "{expected}"')
+                return False
+            break
+    return True
+
+def main():
+    root = 'pages/docs'
+    all_ok = True
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith('.mdx'):
+                file_ok = check_file(os.path.join(dirpath, name))
+                if not file_ok:
+                    all_ok = False
+    if not all_ok:
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python script `check_titlecase.py` to validate title casing for docs
- run the new script in CI so PRs fail when titles are not in title case

## Testing
- `python scripts/check_titlecase.py`
- `node scripts/check-h1-headings.js`
- `pnpm -v` *(fails: Connect Timeout Error)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `check_titlecase.py` to enforce title casing in documentation and integrates it into CI workflow.
> 
>   - **Behavior**:
>     - Adds `check_titlecase.py` to validate title casing in markdown files under `pages/docs`.
>     - Integrates title case validation into CI via `.github/workflows/ci.yml`.
>     - CI fails if any markdown file has incorrect title casing.
>   - **Scripts**:
>     - `check_titlecase.py` checks first-level headings in `.mdx` files, ignoring code blocks.
>     - Uses `title_case()` to format titles, considering small words.
>   - **CI Configuration**:
>     - Adds `check_title_case` job in `ci.yml` to run `check_titlecase.py`.
>     - Job runs on `ubuntu-latest` and requires Python setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5d5bc1fbf8f376fe03af669c83d88a42184aed3e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->