### PR TITLE
fix(tracing): data model link

### DIFF
--- a/pages/docs/tracing-features/metadata.mdx
+++ b/pages/docs/tracing-features/metadata.mdx
@@ -4,7 +4,7 @@ description: Add any customer metadata to your traces to better understand your 
 
 # Metadata
 
-Traces and observations (see [Langfuse Data Model](/docs/tracing)) can be enriched with metadata to better understand your users, application, and experiments. Metadata can be added to traces in the form of arbitrary JSON.
+Traces and observations (see [Langfuse Data Model](/docs/tracing-data-model)) can be enriched with metadata to better understand your users, application, and experiments. Metadata can be added to traces in the form of arbitrary JSON.
 
 <Tabs items={["Python SDK (v3)", "Python SDK (v2)", "JS/TS", "OpenAI (Python v2)", "OpenAI (JS/TS)", "Langchain (Python v2)", "Langchain (JS/TS)", "Flowise"]}>
 <Tab>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix link in `metadata.mdx` to point to the correct data model page.
> 
>   - **Documentation**:
>     - Fix link in `metadata.mdx` to point to `/docs/tracing-data-model` instead of `/docs/tracing`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5adccd05d7cbd9e05c18ed00702f00a8d3eea74a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->