### PR TITLE
[on hold] update docs about langfuse_otel integration with litellm

### DIFF
--- a/pages/docs/integrations/litellm/tracing.mdx
+++ b/pages/docs/integrations/litellm/tracing.mdx
@@ -80,16 +80,13 @@ You can add additional Langfuse attributes to the requests in order to group req
 Instead of the proxy, you can also use the native LiteLLM Python client. You can find more in-depth documentation in the [LiteLLM docs](https://litellm.vercel.app/docs/observability/langfuse_integration).
 
 <Callout type="warning">
-  LiteLLM relies on the <strong>Langfuse Python SDK v2</strong>. It is currently
-  <strong>not compatible</strong> with the newer
-  <strong>[Python SDK v3](/docs/sdk/python/sdk-v3)</strong>. Please refer to the
-  [v2 documentation](/docs/sdk/python/low-level-sdk) and pin the SDK version
-  during installation:
+  LiteLLM `langfuse` integration relies on the <strong>Langfuse Python SDK v2</strong>. To use 
+  litellm with the newer
+  <strong>[Python SDK v3](/docs/sdk/python/sdk-v3)</strong>, use `langfuse_otel` integration instead.
+
+  You need at least version `1.72.6` of `litellm` to be able to use it with `langfuse_otel`! 
 </Callout>
 
-```
-pip install "langfuse>=2,<3" litellm
-```
 
 ```python filename="main.py"
 from litellm import completion
@@ -106,8 +103,9 @@ os.environ["OPENAI_API_KEY"] = ""
 os.environ["COHERE_API_KEY"] = ""
 
 # set callbacks
-litellm.success_callback = ["langfuse"]
-litellm.failure_callback = ["langfuse"]
+# "langfuse_otel" for v3 and "langfuse" for v2 Python SDK
+litellm.success_callback = ["langfuse_otel"]
+litellm.failure_callback = ["langfuse_otel"]
 
 ```
 

--- a/pages/docs/integrations/litellm/tracing.mdx
+++ b/pages/docs/integrations/litellm/tracing.mdx
@@ -84,7 +84,7 @@ Instead of the proxy, you can also use the native LiteLLM Python client. You can
   litellm with the newer
   <strong>[Python SDK v3](/docs/sdk/python/sdk-v3)</strong>, use `langfuse_otel` integration instead.
 
-  You need at least version `1.72.6` of `litellm` to be able to use it with `langfuse_otel`! 
+  You need at least version `XXXXXX TBD XXXXXX` of `litellm` to be able to use it with `langfuse_otel`! 
 </Callout>
 
 


### PR DESCRIPTION
It has been merged 🙌  https://github.com/BerriAI/litellm/releases/tag/v1.72.6.rc
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `tracing.mdx` to document LiteLLM integration with `langfuse_otel` for Python SDK v3, requiring `litellm` version `1.72.6` or higher.
> 
>   - **Documentation Update**:
>     - Updates `tracing.mdx` to reflect that LiteLLM `langfuse` integration now supports `langfuse_otel` for Python SDK v3.
>     - Specifies that `litellm` version `1.72.6` or higher is required for `langfuse_otel`.
>   - **Code Examples**:
>     - Changes `litellm.success_callback` and `litellm.failure_callback` to use `"langfuse_otel"` for Python SDK v3 in `tracing.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 95f9f881455dfb534d95db5c3fb6345013a27692. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->