### PR TITLE
feat: add calculatorOpen flag to pricing page

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -47,6 +47,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useRouter } from "next/router";
 
 // Graduated pricing tiers
 const pricingTiers = [
@@ -166,15 +167,32 @@ const PricingCalculatorModal = ({
   baseFee?: number;
   planName?: string;
 }) => {
-  const [monthlyEvents, setMonthlyEvents] = useState<string>("500,000");
+  const router = useRouter();
+  const [monthlyEvents, setMonthlyEvents] = useState<string>("200,000");
   const [calculatedPrice, setCalculatedPrice] = useState<number>(0);
   const [selectedPlan, setSelectedPlan] = useState<string>(planName);
   const [currentBaseFee, setCurrentBaseFee] = useState<number>(baseFee);
 
+  // Read open state from URL
+  const isOpen = router.query.calculatorOpen === "true";
+
+  // Calculate price when events change
   useEffect(() => {
     const events = parseInt(monthlyEvents.replace(/,/g, "")) || 0;
     setCalculatedPrice(calculateGraduatedPrice(events));
   }, [monthlyEvents]);
+
+  const handleOpenChange = (open: boolean) => {
+    const query = { ...router.query };
+    if (open) {
+      query.calculatorOpen = "true";
+    } else {
+      delete query.calculatorOpen;
+    }
+    router.replace({ pathname: router.pathname, query }, undefined, {
+      shallow: true,
+    });
+  };
 
   const handlePlanChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newPlanName = e.target.value;
@@ -188,7 +206,7 @@ const PricingCalculatorModal = ({
   };
 
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <span className="text-sm hover:text-primary underline cursor-pointer">
           pricing calculator

--- a/pages/docs/tracing-data-model.mdx
+++ b/pages/docs/tracing-data-model.mdx
@@ -122,6 +122,8 @@ Langfuse Cloud [pricing](/pricing) is based on the number of ingested tracing un
 
 `Billable Units = Traces + Observations + Scores` (see above)
 
+Use our [pricing calculator](/pricing?calculatorOpen=true) to estimate your monthly costs based on your expected usage.
+
 ### FAQ
 
 > How can I track my Langfuse Cloud usage?

--- a/pages/faq/all/cutting-costs.mdx
+++ b/pages/faq/all/cutting-costs.mdx
@@ -12,6 +12,8 @@ Langfuse Cloud [pricing](/pricing) is based on the number of ingested tracing un
 Most cost spikes result from ingesting **too many traces or overly verbose observations**.
 You can **cut costs quickly by sampling fewer traces or logging only essential data**—all while preserving your core insights.
 
+Use our [pricing calculator](/pricing?calculatorOpen=true) to estimate how different usage levels impact your monthly costs.
+
 You can track your unit consumption in real-time via the "Langfuse Usage Management" dashboard:
 
 <Frame>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `calculatorOpen` query parameter to control pricing calculator visibility on the pricing page and updates documentation with usage links.
> 
>   - **Behavior**:
>     - Adds `calculatorOpen` query parameter to control the visibility of the pricing calculator in `PricingCalculatorModal` in `Pricing.tsx`.
>     - Updates `PricingCalculatorModal` to read `calculatorOpen` from URL and adjust dialog state accordingly.
>   - **Documentation**:
>     - Adds links to open the pricing calculator with `calculatorOpen=true` in `tracing-data-model.mdx` and `cutting-costs.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d588a569f767382e2f408462955945e3c33aec45. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->