### PR TITLE
chore: prioritize ask ai

### DIFF
--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -7,12 +7,10 @@ import {
   Copy as CopyIcon,
   Check as CheckIcon,
   LifeBuoy,
-  MessageSquare,
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
 import { Textarea } from "./ui/textarea";
-import { showChat } from "./supportChat";
 import { Background } from "./Background";
 import { NotebookBanner } from "./NotebookBanner";
 import { COOKBOOK_ROUTE_MAPPING } from "@/lib/cookbook_route_mapping";
@@ -234,10 +232,6 @@ export const DocsSupport = () => {
           <span>Support</span>
           <LifeBuoy className="h-4 w-4 ml-2" />
         </a>
-      </Button>
-      <Button variant="outline" size="sm" onClick={() => showChat()}>
-        <span>Chat</span>
-        <MessageSquare className="h-4 w-4 ml-2" />
       </Button>
     </div>
   );

--- a/components/supportChat/index.tsx
+++ b/components/supportChat/index.tsx
@@ -41,7 +41,12 @@ export const PlainChat = () => {
             launcherBackgroundColor: "#666666", // These can also be passed in this format { light: '#FFFFFF', dark: '#000000' }
             launcherIconColor: "#FFFFFF",
           },
-
+          chatButtons: [
+            {
+              icon: "email",
+              text: "Contact Support",
+            },
+          ],
           position: {
             right: "25px",
             bottom: "80px",

--- a/pages/support.mdx
+++ b/pages/support.mdx
@@ -23,7 +23,7 @@ import InkeepEmbeddedChat from "@/components/inkeep/InkeepEmbeddedChat";
 <div className="h-5" />
 <InkeepEmbeddedChat />
 
-## Support Channels
+## Public Support Channels
 
 - **Ask any question in our [public Q&A](/gh-support) on GitHub Discussions.** Please include as much detail as possible (e.g. code snippets, screenshots, background information) to help us understand your question.
 - [Request a feature](/ideas) on GitHub Discussions.
@@ -36,18 +36,26 @@ import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsP
 
 <GhDiscussionsPreview defaultSort="recent" />
 
+## Private Support Channels
+
+import { showChat } from "@/components/supportChat";
+
+For more sensitive or private matters, you can reach out to us directly. Please consider the public channels first.
+
+- Email via support@langfuse.com
+- Create a <button onClick={showChat} className="nextra-focus _text-primary-600 _underline hover:_no-underline _decoration-from-font [text-underline-position:from-font] cursor-pointer">support ticket</button>
+- [Schedule a Call](/talk-to-us) for sales or partnerships inquiries. Please provide a little context about why you'd like to speak.
+- Pro/Teams/Enterprise plan users: private Slack Connect channel with the Langfuse team. Request an invite via support@langfuse.com
+
 ## Community Discord
 
 [![Discord](https://img.shields.io/discord/1111061815649124414?style=flat&logo=discord&logoColor=white)](/discord)
 
 Over 1,700 users are on our [Discord Server](/discord). It's a great place to ask questions, share your projects, and get to know other Langfuse users.
 
-Please note: The Langfuse team does not provide dedicated support on Discord. Please use our [GitHub Discussions](/ideas) or Email (support@langfuse.com) if your request is sensitive. Feel free to cross-post from GitHub to Discord to raise awareness for your issue or question.
-
-## Email, Meeting and Slack
-
-For more sensitive or private matters, you can reach out to us directly. Please consider the public channels first.
-
-- Email via support@langfuse.com
-- [Schedule a Call](/talk-to-us) with one of the founders for sales or partnerships inquiries. Please provide a little context about why you'd like to speak.
-- Pro/Teams/Enterprise plan users: private Slack Connect channel with the Langfuse team. Request an invite via support@langfuse.com
+<Callout type="info">
+  Please note: The Langfuse team does not provide dedicated support on Discord.
+  Please use our [GitHub Discussions](/ideas) or Email (support@langfuse.com) if
+  your request is sensitive. Feel free to cross-post from GitHub to Discord to
+  raise awareness for your issue or question.
+</Callout>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prioritize 'Ask AI' over support chat by removing chat button from UI and updating support documentation.
> 
>   - **UI Changes**:
>     - Remove support chat button from `DocsSupport` in `MainContentWrapper.tsx`.
>     - Update `support.mdx` to prioritize 'Ask AI' and adjust support channel descriptions.
>   - **Support Chat**:
>     - Add 'Contact Support' button in `PlainChat` configuration in `supportChat/index.tsx`.
>   - **Documentation**:
>     - Rename 'Support Channels' to 'Public Support Channels' in `support.mdx`.
>     - Reorder sections in `support.mdx` to emphasize public channels first.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3e01c4f4e07e78efc47189b56c53336e43de0994. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->