### PR TITLE
chore: dynamically load terraform readme for latest changelog to make this more maintainable

### DIFF
--- a/pages/changelog/2025-05-22-terraform-modules.mdx
+++ b/pages/changelog/2025-05-22-terraform-modules.mdx
@@ -9,6 +9,72 @@ showOgInHeader: false
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { useData } from "nextra/hooks";
+import { Playground } from "nextra/components";
+
+export const getStaticProps = async () => {
+  const [awsRes, gcpRes, azureRes] = await Promise.all([
+    fetch(
+      "https://raw.githubusercontent.com/langfuse/langfuse-terraform-aws/refs/heads/main/README.md"
+    ),
+    fetch(
+      "https://raw.githubusercontent.com/langfuse/langfuse-terraform-gcp/main/README.md"
+    ),
+    fetch(
+      "https://raw.githubusercontent.com/langfuse/langfuse-terraform-azure/main/README.md"
+    ),
+  ]);
+  const [awsReadme, gcpReadme, azureReadme] = await Promise.all([
+    awsRes.text(),
+    gcpRes.text(),
+    azureRes.text(),
+  ]);
+  return {
+    props: {
+      ssg: {
+        awsTerraformReadme: awsReadme,
+        gcpTerraformReadme: gcpReadme,
+        azureTerraformReadme: azureReadme,
+      },
+    },
+  };
+};
+
+export function AwsTerraformReadme() {
+  const { awsTerraformReadme } = useData();
+  if (!awsTerraformReadme) {
+    return <p>Error loading README content.</p>;
+  }
+  const readmeString =
+    typeof awsTerraformReadme === "string"
+      ? awsTerraformReadme
+      : JSON.stringify(awsTerraformReadme);
+  return <Playground source={readmeString} />;
+}
+
+export function GcpTerraformReadme() {
+  const { gcpTerraformReadme } = useData();
+  if (!gcpTerraformReadme) {
+    return <p>Error loading README content.</p>;
+  }
+  const readmeString =
+    typeof gcpTerraformReadme === "string"
+      ? gcpTerraformReadme
+      : JSON.stringify(gcpTerraformReadme);
+  return <Playground source={readmeString} />;
+}
+
+export function AzureTerraformReadme() {
+  const { azureTerraformReadme } = useData();
+  if (!azureTerraformReadme) {
+    return <p>Error loading README content.</p>;
+  }
+  const readmeString =
+    typeof azureTerraformReadme === "string"
+      ? azureTerraformReadme
+      : JSON.stringify(azureTerraformReadme);
+  return <Playground source={readmeString} />;
+}
 
 <ChangelogHeader />
 
@@ -38,174 +104,34 @@ Create your own scalable Langfuse environment within minutes on your favorite hy
 
 Use the following snippets to include the respective module in your Terraform code and deploy Langfuse.
 
-  <Tabs items={["AWS", "GCP","Azure"]}>
+<Tabs items={["AWS", "GCP","Azure"]}>
+  <Tab>
+    Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-aws) for the full deployment guide.
 
-    <Tab>
+    <div className="p-6 mt-6 border bg-card rounded-md">
+      <AwsTerraformReadme />
+    </div>
 
-      Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-aws) for the full deployment guide.
+  </Tab>
 
