### PR TITLE
chore: update data retention to have a minimum of 3 days

### DIFF
--- a/pages/changelog/2025-01-30-data-retention.mdx
+++ b/pages/changelog/2025-01-30-data-retention.mdx
@@ -11,8 +11,8 @@ import { FileCode, BookOpen, GitCommit } from "lucide-react";
 
 <ChangelogHeader />
 
-With Langfuse's Data Retention feature, you can control how long your event data (Traces, Observations, Scores, and Media Assets) is stored in Langfuse.D
-ata retention is configured on a project level, and we accept a number of days with a minimum of 7 days.
+With Langfuse's Data Retention feature, you can control how long your event data (Traces, Observations, Scores, and Media Assets) is stored in Langfuse.
+Data retention is configured on a project level, and we accept a number of days with a minimum of 3 days.
 Project owners and administrators can change the data retention setting within the Project Settings view.
 
 See [documentation](/docs/data-retention) for more information.

--- a/pages/docs/data-retention.mdx
+++ b/pages/docs/data-retention.mdx
@@ -15,7 +15,7 @@ description: Control Data Retention in Langfuse
 />
 
 With Langfuse's Data Retention feature, you can control how long your event data (Traces, Observations, Scores, and Media Assets) is stored in Langfuse.
-Data retention is configured on a project level, and we accept a number of days with a minimum of 7 days.
+Data retention is configured on a project level, and we accept a number of days with a minimum of 3 days.
 Project owners and administrators can change the data retention setting within the Project Settings view.
 
 <Frame className="my-10" fullWidth>

--- a/pages/security/privacy-faq.mdx
+++ b/pages/security/privacy-faq.mdx
@@ -12,7 +12,7 @@ Yes. You can enter into a [DPA](/security/dpa) with Langfuse.
 
 > **How long is data retained?**
 
-[Data retention](/docs/data-retention) can be defined via project‑level policies: ≥ 7 days up to unlimited. Data is purged nightly.
+[Data retention](/docs/data-retention) can be defined via project‑level policies: ≥ 3 days up to unlimited. Data is purged nightly.
 
 > **How can we delete data?**
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates minimum data retention period from 7 days to 3 days in documentation files.
> 
>   - **Behavior**:
>     - Updates minimum data retention period from 7 days to 3 days in `2025-01-30-data-retention.mdx`, `data-retention.mdx`, and `privacy-faq.mdx`.
>     - Data retention is still configured on a project level and can be set to unlimited.
>   - **Documentation**:
>     - Reflects new minimum retention period in changelog, documentation, and privacy FAQ.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 51c2d4ee77b724afb804ea024dabd594abcd3aae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->