### PR TITLE
docs: update license key and organization API docs

### DIFF
--- a/pages/self-hosting/_meta.tsx
+++ b/pages/self-hosting/_meta.tsx
@@ -7,7 +7,7 @@ export default {
   },
   index: "Overview",
   configuration: "Configuration",
-  "license-key": "License Key",
+  "license-key": "License Key (EE)",
   troubleshooting: "Troubleshooting",
   scaling: "Sizing & Scaling",
   backups: "Backups",

--- a/pages/self-hosting/organization-management-api.mdx
+++ b/pages/self-hosting/organization-management-api.mdx
@@ -6,15 +6,11 @@ label: "Version: v3"
 
 # Organization Management API
 
-<AvailabilityBanner
-  availability={{
-    hobby: "not-available",
-    core: "not-available",
-    pro: "not-available",
-    enterprise: "not-available",
-    selfHosted: "ee",
-  }}
-/>
+<Callout type="info">
+
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
+
+</Callout>
 
 ## Overview
 


### PR DESCRIPTION
Streamline feature references for enterprise features in self-hosting
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation to clarify that certain self-hosting features are exclusive to the Enterprise Edition, including the license key and organization management API.
> 
>   - **Documentation Updates**:
>     - In `pages/self-hosting/_meta.tsx`, renamed "License Key" to "License Key (EE)" to indicate enterprise edition.
>     - In `pages/self-hosting/organization-management-api.mdx`, replaced `<AvailabilityBanner>` with `<Callout>` to specify that the Organization Management API is only available in the Enterprise Edition and requires a license key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e955427e6ee40b11c1740a65298287d4ba0fabdc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->