### PR TITLE
simple embed ashby

### DIFF
--- a/components/CTACard.tsx
+++ b/components/CTACard.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CTACardProps {
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+  className?: string;
+  showArrow?: boolean;
+}
+
+export function CTACard({ title, description, children, className, showArrow = false }: CTACardProps) {
+  return (
+    <Card className={cn("border bg-card mt-8", className)}>
+      <CardContent className="p-8">
+        <div className="flex flex-col md:flex-row md:items-center gap-6">
+          <div className="flex-1 md:flex-[2] space-y-2">
+            <h3 className="text-xl font-semibold text-foreground">
+              {title}
+            </h3>
+            <p className="text-muted-foreground">
+              {description}
+            </p>
+          </div>
+          {children && (
+            <div className="flex flex-col sm:flex-row gap-3 justify-center md:justify-end items-center md:flex-1">
+              {showArrow ? (
+                React.Children.map(children, (child) => {
+                  if (React.isValidElement(child) && (child.type === Button || child.props.asChild)) {
+                    return React.cloneElement(child, {
+                      children: (
+                        <div className="flex items-center gap-2">
+                          {child.props.children}
+                          <ArrowRight className="h-4 w-4" />
+                        </div>
+                      )
+                    } as any);
+                  }
+                  return child;
+                })
+              ) : (
+                children
+              )}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/pages/careers.mdx
+++ b/pages/careers.mdx
@@ -2,6 +2,9 @@
 description: "Join the Langfuse team to build the leading open-source LLM engineering platform"
 ---
 
+import { CTACard } from "@/components/CTACard"
+import { Button } from "@/components/ui/button"
+
 # Join Us!
 
 Langfuse is building the leading **open-source LLM engineering platform** (**[Why Langfuse?](/why)**).
@@ -51,51 +54,34 @@ We have raised a [$4M seed round](/blog/announcing-our-seed-round) from Lightspe
 - Akio Nuernberger, [@AkioNuernberger](https://x.com/AkioNuernberger), [LinkedIn](https://www.linkedin.com/in/akio-nuernberger/)
 - Nimar Blume, [GitHub](https://github.com/nimarb), [LinkedIn](https://www.linkedin.com/in/nimar/) 
 
-**A few tidbits that might help you understand what kind of company we are:**
 
+## How we operate
 - We have 2 scheduled meetings per week: 15 min planning on Monday, 60 min demo on Friday
-- We are a very high-trust environment, Reed Hastings' 'No Rules Rules' inspires our culture, [here's a summary](https://www.mattswain.com/booknotes/no-rules-rules)
-- In everyone that's joining us, we are mostly looking for agency and taste as this leads to the team being very effective. While this is quite vague, we like [this write up](https://www.benkuhn.net/impact) that makes it more explicit.
-- Most team members have led projects/teams before and are excited about shipping more at Langfuse as a strong IC
+- We are a very high-trust environment, [Reed Hastings' 'No Rules Rules'](https://www.mattswain.com/booknotes/no-rules-rules), inspires our culture
+- In everyone that's joining us, we are mostly looking for [high agency and good taste](https://www.benkuhn.net/impact)
+- Most team members have led projects/teams before but are excited about shipping as an IC
 - We were heavily influenced by our time at Y Combinator and follow its ethos. We're a Silicon Valley Startup in Berlin - [more here](https://www.ycombinator.com/library/4D-yc-s-essential-startup-advice)
-- Use AI to the upmost extent to give us leverage across everything we do, [some highlights](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)
+- We use AI to the upmost extent to give us leverage across everything we do, [some highlights](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)
 
-PS: We are based in Berlin (Germany) and work in person. Come join us build one of the most exciting open source devtool companies in Europe!
+## Open Roles
 
-## Roles
+<CTACard 
+  title="Curious to build with us?"
+  description="If you are excited about delivering exceptional open-source developer experiences alongside an insanely motivated team that ships, reach out!"
+  showArrow={true}
+>
+  <Button asChild variant="default" size="sm">
+    <a href="https://jobs.ashbyhq.com/langfuse" target="_blank" rel="noopener noreferrer">
+      See open Roles
+    </a>
+  </Button>
+</CTACard>
 
-<Callout type="info">
-  Can't find a role that's a perfect fit? If you are excited about delivering
-  exceptional developer experiences and building a high-quality open-source
-  product alongside an insanely motivated team that [ships](/changelog), feel
-  free to reach out: careers@langfuse.com
-</Callout>
-
-- [Design Engineer](https://www.ycombinator.com/companies/langfuse/jobs/mDquP95-design-engineer)
-  - _Berlin, €70K - €130K EUR, 0.1% - 0.35%_
-  - You are a design-minded frontend engineer who is passionate about building beautiful, functional, and user-friendly interfaces. You own UI/UX in the Langfuse application to help our users achieve their goals and create how thousands of teams build their LLM applications.
-- [Backend Engineer](https://www.ycombinator.com/companies/langfuse/jobs/1bO16H6-backend-engineer)
-  - _Berlin, €70K - €130K EUR, 0.1% - 0.35%_
-  - You will work on our backend systems, powering the core infrastructure of Langfuse. You work on a data-intensive application that is used by hundreds of companies and thousands of developers ingesting hundreds of millions of events.
-  - The [technical blog post on the v3 release](/blog/2024-12-langfuse-v3-infrastructure-evolution) is a great example of what you could have worked on.
-- [Product Engineer](https://www.ycombinator.com/companies/langfuse/jobs/aAvmoFB-product-engineer)
-  - _Berlin, €70K - €130K EUR, 0.1% - 0.35%_
-  - Design, scope, ship, and launch new full-stack (UI, backend, SDKs, integrations) features on top of our existing data platform. You'll own what you build truly end-to-end from first conversations with users to operating it in production.
-  - See launch weeks ([#1](/blog/launch-week-1), [#2](/blog/2024-11-17-launch-week-2)) and [changelog](/changelog) for a good selection of things you could have worked on.
-- [Developer Advocate](https://www.ycombinator.com/companies/langfuse/jobs/uHysbKH-developer-advocate-devrel)
-  - _Berlin, €70K - €130K EUR, 0.1% - 0.35%_
-  - Run our bottom-up go-to-market via developer-focused content, documentation, partnerships, events, and community-building. Langfuse is a platform of many building blocks and there are lots of common workflows we can educate on to drive awareness and adoption.
-  - Examples: Hugging Face and Posthog partnerships, LLM Security Monitoring guides/examples, AWS partnership, our YouTube channel
-- [Founding GTM Engineer](https://www.ycombinator.com/companies/langfuse/jobs/CjRH5FL-founding-gtm-engineer)
-  - _Berlin/San Francisco, €70K - €130K EUR, 0.1% - 0.35%_
-  - Work closely with our enterprise customers throughout the inbound sales cycle. Help them resolve complex technical questions, succeed in POCs, and expand after initial adoption.
-  - Build ressources and improve the process to further increase scalability of our GTM.
-
-Please apply via [Work At a Startup](https://www.ycombinator.com/companies/langfuse/jobs) or send us an email with your CV/LinkedIn to careers@langfuse.com
+Can't find a role that's a perfect fit? Feel free to reach out: careers@langfuse.com
 
 You need to be located in Berlin, Germany or willing to relocate. The first few interviews can be done remotely via Zoom. In the final stage, we will work one day onsite together (usually on an actual high-priority project).
 
-## Why Join Langfuse?
+## Why Join?
 
 <div className="flex flex-row gap-4">
 
@@ -123,3 +109,15 @@ You need to be located in Berlin, Germany or willing to relocate. The first few 
 import PublicMetrics from "@/components-mdx/public-metrics.mdx";
 
 <PublicMetrics />
+
+<CTACard 
+  title="Curious to build with us?"
+  description="If you are excited about delivering exceptional open-source developer experiences alongside an insanely motivated team that ships, reach out!"
+  showArrow={true}
+>
+  <Button asChild variant="default" size="sm">
+    <a href="https://jobs.ashbyhq.com/langfuse" target="_blank" rel="noopener noreferrer">
+      See open Roles
+    </a>
+  </Button>
+</CTACard>


### PR DESCRIPTION
<img width="891" alt="image" src="https://github.com/user-attachments/assets/510b59e2-6561-4b03-a10d-c30f4c213dfd" />

Components New: 
- simple "CTACard" that can be easily reused in blog posts or docs

linking to Ashby job board https://jobs.ashbyhq.com/langfuse

**Design Considerations:**
- i went for this version because getting ashby job board embeded (easy) but styled correctly + dark mode (was complicated)
- longterm I'd opt for building a custom frontend on top of the API  like https://vercel.com/careers
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `CTACard` component and update `careers.mdx` to link to Ashby job board using this component.
> 
>   - **Components**:
>     - Add `CTACard` component in `components/CTACard.tsx` for displaying call-to-action cards with title, description, and optional children.
>     - Supports optional arrow icon for child elements of type `Button`.
>   - **Pages**:
>     - Update `pages/careers.mdx` to use `CTACard` for linking to Ashby job board.
>     - Removes detailed job listings and replaces with a single link to Ashby.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3a17c4ad9c5f306bcf265ecfc7dad6d6d3a96899. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->