### PR TITLE
chore: provide github token to gh actions to fetch contributors during build

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Build next.js app
         # change this if your site requires a custom build command
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./node_modules/.bin/next build
 
       # Here's the first place where next-bundle-analysis' own script is used

--- a/.github/workflows/update-available-internal-links-cursor-rule.yml
+++ b/.github/workflows/update-available-internal-links-cursor-rule.yml
@@ -29,6 +29,8 @@ jobs:
         run: pnpm install
 
       - name: Build sitemap and generate llms.txt
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build
         # The llms.txt generation happens automatically as part of the postbuild process
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GITHUB_ACCESS_TOKEN` to GitHub Actions workflows to fetch contributors during build.
> 
>   - **Workflows**:
>     - Add `GITHUB_ACCESS_TOKEN` environment variable using `${{ secrets.GITHUB_TOKEN }}` in `nextjs_bundle_analysis.yml` and `update-available-internal-links-cursor-rule.yml`.
>   - **Purpose**:
>     - Allows GitHub Actions to fetch contributors during the build process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 29a70cd33010b0fa33fb81a4d6009937b30b14a4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->