### PR TITLE
fix: Add GitHub key to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
     if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Add `GITHUB_ACCESS_TOKEN` to `build-and-check-links` CI job to resolve GitHub API rate limiting.