### PR TITLE
mark mcp as optional

### DIFF
--- a/pages/docs/get-started.mdx
+++ b/pages/docs/get-started.mdx
@@ -273,7 +273,7 @@ This might or might not work very well (depending on your code base). Please sha
 
 <Steps>
 
-### Install the Langfuse Docs MCP Server
+### Install the Langfuse Docs MCP Server (optional)
 
 The agent will use the Langfuse `searchLangfuseDocs` tool ([docs](/docs/docs-mcp)) to find the correct documentation for the integration you are looking for. This is optional, alternatively the agent can use its native websearch capabilities.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `get-started.mdx` to mark Langfuse Docs MCP Server installation as optional.
> 
>   - **Documentation**:
>     - Update `get-started.mdx` to mark the installation of the Langfuse Docs MCP Server as optional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7f7589c9607ecbb243bb8beb73d828b8dc646869. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->