### PR TITLE
ci: Add consolidated ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,42 @@ jobs:
 
           # Exit with the sitemap checker's exit code
           exit $SITEMAP_CHECK_EXIT
+
+  # Summary job that depends on all other jobs
+  # This allows you to require only this single check in branch protection rules
+  all-checks-pass:
+    needs:
+      - pre-job
+      - check_h1
+      - check-notebook-docs-sync
+      - build-and-check-links
+      - check-sitemap-links
+    if: always() && needs.pre-job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs status
+        run: |
+          # Check if any required job failed
+          if [[ "${{ needs.check_h1.result }}" == "failure" || \
+                "${{ needs.check-notebook-docs-sync.result }}" == "failure" || \
+                "${{ needs.build-and-check-links.result }}" == "failure" || \
+                "${{ needs.check-sitemap-links.result }}" == "failure" ]]; then
+            echo "❌ One or more CI checks failed"
+            exit 1
+          fi
+          
+          # Check if any required job was cancelled
+          if [[ "${{ needs.check_h1.result }}" == "cancelled" || \
+                "${{ needs.check-notebook-docs-sync.result }}" == "cancelled" || \
+                "${{ needs.build-and-check-links.result }}" == "cancelled" || \
+                "${{ needs.check-sitemap-links.result }}" == "cancelled" ]]; then
+            echo "❌ One or more CI checks were cancelled"
+            exit 1
+          fi
+          
+          # Note: check-sitemap-links only runs on main branch PRs, so it can be skipped
+          if [[ "${{ needs.check-sitemap-links.result }}" == "skipped" ]]; then
+            echo "ℹ️ Sitemap check was skipped (not a main branch PR)"
+          fi
+          
+          echo "✅ All CI checks passed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,13 +182,18 @@ jobs:
         build-and-check-links,
         check-sitemap-links,
       ]
-    if: always() && needs.pre-job.outputs.should_skip != 'true'
+    if: always()
     steps:
+      - name: All checks skipped
+        if: ${{ needs.pre-job.outputs.should_skip == 'true' }}
+        run: |
+          echo "✅ All checks were skipped due to duplicate actions"
+          exit 0
       - name: Successful CI
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ needs.pre-job.outputs.should_skip != 'true' && !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled')) }}
         run: exit 0
         working-directory: .
       - name: Failing CI
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ needs.pre-job.outputs.should_skip != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 1
         working-directory: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,16 +184,11 @@ jobs:
       ]
     if: always()
     steps:
-      - name: All checks skipped
-        if: ${{ needs.pre-job.outputs.should_skip == 'true' }}
-        run: |
-          echo "✅ All checks were skipped due to duplicate actions"
-          exit 0
       - name: Successful CI
-        if: ${{ needs.pre-job.outputs.should_skip != 'true' && !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled')) }}
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0
         working-directory: .
       - name: Failing CI
-        if: ${{ needs.pre-job.outputs.should_skip != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+        if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
         working-directory: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,38 +173,22 @@ jobs:
   # Summary job that depends on all other jobs
   # This allows you to require only this single check in branch protection rules
   all-checks-pass:
-    needs:
-      - pre-job
-      - check_h1
-      - check-notebook-docs-sync
-      - build-and-check-links
-      - check-sitemap-links
-    if: always() && needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    needs:
+      [
+        pre-job,
+        check_h1,
+        check-notebook-docs-sync,
+        build-and-check-links,
+        check-sitemap-links,
+      ]
+    if: always() && needs.pre-job.outputs.should_skip != 'true'
     steps:
-      - name: Check all jobs status
-        run: |
-          # Check if any required job failed
-          if [[ "${{ needs.check_h1.result }}" == "failure" || \
-                "${{ needs.check-notebook-docs-sync.result }}" == "failure" || \
-                "${{ needs.build-and-check-links.result }}" == "failure" || \
-                "${{ needs.check-sitemap-links.result }}" == "failure" ]]; then
-            echo "❌ One or more CI checks failed"
-            exit 1
-          fi
-          
-          # Check if any required job was cancelled
-          if [[ "${{ needs.check_h1.result }}" == "cancelled" || \
-                "${{ needs.check-notebook-docs-sync.result }}" == "cancelled" || \
-                "${{ needs.build-and-check-links.result }}" == "cancelled" || \
-                "${{ needs.check-sitemap-links.result }}" == "cancelled" ]]; then
-            echo "❌ One or more CI checks were cancelled"
-            exit 1
-          fi
-          
-          # Note: check-sitemap-links only runs on main branch PRs, so it can be skipped
-          if [[ "${{ needs.check-sitemap-links.result }}" == "skipped" ]]; then
-            echo "ℹ️ Sitemap check was skipped (not a main branch PR)"
-          fi
-          
-          echo "✅ All CI checks passed successfully"
+      - name: Successful CI
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+        working-directory: .
+      - name: Failing CI
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+        working-directory: .


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `all-checks-pass` job to CI workflow for consolidated status check.
> 
>   - **CI Workflow**:
>     - Adds `all-checks-pass` job in `.github/workflows/ci.yml`.
>     - `all-checks-pass` depends on `pre-job`, `check_h1`, `check-notebook-docs-sync`, `build-and-check-links`, and `check-sitemap-links`.
>     - Job runs on `ubuntu-latest` and always executes.
>     - Exits with success if no failures in dependencies, otherwise exits with failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for fd87bfd3448c442b3938f50dba4a2623766e69a4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->