### PR TITLE
docs: data retention

### DIFF
--- a/pages/docs/data-retention.mdx
+++ b/pages/docs/data-retention.mdx
@@ -18,6 +18,10 @@ With Langfuse's Data Retention feature, you can control how long your event data
 Data retention is configured on a project level, and we accept a number of days with a minimum of 3 days.
 Project owners and administrators can change the data retention setting within the Project Settings view.
 
+<Callout type="info">
+  By default, Langfuse stores event data (Traces, Observations, Scores, and Media Assets) indefinitely.
+</Callout>
+
 <Frame className="my-10" fullWidth>
   ![Configure data retention in Langfuse](/images/docs/data-retention.png)
 </Frame>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a callout in `data-retention.mdx` to specify Langfuse's default indefinite data retention policy.
> 
>   - **Documentation Update**:
>     - Adds a callout in `data-retention.mdx` to specify that Langfuse stores event data indefinitely by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5123523f0695238cd1b25ac8180e207c7f4b3b79. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->