### PR TITLE
fix: make page titles consistently black across all pages

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,7 +26,7 @@ export const Header = ({
       )}
     >
       {title && (
-        <TitleTag className="mt-2 text-4xl font-bold tracking-tight sm:text-7xl text-balance font-mono">
+        <TitleTag className="mt-2 text-4xl font-bold tracking-tight sm:text-7xl text-balance font-mono text-foreground">
           {title}
         </TitleTag>
       )}


### PR DESCRIPTION
<img width="1135" alt="Screenshot 2025-06-02 at 11 16 41" src="https://github.com/user-attachments/assets/47800a46-6182-4468-992e-979f0a0031bb" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `Header` component to use `text-foreground` class for consistent black title color.
> 
>   - **Styling**:
>     - Update `Header` component in `components/Header.tsx` to use `text-foreground` class for title, ensuring consistent black color across all pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e2114110793c9b5119c8092f273da24202e50f38. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->