### PR TITLE
chore: add imports across quick starts

### DIFF
--- a/pages/docs/prompts/get-started.mdx
+++ b/pages/docs/prompts/get-started.mdx
@@ -7,6 +7,27 @@ description: Manage and version your prompts in Langfuse (open source). When ret
 
 Use Langfuse to effectively **manage** and **version** your prompts. Langfuse prompt management is a **Prompt CMS** (Content Management System).
 
+## Installation
+
+<Tabs items={["Python", "JS/TS"]}>
+<Tab>
+
+```bash
+pip install langfuse
+```
+
+</Tab>
+<Tab>
+
+```bash
+npm install langfuse
+# or
+yarn add langfuse
+```
+
+</Tab>
+</Tabs>
+
 import PromptOverview from "@/components-mdx/prompt-overview-gifs.mdx";
 
 <PromptOverview />
@@ -195,6 +216,11 @@ compiled_chat_prompt = chat_prompt.compile(criticlevel="expert", movie="Dune 2")
 Optional parameters
 
 ```python
+from langfuse import get_client
+
+# Initialize Langfuse client
+langfuse = get_client()
+
 # Get specific version
 prompt = langfuse.get_prompt("movie-critic", version=1)
 
@@ -217,6 +243,12 @@ prompt = langfuse.get_prompt("movie-critic", fetch_timeout_seconds=3)
 Attributes
 
 ```python
+from langfuse import get_client
+
+# Initialize Langfuse client
+langfuse = get_client()
+prompt = langfuse.get_prompt("movie-critic")
+
 # Raw prompt including {{variables}}. For chat prompts, this is a list of chat messages.
 prompt.prompt
 
@@ -231,7 +263,7 @@ prompt.config
 ```ts
 import { Langfuse } from "langfuse";
 
-// Iniitialize the Langfuse client
+// Initialize the Langfuse client
 const langfuse = new Langfuse();
 
 // Get current `production` version
@@ -248,6 +280,11 @@ const compiledPrompt = prompt.compile({
 Chat prompts
 
 ```ts
