### PR TITLE
docs: misc v3 migration changes

### DIFF
--- a/components-mdx/datasets-create-dataset-item.mdx
+++ b/components-mdx/datasets-create-dataset-item.mdx
@@ -19,7 +19,7 @@ langfuse.create_dataset_item(
 )
 ```
 
-_See [low-level SDK](/docs/sdk/python/low-level-sdk) docs for details on how to initialize the Python client._
+_See [Python SDK v3](/docs/sdk/python/sdk-v3) docs for details on how to initialize the Python client._
 
 </Tab>
 <Tab>

--- a/components-mdx/datasets-create-dataset.mdx
+++ b/components-mdx/datasets-create-dataset.mdx
@@ -15,7 +15,7 @@ langfuse.create_dataset(
 )
 ```
 
-_See [low-level SDK](/docs/sdk/python/low-level-sdk) docs for details on how to initialize the Python client._
+_See [Python SDK v3](/docs/sdk/python/sdk-v3) docs for details on how to initialize the Python client._
 
 </Tab>
 <Tab>

--- a/cookbook/example_synthetic_datasets.ipynb
+++ b/cookbook/example_synthetic_datasets.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "In this notebook, we will explore how to **generate synthetic datasets** using language models and uploading them to [Langfuse](https://langfuse.com) for evaluation. \n",
         "\n",
-        "## What Langfuse Datasets?\n",
+        "## What are Langfuse Datasets?\n",
         "\n",
         "In Langfuse, a *dataset* is a collection of *dataset items*, each typically containing an `input` (e.g., user prompt/question), `expected_output` (the ground truth or ideal answer) and optional metadata.\n",
         "\n",

--- a/cookbook/otel_integration_python_sdk.ipynb
+++ b/cookbook/otel_integration_python_sdk.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "## Setup\n",
         "\n",
