### PR TITLE
docs: update banner + /ph redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -127,7 +127,7 @@ const nonPermanentRedirects = [
   ["/video", "/watch-demo"],
   ["/docs/video", "/watch-demo"],
   ["/roadmap", "/docs/roadmap"],
-  ["/ph", "https://www.producthunt.com/products/langfuse"],
+  ["/ph", "https://www.producthunt.com/posts/langfuse-analytics"],
   ["/loom-gpt4-PR", "https://www.loom.com/share/5c044ca77be44ff7821967834dd70cba"],
   ["/issue", "https://github.com/langfuse/langfuse/issues/new/choose"],
   ["/new-issue", "/issue"],

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -196,15 +196,15 @@ const config: DocsThemeConfig = {
     Video,
   },
   banner: {
-    key: "lw3-2",
+    key: "lw3-3",
     dismissible: true,
     content: (
-      <Link href="/changelog/2025-05-20-save-table-views">
+      <Link href="/ph">
         {/* mobile */}
-        <span className="sm:hidden">LW3 Day 2: Save and share table views →</span>
+        <span className="sm:hidden">Langfuse live on Product Hunt: Custom Dashboards →</span>
         {/* desktop */}
         <span className="hidden sm:inline">
-        Langfuse Launch Week #3, Day 2: Save and share table views →
+        On Product Hunt: Custom Dashboards →
         </span>
       </Link>
     ),


### PR DESCRIPTION
To go live 21.05.2025 – 10am CEST
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `/ph` redirect and banner content for Product Hunt launch in `next.config.mjs` and `theme.config.tsx`.
> 
>   - **Redirects**:
>     - Update `/ph` redirect in `next.config.mjs` to `https://www.producthunt.com/posts/langfuse-analytics`.
>   - **Banner**:
>     - Update banner `key` to `lw3-3` and content in `theme.config.tsx` to announce "Langfuse live on Product Hunt: Custom Dashboards".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 311e77aa72b5c9bd7487de8efbdee7c739d50626. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->