### PR TITLE
feat: added simple CTA at bottom of home page - promting visitor to get started

### DIFF
--- a/components/home/CTASocial.tsx
+++ b/components/home/CTASocial.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { UsersMarquee } from "./UsersMarquee";
+import { Button } from "../ui/button";
+import Image from "next/image";
+import phLight from "./img/ph_product_of_the_day_light.png";
+import phDark from "./img/ph_product_of_the_day_dark.png";
+import GoldenKittyAwardSVG from "./img/ph_gke_ai_infra.svg";
+import GoldenKittyAwardSVGWhite from "./img/ph_gke_ai_infra_white.svg";
+import { YCLogo } from "./img/ycLogo";
+
+export function CTASocial() {
+  return (
+    <section className="pt-0 pb-20 lg:pb-32 mx-auto max-w-7xl px-5 sm:px-7 xl:px-10 flex flex-col items-center">
+      {/* Social/Award Links */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-y-5 gap-x-4 items-center justify-items-center my-4 flex-wrap">
+        <div>
+          <img
+            alt="Langfuse Github stars"
+            src="https://img.shields.io/github/stars/langfuse/langfuse?label=langfuse&style=social"
+          />
+        </div>
+        <div className="flex flex-col sm:flex-row items-center gap-x-2 gap-y-1">
+          <div className="text-primary/70 text-sm">Backed by</div>
+          <YCLogo />
+        </div>
+        <div>
+          <Image
+            src={GoldenKittyAwardSVG}
+            alt="Langfuse won #1 Golden Kitty in AI Infra Category"
+            className="block dark:hidden"
+          />
+          <Image
+            src={GoldenKittyAwardSVGWhite}
+            alt="Langfuse won #1 Golden Kitty in AI Infra Category"
+            className="hidden dark:block"
+          />
+        </div>
+        <div className="max-w-full w-52 px-1">
+          <Image
+            src={phLight}
+            alt="Product Hunt - Product of the Day"
+            width={250}
+            height={54}
+            className="block dark:hidden"
+          />
+          <Image
+            src={phDark}
+            alt="Product Hunt - Product of the Day"
+            width={250}
+            height={54}
+            className="hidden dark:block"
+          />
+        </div>
+      </div>
+      {/* Headline */}
+      <h2 className="mt-4 mb-4 text-4xl font-bold tracking-tight sm:text-7xl text-balance font-mono text-foreground text-center">
+        Start building on Langfuse today.
+      </h2>
+      {/* CTA Button */}
+      <div className="mt-4 mb-0">
+        <Button size="lg" variant="cta" asChild>
+          <Link href="https://cloud.langfuse.com">Start building</Link>
+        </Button>
+      </div>
+      
+    </section>
+  );
+} 

--- a/components/home/index.tsx
+++ b/components/home/index.tsx
@@ -3,6 +3,7 @@ import { Hero } from "./Hero";
 import Security from "./Security";
 import { Usage } from "./Usage";
 import dynamic from "next/dynamic";
+import { CTASocial } from "./CTASocial";
 
 const FeatureBento = dynamic(() => import("./FeatureBento"), {
   ssr: false,
@@ -27,6 +28,7 @@ export const Home = () => (
       <OpenSource />
       <Security />
       <Pricing />
+      <CTASocial />
       {/* <FromTheBlog /> */}
       {/* <CTA /> */}
       {/* <Footer /> */}


### PR DESCRIPTION
### Web
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/09d60c35-1e4c-4754-9bd5-1728176719e2" />

### Mobile: 
<img width="392" alt="image" src="https://github.com/user-attachments/assets/87848222-2ab7-4eb6-92a9-a61d84203050" />

### Design Choices
- button links to cloud.langfuse.com
- badges are non clickable to not distract from conversion 
- maybe add secondary button to "talk to sales" later
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `CTASocial` component to home page with social proof badges and a CTA button linking to Langfuse cloud.
> 
>   - **New Component**:
>     - Adds `CTASocial` component in `components/home/CTASocial.tsx`.
>     - Displays social proof badges and a CTA button linking to `cloud.langfuse.com`.
>     - Includes non-clickable badges for GitHub stars, YC backing, Golden Kitty Award, and Product Hunt recognition.
>   - **Integration**:
>     - Integrates `CTASocial` into the home page in `index.tsx` below the `Pricing` section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ec195b5d6a755e7b123c79f6316067ac8b47a677. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->