### PR TITLE
fix(strands): update strands-agents traces setup guide

### DIFF
--- a/cookbook/integration_aws_strands_agents.ipynb
+++ b/cookbook/integration_aws_strands_agents.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
     ").decode()\n",
     " \n",
     "# Configure OpenTelemetry endpoint & headers\n",
-    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = os.environ.get(\"LANGFUSE_HOST\") + \"/api/public/otel/v1/traces\"\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = os.environ.get(\"LANGFUSE_HOST\") + \"/api/public/otel\"\n",
     "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\""
    ]
   },
@@ -107,16 +107,23 @@
     "This cell performs the following key actions:\n",
     "1.  Defines a detailed `system_prompt`.\n",
     "2.  Configures the `BedrockModel`.\n",
-    "3.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI."
+    "3.  Creates new tracer and meter using `StrandsTelemetry`\n",
+    "4.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI."
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from strands import Agent\n",
+    "from strands.telemetry import StrandsTelemetry\n",
     "from strands.models.bedrock import BedrockModel\n",
     "\n",
     "# Define the system prompt for the agent\n",
@@ -150,6 +157,10 @@
     "model = BedrockModel(\n",
     "    model_id=\"us.anthropic.claude-3-7-sonnet-20250219-v1:0\", # Example model ID\n",
     ")\n",
+    "\n",
+    "# Configure the telemetry\n",
+    "# (Creates new tracer provider and sets it as global)\n",
+    "strands_telemetry = StrandsTelemetry().setup_otlp_exporter()\n",
     "\n",
     "# Configure the agent\n",
     "# Pass optional tracing attributes such as session id, user id or tags to Langfuse.\n",

--- a/pages/docs/integrations/strands-agents.mdx
+++ b/pages/docs/integrations/strands-agents.mdx
@@ -47,7 +47,7 @@ LANGFUSE_AUTH = base64.b64encode(
 ).decode()
  
 # Configure OpenTelemetry endpoint & headers
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_HOST") + "/api/public/otel/v1/traces"
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_HOST") + "/api/public/otel"
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
 ```
 
@@ -69,11 +69,13 @@ With the environment set up, we can now initialize the Strands agent. This invol
 This cell performs the following key actions:
 1.  Defines a detailed `system_prompt`.
 2.  Configures the `BedrockModel`.
-3.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI.
+3.  Creates new tracer and meter using `StrandsTelemetry`
+4.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI.
 
 
 ```python
 from strands import Agent
+from strands.telemetry import StrandsTelemetry
 from strands.models.bedrock import BedrockModel
 
 # Define the system prompt for the agent
@@ -107,6 +109,10 @@ system_prompt = """You are \"Restaurant Helper\", a restaurant assistant helping
 model = BedrockModel(
     model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0", # Example model ID
 )
+
+# Configure the telemetry
+# (Creates new tracer provider and sets it as global)
+strands_telemetry = StrandsTelemetry().setup_otlp_exporter()
 
 # Configure the agent
 # Pass optional tracing attributes such as session id, user id or tags to Langfuse.

--- a/pages/guides/cookbook/integration_aws_strands_agents.mdx
+++ b/pages/guides/cookbook/integration_aws_strands_agents.mdx
@@ -47,7 +47,7 @@ LANGFUSE_AUTH = base64.b64encode(
 ).decode()
  
 # Configure OpenTelemetry endpoint & headers
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_HOST") + "/api/public/otel/v1/traces"
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_HOST") + "/api/public/otel"
 os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
 ```
 
@@ -69,11 +69,13 @@ With the environment set up, we can now initialize the Strands agent. This invol
 This cell performs the following key actions:
 1.  Defines a detailed `system_prompt`.
 2.  Configures the `BedrockModel`.
-3.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI.
+3.  Creates new tracer and meter using `StrandsTelemetry`
+4.  Instantiates the `Agent` with the configured model, system prompt, and optional `trace_attributes`. Tracing attributes, such as `session.id`, `user.id`, and `langfuse.tags`, are sent to Langfuse with the traces and help organize, filter, and analyze traces in the Langfuse UI.
 
 
 ```python
 from strands import Agent
+from strands.telemetry import StrandsTelemetry
 from strands.models.bedrock import BedrockModel
 
 # Define the system prompt for the agent
@@ -107,6 +109,10 @@ system_prompt = """You are \"Restaurant Helper\", a restaurant assistant helping
 model = BedrockModel(
     model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0", # Example model ID
 )
+
+# Configure the telemetry
+# (Creates new tracer provider and sets it as global)
+strands_telemetry = StrandsTelemetry().setup_otlp_exporter()
 
 # Configure the agent
 # Pass optional tracing attributes such as session id, user id or tags to Langfuse.


### PR DESCRIPTION
Strands recently updated the telemetry setup([pr1](https://github.com/strands-agents/sdk-python/pull/286), [pr2](https://github.com/strands-agents/sdk-python/pull/316)). 

It is required to initiate StrandsTelemetry to allow Strands to create tracer and meter. Therefore updating the docs on the Langfuse side too.

Doc on Strands side: https://strandsagents.com/latest/user-guide/observability-evaluation/traces/#code-configuration