### PR TITLE
Add Langfuse MCP server integration

### DIFF
--- a/components-mdx/docs-mcp-server-installation.mdx
+++ b/components-mdx/docs-mcp-server-installation.mdx
@@ -1,7 +1,52 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-<Tabs items={["Cursor", "Copilot in VSCode", "Windsurf", "Other MCP Clients"]}>
+<Tabs items={["Claude Code", "Cursor", "Copilot in VSCode", "Windsurf", "Other MCP Clients"]}>
+
+<Tab>
+
+Add Langfuse Docs MCP to Claude Code via the CLI:
+
+#### Quick setup (recommended)
+
+```bash
+claude mcp add \
+  --transport http \
+  langfuse-docs \
+  https://langfuse.com/api/mcp \
+  --scope user
+```
+
+#### Manual configuration
+
+Alternatively, add the following to your settings file:
+
+- **User scope**: `~/.claude/settings.json`
+- **Project scope**: `your-repo/.claude/settings.json`
+- **Local scope**: `your-repo/.claude/settings.local.json`
+
+```json
+{
+  "mcpServers": {
+    "langfuse-docs": {
+      "transportType": "http",
+      "url": "https://langfuse.com/api/mcp",
+      "verifySsl": true
+    }
+  }
+}
+```
+
+#### One-liner JSON import
+
+```bash
+claude mcp add-json langfuse-docs \
+  '{"type":"http","url":"https://langfuse.com/api/mcp"}'
+```
+
+Once added, start a Claude Code session (`claude`) and type `/mcp` to confirm the connection.
+
+</Tab>
 
 <Tab>
 

--- a/components-mdx/docs-mcp-server-installation.mdx
+++ b/components-mdx/docs-mcp-server-installation.mdx
@@ -1,7 +1,34 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-<Tabs items={["Claude Code", "Cursor", "Copilot in VSCode", "Windsurf", "Other MCP Clients"]}>
+<Tabs items={["Cursor", "Copilot in VSCode", "Claude Code", "Windsurf", "Other MCP Clients"]}>
+
+<Tab>
+
+Add Langfuse Docs MCP to Cursor via the one-click install:
+
+<div className="flex gap-2 mt-3 mb-6">
+  <Button asChild>
+    <Link href="https://cursor.com/install-mcp?name=langfuse-docs&config=eyJ1cmwiOiJodHRwczovL2xhbmdmdXNlLmNvbS9hcGkvbWNwIn0%3D" target="_blank" rel="noopener noreferrer">
+      Install MCP Server in Cursor
+    </Link>
+  </Button>
+</div>
+
+</Tab>
+
+<Tab>
+
+Add Langfuse Docs MCP to Copilot in VSCode via the following steps:
+
+1. Open Command Palette (⌘+Shift+P)
+2. Open "MCP: Add Server..."
+3. Select `HTTP`
+4. Paste `https://langfuse.com/api/mcp`
+5. Select name (e.g. `langfuse-docs`) and whether to save in user or workspace settings
+6. You're all set! The MCP server is now available in Agent mode
+
+</Tab>
 
 <Tab>
 
@@ -45,33 +72,6 @@ claude mcp add-json langfuse-docs \
 ```
 
 Once added, start a Claude Code session (`claude`) and type `/mcp` to confirm the connection.
-
-</Tab>
-
-<Tab>
-
-Add Langfuse Docs MCP to Cursor via the one-click install:
-
-<div className="flex gap-2 mt-3 mb-6">
-  <Button asChild>
-    <Link href="https://cursor.com/install-mcp?name=langfuse-docs&config=eyJ1cmwiOiJodHRwczovL2xhbmdmdXNlLmNvbS9hcGkvbWNwIn0%3D" target="_blank" rel="noopener noreferrer">
-      Install MCP Server in Cursor
-    </Link>
-  </Button>
-</div>
-
-</Tab>
-
-<Tab>
-
-Add Langfuse Docs MCP to Copilot in VSCode via the following steps:
-
-1. Open Command Palette (⌘+Shift+P)
-2. Open "MCP: Add Server..."
-3. Select `HTTP`
-4. Paste `https://langfuse.com/api/mcp`
-5. Select name (e.g. `langfuse-docs`) and whether to save in user or workspace settings
-6. You're all set! The MCP server is now available in Agent mode
 
 </Tab>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Langfuse MCP server integration instructions for multiple clients in `docs-mcp-server-installation.mdx`.
> 
>   - **Documentation**:
>     - Adds Langfuse MCP server integration instructions to `docs-mcp-server-installation.mdx`.
>     - Includes setup steps for Claude Code, Copilot in VSCode, and Windsurf.
>     - Provides quick setup, manual configuration, and JSON import methods for Claude Code.
>     - Details `streamableHttp` protocol usage and alternatives for unsupported clients.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 6699c53b77fb04d465e38b0655a9a5420382de12. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->