### PR TITLE
fix: replace Yelp with PwC in customer story

### DIFF
--- a/pages/customers/magic-patterns-ai-design-tools.mdx
+++ b/pages/customers/magic-patterns-ai-design-tools.mdx
@@ -24,7 +24,7 @@ import { ImpactChart } from "@/components/customers/ImpactChart";
 
 [Magic Patterns](https://www.magicpatterns.com) is transforming how product teams prototype.
 
-Unlike typical AI coding assistants, they've built a platform that generates UI components using your existing design system. Thousands of product teams at companies like Yelp, Lendi Group and Zeal use Magic Patterns to go from idea to interactive prototype in minutes, all while maintaining brand consistency.
+Unlike typical AI coding assistants, they've built a platform that generates UI components using your existing design system. Thousands of product teams at companies like PwC, Lendi Group and Zeal use Magic Patterns to go from idea to interactive prototype in minutes, all while maintaining brand consistency.
 
 The product is proudly built and operated by the two founders who believe in a new type of company: extremely small AI native teams creating world-class products at global scale.
 
@@ -44,7 +44,7 @@ Users can request anything from a simple button to a complete invoice system. Th
 
 #### 3. Customer-Specific Requirements
 
-The real differentiator of Magic Patterns is ensuring generated code uses each company's specific UI components. When someone from Yelp requests an invoice page, it should use Yelp's actual Button component, not a generic one.
+The real differentiator of Magic Patterns is ensuring generated code uses each company's specific UI components. When someone from Zeal requests an invoice page, it should use Zeal's actual Button component, not a generic one.
 
 <CustomerQuote
   quote="AI applications are really easy to launch on a weekend, but really hard to run at scale. The AI, no matter what guardrails you give, will go off the rails sometimes."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace 'Yelp' with 'PwC' and adjust example to use 'Zeal' in `magic-patterns-ai-design-tools.mdx`.
> 
>   - **Content Update**:
>     - Replace 'Yelp' with 'PwC' in the customer list in `magic-patterns-ai-design-tools.mdx`.
>     - Change example from 'Yelp' to 'Zeal' in the customer-specific requirements section in `magic-patterns-ai-design-tools.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 65433e9b6241d4ca129a9d19f22e1c9ea88806a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->