### PR TITLE
Update enterprise page for OSS support

### DIFF
--- a/pages/enterprise.mdx
+++ b/pages/enterprise.mdx
@@ -6,15 +6,12 @@ description: FAQ and deployment options for Langfuse in an enterprise environmen
 
 Langfuse addresses key challenges when deploying LLM-based applications within an enterprise. As an [open source](/open-source) project, Langfuse is the ideal platform **to address data security and privacy concerns by self-hosting.** This document outlines common queries related to using Langfuse in an enterprise setting.
 
-Langfuse is licensed as an open-core project. It's core product (tracing, observability, evals, prompt management and API/SDK endpoints) is MIT-licensed and freely available (also without limitation for commercial use). Some Langfuse features on the periphery of the core product are not available in the open-source version and cannot be used out of the box. As of today, these are either a) quality of life features (such as LLM-as-a-judge service, prompt playground) or b) security & compliance features (e.g. SSO enforcement, data retention)
-
-Please refer to our [feature overview](/pricing-self-host) and the Enterprise Edition FAQ [here](/open-source#enterprise-edition-ee-faq). Please reach out to enterprise@langfuse.com to discuss an enterprise license (self-hosted or cloud) for your team.
+Langfuse is fully open source under the Apache 2.0 license. Customers may self-host Langfuse or use Langfuse Cloud. Enterprise-grade support is available—see [Self-hosting](/self-hosting) for details or contact [enterprise@langfuse.com](mailto:enterprise@langfuse.com).
 
 **Select Resources**
 
 - [Why Langfuse?](/why)
 - [Langfuse has twice been included in the Thoughtworks Tech Radar](https://www.thoughtworks.com/en-us/radar/platforms/langfuse)
-- [Enterprise Edition (EE) FAQ](/open-source#enterprise-edition-ee-faq)
 - Langfuse can be procured through the [AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu).
 
 ## Talk to us
@@ -99,8 +96,8 @@ We are happy to introduce prospects to our contact at Shakudo and GAO for more i
 ### What is the difference between Langfuse Cloud and the open-source version?
 
 The Langfuse team provides Langfuse Cloud as a managed solution to simplify the initial setup of Langfuse and to minimize the operational overhead of maintaining high availability in production. You can chose to self-host Langfuse on your own infrastructure.
+Self-hosting runs the same open source code as Langfuse Cloud; see [Self-hosting](/self-hosting) for deployment guides.
 
-Some features are not available in the open-source version. Please refer to the overview [here](/pricing-self-host).
 
 ### How does Authentication and RBAC work in Langfuse?
 


### PR DESCRIPTION
## Summary
- update enterprise page to reflect full open source licensing
- mention enterprise support with link to self-hosting docs

## Testing
- `node scripts/check-h1-headings.js`
- `node scripts/check-links.js` *(fails: many dead links)*
