### PR TITLE
chore: add metadata mapping clarification for OTel

### DIFF
--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -302,7 +302,7 @@ These mappings are based on OTel GenAI semantic conventions and vendor-specific 
 ## Metadata Properties
 
 Langfuse only supports filtering on top-level keys within the `metadata` of an event.
-Per default, all OpenTelemetry attributes and resource attributes are mapped into an `attributes` and `resourceAttributes` key within `metadata` and, therefore, not queryable.
+By default, all OpenTelemetry attributes and resource attributes are mapped into an `attributes` and `resourceAttributes` key within `metadata` and, therefore, not queryable.
 If you want to query on specific attributes, you can use the `langfuse.metadata` prefix to map them to the top-level `metadata` object.
 The following snippet will produce a filterable `user_name` property in the `metadata` object of the trace:
 

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -303,7 +303,8 @@ These mappings are based on OTel GenAI semantic conventions and vendor-specific 
 
 Langfuse only supports filtering on top-level keys within the `metadata` of an event.
 Per default, all OpenTelemetry attributes and resource attributes are mapped into an `attributes` and `resourceAttributes` key within `metadata` and, therefore, not queryable.
-If you want to query on specific attributes, you can use the `langfuse.metadata` prefix to map them to the top-level `metadata` object, e.g.
+If you want to query on specific attributes, you can use the `langfuse.metadata` prefix to map them to the top-level `metadata` object.
+The following snippet will produce a filterabl `user_name` property in the `metadata` object of the trace:
 
 ```python
 with tracer.start_as_current_span("Langfuse Attributes") as span:

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -304,7 +304,7 @@ These mappings are based on OTel GenAI semantic conventions and vendor-specific 
 Langfuse only supports filtering on top-level keys within the `metadata` of an event.
 Per default, all OpenTelemetry attributes and resource attributes are mapped into an `attributes` and `resourceAttributes` key within `metadata` and, therefore, not queryable.
 If you want to query on specific attributes, you can use the `langfuse.metadata` prefix to map them to the top-level `metadata` object.
-The following snippet will produce a filterabl `user_name` property in the `metadata` object of the trace:
+The following snippet will produce a filterable `user_name` property in the `metadata` object of the trace:
 
 ```python
 with tracer.start_as_current_span("Langfuse Attributes") as span:

--- a/pages/docs/opentelemetry/get-started.mdx
+++ b/pages/docs/opentelemetry/get-started.mdx
@@ -13,9 +13,9 @@ As the [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attrib
 
 ## OpenTelemetry native Langfuse SDK v3
 
-The quickest path to start tracing with Langfuse is the new **OTEL-native Langfuse SDK v3**. The SDK is a thin layer on top of the official OpenTelemetry client that automatically converts all emitted spans into rich Langfuse observations (spans, generations, events) and adds first-class helpers for LLM-specific features such as token usage, cost tracking, prompt linking, and scoring. 
+The quickest path to start tracing with Langfuse is the new **OTEL-native Langfuse SDK v3**. The SDK is a thin layer on top of the official OpenTelemetry client that automatically converts all emitted spans into rich Langfuse observations (spans, generations, events) and adds first-class helpers for LLM-specific features such as token usage, cost tracking, prompt linking, and scoring.
 
-Because it lives in the shared OpenTelemetry context, any other library that is already instrumented with OTEL (HTTP frameworks, databases, GenAI instrumentation like OpenLLMetry/OpenLIT, etc.) will seamlessly show up in the same Langfuse traces without additional configuration. 
+Because it lives in the shared OpenTelemetry context, any other library that is already instrumented with OTEL (HTTP frameworks, databases, GenAI instrumentation like OpenLLMetry/OpenLIT, etc.) will seamlessly show up in the same Langfuse traces without additional configuration.
 
 Get started by following the dedicated guide for the Python implementation here: [/docs/sdk/python/sdk-v3](/docs/sdk/python/sdk-v3).
 
@@ -298,6 +298,17 @@ These mappings are based on OTel GenAI semantic conventions and vendor-specific 
 | `mlflow.spanOutputs`          | `output`            | Output field. Used by MLflow based traces.                                                                                                                       |
 | `deployment.environment.name` | `environment`       | The environment for the request.                                                                                                                                 |
 | `deployment.environment`      | `environment`       | The environment for the request.                                                                                                                                 |
+
+## Metadata Properties
+
+Langfuse only supports filtering on top-level keys within the `metadata` of an event.
+Per default, all OpenTelemetry attributes and resource attributes are mapped into an `attributes` and `resourceAttributes` key within `metadata` and, therefore, not queryable.
+If you want to query on specific attributes, you can use the `langfuse.metadata` prefix to map them to the top-level `metadata` object, e.g.
+
+```python
+with tracer.start_as_current_span("Langfuse Attributes") as span:
+    span.set_attribute("langfuse.metadata.user_name", "user-123")
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds clarification on metadata mapping and filtering in Langfuse's OpenTelemetry documentation.
> 
>   - **Documentation Update**:
>     - Adds a new section "Metadata Properties" in `get-started.mdx`.
>     - Clarifies that Langfuse only supports filtering on top-level keys within `metadata`.
>     - Explains how to map specific OpenTelemetry attributes to top-level `metadata` using `langfuse.metadata` prefix.
>     - Provides a Python code snippet demonstrating how to set a filterable `user_name` property in `metadata`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f0b705a6dba9df38683fbab4aad3cd9000d44174. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->