### PR TITLE
fix: add version constraints for vercel-ai-sdk implementation

### DIFF
--- a/pages/docs/integrations/vercel-ai-sdk.mdx
+++ b/pages/docs/integrations/vercel-ai-sdk.mdx
@@ -88,7 +88,7 @@ NextJS has support for OpenTelemetry instrumentation on the framework level. Lea
 Install dependencies:
 
 ```bash
-npm install @vercel/otel langfuse-vercel @opentelemetry/api-logs @opentelemetry/instrumentation @opentelemetry/sdk-logs
+npm install @vercel/otel langfuse-vercel @opentelemetry/api-logs@0.57.2 @opentelemetry/instrumentation@0.57.2 @opentelemetry/sdk-logs@0.57.2
 ```
 
 <details>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add version constraints for `@opentelemetry` packages in `vercel-ai-sdk.mdx` to ensure compatibility.
> 
>   - **Dependencies**:
>     - Add version constraints `@0.57.2` for `@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, and `@opentelemetry/sdk-logs` in `vercel-ai-sdk.mdx` installation instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 44f333bda3f4a3f9d748af7ed5ca7bbeafe8cbc9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->