### PR TITLE
chore(prompts): add message placeholder example code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This repository contains the website, documentation and changelog of the software Langfuse (https://langfuse.com).
+
+## Development Commands
+
+### Core Development
+- `pnpm dev` - Start development server on localhost:3333
+- `pnpm build` - Build the production version
+- `pnpm start` - Start production server on localhost:3333
+
+### Content Management
+- `pnpm run prebuild` - Updates GitHub stars and generates contributor data (runs automatically before build)
+- `bash scripts/update_cookbook_docs.sh` - Convert Jupyter notebooks to markdown (requires Poetry shell)
+- `pnpm run link-check` - Check for broken links in documentation
+
+### Analysis
+- `pnpm run analyze` - Analyze bundle size using @next/bundle-analyzer
+
+## Architecture Overview
+
+This is a **Nextra-based documentation site** for Langfuse built with Next.js. Key architectural components:
+
+### Technology Stack
+- **Nextra** (3.0.15) - Documentation framework built on Next.js
+- **Next.js** (15.2.4) - React framework
+- **shadcn/ui** - UI component library with semantic color tokens
+- **Tailwind CSS** - Styling (always use semantic color tokens, never explicit colors)
+- **TypeScript** - Type safety
+- **pnpm** - Package manager (v9.5.0)
+
+### Content Architecture
+- **MDX/Markdown Pages**: `/pages/` - All documentation content
+- **Components**: `/components/` - React components including custom MDX components
+- **Cookbook**: `/cookbook/` - Jupyter notebooks converted to markdown
+- **Static Assets**: `/public/` - Images, icons, and other static files
+
+### Key Directories
+- `components/` - Reusable React components
+- `pages/` - All site pages (docs, blog, changelog, FAQ)
+- `cookbook/` - Jupyter notebooks (Python/JS) that get converted to markdown
+- `components-mdx/` - MDX components used across pages
+- `scripts/` - Build and maintenance scripts
+- `lib/` - Utility functions and configurations
+
+### Content Management Workflow
+1. **Jupyter Notebooks**: Edit `.ipynb` files in `/cookbook/`
+2. **Conversion**: Run `bash scripts/update_cookbook_docs.sh` to convert to markdown
+3. **Location**: Generated markdown files are placed in `/pages/guides/cookbook/`
+4. **Important**: Never edit generated `.md` files directly - always edit the source notebooks
+
+### Key Configuration Files
+- `next.config.mjs` - Next.js configuration with extensive redirects
+- `theme.config.tsx` - Nextra theme configuration
+- `components.json` - shadcn/ui configuration
+- `tailwind.config.js` - Tailwind CSS configuration
+
+### Styling Guidelines
+- Use semantic color tokens from shadcn/ui, never explicit colors
+- Components follow shadcn/ui patterns and conventions
+- Responsive design with mobile-first approach
+
+### Content Types
+- **Documentation**: `/pages/docs/` - Technical documentation
+- **Blog**: `/pages/blog/` - Blog posts with MDX
+- **Changelog**: `/pages/changelog/` - Product updates
+- **Cookbook**: `/pages/guides/cookbook/` - Generated from Jupyter notebooks
+- **FAQ**: `/pages/faq/` - Frequently asked questions
+
+### Development Notes
+- Development server runs on port 3333 (not standard 3000)
+- Requires Node.js 20+ 
+- Uses pnpm as package manager
+- Auto-generates contributor data and GitHub stars before builds
+- Extensive redirect configuration for URL management
+- CSP headers configured for security in production

--- a/pages/docs/prompts/get-started.mdx
+++ b/pages/docs/prompts/get-started.mdx
@@ -917,13 +917,15 @@ const prompt = await langfuse.getPrompt("movie-critic-chat", undefined, {
 });
 
 // Compile the variable and resolve the placeholder with a list of messages.
-const compiledPrompt = prompt.compile({
-  criticlevel: "expert",
-  chat_history: [
-    { role: "user", content: "I love Ron Fricke movies like Baraka" },
-    { role: "user", content: "Also, the Korean movie Memories of a Murderer" },
-  ],
-});
+const compiledPrompt = prompt.compile(
+  { criticlevel: "expert" },
+  {
+    chat_history: [
+      { role: "user", content: "I love Ron Fricke movies like Baraka" },
+      { role: "user", content: "Also, the Korean movie Memories of a Murderer" },
+    ],
+  }
+);
 
 // -> compiledPrompt = [
 //   { role: "system", content: "You are an expert movie critic" },
@@ -937,7 +939,7 @@ const langchainPrompt = prompt.getLangchainPrompt();
 
 // -> langchainPrompt = [
 //   { role: "system", content: "You are an expert movie critic" },
-//   MessagesPlaceholder("chat_history"),
+//   { variableName: "chat_history", optional: false },  // Langchain MessagesPlaceholder structure
 //   { role: "user", content: "What should I watch next?" },
 // ]
 ```

--- a/pages/docs/prompts/get-started.mdx
+++ b/pages/docs/prompts/get-started.mdx
@@ -106,7 +106,7 @@ Depending on the scale of your experiments, there are different approaches you c
 
 - `name`: Unique name of the prompt within a Langfuse project.
 - `type`: The type of the prompt content (`text` or `chat`). Default is `text`.
-- `prompt`: The text template with variables (e.g. `This is a prompt with a {{variable}}`). For chat prompts, this is a list of chat messages each with `role` and `content`.
+- `prompt`: The text template with variables (e.g. `This is a prompt with a {{variable}}`). For chat prompts, this is a list of chat messages each with `role` and `content` but can also contain [placeholders](#message-placeholders).
 - `config`: Optional JSON object to store any parameters (e.g. model parameters or model tools).
 - `version`: Integer to indicate the version of the prompt. The version is automatically incremented when creating a new prompt version.
 - `labels`: [Labels](#labels) that can be used to fetch specific prompt versions in the SDKs.
@@ -858,6 +858,92 @@ To create a folder, add slashes (`/`) to a prompt name. The UI shows every segme
 
 Message placeholders allow you to insert chat messages at specific positions within a chat prompt.
 This is for example useful to provide a message history as context to an LLM.
+
+<Tabs items={["Python", "JS/TS"]}>
+<Tab>
+
+```python
+langfuse.create_prompt(
+    name="movie-critic-chat",
+    type="chat",
+    prompt=[
+      { "role": "system", "content": "You are an {{criticlevel}} movie critic" },
+      { "type": "placeholder", "name": "chat_history" },
+      { "role": "user", "content": "What should I watch next?" },
+    ],
+    labels=["production"],  # directly promote to production
+)
+prompt = langfuse.get_prompt("movie-critic-chat")
+# Compile the variable and resolve the placeholder with a list of messages.
+compiled_prompt = prompt.compile(criticlevel="expert", chat_history=[
+  {"role": "user", "content": "I love Ron Fricke movies like Baraka"},
+  {"role": "user", "content": "Also, the Korean movie Memories of a Murderer"}
+])
+
+# -> compiled_prompt = [
+#   { "role": "system", "content": "You are an expert movie critic" },
+#   { "role": "user", "content": "I love Ron Fricke movies like Baraka" },
+#   { "role": "user", "content": "Also, the Korean movie Memories of a Murderer" },
+#   { "role": "user", "content": "What should I watch next?" },
+# ]
+
+# Using langchain, you can obtain a MessagesPlaceholder object for unresolved placeholders
+langchain_prompt = prompt.get_langchain_prompt()
+
+# -> langchain_prompt = [
+#   ( "system", "You are an expert movie critic" ),
+#   MessagesPlaceholder("chat_history"),
+#   ( "user", "What should I watch next?" ),
+# ]
+```
+</Tab>
+
+<Tab>
+
+```typescript
+await langfuse.createPrompt({
+  name: "movie-critic-chat",
+  type: "chat",
+  prompt: [
+    { role: "system", content: "You are an {{criticlevel}} movie critic" },
+    { type: "placeholder", name: "chat_history" },
+    { role: "user", content: "What should I watch next?" },
+  ],
+  labels: ["production"], // directly promote to production
+});
+
+const prompt = await langfuse.getPrompt("movie-critic-chat", undefined, {
+  type: "chat",
+});
+
+// Compile the variable and resolve the placeholder with a list of messages.
+const compiledPrompt = prompt.compile({
+  criticlevel: "expert",
+  chat_history: [
+    { role: "user", content: "I love Ron Fricke movies like Baraka" },
+    { role: "user", content: "Also, the Korean movie Memories of a Murderer" },
+  ],
+});
+
+// -> compiledPrompt = [
+//   { role: "system", content: "You are an expert movie critic" },
+//   { role: "user", content: "I love Ron Fricke movies like Baraka" },
+//   { role: "user", content: "Also, the Korean movie Memories of a Murderer" },
+//   { role: "user", content: "What should I watch next?" },
+// ]
+
+// Using langchain, you can obtain a MessagesPlaceholder object for unresolved placeholders
+const langchainPrompt = prompt.getLangchainPrompt();
+
+// -> langchainPrompt = [
+//   { role: "system", content: "You are an expert movie critic" },
+//   MessagesPlaceholder("chat_history"),
+//   { role: "user", content: "What should I watch next?" },
+// ]
+```
+
+</Tab>
+</Tabs>
 
 A placeholder has the structure:
 ```json

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 13219;
+export const GITHUB_STARS = 13308;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds example code for message placeholders in chat prompts to the documentation and updates GitHub stars count.
> 
>   - **Documentation**:
>     - Adds example code for message placeholders in chat prompts to `get-started.mdx`.
>     - Provides examples in both Python and JS/TS.
>   - **Misc**:
>     - Updates `GITHUB_STARS` in `github-stars.ts` from 13219 to 13308.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a502a0176947aab67d9475e61377696204a3fbc3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->