### PR TITLE
Update LiteLLM integration docs

### DIFF
--- a/pages/docs/integrations/litellm/tracing.mdx
+++ b/pages/docs/integrations/litellm/tracing.mdx
@@ -79,8 +79,16 @@ You can add additional Langfuse attributes to the requests in order to group req
 
 Instead of the proxy, you can also use the native LiteLLM Python client. You can find more in-depth documentation in the [LiteLLM docs](https://litellm.vercel.app/docs/observability/langfuse_integration).
 
+<Callout type="warning">
+  LiteLLM relies on the <strong>Langfuse Python SDK v2</strong>. It is currently
+  <strong>not compatible</strong> with the newer
+  <strong>[Python SDK v3](/docs/sdk/python/sdk-v3)</strong>. Please refer to the
+  [v2 documentation](/docs/sdk/python/low-level-sdk) and pin the SDK version
+  during installation:
+</Callout>
+
 ```
-pip install langfuse>=2.0.0 litellm
+pip install "langfuse>=2,<3" litellm
 ```
 
 ```python filename="main.py"


### PR DESCRIPTION
## Summary
- note that LiteLLM currently requires the Langfuse Python SDK v2
- link to the v2 and v3 SDK documentation
- pin the pip install command to `langfuse>=2,<3`

## Testing
- `pnpm link-check` *(fails: ELIFECYCLE exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6848ac744e148329ac0a5d3c2123c9c4
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update LiteLLM integration docs to specify Langfuse Python SDK v2 requirement and update pip install command.
> 
>   - **Documentation**:
>     - Adds a warning in `tracing.mdx` that LiteLLM requires Langfuse Python SDK v2 and is not compatible with v3.
>     - Links to [v2 documentation](/docs/sdk/python/low-level-sdk) and [v3 documentation](/docs/sdk/python/sdk-v3).
>     - Updates pip install command to `pip install "langfuse>=2,<3" litellm` in `tracing.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f0e802ecd870d6b4730203691c8e140ae5bce3dc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->