-      ```terraform
-      module "langfuse" {
-        source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.3"
+  <Tab>
+    Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-gcp) for the full deployment guide.
 
-        domain = "langfuse.example.com"
+    <div className="p-6 mt-6 border bg-card rounded-md">
+      <GcpTerraformReadme />
+    </div>
 
-        # Optional use a different name for your installation
-        # e.g. when using the module multiple times on the same AWS account
-        name   = "langfuse"
+  </Tab>
 
-        # Optional: Configure the VPC
-        vpc_cidr = "10.0.0.0/16"
-        use_single_nat_gateway = false  # Using a single NAT gateway decreases costs, but is less resilient
+  <Tab>
+    Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-azure) for the full deployment guide.
 
-        # Optional: Configure the Kubernetes cluster
-        kubernetes_version = "1.32"
-        fargate_profile_namespaces = ["kube-system", "langfuse", "default"]
+    <div className="p-6 mt-6 border bg-card rounded-md">
+      <AzureTerraformReadme />
+    </div>
 
-        # Optional: Configure the database instances
-        postgres_instance_count = 2
-        postgres_min_capacity = 0.5
-        postgres_max_capacity = 2.0
-
-        # Optional: Configure the cache
-        cache_node_type = "cache.t4g.small"
-        cache_instance_count = 2
-      }
-
-      provider "kubernetes" {
-        host                   = module.langfuse.cluster_host
-        cluster_ca_certificate = module.langfuse.cluster_ca_certificate
-        token                  = module.langfuse.cluster_token
-
-        exec {
-          api_version = "client.authentication.k8s.io/v1beta1"
-          command     = "aws"
-          args        = ["eks", "get-token", "--cluster-name", module.langfuse.cluster_name]
-        }
-      }
-
-      provider "helm" {
-        kubernetes {
-          host                   = module.langfuse.cluster_host
-          cluster_ca_certificate = module.langfuse.cluster_ca_certificate
-          token                  = module.langfuse.cluster_token
-
-          exec {
-            api_version = "client.authentication.k8s.io/v1beta1"
-            command     = "aws"
-            args        = ["eks", "get-token", "--cluster-name", module.langfuse.cluster_name]
-          }
-        }
-      }
-      ```
-
-    </Tab>
-
-    <Tab>
-
-      Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-gcp) for the full deployment guide.
-
-      ```terraform
-      module "langfuse" {
-        source = "github.com/langfuse/langfuse-terraform-gcp?ref=0.1.0"
-
-        domain = "langfuse.example.com"
-
-        # Optional use a different name for your installation
-        # e.g. when using the module multiple times on the same GCP project
-        name   = "langfuse"
-
-        # Optional: Configure the VPC
-        subnetwork_cidr = "10.0.0.0/16"
-      }
-
-      provider "kubernetes" {
-        host                   = module.langfuse.cluster_host
-        cluster_ca_certificate = module.langfuse.cluster_ca_certificate
-        token                  = module.langfuse.cluster_token
-      }
-
-      provider "helm" {
-        kubernetes {
-          host                   = module.langfuse.cluster_host
-          cluster_ca_certificate = module.langfuse.cluster_ca_certificate
-          token                  = module.langfuse.cluster_token
-        }
-      }
-      ```
-
-    </Tab>
-
-    <Tab>
-
-      Checkout the [Readme](https://github.com/langfuse/langfuse-terraform-azure) for the full deployment guide.
-
-      ```terraform
-      module "langfuse" {
-        source = "github.com/langfuse/langfuse-terraform-azure?ref=0.1.0"
-
-        domain              = "langfuse.example.com"
-        location            = "westeurope"  # Optional: defaults to westeurope
-
-        # Optional use a different name for your installation
-        # e.g. when using the module multiple times on the same Azure subscription
-        name = "langfuse"
-
-        # Optional: Configure the Virtual Network
-        virtual_network_address_prefix = "10.224.0.0/12"
-        aks_subnet_address_prefix     = "10.224.0.0/16"
-        app_gateway_subnet_address_prefix = "10.225.0.0/16"
-        db_subnet_address_prefix      = "10.226.0.0/24"
-        redis_subnet_address_prefix   = "10.226.1.0/24"
-        storage_subnet_address_prefix = "10.226.2.0/24"
-
-        # Optional: Configure the Kubernetes cluster
-        kubernetes_version = "1.32"
-        aks_service_cidr   = "192.168.0.0/20"
-        aks_dns_service_ip = "192.168.0.10"
-        node_pool_vm_size  = "Standard_D8s_v6"
-        node_pool_min_count = 2
-        node_pool_max_count = 10
-
-        # Optional: Configure the database instances
-        postgres_instance_count = 2
-        postgres_ha_mode       = "SameZone"
-        postgres_sku_name      = "GP_Standard_D2s_v3"
-        postgres_storage_mb    = 32768
-
-        # Optional: Configure the cache
-        redis_sku_name = "Basic"
-        redis_family   = "C"
-        redis_capacity = 1
-
-        # Optional: Configure Application Gateway
-        app_gateway_capacity = 1
-
-        # Optional: Security features
-        use_encryption_key = false
-        use_ddos_protection = true
-      }
-
-      provider "kubernetes" {
-        host                   = module.langfuse.aks_cluster_host
-        client_certificate     = base64decode(module.langfuse.aks_cluster_client_certificate)
-        client_key             = base64decode(module.langfuse.aks_cluster_client_key)
-        cluster_ca_certificate = base64decode(module.langfuse.aks_cluster_ca_certificate)
-      }
-
-      provider "helm" {
-        kubernetes {
-          host                   = module.langfuse.aks_cluster_host
-          client_certificate     = base64decode(module.langfuse.aks_cluster_client_certificate)
-          client_key             = base64decode(module.langfuse.aks_cluster_client_key)
-          cluster_ca_certificate = base64decode(module.langfuse.aks_cluster_ca_certificate)
-        }
-      }
-      ```
-
-    </Tab>
-
-  </Tabs>
+  </Tab>
+</Tabs>
 
 ## Learn More
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Dynamically loads Terraform README files for AWS, GCP, and Azure in the changelog page, replacing static snippets with live content from GitHub.
> 
>   - **Behavior**:
>     - Dynamically loads Terraform README files for AWS, GCP, and Azure in `2025-05-22-terraform-modules.mdx` using `getStaticProps`.
>     - Replaces static Terraform code snippets with dynamically fetched content from GitHub repositories.
>   - **Components**:
>     - Adds `AwsTerraformReadme`, `GcpTerraformReadme`, and `AzureTerraformReadme` components to render README content using `Playground`.
>   - **Misc**:
>     - Updates `<Tabs>` in `2025-05-22-terraform-modules.mdx` to include dynamically loaded README content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 27ffc6cfa3b146bee30b7a8dd047e53156815001. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->