### PR TITLE
feat: document how to manage disk size for clickhouse

### DIFF
--- a/pages/self-hosting/infrastructure/clickhouse.mdx
+++ b/pages/self-hosting/infrastructure/clickhouse.mdx
@@ -138,6 +138,56 @@ CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=changeme
 ```
 
+#### Troubleshooting
+
+- **NOT_ENOUGH_SPACE error**: This error occurs when ClickHouse runs out of disk space. In Kubernetes environments, this typically means the persistent volume claims (PVCs) need to be expanded. Here's how to resolve it:
+
+  **1. Check current disk usage:**
+  ```bash
+  # Check PVC status
+  kubectl get pvc -l app.kubernetes.io/name=clickhouse
+
+  # Check disk usage inside ClickHouse pods
+  kubectl exec -it <clickhouse-pod-name> -- df -h /var/lib/clickhouse
+  ```
+
+  **2. Expand the PVC (requires storage class with allowVolumeExpansion: true):**
+  ```bash
+  # Edit the PVC directly
+  kubectl edit pvc data-<chart-name>-clickhouse-0
+
+  # Or patch all ClickHouse PVCs at once
+  kubectl patch pvc data-<chart-name>-clickhouse-0 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
+  kubectl patch pvc data-<chart-name>-clickhouse-1 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
+  kubectl patch pvc data-<chart-name>-clickhouse-2 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
+  ```
+
+  **3. Alternative: Update Helm values and upgrade:**
+  ```yaml
+  # values.yaml
+  clickhouse:
+    persistence:
+      size: 200Gi  # Increase from previous size
+  ```
+  ```bash
+  helm upgrade <release-name> <chart-name> -f values.yaml
+  ```
+
+  **4. Monitor expansion progress:**
+  ```bash
+  # Watch PVC status
+  kubectl get pvc -w
+
+  # Check if pods recognize the new space
+  kubectl exec -it <clickhouse-pod-name> -- df -h /var/lib/clickhouse
+  ```
+
+  **Prevention tips:**
+  - Set up monitoring alerts for disk usage (recommend alerting at 80% capacity)
+  - Use storage classes with `allowVolumeExpansion: true` (default for most cloud providers)
+  - Consider implementing automatic PVC expansion using tools like [volume-autoscaler](https://github.com/DevOps-Nirvana/Kubernetes-Volume-Autoscaler)
+  - For high-growth environments, consider using [blob storage as disk](#blob-storage-as-disk) for automatic scaling
+
 ### Docker
 
 You can run ClickHouse in a single [Docker](https://hub.docker.com/r/clickhouse/clickhouse-server) container for development purposes.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds troubleshooting steps for NOT_ENOUGH_SPACE error in ClickHouse Kubernetes deployments to documentation.
> 
>   - **Documentation**:
>     - Adds troubleshooting section for `NOT_ENOUGH_SPACE` error in `clickhouse.mdx`.
>     - Provides steps to check disk usage, expand PVCs, update Helm values, and monitor progress.
>     - Offers prevention tips: monitoring alerts, storage classes with `allowVolumeExpansion`, automatic PVC expansion tools, and blob storage for scaling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 110ba8e33f195a850d4a01fb1cb99641b53de207. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->