### PR TITLE
chore: Introduce prettier rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,15 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+# Markdown and MDX files
+[*.{md,mdx}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
 # Specific settings for the .mdx file you want to format as JavaScript
 [pages/_app.mdx]
 language = javascript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,33 @@ jobs:
       - name: Run H1 heading check
         run: node scripts/check-h1-headings.js
 
+  check-prettier:
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        id: pnpm-install
+        with:
+          version: 9.5.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check Prettier formatting
+        run: pnpm format:check
+
   check-notebook-docs-sync:
     needs:
       - pre-job

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,69 @@
+# Dependencies
+node_modules/
+.pnpm-store/
+
+# Build outputs
+.next/
+dist/
+out/
+build/
+
+# Cache directories
+.cache/
+.vercel/
+
+# Git
+.git/
+
+# Environment files
+.env*
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Generated files
+.next/
+public/generated/
+data/generated/
+
+# Lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Jupyter notebooks (formatted separately)
+*.ipynb
+
+# Large data files
+*.csv
+*.json.gz
+
+# Binary files
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.pdf
+*.woff*
+*.ttf
+*.eot
+
+# Specific exclusions
+CLAUDE.md
+LICENSE

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,46 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "proseWrap": "always",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "lf",
+  "embeddedLanguageFormatting": "auto",
+  "singleAttributePerLine": false,
+  "plugins": [
+    "prettier-plugin-organize-imports",
+    "@prettier/plugin-xml"
+  ],
+  "overrides": [
+    {
+      "files": ["*.md", "*.mdx"],
+      "options": {
+        "proseWrap": "always",
+        "printWidth": 80,
+        "tabWidth": 2,
+        "useTabs": false
+      }
+    },
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "tabWidth": 2,
+        "printWidth": 80
+      }
+    },
+    {
+      "files": ["*.json"],
+      "options": {
+        "tabWidth": 2,
+        "printWidth": 80
+      }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "esbenp.prettier-vscode"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,44 @@
     "Quickstart"
   ],
   "editor.wordWrap": "on",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "[markdown]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.wordWrap": "on"
+  },
+  "[mdx]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.wordWrap": "on"
+  },
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "postbuild:cleanup": "echo 'Removing .next/cache to resolve Nextra caching bug' && rm -rf .next/cache",
     "postbuild:llms-txt": "node scripts/generate_llms_txt.js",
     "link-check": "node scripts/check-links.js",
-    "sitemap-check": "node scripts/check-sitemap-links.js"
+    "sitemap-check": "node scripts/check-sitemap-links.js",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "format:docs": "prettier --write 'pages/**/*.{md,mdx}'",
+    "format:components": "prettier --write 'components/**/*.{ts,tsx,md,mdx}'"
   },
   "engines": {
     "node": "20"
@@ -79,6 +83,9 @@
     "@types/node": "20.11.1",
     "cross-env": "^7.0.3",
     "markdown-link-check": "^3.13.6",
+    "prettier": "^3.4.2",
+    "prettier-plugin-organize-imports": "^4.1.0",
+    "@prettier/plugin-xml": "^3.5.0",
     "typescript": "^5.6.3",
     "xml2js": "^0.6.2"
   },


### PR DESCRIPTION
Introduce Prettier to enforce consistent code formatting across the repository, especially for Markdown and MDX files.