-        "_**Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._"
+        "_**⚠️ Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._"
       ]
     },
     {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -247,6 +247,7 @@ const nonPermanentRedirects = [
   ["/docs/analytics/integrations", "/docs/analytics/integrations/posthog"],
   ["/docs/analytics/daily-metrics-api", "/docs/analytics/metrics-api#daily-metrics"],
   ["/docs/opentelemetry/example-opentelemetry-collector", "/docs/opentelemetry/get-started#export-from-opentelemetry-collector"],
+  ["/docs/sdk/python/decorators", "https://langfuse.com/docs/sdk/python/sdk-v3#observe-decorator"],
 
   // new self-hosting section
   ["/docs/self-hosting", "/self-hosting"],

--- a/pages/docs/api.mdx
+++ b/pages/docs/api.mdx
@@ -66,7 +66,7 @@ When fetching [prompts](/docs/prompts/get-started#use-prompt), please use the `g
 <Tabs items={["Python SDK", "JS/TS SDK", "Java SDK"]}>
 <Tab>
 
-When using the [low-level SDK](/docs/sdk/python/low-level-sdk):
+When using the [Python SDK v3](/docs/sdk/python/sdk-v3):
 
 ```python
 from langfuse import get_client

--- a/pages/docs/datasets/example-synthetic-datasets.md
+++ b/pages/docs/datasets/example-synthetic-datasets.md
@@ -7,7 +7,7 @@ category: Evaluation
 
 In this notebook, we will explore how to **generate synthetic datasets** using language models and uploading them to [Langfuse](https://langfuse.com) for evaluation. 
 
-## What Langfuse Datasets?
+## What are Langfuse Datasets?
 
 In Langfuse, a *dataset* is a collection of *dataset items*, each typically containing an `input` (e.g., user prompt/question), `expected_output` (the ground truth or ideal answer) and optional metadata.
 

--- a/pages/docs/datasets/get-started.mdx
+++ b/pages/docs/datasets/get-started.mdx
@@ -31,6 +31,8 @@ Frequently, you want to create synthetic examples to test your application to bo
 
 Once generated, you can upload them to Langfuse via the SDKs.
 
+To get started have a look at this [cookbook](/docs/datasets/example-synthetic-datasets) for examples on how to generate synthetic datasets.
+
 </details>
 
 <details>

--- a/pages/docs/opentelemetry/example-python-sdk.md
+++ b/pages/docs/opentelemetry/example-python-sdk.md
@@ -12,7 +12,7 @@ In this example, we'll use the [Python OpenTelemetry SDK](https://opentelemetry.
 
 ## Setup
 
-_**Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._
+_**⚠️ Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._
 
 
 ```python

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -5,12 +5,19 @@ description: How to connect Langfuse with OpenTelemetry to observe LLM applicati
 
 # LLM Observability via OpenTelemetry
 
-
 [OpenTelemetry](https://opentelemetry.io/) is a [CNCF](https://www.cncf.io/) project that provides a set of specifications, APIs, libraries that define a standard way to collect distributed traces and metrics from your application.
 
 Langfuse can operate as an OpenTelemetry Backend to receive traces on the `/api/public/otel` (OTLP) endpoint. In addition to the [Langfuse SDKs](/docs/sdk/overview) and [native integrations](/docs/integrations/overview), this OpenTelemetry endpoint is designed to increase compatibility with frameworks, libraries, and languages beyond the SDKs and native integrations. Popular OpenTelemetry libraries include OpenLLMetry and OpenLIT which extend Language support of Langfuse tracing to Java and Go and cover frameworks such as AutoGen, Semantic Kernel, and more.
 
 As the [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) for GenAI attributes on traces are still evolving, Langfuse maps the received OTel traces to the [Langfuse data model](/docs/tracing-data-model) and supports additional attributes that are popular in the OTel GenAI ecosystem ([property mapping](#property-mapping)). Please contribute to the discussion on [GitHub](https://github.com/orgs/langfuse/discussions/2509) if an integration does not work as expected or does not parse the correct attributes.
+
+## OpenTelemetry native Langfuse SDK v3
+
+The quickest path to start tracing with Langfuse is the new **OTEL-native Langfuse SDK v3**. The SDK is a thin layer on top of the official OpenTelemetry client that automatically converts all emitted spans into rich Langfuse observations (spans, generations, events) and adds first-class helpers for LLM-specific features such as token usage, cost tracking, prompt linking, and scoring. 
+
+Because it lives in the shared OpenTelemetry context, any other library that is already instrumented with OTEL (HTTP frameworks, databases, GenAI instrumentation like OpenLLMetry/OpenLIT, etc.) will seamlessly show up in the same Langfuse traces without additional configuration. 
+
+Get started by following the dedicated guide for the Python implementation here: [/docs/sdk/python/sdk-v3](/docs/sdk/python/sdk-v3).
 
 ## OpenTelemetry endpoint
 
@@ -146,6 +153,7 @@ Any OpenTelemetry compatible instrumentation can be used to export traces to Lan
 - [Semantic Kernel](/docs/integrations/semantic-kernel)
 - [Pydantic AI](/docs/integrations/pydantic-ai)
 - [Spring AI](/docs/integrations/spring-ai)
+- [LlamaIndex](/docs/integrations/llama-index)
 - [LlamaIndex Workflows](/docs/integrations/llama-index/workflows)
 
 ## Export from OpenTelemetry Collector

--- a/pages/guides/cookbook/example_synthetic_datasets.md
+++ b/pages/guides/cookbook/example_synthetic_datasets.md
@@ -7,7 +7,7 @@ category: Evaluation
 
 In this notebook, we will explore how to **generate synthetic datasets** using language models and uploading them to [Langfuse](https://langfuse.com) for evaluation. 
 
-## What Langfuse Datasets?
+## What are Langfuse Datasets?
 
 In Langfuse, a *dataset* is a collection of *dataset items*, each typically containing an `input` (e.g., user prompt/question), `expected_output` (the ground truth or ideal answer) and optional metadata.
 

--- a/pages/guides/cookbook/otel_integration_python_sdk.md
+++ b/pages/guides/cookbook/otel_integration_python_sdk.md
@@ -12,7 +12,7 @@ In this example, we'll use the [Python OpenTelemetry SDK](https://opentelemetry.
 
 ## Setup
 
-_**Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._
+_**⚠️ Note:** We have a new OpenTelemetry native Langfuse SDK. Please check out the [SDK v3](https://langfuse.com/docs/sdk/python/sdk-v3) for a more powerful and simpler to use SDK._
 
 
 ```python


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to reflect Python SDK v3 and add new redirects for improved navigation.
> 
>   - **Documentation Updates**:
>     - Update references from "low-level SDK" to "Python SDK v3" in `datasets-create-dataset-item.mdx`, `datasets-create-dataset.mdx`, and `api.mdx`.
>     - Add a note about the new OpenTelemetry native Langfuse SDK in `example-python-sdk.md` and `otel_integration_python_sdk.md`.
>     - Add a section on "OpenTelemetry native Langfuse SDK v3" in `get-started.mdx`.
>     - Fix typo in `example-synthetic-datasets.md` and `example_synthetic_datasets.md`.
>   - **Redirects**:
>     - Add redirect from `/docs/sdk/python/decorators` to `https://langfuse.com/docs/sdk/python/sdk-v3#observe-decorator` in `next.config.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2c5a1fb7df13ccacdc2a8e24db66537fd03e7ccc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->