### PR TITLE
ci: check whole repo for changes after rerunning cookbook script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,18 @@ jobs:
           bash scripts/update_cookbook_docs.sh
 
           # Check if any files changed
-          if ! git diff --quiet pages/guides/cookbook/; then
-            echo "❌ Cookbook documentation is out of sync with notebooks!"
+          if ! git diff --quiet; then
+            echo "❌ Repository has changes after regenerating cookbook documentation!"
             echo "The following files have changes:"
-            git diff --name-only pages/guides/cookbook/
+            git diff --name-only
             echo ""
             echo "Please run 'bash scripts/update_cookbook_docs.sh' locally and commit the changes."
             echo ""
             echo "Detailed diff:"
-            git diff pages/guides/cookbook/
+            git diff
             exit 1
           else
-            echo "✅ Cookbook documentation is up to date with notebooks"
+            echo "✅ Repository is up to date after regenerating cookbook documentation"
           fi
 
   build-and-check-links:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,6 @@ jobs:
 
       - name: Check if notebook docs are up to date
         run: |
-          # Create a backup of the current state
-          cp -r pages/guides/cookbook pages/guides/cookbook.backup
-
           # Run the update script
           bash scripts/update_cookbook_docs.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,16 +59,17 @@ jobs:
           # Run the update script
           bash scripts/update_cookbook_docs.sh
 
-          # Check if any files changed
-          if ! git diff --quiet; then
+          # Check if any files changed (staged, unstaged, or untracked)
+          if [[ -n $(git status --porcelain) ]]; then
             echo "❌ Repository has changes after regenerating cookbook documentation!"
             echo "The following files have changes:"
-            git diff --name-only
+            git status --porcelain
             echo ""
             echo "Please run 'bash scripts/update_cookbook_docs.sh' locally and commit the changes."
             echo ""
             echo "Detailed diff:"
             git diff
+            git diff --staged
             exit 1
           else
             echo "✅ Repository is up to date after regenerating cookbook documentation"


### PR DESCRIPTION
Expand CI check for cookbook documentation to cover the entire repository and remove an unnecessary backup.