+import { Langfuse } from "langfuse";
+
+// Initialize the Langfuse client
+const langfuse = new Langfuse();
+
 // Get current `production` version of a chat prompt
 const chatPrompt = await langfuse.getPrompt("movie-critic-chat", undefined, {
   type: "chat",
@@ -264,6 +301,11 @@ const compiledChatPrompt = chatPrompt.compile({
 Optional parameters
 
 ```ts
+import { Langfuse } from "langfuse";
+
+// Initialize the Langfuse client
+const langfuse = new Langfuse();
+
 // Get specific version of a prompt (here version 1)
 const prompt = await langfuse.getPrompt("movie-critic", 1);
 
@@ -281,29 +323,17 @@ const prompt = await langfuse.getPrompt("movie-critic", undefined, {
 const prompt = await langfuse.getPrompt("movie-critic", undefined, {
   cacheTtlSeconds: 300,
 });
-
-// Number of retries on fetching prompts from the server. Default is 2.
-const promptWithMaxRetries = await langfuse.getPrompt(
-  "movie-critic",
-  undefined,
-  {
-    maxRetries: 5,
-  }
-);
-
-// Timeout per call to the Langfuse API in milliseconds. Default is 10 seconds.
-const promptWithFetchTimeout = await langfuse.getPrompt(
-  "movie-critic",
-  undefined,
-  {
-    fetchTimeoutMs: 5000,
-  }
-);
 ```
 
 Attributes
 
 ```ts
+import { Langfuse } from "langfuse";
+
+// Initialize the Langfuse client
+const langfuse = new Langfuse();
+const prompt = await langfuse.getPrompt("movie-critic");
+
 // Raw prompt including {{variables}}. For chat prompts, this is a list of chat messages.
 prompt.prompt;
 
@@ -337,6 +367,12 @@ langchain_prompt = ChatPromptTemplate.from_template(langfuse_prompt.get_langchai
 Chat prompts
 
 ```python
+from langfuse import Langfuse
+from langchain_core.prompts import ChatPromptTemplate
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+
 # Get current `production` version of a chat prompt
 langfuse_prompt = langfuse.get_prompt("movie-critic-chat", type="chat")
 
@@ -347,6 +383,11 @@ langchain_prompt = ChatPromptTemplate.from_messages(langfuse_prompt.get_langchai
 Optional parameters
 
 ```python
+from langfuse import Langfuse
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+
 # Get specific version
 prompt = langfuse.get_prompt("movie-critic", version=1)
 
@@ -363,6 +404,12 @@ prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=300)
 Attributes
 
 ```python
+from langfuse import Langfuse
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+prompt = langfuse.get_prompt("movie-critic")
+
 # Raw prompt including {{variables}}. For chat prompts, this is a list of chat messages.
 prompt.prompt
 
@@ -394,6 +441,11 @@ const promptTemplate = PromptTemplate.fromTemplate(
 Chat prompts
 
 ```ts
+import { Langfuse } from "langfuse";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+
+const langfuse = new Langfuse();
+
 // Get current `production` version of a chat prompt
 const langfusePrompt = await langfuse.getPrompt(
   "movie-critic-chat",
@@ -410,6 +462,10 @@ const promptTemplate = ChatPromptTemplate.fromMessages(
 Optional parameters
 
 ```ts
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+
 // Get specific version of a prompt (here version 1)
 const prompt = await langfuse.getPrompt("movie-critic", 1);
 
@@ -432,6 +488,11 @@ const prompt = await langfuse.getPrompt("movie-critic", undefined, {
 Attributes
 
 ```ts
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+const prompt = await langfuse.getPrompt("movie-critic");
+
 // Raw prompt including {{variables}}. For chat prompts, this is a list of chat messages.
 prompt.prompt;
 
@@ -926,6 +987,11 @@ The caching duration is configurable if you wish to reduce network overhead of t
 <Tab>
 
 ```python
+from langfuse import Langfuse
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+
 # Get current `production` prompt version and cache for 5 minutes
 prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=300)
 ```
@@ -935,6 +1001,11 @@ prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=300)
 <Tab>
 
 ```ts
+import { Langfuse } from "langfuse";
+
+// Initialize Langfuse client
+const langfuse = new Langfuse();
+
 // Get current `production` version and cache prompt for 5 minutes
 const prompt = await langfuse.getPrompt("movie-critic", undefined, {
   cacheTtlSeconds: 300,
@@ -953,6 +1024,11 @@ You can disable caching by setting the `cacheTtlSeconds` to `0`. This will ensur
 <Tab>
 
 ```python
+from langfuse import Langfuse
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+
 prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=0)
 
 # Common in non-production environments, no cache + latest version
@@ -964,6 +1040,11 @@ prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=0, label="latest"
 <Tab>
 
 ```ts
+import { Langfuse } from "langfuse";
+
+// Initialize Langfuse client
+const langfuse = new Langfuse();
+
 const prompt = await langfuse.getPrompt("movie-critic", undefined, {
   cacheTtlSeconds: 0,
 });
@@ -983,6 +1064,11 @@ const prompt = await langfuse.getPrompt("movie-critic", undefined, {
 We measured the execution time of the following snippet with fully disabled caching.
 
 ```python
+from langfuse import Langfuse
+
+# Initialize Langfuse client
+langfuse = Langfuse()
+
 prompt = langfuse.get_prompt("perf-test")
 prompt.compile(input="test")
 ```
@@ -1089,6 +1175,7 @@ fetchPromptsOnStartup();
 
 ```python /fallback="Do you like {{movie}}?"/ /fallback=[{"role": "system", "content": "You are an expert on {{movie}}"}]/
 from langfuse import Langfuse
+
 langfuse = Langfuse()
 
 # Get `text` prompt with fallback
@@ -1113,6 +1200,7 @@ prompt.is_fallback
 
 ```ts /fallback: "Do you like {{movie}}?"/ /fallback: [{ role: "system", content: "You are an expert on {{movie}}" }]/
 import { Langfuse } from "langfuse";
+
 const langfuse = new Langfuse();
 
 // Get `text` prompt with fallback

--- a/pages/docs/prompts/get-started.mdx
+++ b/pages/docs/prompts/get-started.mdx
@@ -174,6 +174,11 @@ compiled_prompt = prompt.compile(criticlevel="expert", movie="Dune 2")
 Chat prompts
 
 ```python
+from langfuse import get_client
+
+# Initialize Langfuse client
+langfuse = get_client()
+
 # Get current `production` version of a chat prompt
 chat_prompt = langfuse.get_prompt("movie-critic-chat", type="chat") # type arg infers the prompt type (default is 'text')
 
@@ -186,10 +191,10 @@ compiled_chat_prompt = chat_prompt.compile(criticlevel="expert", movie="Dune 2")
 <Tab>
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 
 # Initialize Langfuse client
-langfuse = Langfuse()
+langfuse = get_client()
 
 # Get current `production` version of a text prompt
 prompt = langfuse.get_prompt("movie-critic")
@@ -202,6 +207,11 @@ compiled_prompt = prompt.compile(criticlevel="expert", movie="Dune 2")
 Chat prompts
 
 ```python
+from langfuse import get_client
+
+# Initialize Langfuse client
+langfuse = get_client()
+
 # Get current `production` version of a chat prompt
 chat_prompt = langfuse.get_prompt("movie-critic-chat", type="chat") # type arg infers the prompt type (default is 'text')
 
@@ -345,82 +355,6 @@ prompt.config;
 
 <Tab>
 
-As Langfuse and Langchain process input variables of prompt templates differently (`{}` instead of `{{}}`), we provide the `prompt.get_langchain_prompt()` method to transform the Langfuse prompt into a string that can be used with Langchain's PromptTemplate. You can pass optional keyword arguments to `prompt.get_langchain_prompt(**kwargs)` in order to precompile some variables and handle the others with Langchain's PromptTemplate.
-
-```python
-from langfuse import Langfuse
-from langchain_core.prompts import ChatPromptTemplate
-
-# Initialize Langfuse client
-langfuse = Langfuse()
-
-# Get current `production` version
-langfuse_prompt = langfuse.get_prompt("movie-critic")
-
-# Example using ChatPromptTemplate
-langchain_prompt = ChatPromptTemplate.from_template(langfuse_prompt.get_langchain_prompt())
-
-# Example using ChatPromptTemplate with pre-compiled variables.
-langchain_prompt = ChatPromptTemplate.from_template(langfuse_prompt.get_langchain_prompt(strictness='tough'))
-```
-
-Chat prompts
-
-```python
-from langfuse import Langfuse
-from langchain_core.prompts import ChatPromptTemplate
-
-# Initialize Langfuse client
-langfuse = Langfuse()
-
-# Get current `production` version of a chat prompt
-langfuse_prompt = langfuse.get_prompt("movie-critic-chat", type="chat")
-
-# Create a Langchain ChatPromptTemplate from the Langfuse prompt chat messages
-langchain_prompt = ChatPromptTemplate.from_messages(langfuse_prompt.get_langchain_prompt())
-```
-
-Optional parameters
-
-```python
-from langfuse import Langfuse
-
-# Initialize Langfuse client
-langfuse = Langfuse()
-
-# Get specific version
-prompt = langfuse.get_prompt("movie-critic", version=1)
-
-# Get specific label
-prompt = langfuse.get_prompt("movie-critic", label="staging")
-
-# Get latest prompt version. The 'latest' label is automatically maintained by Langfuse.
-prompt = langfuse.get_prompt("movie-critic", label="latest")
-
-# Extend cache TTL from default 60 to 300 seconds
-prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=300)
-```
-
-Attributes
-
-```python
-from langfuse import Langfuse
-
-# Initialize Langfuse client
-langfuse = Langfuse()
-prompt = langfuse.get_prompt("movie-critic")
-
-# Raw prompt including {{variables}}. For chat prompts, this is a list of chat messages.
-prompt.prompt
-
-# Config object
-prompt.config
-```
-
-</Tab>
-
-<Tab>
-
 As Langfuse and Langchain process input variables of prompt templates differently (`{}` instead of `{{}}`), we provide the `prompt.getLangchainPrompt()` method to transform the Langfuse prompt into a string that can be used with Langchain's PromptTemplate.
 
 ```ts
@@ -433,7 +367,7 @@ const langfuse = new Langfuse();
 const langfusePrompt = await langfuse.getPrompt("movie-critic");
 
 // Example using ChatPromptTemplate
-const promptTemplate = PromptTemplate.fromTemplate(
+const promptTemplate = ChatPromptTemplate.fromTemplate(
   langfusePrompt.getLangchainPrompt()
 );
 ```
@@ -447,15 +381,13 @@ import { ChatPromptTemplate } from "@langchain/core/prompts";
 const langfuse = new Langfuse();
 
 // Get current `production` version of a chat prompt
-const langfusePrompt = await langfuse.getPrompt(
-  "movie-critic-chat",
-  undefined,
-  { type: "chat" }
-);
+const langfusePrompt = await langfuse.getPrompt("movie-critic-chat", undefined, {
+  type: "chat",
+});
 
 // Example using ChatPromptTemplate
 const promptTemplate = ChatPromptTemplate.fromMessages(
-  langfusePrompt.getLangchainPrompt().map((msg) => [msg.role, msg.content])
+  langfusePrompt.getLangchainPrompt().map((m) => [m.role, m.content])
 );
 ```
 
@@ -498,6 +430,137 @@ prompt.prompt;
 
 // Config object
 prompt.config;
+```
+
+</Tab>
+
+<Tab>
+
+```diff
+import { Langfuse } from "langfuse";
+
+// Initialize Langfuse client
+const langfuse = new Langfuse();
+const prompt = await langfuse.getPrompt("movie-critic");
+
+langfuse.generation({
+    ...
++   prompt: prompt
+    ...
+})
+```
+
+</Tab>
+
+<Tab>
+
+```ts /langfusePrompt,/
+import { observeOpenAI } from "langfuse";
+import OpenAI from "openai";
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+const langfusePrompt = await langfuse.getPrompt("prompt-name"); // Fetch a previously created prompt
+
+const res = await observeOpenAI(new OpenAI(), {
+  langfusePrompt,
+}).completions.create({
+  prompt: langfusePrompt.prompt,
+  model: "gpt-3.5-turbo-instruct",
+  max_tokens: 300,
+});
+```
+
+</Tab>
+
+<Tab>
+
+```ts /metadata: { langfusePrompt:/
+import { Langfuse } from "langfuse";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { ChatOpenAI, OpenAI } from "@langchain/openai";
+
+const langfuse = new Langfuse();
+
+// Text prompts
+const langfuseTextPrompt = await langfuse.getPrompt("movie-critic"); // Fetch a previously created text prompt
+
+// Pass the langfuseTextPrompt to the PromptTemplate as metadata to link it to generations that use it
+const langchainTextPrompt = PromptTemplate.fromTemplate(
+  langfuseTextPrompt.getLangchainPrompt()
+).withConfig({
+  metadata: { langfusePrompt: langfuseTextPrompt },
+});
+
+const model = new OpenAI();
+const chain = langchainTextPrompt.pipe(model);
+
+await chain.invoke({ movie: "Dune 2", criticlevel: "expert" });
+
+// Chat prompts
+const langfuseChatPrompt = await langfuse.getPrompt(
+  "movie-critic-chat",
+  undefined,
+  {
+    type: "chat",
+  }
+); // type option infers the prompt type as chat (default is 'text')
+
+const langchainChatPrompt = ChatPromptTemplate.fromMessages(
+  langfuseChatPrompt.getLangchainPrompt().map((m) => [m.role, m.content])
+).withConfig({
+  metadata: { langfusePrompt: langfuseChatPrompt },
+});
+
+const chatModel = new ChatOpenAI();
+const chatChain = langchainChatPrompt.pipe(chatModel);
+
+await chatChain.invoke({ movie: "Dune 2", criticlevel: "expert" });
+```
+
+</Tab>
+
+<Tab>
+
+Link Langfuse prompts to Vercel AI SDK generations by setting the `langfusePrompt` property in the `metadata` field:
+
+```typescript /langfusePrompt: fetchedPrompt.toJSON()/
+import { generateText } from "ai";
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+
+const fetchedPrompt = await langfuse.getPrompt("my-prompt");
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  prompt: fetchedPrompt.prompt,
+  experimental_telemetry: {
+    isEnabled: true,
+    metadata: {
+      langfusePrompt: fetchedPrompt.toJSON(),
+    },
+  },
+});
+```
+
+</Tab>
+
+<Tab>
+
+You can assign labels when [creating a new prompt (version)](#create-update-prompt).
+
+Alternatively, you can also update the labels of an existing prompt version:
+
+```ts
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+await langfuse.updatePrompt({
+  name: "movie-critic",
+  version: 1,
+  newLabels: ["john", "doe"],
+});
 ```
 
 </Tab>
@@ -579,6 +642,12 @@ main()
 **Low-level SDK**
 
 ```diff
+from langfuse import get_client
+
+# Initialize Langfuse client
+langfuse = get_client()
+prompt = langfuse.get_prompt("movie-critic")
+
 langfuse.generation(
     ...
 +   prompt=prompt
@@ -591,6 +660,12 @@ langfuse.generation(
 <Tab>
 
 ```diff
+import { Langfuse } from "langfuse";
+
+// Initialize Langfuse client
+const langfuse = new Langfuse();
+const prompt = await langfuse.getPrompt("movie-critic");
+
 langfuse.generation({
     ...
 +   prompt: prompt
@@ -602,7 +677,12 @@ langfuse.generation({
 
 <Tab>
 
-```python /langfuse_prompt=prompt/
+```python /"langfuse_prompt"/
+from langfuse import get_client
+import openai
+
+# Initialize Langfuse client
+langfuse = get_client()
 prompt = langfuse.get_prompt("calculator")
 
 openai.chat.completions.create(
@@ -622,7 +702,7 @@ openai.chat.completions.create(
 import { observeOpenAI } from "langfuse";
 import OpenAI from "openai";
 
-const langfusePrompt = await langfuse.getPrompt("prompt-name"); // Fetch a previously created prompt
+const langfusePrompt = get_client().get_prompt("prompt-name"); // Fetch a previously created prompt
 
 const res = await observeOpenAI(new OpenAI(), {
   langfusePrompt,
@@ -638,14 +718,14 @@ const res = await observeOpenAI(new OpenAI(), {
 <Tab>
 
 ```python /"langfuse_prompt"/
-from langfuse import Langfuse
+from langfuse import get_client
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_openai import ChatOpenAI, OpenAI
 
-langfuse = Langfuse()
+langfuse = get_client()
 
 # Text prompts:
-langfuse_text_prompt = langfuse.get_prompt("movie-critic")
+langfuse_text_prompt = get_client().get_prompt("movie-critic")
 
 ## Pass the langfuse_text_prompt to the PromptTemplate as metadata to link it to generations that use it
 langchain_text_prompt = PromptTemplate.from_template(
@@ -660,7 +740,7 @@ completion_chain = langchain_text_prompt | llm
 completion_chain.invoke({"movie": "Dune 2", "criticlevel": "expert"})
 
 # Chat prompts:
-langfuse_chat_prompt = langfuse.get_prompt("movie-critic-chat", type="chat")
+langfuse_chat_prompt = get_client().get_prompt("movie-critic-chat", type="chat")
 
 ## Manually set the metadata on the langchain_chat_prompt to link it to generations that use it
 langchain_chat_prompt = ChatPromptTemplate.from_messages(
@@ -673,7 +753,7 @@ langchain_chat_prompt.metadata = {"langfuse_prompt": langfuse_chat_prompt}
 ## See: https://github.com/langfuse/langfuse/issues/5374
 langchain_chat_prompt = ChatPromptTemplate(
     langfuse_chat_prompt.get_langchain_prompt(),
-    metadata={"langfuse_prompt": langfuse_prompt}
+    metadata={"langfuse_prompt": langfuse_chat_prompt}
 )
 
 ## Use the chat prompt in a Langchain chain
@@ -683,7 +763,7 @@ chat_chain = langchain_chat_prompt | chat_llm
 chat_chain.invoke({"movie": "Dune 2", "criticlevel": "expert"})
 ```
 
-<Callout type="info">
+<Callout>
   If you use the `with_config` method on the PromptTemplate to create a new
   Langchain Runnable with updated config, please make sure to pass the
   `langfuse_prompt` in the `metadata` key as well.
@@ -706,7 +786,7 @@ import { ChatOpenAI, OpenAI } from "@langchain/openai";
 const langfuse = new Langfuse();
 
 // Text prompts
-const langfuseTextPrompt = await langfuse.getPrompt("movie-critic"); // Fetch a previously created text prompt
+const langfuseTextPrompt = get_client().get_prompt("movie-critic"); // Fetch a previously created text prompt
 
 // Pass the langfuseTextPrompt to the PromptTemplate as metadata to link it to generations that use it
 const langchainTextPrompt = PromptTemplate.fromTemplate(
@@ -721,7 +801,7 @@ const chain = langchainTextPrompt.pipe(model);
 await chain.invoke({ movie: "Dune 2", criticlevel: "expert" });
 
 // Chat prompts
-const langfuseChatPrompt = await langfuse.getPrompt(
+const langfuseChatPrompt = get_client().get_prompt(
   "movie-critic-chat",
   undefined,
   {
@@ -826,7 +906,9 @@ You can assign labels when [creating a new prompt (version)](#create-update-prom
 Alternatively, you can also update the labels of an existing prompt version:
 
 ```python
-langfuse = Langfuse()
+from langfuse import get_client
+
+langfuse = get_client()
 langfuse.update_prompt(
     name="movie-critic",
     version=1,
@@ -842,7 +924,9 @@ You can assign labels when [creating a new prompt (version)](#create-update-prom
 Alternatively, you can also update the labels of an existing prompt version:
 
 ```ts
-langfuse = Langfuse();
+from langfuse import get_client
+
+langfuse = get_client()
 await langfuse.updatePrompt({
   name: "movie-critic",
   version: 1,
@@ -922,11 +1006,11 @@ _Example implementations:_
 
 ```python
 from flask import Flask, jsonify
-from langfuse import Langfuse
+from langfuse import get_client
 
 # Initialize the Flask app and Langfuse client
 app = Flask(__name__)
-langfuse = Langfuse()
+langfuse = get_client()
 
 def fetch_prompts_on_startup():
     # Fetch and cache the production version of the prompt
@@ -987,10 +1071,10 @@ The caching duration is configurable if you wish to reduce network overhead of t
 <Tab>
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 
 # Initialize Langfuse client
-langfuse = Langfuse()
+langfuse = get_client()
 
 # Get current `production` prompt version and cache for 5 minutes
 prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=300)
@@ -1024,10 +1108,10 @@ You can disable caching by setting the `cacheTtlSeconds` to `0`. This will ensur
 <Tab>
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 
 # Initialize Langfuse client
-langfuse = Langfuse()
+langfuse = get_client()
 
 prompt = langfuse.get_prompt("movie-critic", cache_ttl_seconds=0)
 
@@ -1064,12 +1148,12 @@ const prompt = await langfuse.getPrompt("movie-critic", undefined, {
 We measured the execution time of the following snippet with fully disabled caching.
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 
 # Initialize Langfuse client
-langfuse = Langfuse()
+langfuse = get_client()
 
-prompt = langfuse.get_prompt("perf-test")
+prompt = get_client().get_prompt("perf-test")
 prompt.compile(input="test")
 ```
 
@@ -1120,11 +1204,11 @@ To gurantee 100% availability, there are two options:
 <Tab>
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 import sys
 
 # Initialize Langfuse client
-langfuse = Langfuse()
+langfuse = get_client()
 
 def fetch_prompts_on_startup():
     try:
@@ -1174,9 +1258,9 @@ fetchPromptsOnStartup();
 <Tab>
 
 ```python /fallback="Do you like {{movie}}?"/ /fallback=[{"role": "system", "content": "You are an expert on {{movie}}"}]/
-from langfuse import Langfuse
+from langfuse import get_client
 
-langfuse = Langfuse()
+langfuse = get_client()
 
 # Get `text` prompt with fallback
 prompt = langfuse.get_prompt(

--- a/pages/docs/tracing.mdx
+++ b/pages/docs/tracing.mdx
@@ -30,6 +30,27 @@ LLM applications use increasingly complex abstractions, such as chains, agents w
 
 </details>
 
+## Installation
+
+<Tabs items={["Python", "JS/TS"]}>
+<Tab>
+
+```bash
+pip install langfuse
+```
+
+</Tab>
+<Tab>
+
+```bash
+npm install langfuse
+# or
+yarn add langfuse
+```
+
+</Tab>
+</Tabs>
+
 import TracingOverview from "@/components-mdx/tracing-overview-gifs.mdx";
 
 <TracingOverview />
@@ -174,14 +195,11 @@ If you want to send a batch immediately, you can call the `flush` method on the 
 ```python
 from langfuse import get_client
 
-# access the client directly
-
+# Access the client directly
 langfuse = get_client()
 
 # Flush all pending observations
-
 langfuse.flush()
-
 ```
 
 If you exit the application, use `shutdown` method to make sure all requests are flushed and pending requests are awaited before the process exits. On success of this function, no more events will be sent to Langfuse API.
@@ -200,17 +218,23 @@ langfuse.shutdown()
 {/* Python SDK v2 */}
 
 ```python
-# Decorator
+from langfuse import Langfuse
 from langfuse.decorators import langfuse_context
+
+# Decorator
 langfuse_context.flush()
 
-# low-level SDK
+# Low-level SDK
+langfuse = Langfuse()
 langfuse.flush()
 ```
 
 If you exit the application, use `shutdown` method to make sure all requests are flushed and pending requests are awaited before the process exits. On success of this function, no more events will be sent to Langfuse API.
 
 ```python
+from langfuse import Langfuse
+
+langfuse = Langfuse()
 langfuse.shutdown()
 ```
 
@@ -219,12 +243,20 @@ langfuse.shutdown()
 {/* JS/TS */}
 
 ```javascript
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+
 await langfuse.flushAsync();
 ```
 
 If you exit the application, use `shutdownAsync` method to make sure all requests are flushed and pending requests are awaited before the process exits.
 
 ```javascript
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
+
 await langfuse.shutdownAsync();
 ```
 
@@ -236,6 +268,9 @@ npm i @vercel/functions
 
 ```javascript
 import { waitUntil } from "@vercel/functions";
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse();
 
 export async function POST(req, res) {
   // your code involving langfuse
@@ -256,7 +291,7 @@ For Python SDK v3
 ```python
 from langfuse import get_client
 
-# access the client directly
+# Access the client directly
 langfuse = get_client()
 
 # Flush all pending observations
@@ -267,6 +302,7 @@ For Python SDK v2
 
 ```python
 from langfuse.openai import openai
+
 openai.flush_langfuse()
 ```
 
@@ -282,14 +318,16 @@ langfuse = get_client()
 
 langfuse.flush()
 
-# access the client directly
+# Access the client directly
 langfuse_handler.client.flush()
-
 ```
 
 For Python SDK v2
 
 ```python
+from langfuse.callback import CallbackHandler
+
+langfuse_handler = CallbackHandler()
 langfuse_handler.flush()
 ```
 
@@ -298,12 +336,20 @@ langfuse_handler.flush()
 {/* Langchain (JS) */}
 
 ```javascript
+import { CallbackHandler } from "langfuse-langchain";
+
+const langfuseHandler = new CallbackHandler();
+
 await langfuseHandler.flushAsync();
 ```
 
 If you exit the application, use `shutdownAsync` method to make sure all requests are flushed and pending requests are awaited before the process exits.
 
 ```javascript
+import { CallbackHandler } from "langfuse-langchain";
+
+const langfuseHandler = new CallbackHandler();
+
 await langfuseHandler.shutdownAsync();
 ```
 
@@ -312,7 +358,11 @@ await langfuseHandler.shutdownAsync();
 {/* LlamaIndex */}
 
 ```python
+from llama_index.core.callbacks import CallbackManager
+from llama_index.callbacks.langfuse import LangfuseCallbackHandler
+
 # For Python SDK v2
+langfuse_handler = LangfuseCallbackHandler()
 langfuse_handler.flush()
 ```
 

--- a/pages/docs/tracing.mdx
+++ b/pages/docs/tracing.mdx
@@ -218,23 +218,23 @@ langfuse.shutdown()
 {/* Python SDK v2 */}
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 from langfuse.decorators import langfuse_context
 
 # Decorator
 langfuse_context.flush()
 
 # Low-level SDK
-langfuse = Langfuse()
+langfuse = get_client()
 langfuse.flush()
 ```
 
 If you exit the application, use `shutdown` method to make sure all requests are flushed and pending requests are awaited before the process exits. On success of this function, no more events will be sent to Langfuse API.
 
 ```python
-from langfuse import Langfuse
+from langfuse import get_client
 
-langfuse = Langfuse()
+langfuse = get_client()
 langfuse.shutdown()
 ```
 


### PR DESCRIPTION
Documentation pages for tracing and prompts (`/docs/tracing.mdx`, `/docs/prompts/get-started.mdx`) were updated to include installation instructions and ensure all code blocks are standalone. This involved adding missing imports and client initialization (`from langfuse import get_client`, `new Langfuse()`) to examples.

Python examples were standardized to use `get_client()` for client initialization, replacing `Langfuse()`. This was applied across various integrations, including LangChain, OpenAI SDK, Agno, and Smolagents. For OpenAI SDK, `openai.flush_langfuse()` now handles flushing.

The LangChain integration guide (`pages/docs/integrations/langchain/example-python.md`) was expanded with new sections for `ConversationChain`, `Agent`, custom trace naming, and interoperability with the `@observe` decorator, ensuring all new code includes necessary imports.

Agno and Smolagents integration examples were refined to explicitly configure OpenTelemetry for tracing, aligning with their OpenTelemetry-based instrumentation.

This ensures developers can copy and run code examples directly, improving documentation clarity and usability.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improved documentation by adding installation instructions, standardizing client initialization, and enhancing LangChain integration guide for better clarity and usability.
> 
>   - **Documentation Updates**:
>     - Added installation instructions to `/docs/tracing.mdx` and `/docs/prompts/get-started.mdx`.
>     - Ensured all code blocks are standalone by adding missing imports and client initialization.
>   - **Client Initialization**:
>     - Standardized Python examples to use `get_client()` instead of `Langfuse()`.
>     - Updated examples for LangChain, OpenAI SDK, Agno, and Smolagents.
>     - For OpenAI SDK, `openai.flush_langfuse()` now handles flushing.
>   - **LangChain Integration**:
>     - Expanded `example-python.md` with sections for `ConversationChain`, `Agent`, custom trace naming, and interoperability with `@observe` decorator.
>     - Ensured new code includes necessary imports.
>   - **OpenTelemetry Configuration**:
>     - Refined Agno and Smolagents examples to configure OpenTelemetry for tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 89e5ccc887802919d98a834542a59c59c78f3974. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->