### PR TITLE
add faq for users that cannot find org

### DIFF
--- a/pages/faq/all/cannot-see-organization.mdx
+++ b/pages/faq/all/cannot-see-organization.mdx
@@ -1,49 +1,34 @@
 ---
 title: I cannot see my organization in Langfuse
 description: Troubleshoot organization visibility issues in Langfuse Cloud. Learn how to verify your cloud region, email address, and resolve common access problems.
-tags: [cloud, auth, setup]
+tags: [cloud, setup]
 ---
 
 # I Cannot See My Organization in Langfuse
 
-## I'm a member but can't see my organization
-
 If you've been added as a member to an organization but can't see it in your dashboard, there are several common causes and solutions to check.
 
-### Are you on the correct Langfuse Cloud region?
+## Are you on the correct Langfuse Cloud region?
 
-Langfuse operates in multiple data regions. Make sure you're logged into the same region where your organization was created.
-
-We run Langfuse in two data regions:
-- **European Union**: [https://cloud.langfuse.com](https://cloud.langfuse.com)
-- **United States**: [https://us.cloud.langfuse.com](https://us.cloud.langfuse.com)
-
-You can see which region you're currently on by checking the URL in your browser. If you're not sure which region your organization is in, try logging into both regions to see where your organization appears.
+Langfuse operates in multiple data regions and all data is fully isolated. Make sure you're logged into the same region where your organization was created.
 
 Learn more about [Langfuse Cloud Data Regions](/security/data-regions).
 
-### Are you using the correct email address?
+## Are you using the correct email address?
 
 Organization invitations are sent to specific email addresses. Make sure you're logging in with the exact email address that received the invitation.
 
 **Common issues:**
+
 - Your SSO provider (Google, GitHub, etc.) might use a different email than you expected
 - You might have multiple email addresses and the invitation was sent to a different one
 - Check your invitation email to confirm which address it was sent to
 
 **To verify your current email address:**
+
 1. Click your profile in the bottom left of the Langfuse UI
 2. Check the email address displayed there
 3. Ensure it matches the email that received the organization invitation
-
-### Check your invitation email
-
-Look for the organization invitation email in your inbox (including spam/junk folders). The invitation will contain:
-- The organization name
-- A link to accept the invitation
-- The specific email address it was sent to
-
-If you can't find the invitation email, ask your organization admin to resend it.
 
 ## Still having issues?
 
@@ -55,9 +40,3 @@ If you've verified your cloud region and email address but still can't see your 
 - Any error messages you're seeing
 
 **Contact support:** [support@langfuse.com](mailto:support@langfuse.com)
-
-## Related topics
-
-- [Data Regions](/security/data-regions)
-- [Role-Based Access Controls](/docs/rbac)
-- [Inviting co-workers to Langfuse](/faq/all/inviting-in-langfuse)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new FAQ page to help users troubleshoot visibility issues with their organization in Langfuse.
> 
>   - **New FAQ Page**:
>     - Adds `cannot-see-organization.mdx` to `pages/faq/all/`.
>     - Provides troubleshooting steps for users who cannot see their organization in Langfuse.
>   - **Troubleshooting Steps**:
>     - Verify correct Langfuse Cloud region.
>     - Confirm correct email address used for login.
>     - Instructions to verify email in Langfuse UI.
>   - **Support Contact**:
>     - Provides support contact information for unresolved issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8cc31ecc66f126f76ec350c29a4f0c044d871cfb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->