### PR TITLE
changelog: add claude 4 support

### DIFF
--- a/pages/changelog/2025-05-22-claude-4-support.mdx
+++ b/pages/changelog/2025-05-22-claude-4-support.mdx
@@ -1,0 +1,24 @@
+---
+date: 2025-05-22
+title: Claude Sonnet and Opus 4 support
+description: Langfuse says hello to Anthropic Claude Sonnet 4 & Opus 4 with day 1 support for both the LLM playground, LLM-as-a-judge and cost tracking.
+author: Hassieb
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Anthropic has released their latest models, Claude Sonnet 4 & Opus 4 with exciting new capabilities, from the [Anthropic release notes](https://www.anthropic.com/news/claude-4):
+
+- **Extended Thinking with Tool Use**: Both Claude Opus 4 and Sonnet 4 can utilize tools like web search during extended thinking, allowing them to alternate between reasoning and tool use for improved responses.
+- **New Model Capabilities**: The models can execute tools in parallel, follow instructions more precisely, and demonstrate improved memory capabilities when given access to local files, enhancing continuity and tacit knowledge over time.
+
+Langfuse supports both models with day 1 support for the LLM playground, LLM-as-a-judge and cost tracking.
+
+
+## Try it out
+
+- [Langfuse LLM playground](/docs/playground)
+- [Langfuse LLM-as-a-judge](/docs/scores/model-based-evals)
+- [Langfuse model usage and cost tracking](/docs/model-usage-and-cost)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for Claude Sonnet 4 & Opus 4 support in Langfuse with details on new capabilities and immediate feature support.
> 
>   - **Changelog Entry**:
>     - Adds `2025-05-22-claude-4-support.mdx` to document support for Claude Sonnet 4 & Opus 4.
>     - Highlights new model capabilities: extended thinking with tool use, parallel tool execution, precise instruction following, and improved memory.
>     - Mentions day 1 support in Langfuse for LLM playground, LLM-as-a-judge, and cost tracking.
>   - **Links**:
>     - Provides links to Langfuse LLM playground, LLM-as-a-judge, and model usage and cost tracking documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8f2551c8c359f8987367438969eadd3367bda61f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->