### PR TITLE
Fix pipecat otel exporter endpoint

### DIFF
--- a/pages/docs/integrations/pipecat.mdx
+++ b/pages/docs/integrations/pipecat.mdx
@@ -83,7 +83,8 @@ Create a `.env` file with your API keys to enable tracing:
 ```bash filename=".env"
 ENABLE_TRACING=true
 # OTLP endpoint (defaults to localhost:4317 if not set)
-OTEL_EXPORTER_OTLP_ENDPOINT=http://cloud.langfuse.com/api/public/otel
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+# OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64_encoded_api_key>
 # Set to any value to enable console output for debugging
 # OTEL_CONSOLE_EXPORT=true


### PR DESCRIPTION
The original `http://cloud.langfuse.com/api/public/otel` is using `http` instead of `https`.
Also update the env file to explicitly list out EU and US endpoints.