### PR TITLE
chore: add to handling failed migration docs

### DIFF
--- a/pages/self-hosting/troubleshooting.mdx
+++ b/pages/self-hosting/troubleshooting.mdx
@@ -76,6 +76,7 @@ error: Dirty database version 16. Fix and force version.
 ```
 
 You will have to force your database to the last successful version, which is 15. Make sure to replace the database credentials with your own.
+Before running the command below, navigate to the root of your Langfuse project folder in your terminal. Then run the following command:
 
 ```bash
 migrate -path migrations/ -database clickhouse://test:test@localhost:8123/dummy force 15


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds instruction to navigate to the Langfuse project root before running migration command in `troubleshooting.mdx`.
> 
>   - **Documentation**:
>     - Adds instruction to navigate to the root of the Langfuse project folder before running the migration command in `troubleshooting.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ade3c7e444f2f42c4384ab77685a8dd6ac0f2262. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->