### PR TITLE
Add Posthog tracking to MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-three/fiber": "^8.17.10",
     "@supabase/supabase-js": "^2.47.10",
     "@tanstack/react-table": "^8.20.6",
+    "@vercel/functions": "^2.2.2",
     "@vercel/mcp-adapter": "^0.11.1",
     "@vercel/og": "^0.6.8",
     "@vidstack/react": "^0.6.15",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "openai-edge": "^1.2.2",
     "postcss": "^8.4.49",
     "posthog-js": "^1.203.1",
+    "posthog-node": "^5.1.1",
     "react": "^18.3.1",
     "react-country-flag": "^3.1.0",
     "react-dom": "^18.3.1",

--- a/pages/api/mcp.ts
+++ b/pages/api/mcp.ts
@@ -9,6 +9,8 @@ const posthog = new PostHog(
   process.env.POSTHOG_API_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY || "",
   {
     host: process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
+    flushAt:1,
+    flushInterval: 0
   }
 );
 
@@ -53,15 +55,15 @@ const mcpHandler = createMcpHandler(
 
           // Track successful MCP tool event
           posthog.capture({
-            distinctId: "mcp-server",
-            event: "MCP",
+            distinctId: "docs-mcp-server",
+            event: "docs_mcp:execute_tool",
             properties: {
               tool_name: "searchLangfuseDocs",
               query: query,
               status: "success",
               response_length: responseContent.length,
-              timestamp: new Date().toISOString(),
-            },
+              $process_person_profile: false,
+          },
           });
 
           // Return the actual documentation content in MCP format
@@ -78,14 +80,13 @@ const mcpHandler = createMcpHandler(
         } catch (error) {
           // Track error MCP tool event
           posthog.capture({
-            distinctId: "mcp-server",
-            event: "MCP",
+            distinctId: "docs-mcp-server",
+            event: "docs_mcp:execute_tool",
             properties: {
               tool_name: "searchLangfuseDocs",
               query: query,
               status: "error",
               error_message: error instanceof Error ? error.message : "Unknown error",
-              timestamp: new Date().toISOString(),
             },
           });
 

--- a/pages/api/mcp.ts
+++ b/pages/api/mcp.ts
@@ -6,17 +6,11 @@ import { PostHog } from "posthog-node";
 import { waitUntil } from "@vercel/functions";
 
 // Initialize PostHog client for server-side tracking
-const posthog = new PostHog(
-  process.env.POSTHOG_API_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY || "",
-  {
-    host:
-      process.env.POSTHOG_HOST ||
-      process.env.NEXT_PUBLIC_POSTHOG_HOST ||
-      "https://eu.posthog.com",
-    flushAt: 1,
-    flushInterval: 0,
-  }
-);
+const posthog = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY || "", {
+  host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
+  flushAt: 1,
+  flushInterval: 0,
+});
 
 // Create the MCP handler using Vercel's adapter
 const mcpHandler = createMcpHandler(
@@ -74,7 +68,7 @@ const mcpHandler = createMcpHandler(
                 });
 
                 // Ensure events are flushed before function shutdown
-                await posthog.shutdown();
+                await posthog.flush();
               } catch (error) {
                 console.error("Error tracking PostHog event:", error);
               }
@@ -111,7 +105,7 @@ const mcpHandler = createMcpHandler(
                 });
 
                 // Ensure events are flushed before function shutdown
-                await posthog.shutdown();
+                await posthog.flush();
               } catch (trackingError) {
                 console.error("Error tracking PostHog event:", trackingError);
               }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.20.6
         version: 8.20.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vercel/functions':
+        specifier: ^2.2.2
+        version: 2.2.2
       '@vercel/mcp-adapter':
         specifier: ^0.11.1
         version: 0.11.1(@modelcontextprotocol/sdk@1.13.2)(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1702,6 +1705,15 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@vercel/functions@2.2.2':
+    resolution: {integrity: sha512-wgtgFwhYAUzS7UOvw44q14FaoRPONEnyoM0JlrjcDkI+kzSu7M8J5Tk5T3Kvv52//8is+HGxVQtaBSiO3G0wbw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
 
   '@vercel/mcp-adapter@0.11.1':
     resolution: {integrity: sha512-6IUuBSrHhc4nn4g/B64LCPDJGAQsChs60HKSzcifkQd7/0bgiIwAQ29ap6FdFHwYvRsXC4UcVPRcBUxhK9PsgQ==}
@@ -6527,6 +6539,8 @@ snapshots:
     dependencies:
       '@use-gesture/core': 10.3.1
       react: 18.3.1
+
+  '@vercel/functions@2.2.2': {}
 
   '@vercel/mcp-adapter@0.11.1(@modelcontextprotocol/sdk@1.13.2)(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       posthog-js:
         specifier: ^1.203.1
         version: 1.203.1
+      posthog-node:
+        specifier: ^5.1.1
+        version: 5.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3840,6 +3843,10 @@ packages:
 
   posthog-js@1.203.1:
     resolution: {integrity: sha512-r/WiSyz6VNbIKEV/30+aD5gdrYkFtmZwvqNa6h9frl8hG638v098FrXaq3EYzMcCdkQf3phaZTDIAFKegpiTjw==}
+
+  posthog-node@5.1.1:
+    resolution: {integrity: sha512-6VISkNdxO24ehXiDA4dugyCSIV7lpGVaEu5kn/dlAj+SJ1lgcDru9PQ8p/+GSXsXVxohd1t7kHL2JKc9NoGb0w==}
+    engines: {node: '>=20'}
 
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
@@ -9273,6 +9280,8 @@ snapshots:
       fflate: 0.4.8
       preact: 10.25.3
       web-vitals: 4.2.4
+
+  posthog-node@5.1.1: {}
 
   potpack@1.0.2: {}
 


### PR DESCRIPTION
Add server-side Posthog tracking for the `searchLangfuseDocs` tool to gather usage analytics.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add server-side Posthog tracking for `searchLangfuseDocs` tool in MCP server to capture usage analytics.
> 
>   - **Behavior**:
>     - Adds server-side Posthog tracking for `searchLangfuseDocs` tool in `pages/api/mcp.ts`.
>     - Tracks both successful and error events with `posthog.capture()`.
>     - Uses `waitUntil` to ensure events are flushed before function shutdown.
>   - **Dependencies**:
>     - Adds `posthog-node` to `package.json` for server-side tracking.
>     - Adds `@vercel/functions` to `package.json` for `waitUntil` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 66f798a24e6660a7eea1938f8b0c492bbbdb1a14. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->