### PR TITLE
Fix LangFuse casing

### DIFF
--- a/pages/docs/analytics/posthog.mdx
+++ b/pages/docs/analytics/posthog.mdx
@@ -101,7 +101,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_release`: Information relating to the event release.
 - `langfuse_version`: The version of the event.
 - `langfuse_tags`: Any tags associated with the event.
-- `langfuse_event_version`: The integration version of LangFuse.
+- `langfuse_event_version`: The integration version of Langfuse.
 
 #### Event: `langfuse generation`
 
@@ -124,7 +124,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_model`: The model used during this generation's process.
 - `langfuse_level`: The level associated with the generation.
 - `langfuse_tags`: Any tags attached to the trace of the generation.
-- `langfuse_event_version`: The integration version with LangFuse.
+- `langfuse_event_version`: The integration version with Langfuse.
 
 #### Event `langfuse score`
 
@@ -139,7 +139,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_user_id`: The user ID that triggered the trace tied with the score. If not available, defaults to `langfuse_unknown_user`.
 - `langfuse_release`: The release information of the trace associated with the score.
 - `langfuse_tags`: Any tags related to the trace of the score.
-- `langfuse_event_version`: The integration version with LangFuse.
+- `langfuse_event_version`: The integration version with Langfuse.
 
 ## Troubleshooting
 

--- a/pages/docs/integrations/quarkus-langchain4j.mdx
+++ b/pages/docs/integrations/quarkus-langchain4j.mdx
@@ -118,7 +118,7 @@ public interface MyAiService {
 public class Startup {
 
     public void writeAPoem(@Observes StartupEvent event, MyAiService service) {
-        System.out.println(service.writeAPoem("LangFuse", 4));
+        System.out.println(service.writeAPoem("Langfuse", 4));
     }
 }
 ```

--- a/pages/guides/videos/beginners-guide-to-rag-evaluation.mdx
+++ b/pages/guides/videos/beginners-guide-to-rag-evaluation.mdx
@@ -52,10 +52,10 @@ particularly when combined with [Ragas](https://docs.ragas.io) metrics.
   - Conciseness: Measures how succinct an answer is.
   - Helpfulness: Evaluates the usefulness of an answer.
 - Tools:
-  - [LangFuse](/): Used for tracing and logging RAG operations.
+  - [Langfuse](/): Used for tracing and logging RAG operations.
   - [RAGAS](https://docs.ragas.io) (RAG Assessment): Provides detailed metrics for evaluating RAG systems.
 
-### 4. LangFuse
+### 4. Langfuse
 
 - [Features](/docs):
   - Logs each step in the RAG process.
@@ -63,8 +63,8 @@ particularly when combined with [Ragas](https://docs.ragas.io) metrics.
   - Allows for comparison of different interactions.
   - Many additional LLM Ops features such as prompt management, cost analysis, benchmarking, and more.
 - Demo:
-  - Demonstrated a chatbot application using LangFuse for tracing and logging interactions. Public link: [langfuse.com/demo](https://langfuse.com/docs/demo)
-  - Showed how to analyze the performance of the RAG system using LangFuse metrics.
+  - Demonstrated a chatbot application using Langfuse for tracing and logging interactions. Public link: [langfuse.com/demo](https://langfuse.com/docs/demo)
+  - Showed how to analyze the performance of the RAG system using Langfuse metrics.
 
 ### 5. RAGAS
 

--- a/pages/jp.mdx
+++ b/pages/jp.mdx
@@ -109,7 +109,7 @@ Langfuse は[インテグレーションや SDK を通して](/docs/integrations
 - [Blog 記事: Google Cloud で LLM アプリ監視ツール Langfuse をセルフホスティングする方法](https://zenn.dev/cloud_ace/articles/2a3668221e9c90)
 - [Youtube: LLMアプリの料金設計とLangfuseを活用した分析設計 | 山下 徳光 / 株式会社グランドリームさん](https://www.youtube.com/watch?v=kTIFd6cby_I)
 - [Blog 記事: ペアーズにおける評価ドリブンなリリースサイクル：Langfuseをフル活用したLLMOps基盤](https://medium.com/eureka-engineering/ペアーズにおける評価ドリブンなリリースサイクル-langfuseをフル活用したllmops基盤-957986e3dcb2)
-- [YouTube: Difyで作ったリモ研RAGのデータを、LangFuseから出力し、マクロで整形して、LLMとMapifyで可視化し、そこからリモ研RAGのキャッチコピーに](https://www.youtube.com/watch?v=p1jTGXAYbRs)
+- [YouTube: Difyで作ったリモ研RAGのデータを、Langfuseから出力し、マクロで整形して、LLMとMapifyで可視化し、そこからリモ研RAGのキャッチコピーに](https://www.youtube.com/watch?v=p1jTGXAYbRs)
 
 _リソースを追加したい場合は、[プルリクエストを上げて](https://github.com/langfuse/langfuse-docs)ください。_
 


### PR DESCRIPTION
## Summary
- fix LangFuse -> Langfuse in docs

## Testing
- `pnpm -v` *(fails: Connect Timeout Error)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes casing of 'LangFuse' to 'Langfuse' across multiple documentation files for consistency.
> 
>   - **Documentation**:
>     - Corrects casing from `LangFuse` to `Langfuse` in `posthog.mdx`, `quarkus-langchain4j.mdx`, and `beginners-guide-to-rag-evaluation.mdx`.
>     - Updates example code in `quarkus-langchain4j.mdx` to reflect the correct casing.
>     - Adjusts Japanese documentation in `jp.mdx` for consistency in naming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8e96b49426a0fe2a28b4e360c094609cfc7e3458. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->