### PR TITLE
chore: add encryption note on postgres, redis, blob store

### DIFF
--- a/pages/self-hosting/encryption.mdx
+++ b/pages/self-hosting/encryption.mdx
@@ -47,6 +47,8 @@ Database-level encryption is recommended for a secure production deployment and 
 On Langfuse Cloud, we use AES-256 across all databases.
 
 See [ClickHouse encryption documentation](/self-hosting/infrastructure/clickhouse#encryption) for details on how to enable encryption at rest for ClickHouse.
+For Postgres, Redis, and S3/Blob Storage, we recommend to use managed services by your cloud provider, which typically offer built-in encryption at rest.
+For self-managed, containerized deployments, refer to the documentation of the respective database system.
 
 ## Additional application-level encryption [#application-level-encryption]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds encryption recommendations for Postgres, Redis, and Blob Storage in `encryption.mdx`.
> 
>   - **Documentation**:
>     - Adds a note in `encryption.mdx` recommending the use of managed services for Postgres, Redis, and S3/Blob Storage for built-in encryption at rest.
>     - Suggests referring to respective database documentation for self-managed, containerized deployments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e67e8ece17a239e540f2fd8e098b18d86b166f09. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->