### PR TITLE
docs: add new security researcher contribution for hyperlink injection

### DIFF
--- a/pages/security/responsible-disclosure.mdx
+++ b/pages/security/responsible-disclosure.mdx
@@ -36,6 +36,7 @@ We appreciate the efforts of security researchers who help keep Langfuse secure.
 | Reported by                                             | PR with fix                                             | Description                                    |
 | ------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------- |
 | [Ather Iqbal](https://linkedin.com/in/atheriqbalhacker) | [#4434](https://github.com/langfuse/langfuse/pull/4434) | Password complexity + block links in user name |
+| [Milan Jain](https://linkedin.com/in/milan-jain-scriptkiddie-50a738213) | [#6703](https://github.com/langfuse/langfuse/pull/6703) | Hyperlink injection in organization invite email |
 
 ## Contact
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Milan Jain to the Hall of Fame for reporting a hyperlink injection vulnerability in `responsible-disclosure.mdx`.
> 
>   - **Documentation**:
>     - Added Milan Jain to the Hall of Fame in `responsible-disclosure.mdx` for reporting a hyperlink injection vulnerability in organization invite email.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 432a34da0631219641b32ac9bc514e1f5df55142. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->