### PR TITLE
Add new tool to MCP docs

### DIFF
--- a/pages/docs/docs-mcp.mdx
+++ b/pages/docs/docs-mcp.mdx
@@ -12,6 +12,7 @@ Core use case: Use Cursor (or other AI Coding Agent) to automatically integrate 
 - Transport: `streamableHttp`
 - Tools:
   - `searchLangfuseDocs` returns relevant context from the Langfuse Docs, GitHub Issues, and GitHub Discussions. Powered by [Inkeep RAG API](https://docs.inkeep.com/ai-api/rag-mode/http-request).
+  - `getLangfuseOverview` provides an initial overview of Langfuse documentation and features by fetching the [llms.txt](https://langfuse.com/llms.txt) file from langfuse.com.
 
 ## Usage
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `getLangfuseOverview` tool to `docs-mcp.mdx` for fetching Langfuse documentation overview.
> 
>   - **Docs**:
>     - Adds `getLangfuseOverview` tool to `docs-mcp.mdx`, which fetches an overview of Langfuse documentation and features from `llms.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 33df45a2bf7b634af79155dfdad6f38074dcb12a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->