### PR TITLE
chore: add recommendations on bucket settings for S3 clickhouse disks

### DIFF
--- a/pages/self-hosting/infrastructure/clickhouse.mdx
+++ b/pages/self-hosting/infrastructure/clickhouse.mdx
@@ -243,6 +243,16 @@ For a full overview of the feature, see the [ClickHouse External Disks documenta
 Below, we give a config.xml example to use S3 and Azure Blob Storage as disks for ClickHouse Docker containers using Docker Compose.
 Keep in mind that metadata is still stored on local disk, i.e. you need to use a persistent volume for the ClickHouse container or risk loosing access to your tables.
 
+<Callout type="warning">
+
+  We recommend the following settings when using Blob Storage as a disk for your ClickHouse deployment:
+
+  - **Do not enable bucket versioning**: ClickHouse will write and update many files within its merge processing. Having versioned buckets will retain the full history and quickly grow your storage consumption.
+  - **Do not enable lifecycle policies for deletion**: Avoid deletion lifecycle policies as this may break ClickHouse's internal consistency model. Instead, delete data via the Langfuse application or using ClickHouse TTLs.
+  - **Do not enable lifecycle policies for aborted multi-part uploads**.
+
+</Callout>
+
 ### S3 Example
 
 Create a config.xml file with the following contents in your local working directory:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add recommendations in `clickhouse.mdx` for S3 bucket settings to prevent storage and consistency issues.
> 
>   - **Recommendations**:
>     - Added recommendations in `clickhouse.mdx` for S3 bucket settings when used as ClickHouse disks.
>     - Advise against enabling bucket versioning to prevent excessive storage consumption.
>     - Advise against enabling lifecycle policies for deletion and aborted multi-part uploads to maintain ClickHouse consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 60fe2bef8169db849c706c78168b751544b85bb0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->