### PR TITLE
chore: document stuck migration fixes

### DIFF
--- a/pages/self-hosting/background-migrations.mdx
+++ b/pages/self-hosting/background-migrations.mdx
@@ -43,3 +43,25 @@ We can circumvent the issue by loading fewer rows at the same time.
 To do so, adjust the batchSize of your migration by editing the `background_migrations` table.
 Add `{ "batchSize": 2500 }` to the `args` column of the migration you want to adjust.
 Afterward, restart the migration via the UI.
+
+### Migrations Stuck on Single Date
+
+If you observe repeated log lines that refer to the same date, e.g.
+```
+langfuse-worker-1    | 2025-06-03T08:38:21.918Z info      [Background Migration] Acquired lock for background migration 20241024_1730_migrate_traces_from_pg_to_ch
+langfuse-worker-1    | 2025-06-03T08:38:21.949Z info      Migrating traces from postgres to clickhouse with {}
+langfuse-worker-1    | 2025-06-03T08:38:22.429Z info      Got 1000 records from Postgres in 475ms
+langfuse-worker-1    | 2025-06-03T08:38:22.914Z info      Inserted 1000 traces into Clickhouse in 485ms
+langfuse-worker-1    | 2025-06-03T08:38:22.919Z info      Processed batch in 965ms. Oldest record in batch: 2025-06-03T08:34:15.231Z
+langfuse-worker-1    | 2025-06-03T08:38:23.391Z info      Got 1000 records from Postgres in 472ms
+langfuse-worker-1    | 2025-06-03T08:38:23.811Z info      Inserted 1000 traces into Clickhouse in 420ms
+langfuse-worker-1    | 2025-06-03T08:38:23.815Z info      Processed batch in 896ms. Oldest record in batch: 2025-06-03T08:34:15.231Z
+langfuse-worker-1    | 2025-06-03T08:38:24.256Z info      Got 1000 records from Postgres in 441ms
+langfuse-worker-1    | 2025-06-03T08:38:24.638Z info      Inserted 1000 traces into Clickhouse in 382ms
+```
+this might be due to a couple of reasons:
+- You have many events that were created at exactly the same time.
+- Your instance was created before 2024-05-03 and rarely updated since.
+
+In both cases, you can try to adjust the `batchSize` as described above.
+If this does not resolve the problem, you can customize the migration scripts (see langfuse-repo `/worker/src/backgroundMigrations/`) to use the `timestamp` or `start_time` instead of `created_at` as a cursor.


### PR DESCRIPTION
Addresses https://github.com/langfuse/langfuse/issues/7117
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for resolving stuck migrations by adjusting `batchSize` and customizing migration scripts in `background-migrations.mdx`.
> 
>   - **Documentation**:
>     - Adds section "Migrations Stuck on Single Date" in `background-migrations.mdx`.
>     - Provides guidance on adjusting `batchSize` in `background_migrations` table to resolve stuck migrations.
>     - Suggests customizing migration scripts to use `timestamp` or `start_time` instead of `created_at` if adjusting `batchSize` fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for eefef17d783f1fc8abd1eeba7a53f080515c00c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->