### PR TITLE
chore: fix unit calculation and add teams tier to pricing calculator

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -96,6 +96,7 @@ type PlanConfig = {
 const PLAN_CONFIGS: PlanConfig[] = [
   { name: "Core", baseFee: 59 },
   { name: "Pro", baseFee: 199 },
+  { name: "Pro + Teams", baseFee: 499 }
 ];
 
 // Utility functions
@@ -132,10 +133,11 @@ const calculateTierBreakdown = (
   } else {
     // Paid tiers
     if (events > tier.min) {
-      const tierStart = Math.max(100000, tier.min);
+      // Fix: Adjust tierStart to be exactly tier.min for correct boundary calculation
+      const tierStart = tier.min;
       const tierEnd =
         tier.max === Infinity ? events : Math.min(events, tier.max);
-      eventsInTier = Math.max(0, tierEnd - tierStart);
+      eventsInTier = Math.max(0, tierEnd - tierStart + 1);
       costForTier = (eventsInTier / 100000) * tier.rate;
     }
     tierRate = `$${tier.rate}/100k`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds "Pro + Teams" tier and fixes unit calculation in `Pricing.tsx`.
> 
>   - **Pricing Tier**:
>     - Adds "Pro + Teams" tier with a base fee of $499 to `PLAN_CONFIGS` in `Pricing.tsx`.
>   - **Calculation Fix**:
>     - Fixes unit calculation in `calculateTierBreakdown()` in `Pricing.tsx` by adjusting `tierStart` to `tier.min` and correcting `eventsInTier` calculation to include the last unit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 0de8e5e5c1ff06242cdc7f86785ec2dd4a45c770. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->