### PR TITLE
Update langchain to langfuse in examples

### DIFF
--- a/pages/docs/scores/user-feedback.mdx
+++ b/pages/docs/scores/user-feedback.mdx
@@ -25,10 +25,10 @@ Depending on the type of the application, there are different **types of feedbac
 A common workflow is to:
 
 1. Collection of feedback alongside LLM traces in Langfuse
-   > Example: _Negative, Langchain not included in response_
+   > Example: _Negative, Langfuse not included in response_
 2. Browsing of all user feedback, especially when collecting comments from users
 3. Identification of the root cause of the low-quality response (can be managed via [annotation queues](/docs/scores/annotation))
-   > Example: _Docs on Langchain integration are not included in embedding similarity search_
+   > Example: _Docs on Langfuse integration are not included in embedding similarity search_
 
 </details>
 


### PR DESCRIPTION
Weird to have langchain mentioned here, confusing for users.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update references from 'Langchain' to 'Langfuse' in `user-feedback.mdx` to avoid user confusion.
> 
>   - **Text Update**:
>     - Change 'Langchain' to 'Langfuse' in `user-feedback.mdx` to correct examples and avoid user confusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8b5fdc81e124026b6a3e09fe2111782fdb0fc1a9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->