### PR TITLE
docs: update crewai, mlflow instead of openlit

### DIFF
--- a/cookbook/integration_crewai.ipynb
+++ b/cookbook/integration_crewai.ipynb
@@ -6,13 +6,13 @@
    "source": [
     "---\n",
     "title: Observability for CrewAI with Langfuse\n",
-    "description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using OpenLit\n",
+    "description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using MLflow\n",
     "category: Integrations\n",
     "---\n",
     "\n",
     "# Integrate Langfuse with CrewAI\n",
     "\n",
-    "This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **OpenLit** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.\n",
+    "This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **MLflow** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.\n",
     "\n",
     "> **What is CrewAI?** [CrewAI](https://github.com/crewAIInc/crewAI) is a framework for orchestrating autonomous AI agents. CrewAI enables you to create AI teams where each agent has specific roles, tools, and goals, working together to accomplish complex tasks. Each member (agent) brings unique skills and expertise, collaborating seamlessly to achieve your objectives.\n",
     "\n",
@@ -20,7 +20,7 @@
     "\n",
     "## Get Started\n",
     "\n",
-    "We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using OpenLit.\n",
+    "We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using MLflow.\n",
     "\n",
     "### Step 1: Install Dependencies"
    ]
@@ -31,8 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install langfuse crewai crewai_tools transformers\n",
-    "%pip install openlit==\"1.33\""
+    "%pip install mlflow crewai -q"
    ]
   },
   {
@@ -53,13 +52,14 @@
     "import os\n",
     "import base64\n",
     "\n",
-    "LANGFUSE_PUBLIC_KEY=\"pk-lf-...\"\n",
-    "LANGFUSE_SECRET_KEY=\"sk-lf-...\"\n",
+    "LANGFUSE_PUBLIC_KEY = \"pk-lf-...\"\n",
+    "LANGFUSE_SECRET_KEY = \"sk-lf-...\"\n",
     "LANGFUSE_AUTH=base64.b64encode(f\"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}\".encode()).decode()\n",
     "\n",
-    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = \"https://cloud.langfuse.com/api/public/otel\" # EU data region\n",
-    "# os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = \"https://us.cloud.langfuse.com/api/public/otel\" # US data region\n",
-    "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\"\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\"] = \"https://cloud.langfuse.com/api/public/otel/v1/traces\"  # 🇪🇺 EU data region\n",
+    "# os.environ[\"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\"] = \"https://us.cloud.langfuse.com/api/public/otel/v1/traces\"  # 🇺🇸 US data region\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_TRACES_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\"\n",
+    "os.environ['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL']= \"http/protobuf\"\n",
     "\n",
     "# your openai key\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
@@ -69,9 +69,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 3: Initialize OpenLit\n",
+    "### Step 3: Initialize MLflow\n",
     "\n",
-    "Initialize the OpenLit OpenTelemetry instrumentation SDK to start capturing OpenTelemetry traces."
+    "Initialize the [MLflow OpenTelemetry instrumentation SDK](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html) to start capturing OpenTelemetry traces."
    ]
   },
   {
@@ -80,9 +80,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openlit\n",
+    "import mlflow\n",
     "\n",
-    "openlit.init()"
+    "mlflow.crewai.autolog()"
    ]
   },
   {
@@ -141,7 +141,8 @@
     "## References\n",
     "\n",
     "- [Langfuse OpenTelemetry Docs](https://langfuse.com/docs/opentelemetry/get-started)\n",
-    "- [CrewAI Documentation](https://docs.crewai.com/introduction)\n"
+    "- [CrewAI Documentation](https://docs.crewai.com/introduction)\n",
+    "- [MLflow Documentation](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html)\n"
    ]
   },
   {

--- a/pages/docs/integrations/crewai.md
+++ b/pages/docs/integrations/crewai.md
@@ -1,12 +1,12 @@
 ---
 title: Observability for CrewAI with Langfuse
-description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using OpenLit
+description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using MLflow
 category: Integrations
 ---
 
 # Integrate Langfuse with CrewAI
 
-This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **OpenLit** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.
+This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **MLflow** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.
 
 > **What is CrewAI?** [CrewAI](https://github.com/crewAIInc/crewAI) is a framework for orchestrating autonomous AI agents. CrewAI enables you to create AI teams where each agent has specific roles, tools, and goals, working together to accomplish complex tasks. Each member (agent) brings unique skills and expertise, collaborating seamlessly to achieve your objectives.
 
@@ -14,14 +14,13 @@ This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using O
 
 ## Get Started
 
-We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using OpenLit.
+We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using MLflow.
 
 ### Step 1: Install Dependencies
 
 
 ```python
-%pip install langfuse crewai crewai_tools transformers
-%pip install openlit=="1.33"
+%pip install mlflow crewai -q
 ```
 
 ### Step 2: Set Up Environment Variables
@@ -33,27 +32,28 @@ Set your Langfuse API keys and configure OpenTelemetry export settings to send t
 import os
 import base64
 
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
 LANGFUSE_AUTH=base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
 
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel" # EU data region
-# os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel" # US data region
-os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel/v1/traces"  # 🇪🇺 EU data region
+# os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel/v1/traces"  # 🇺🇸 US data region
+os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+os.environ['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL']= "http/protobuf"
 
 # your openai key
 os.environ["OPENAI_API_KEY"] = "sk-..."
 ```
 
-### Step 3: Initialize OpenLit
+### Step 3: Initialize MLflow
 
-Initialize the OpenLit OpenTelemetry instrumentation SDK to start capturing OpenTelemetry traces.
+Initialize the [MLflow OpenTelemetry instrumentation SDK](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html) to start capturing OpenTelemetry traces.
 
 
 ```python
-import openlit
+import mlflow
 
-openlit.init()
+mlflow.crewai.autolog()
 ```
 
 ### Step 4: Create a Simple CrewAI Application
@@ -100,6 +100,7 @@ _[Public example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj
 
 - [Langfuse OpenTelemetry Docs](https://langfuse.com/docs/opentelemetry/get-started)
 - [CrewAI Documentation](https://docs.crewai.com/introduction)
+- [MLflow Documentation](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html)
 
 
 

--- a/pages/guides/cookbook/integration_crewai.md
+++ b/pages/guides/cookbook/integration_crewai.md
@@ -1,12 +1,12 @@
 ---
 title: Observability for CrewAI with Langfuse
-description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using OpenLit
+description: Learn how to integrate Langfuse with CrewAI via OpenTelemetry using MLflow
 category: Integrations
 ---
 
 # Integrate Langfuse with CrewAI
 
-This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **OpenLit** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.
+This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using OpenTelemetry via the **MLflow** SDK. By the end of this notebook, you will be able to trace your CrewAI applications with Langfuse for improved observability and debugging.
 
 > **What is CrewAI?** [CrewAI](https://github.com/crewAIInc/crewAI) is a framework for orchestrating autonomous AI agents. CrewAI enables you to create AI teams where each agent has specific roles, tools, and goals, working together to accomplish complex tasks. Each member (agent) brings unique skills and expertise, collaborating seamlessly to achieve your objectives.
 
@@ -14,14 +14,13 @@ This notebook demonstrates how to integrate **Langfuse** with **CrewAI** using O
 
 ## Get Started
 
-We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using OpenLit.
+We'll walk through a simple example of using CrewAI and integrating it with Langfuse via OpenTelemetry using MLflow.
 
 ### Step 1: Install Dependencies
 
 
 ```python
-%pip install langfuse crewai crewai_tools transformers
-%pip install openlit=="1.33"
+%pip install mlflow crewai -q
 ```
 
 ### Step 2: Set Up Environment Variables
@@ -33,27 +32,28 @@ Set your Langfuse API keys and configure OpenTelemetry export settings to send t
 import os
 import base64
 
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
-LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_SECRET_KEY = "sk-lf-..."
 LANGFUSE_AUTH=base64.b64encode(f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()).decode()
 
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel" # EU data region
-# os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel" # US data region
-os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "https://cloud.langfuse.com/api/public/otel/v1/traces"  # 🇪🇺 EU data region
+# os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "https://us.cloud.langfuse.com/api/public/otel/v1/traces"  # 🇺🇸 US data region
+os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+os.environ['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL']= "http/protobuf"
 
 # your openai key
 os.environ["OPENAI_API_KEY"] = "sk-..."
 ```
 
-### Step 3: Initialize OpenLit
+### Step 3: Initialize MLflow
 
-Initialize the OpenLit OpenTelemetry instrumentation SDK to start capturing OpenTelemetry traces.
+Initialize the [MLflow OpenTelemetry instrumentation SDK](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html) to start capturing OpenTelemetry traces.
 
 
 ```python
-import openlit
+import mlflow
 
-openlit.init()
+mlflow.crewai.autolog()
 ```
 
 ### Step 4: Create a Simple CrewAI Application
@@ -100,6 +100,7 @@ _[Public example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj
 
 - [Langfuse OpenTelemetry Docs](https://langfuse.com/docs/opentelemetry/get-started)
 - [CrewAI Documentation](https://docs.crewai.com/introduction)
+- [MLflow Documentation](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html)
 
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates documentation to replace OpenLit with MLflow for integrating Langfuse with CrewAI, including installation, environment setup, and initialization changes.
> 
>   - **Documentation Update**:
>     - Replaces `OpenLit` with `MLflow` in `crewai.md` and `integration_crewai.md` for integrating Langfuse with CrewAI.
>     - Updates installation instructions to use `mlflow` instead of `openlit`.
>     - Modifies environment variable setup to use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and related headers.
>     - Changes initialization from `openlit.init()` to `mlflow.crewai.autolog()`.
>   - **References**:
>     - Adds link to [MLflow Documentation](https://mlflow.org/docs/latest/api_reference/python_api/mlflow.crewai.html).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 75b61fad1441171de4f3e87747f87eba5d111172. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->