### PR TITLE
docs: Add troubleshooting hint to Mastra docs

### DIFF
--- a/pages/docs/integrations/mastra.mdx
+++ b/pages/docs/integrations/mastra.mdx
@@ -121,6 +121,11 @@ This guide shows you how to integrate **Langfuse** with **Mastra** for observabi
 
 </Steps>
 
+## Troubleshooting
+
+- **NextJS Integration Issues**: If you encounter issues when using Mastra with Langfuse in NextJS applications, refer to the [Mastra NextJS tracing documentation](https://mastra.ai/en/docs/observability/nextjs-tracing) for NextJS-specific configuration and setup instructions.
+- **No Traces in Langfuse**: Ensure that your credentials are correct and follow this [troubleshooting guide](/faq/all/missing-traces)
+
 ## References
 
 - [Project Repository](https://github.com/akuya-ekorot/langfuse-mastra)


### PR DESCRIPTION
A `%23%23 Troubleshooting` section was added to `pages/docs/integrations/mastra.mdx`, placed before the `%23%23 References` section.

This new section includes:
*   **NextJS Integration Issues**: A link to the Mastra NextJS tracing documentation (`https://mastra.ai/en/docs/observability/nextjs-tracing`) was added. This directly addresses user feedback regarding difficulties using Mastra with Langfuse in NextJS applications.
*   **No Traces in Langfuse**: A general troubleshooting hint linking to the Langfuse missing traces FAQ (`/faq/all/missing-traces`) was included.

The addition follows the established pattern for troubleshooting sections found in other integration documentation pages, ensuring consistency in structure and readability.