### PR TITLE
chore: add incorrect query troubleshooting for clickhouse on azure

### DIFF
--- a/pages/self-hosting/infrastructure/clickhouse.mdx
+++ b/pages/self-hosting/infrastructure/clickhouse.mdx
@@ -77,6 +77,7 @@ CLICKHOUSE_MIGRATION_SSL=true
 #### Troubleshooting
 
 - **'error: driver: bad connection in line 0' during migration**: If you see the previous error message during startup of your web container, ensure that the `CLICKHOUSE_MIGRATION_SSL` flag is set and that Langfuse Web can access your ClickHouse environment. Review the IP whitelisting if applicable and whether the instance has access to the Private Link.
+- **Code: 80. DB::Exception: It's not initial query. ON CLUSTER is not allowed for Replicated database. (INCORRECT_QUERY)** (on ClickHouse Cloud Azure): ClickHouse Cloud Azure does not seem to handle the ON CLUSTER and Replicated settings well. We recommend to set `CLICKHOUSE_CLUSTER_ENABLED=false` for now. This should not make any difference on performance or high availability.
 
 ### ClickHouse on Kubernetes (Helm)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds troubleshooting step for ClickHouse Cloud Azure error in `clickhouse.mdx`.
> 
>   - **Documentation Update**:
>     - Adds troubleshooting step for `Code: 80. DB::Exception: It's not initial query. ON CLUSTER is not allowed for Replicated database. (INCORRECT_QUERY)` error in `clickhouse.mdx`.
>     - Recommends setting `CLICKHOUSE_CLUSTER_ENABLED=false` for ClickHouse Cloud Azure to avoid the error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 272888602ba5928c310bd466dcc724e556d32655. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->