### PR TITLE
fix: add roles CTA further up

### DIFF
--- a/pages/careers.mdx
+++ b/pages/careers.mdx
@@ -68,7 +68,17 @@ If complex technical problems & great developer experiences excite you, we'd lov
 - Akio Nuernberger, [@AkioNuernberger](https://x.com/AkioNuernberger), [LinkedIn](https://www.linkedin.com/in/akio-nuernberger/)
 - Nimar Blume, [GitHub](https://github.com/nimarb), [LinkedIn](https://www.linkedin.com/in/nimar/) 
 
-
+<CTACard 
+  title="Curious to build with us?"
+  description="If you are excited about delivering exceptional open-source developer experiences alongside an insanely motivated team that ships, reach out!"
+  showArrow={true}
+>
+  <Button asChild variant="default" size="sm">
+    <a href="https://jobs.ashbyhq.com/langfuse" target="_blank" rel="noopener noreferrer">
+      See open Roles
+    </a>
+  </Button>
+</CTACard>
 
 
 ## How we operate


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Moved `<CTACard>` for open roles higher in `careers.mdx` to increase visibility.
> 
>   - **UI Update**:
>     - Moved `<CTACard>` for open roles higher in `careers.mdx` to increase visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5f95fe41da4246012576f0f2439d9c68e89bc59f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->