### PR TITLE
docs(changelog): gemini 2.5 support

### DIFF
--- a/pages/changelog/2025-07-03-gemini-2.5-support.mdx
+++ b/pages/changelog/2025-07-03-gemini-2.5-support.mdx
@@ -1,0 +1,26 @@
+---
+date: 2025-07-03
+title: Gemini 2.5 Pro, Flash, and Flash Lite support for playground, evaluations, and cost tracking
+description: Langfuse says hello to Gemini 2.5 Pro (GA), Gemini 2.5 Flash (GA), and Gemini 2.5 Flash Lite (Preview). Support added for the LLM playground, evaluations, and cost tracking.
+author: Hassieb
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Google has expanded their Gemini 2.5 family of models with stable releases and new additions. From [Google release notes](https://blog.google/products/gemini/gemini-2-5-model-family-expands):
+
+- **Gemini 2.5 Pro**: Now generally available - Advanced model with enhanced reasoning capabilities, optimized for complex tasks and coding
+- **Gemini 2.5 Flash**: Now generally available - Faster, cost-effective variant with 1M token context window, designed for high-volume applications while maintaining strong performance
+- **Gemini 2.5 Flash-Lite**: New model in preview - Google's most cost-efficient and fastest 2.5 model yet, with all-around higher quality than 2.0 Flash-Lite on coding, math, science, reasoning and multimodal benchmarks
+
+All three models are now available in the Langfuse Playground for interactive testing and in LLM-as-a-judge evals. Additionally, we've added cost tracking support for both Gemini 2.5 Flash and Gemini 2.5 Flash-Lite to help you monitor your usage.
+
+(Gemini 2.5 Pro pricing is tiered by context window size and thus not yet supported for automatic cost tracking in Langfuse.)
+
+## Learn more
+
+- [Langfuse LLM playground](/docs/playground)
+- [Langfuse evaluations](/docs/scores/model-based-evals)
+- [Langfuse model usage and cost tracking](/docs/model-usage-and-cost)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changelog entry for Gemini 2.5 model support in Langfuse, detailing new features and documentation links.
> 
>   - **Changelog Addition**:
>     - New file `2025-07-03-gemini-2.5-support.mdx` added to document support for Gemini 2.5 models.
>     - Describes availability of Gemini 2.5 Pro, Flash, and Flash-Lite in Langfuse Playground and evaluations.
>     - Notes cost tracking support for Gemini 2.5 Flash and Flash-Lite, excluding Pro due to pricing structure.
>   - **Documentation Links**:
>     - Links to Langfuse LLM playground, evaluations, and model usage documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f535643247bd1103e32ed9939ba22ed80eeea1e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->