### PR TITLE
fix: Update CallbackHandler import path in LangChain example

### DIFF
--- a/pages/docs/get-started.mdx
+++ b/pages/docs/get-started.mdx
@@ -178,7 +178,7 @@ const res = await openai.chat.completions.create({
 The [integration](/docs/integrations/langchain) uses the Langchain callback system. **Note**: Trace attributes must be set on an enclosing span.
 
 ```python
-from langfuse.langchain import CallbackHandler
+from langfuse.callback import CallbackHandler
 
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate


### PR DESCRIPTION
The example was using `from langfuse.langchain import CallbackHandler`, which raised a `ModuleNotFoundError`.

Changed it to `from langfuse.callback import CallbackHandler`, which works correctly with the current SDK version.

This update ensures the quickstart example runs without import errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected import path for `CallbackHandler` in `get-started.mdx` to fix `ModuleNotFoundError`.
> 
>   - **Import Path Update**:
>     - Corrected import path for `CallbackHandler` in `get-started.mdx` from `from langfuse.langchain` to `from langfuse.callback` to fix `ModuleNotFoundError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ed8fe69e2e7da7f7f064e2632c81e309f242b0ab. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->