### PR TITLE
docs: add prompt experiments to core feature overview

### DIFF
--- a/components-mdx/evaluation-overview-gifs.mdx
+++ b/components-mdx/evaluation-overview-gifs.mdx
@@ -36,7 +36,7 @@ Run fully managed LLM-as-a-judge evaluations on production or development traces
 </Tab>
 <Tab>
 
-Run Prompt Experiments to compare the performance of different prompts on your datasets
+Evaluate prompts and models on datasets directly in the user interface. No custom code is needed.
 
 <CloudflareVideo
   videoId="e7bde8e015f93c3a53c45568fbd5a11d"

--- a/components-mdx/evaluation-overview-gifs.mdx
+++ b/components-mdx/evaluation-overview-gifs.mdx
@@ -1,6 +1,6 @@
 import { CloudflareVideo } from "@/components/Video";
 
-<Tabs items={["Analytics", "User Feedback", "LLM-as-a-Judge", "Annotation Queue", "Custom", "Export via UI"]}>
+<Tabs items={["Analytics", "User Feedback", "LLM-as-a-Judge", "Prompt Experiment", "Annotation Queue", "Custom", "Export via UI"]}>
 <Tab>
 
 Plot evaluation results in the Langfuse Dashboard.
@@ -34,6 +34,19 @@ Run fully managed LLM-as-a-judge evaluations on production or development traces
 />
 
 </Tab>
+<Tab>
+
+Run Prompt Experiments to compare the performance of different prompts on your datasets
+
+<CloudflareVideo
+  videoId="e7bde8e015f93c3a53c45568fbd5a11d"
+  aspectRatio={16 / 9}
+  gifStyle
+/>
+
+
+</Tab>
+
 <Tab>
 
 Baseline your evaluation workflow with human annotations via Annotation Queues.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds "Prompt Experiment" tab to `evaluation-overview-gifs.mdx` with description and video.
> 
>   - **Documentation Update**:
>     - Adds "Prompt Experiment" tab to `evaluation-overview-gifs.mdx`.
>     - Includes description and video for running prompt experiments to compare prompt performance on datasets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 235434f6a8adc960d2884661e19fc43471e191a4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->