### PR TITLE
Remove plus sign from GitHub stars

### DIFF
--- a/components/home/Usage.tsx
+++ b/components/home/Usage.tsx
@@ -82,9 +82,9 @@ const users: User[] = [
 
 export const Usage = () => {
   const stats = [
-    { name: "SDK installs / month", value: 7_000_000 },
-    { name: "GitHub stars", value: getGitHubStars() },
-    { name: "Docker pulls", value: 6_000_000 },
+    { name: "SDK installs / month", value: 7_000_000, showPlus: true },
+    { name: "GitHub stars", value: getGitHubStars(), showPlus: false },
+    { name: "Docker pulls", value: 6_000_000, showPlus: true },
   ];
 
   return (
@@ -125,7 +125,9 @@ export const Usage = () => {
             <div key={item.name} className="text-center">
               <p className="text-xl sm:text-2xl font-bold text-primary/80 font-mono">
                 <NumberTicker value={item.value} />
-                <span className="ml-1 hidden sm:inline">{"+"}</span>
+                {item.showPlus && (
+                  <span className="ml-1 hidden sm:inline">{"+"}</span>
+                )}
               </p>
               <p className="mt-2 text-xs sm:text-sm text-primary/70">
                 {item.name}


### PR DESCRIPTION
Remove the ' ' from the GitHub stars count on the home page to display the exact number.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove plus sign from GitHub stars count on home page by setting `showPlus: false` in `Usage` component.
> 
>   - **Behavior**:
>     - Removes plus sign from GitHub stars count on the home page by setting `showPlus: false` in `Usage` component.
>     - `showPlus: true` for "SDK installs / month" and "Docker pulls" to retain plus sign.
>   - **Code**:
>     - Adds `showPlus` property to `stats` array in `Usage.tsx` to control plus sign display.
>     - Conditional rendering of plus sign in `Usage` component based on `showPlus` value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for bc2a333e26826d5486fdcf23825da5e2a4226be8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->