### PR TITLE
Add internal links to bullet points

### DIFF
--- a/pages/blog/2025-06-30-langfuse-june-update.mdx
+++ b/pages/blog/2025-06-30-langfuse-june-update.mdx
@@ -83,10 +83,10 @@ Add Langfuse to agents like **Cursor, GitHub Copilot, and Windsurf** via our new
 
 - **[Histogram charts](/changelog/2025-06-30-histogram-charts-custom-dashboards)** in custom dashboards
 - **[Export dataset items](/changelog/2025-06-23-exports-datasets-audit-logs)** via the UI
-- **[Download aggregated stats](/docs/analytics/custom-dashboards)** directly from your custom dashboards
-- **[Edit your LLM Connections](/docs/playground)** to add new models or update your API key
+- **[Download aggregated stats](/changelog/2025-06-30-download-dashboard-stats)** directly from your custom dashboards
+- **Edit your LLM Connections** to add new models or update your API key
 - **[Audit-log exports](/changelog/2025-06-23-exports-datasets-audit-logs)** for compliance teams
-- **[Improved JSON support](/docs/prompts/get-started)** for prompts to be consumed via Langchain
+- **Improved JSON support** for prompts to be consumed via Langchain
 
 ## 🪄 Customer spotlight: Magic Patterns
 

--- a/pages/blog/2025-06-30-langfuse-june-update.mdx
+++ b/pages/blog/2025-06-30-langfuse-june-update.mdx
@@ -83,10 +83,10 @@ Add Langfuse to agents like **Cursor, GitHub Copilot, and Windsurf** via our new
 
 - **[Histogram charts](/changelog/2025-06-30-histogram-charts-custom-dashboards)** in custom dashboards
 - **[Export dataset items](/changelog/2025-06-23-exports-datasets-audit-logs)** via the UI
-- **Download aggregated stats** directly from your custom dashboards
-- **Edit your LLM Connections** to add new models or update your API key
+- **[Download aggregated stats](/docs/analytics/custom-dashboards)** directly from your custom dashboards
+- **[Edit your LLM Connections](/docs/playground)** to add new models or update your API key
 - **[Audit-log exports](/changelog/2025-06-23-exports-datasets-audit-logs)** for compliance teams
-- **Improved JSON support** for prompts to be consumed via Langchain
+- **[Improved JSON support](/docs/prompts/get-started)** for prompts to be consumed via Langchain
 
 ## 🪄 Customer spotlight: Magic Patterns
 

--- a/pages/blog/2025-06-30-langfuse-june-update.mdx
+++ b/pages/blog/2025-06-30-langfuse-june-update.mdx
@@ -83,7 +83,7 @@ Add Langfuse to agents like **Cursor, GitHub Copilot, and Windsurf** via our new
 
 - **[Histogram charts](/changelog/2025-06-30-histogram-charts-custom-dashboards)** in custom dashboards
 - **[Export dataset items](/changelog/2025-06-23-exports-datasets-audit-logs)** via the UI
-- **[Download aggregated stats](/changelog/2025-06-30-download-dashboard-stats)** directly from your custom dashboards
+- **[Download aggregated stats](/changelog/2025-06-17-csv-download-dashboard-charts)** directly from your custom dashboards
 - **Edit your LLM Connections** to add new models or update your API key
 - **[Audit-log exports](/changelog/2025-06-23-exports-datasets-audit-logs)** for compliance teams
 - **Improved JSON support** for prompts to be consumed via Langchain


### PR DESCRIPTION
Add internal link to 'Download aggregated stats' bullet in June update blog post to reference its changelog entry.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add internal link to 'Download aggregated stats' bullet in June update blog post to reference its changelog entry.
> 
>   - Add internal link to 'Download aggregated stats' bullet in `2025-06-30-langfuse-june-update.mdx` to reference its changelog entry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 2888f2f5c5a7425951f3673332bc9ad1715f0ebb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->