### PR TITLE
Add installation instructions for MCP server to LLM.txt

### DIFF
--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -29,8 +29,8 @@ async function generateLLMsList() {
         markdownContent += `Connect to the Langfuse Docs MCP server to access documentation directly in your AI editor:\n\n`;
         markdownContent += `- **Endpoint**: \`https://langfuse.com/api/mcp\`\n`;
         markdownContent += `- **Transport**: \`streamableHttp\`\n`;
-        markdownContent += `- **Documentation**: [Langfuse Docs MCP Server](/docs/docs-mcp)\n\n`;
-        markdownContent += `The MCP server provides tools to search Langfuse documentation, GitHub issues, and discussions. See the [installation guide](/docs/docs-mcp) for setup instructions in Cursor, VS Code, Claude Desktop, and other MCP clients.\n\n`;
+        markdownContent += `- **Documentation**: [Langfuse Docs MCP Server](https://langfuse.com/docs/docs-mcp)\n\n`;
+        markdownContent += `The MCP server provides tools to search Langfuse documentation, GitHub issues, and discussions. See the [installation guide](https://langfuse.com/docs/docs-mcp) for setup instructions in Cursor, VS Code, Claude Desktop, and other MCP clients.\n\n`;
 
         // Create a map to store URLs by section
         const urlsBySection = {

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -24,8 +24,7 @@ async function generateLLMsList() {
         markdownContent += `> ${INTRO_DESCRIPTION}\n\n`;
 
         // Add Settings section with MCP server information
-        markdownContent += `## Settings\n\n`;
-        markdownContent += `### Langfuse Docs MCP Server\n\n`;
+        markdownContent += `## Langfuse Docs MCP Server\n\n`;
         markdownContent += `Connect to the Langfuse Docs MCP server to access documentation directly in your AI editor:\n\n`;
         markdownContent += `- **Endpoint**: \`https://langfuse.com/api/mcp\`\n`;
         markdownContent += `- **Transport**: \`streamableHttp\`\n`;

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -23,6 +23,15 @@ async function generateLLMsList() {
         let markdownContent = `# ${TITLE}\n\n`;
         markdownContent += `> ${INTRO_DESCRIPTION}\n\n`;
 
+        // Add Settings section with MCP server information
+        markdownContent += `## Settings\n\n`;
+        markdownContent += `### Langfuse Docs MCP Server\n\n`;
+        markdownContent += `Connect to the Langfuse Docs MCP server to access documentation directly in your AI editor:\n\n`;
+        markdownContent += `- **Endpoint**: \`https://langfuse.com/api/mcp\`\n`;
+        markdownContent += `- **Transport**: \`streamableHttp\`\n`;
+        markdownContent += `- **Documentation**: [Langfuse Docs MCP Server](/docs/docs-mcp)\n\n`;
+        markdownContent += `The MCP server provides tools to search Langfuse documentation, GitHub issues, and discussions. See the [installation guide](/docs/docs-mcp) for setup instructions in Cursor, VS Code, Claude Desktop, and other MCP clients.\n\n`;
+
         // Create a map to store URLs by section
         const urlsBySection = {
             other: [],


### PR DESCRIPTION
Add Langfuse Documentation MCP server installation instructions to the generated LLM.txt file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Langfuse MCP server installation instructions to the generated `llms.txt` file in `generate_llms_txt.js`.
> 
>   - **Behavior**:
>     - Adds a "Settings" section in `generate_llms_txt.js` with Langfuse MCP server installation instructions.
>     - Includes endpoint, transport method, and documentation link for the MCP server.
>     - Provides a brief description of the MCP server's functionality and a link to the installation guide.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9c912c2c6fd6c243e85d78715c217b9d74bee51b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->