### PR TITLE
chore: update Cal.com scheduling links for US and EU regions

### DIFF
--- a/components/CalComScheduleDemo.tsx
+++ b/components/CalComScheduleDemo.tsx
@@ -19,7 +19,7 @@ export function ScheduleDemo({
     })();
   }, []);
 
-  const calLink = region === "us" ? "clemo/us-sales" : "clemo/sales";
+  const calLink = region === "us" ? "team/langfuse/intro" : "team/langfuse/intro-eu";
 
   return (
     <Cal


### PR DESCRIPTION
swap calcom link from individual to team link
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `calLink` in `ScheduleDemo` to use team links for US and EU regions in `CalComScheduleDemo.tsx`.
> 
>   - **Behavior**:
>     - Update `calLink` in `ScheduleDemo` in `CalComScheduleDemo.tsx` to use team links instead of individual links.
>     - For `region === "us"`, use `"team/langfuse/intro"`.
>     - For `region === "eu"`, use `"team/langfuse/intro-eu"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 612af8ece95a119c6593f664ab6b0ca6925c4f04. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->