### PR TITLE
docs: update AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repo guidelines for Codex
+
+This repository hosts the documentation for Langfuse. Refer to the main README for development instructions and additional context.
+
+## Documentation rules
+- Do **not** edit `.md` files under `pages/` directly. They are generated from Jupyter notebooks in the `cookbook/` directory. Modify the notebooks and run `bash scripts/update_cookbook_docs.sh` to regenerate docs.
+- Regular docs are authored in `.mdx` files.
+- Follow the style guides located in `.cursor/rules`. Codex should fetch these rule files dynamically.
+- Store images in `public/images` and reference them with absolute paths like `/images/...`.
+
+## Commit conventions
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages and PR titles.
+
+## Checks before committing
+Run the following commands at repo root and ensure they succeed:
+
+```bash
+pnpm install
+pnpm build
+```
+
+These match the CI workflow.


### PR DESCRIPTION
## Summary
- clarify that this repo hosts Langfuse documentation
- explain that regular docs are authored in `.mdx`
- instruct Codex to fetch style guides in `.cursor/rules` dynamically
- remove failing checks from the commit checklist
- require Conventional Commits for commit messages and PR titles

## Testing
- `pnpm install` *(failed: EHOSTUNREACH)*
- `pnpm build` *(failed: EHOSTUNREACH)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `AGENTS.md` to clarify documentation practices, require Conventional Commits, and adjust commit checklist.
> 
>   - **Documentation**:
>     - Clarifies that the repo hosts Langfuse documentation.
>     - Regular docs should be authored in `.mdx` files.
>     - Codex should fetch style guides in `.cursor/rules` dynamically.
>   - **Commit Conventions**:
>     - Requires Conventional Commits for commit messages and PR titles.
>   - **Commit Checklist**:
>     - Removes failing checks from the checklist.
>     - Specifies `pnpm install` and `pnpm build` as required checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ce0b0f9f4b0d625f61dc22c7562261c60a60fb9c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->