### PR TITLE
docs: add Langchain (Python SDK v3) to metadata and trace_id pages

### DIFF
--- a/pages/docs/observability/features/masking.mdx
+++ b/pages/docs/observability/features/masking.mdx
@@ -236,7 +236,7 @@ See the Python SDK v3 tab for more details.
 
 </Callout>
 
-When using the [CallbackHandler](/integrations/frameworks/langchain), you can pass `mask` as a keyword argument:
+Pass `mask` as a keyword argument:
 
 ```python
 from langfuse.callback import CallbackHandler

--- a/pages/docs/observability/features/metadata.mdx
+++ b/pages/docs/observability/features/metadata.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Metadata
 
 Traces and observations (see [Langfuse Data Model](/docs/tracing-data-model)) can be enriched with metadata to better understand your users, application, and experiments. Metadata can be added to traces in the form of arbitrary JSON.
 
-<Tabs items={["Python SDK (v3)", "Python SDK (v2)", "JS/TS", "OpenAI (Python v2)", "OpenAI (JS/TS)", "Langchain (Python v2)", "Langchain (JS/TS)", "Flowise"]}>
+<Tabs items={["Python SDK (v3)", "Python SDK (v2)", "JS/TS", "OpenAI (Python v2)", "OpenAI (JS/TS)", "Langchain (Python)", "Langchain (JS/TS)", "Flowise"]}>
 <Tab>
 When using the `@observe()` decorator:
 
@@ -178,7 +178,63 @@ const res = await observeOpenAI(new OpenAI(), {
 </Tab>
 <Tab>
 
-When using the [CallbackHandler](/integrations/frameworks/langchain), you can pass `metadata` as a keyword argument:
+**Python SDK v3:**
+
+Option 1: Via metadata fields in chain invocation (simplest approach):
+
+```python
+from langfuse.langchain import CallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+ 
+langfuse_handler = CallbackHandler()
+ 
+llm = ChatOpenAI(model_name="gpt-4o")
+prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
+chain = prompt | llm
+ 
+# Set trace attributes dynamically via metadata
+response = chain.invoke(
+    {"topic": "cats"},
+    config={
+        "callbacks": [langfuse_handler],
+        "metadata": {
+            "foo": "bar",
+            "baz": "qux"
+        }
+    }
+)
+```
+
+Option 2: Via enclosing span (for more control):
+
+```python
+from langfuse import get_client
+from langfuse.langchain import CallbackHandler
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+ 
+langfuse = get_client()
+langfuse_handler = CallbackHandler()
+ 
+llm = ChatOpenAI(model_name="gpt-4o")
+prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
+chain = prompt | llm
+ 
+# Set trace attributes dynamically via enclosing span
+with langfuse.start_as_current_span(name="dynamic-langchain-trace") as span:
+    span.update_trace(
+        metadata={"foo": "bar", "baz": "qux"}
+    )
+
+    response = chain.invoke({"topic": "cats"}, config={"callbacks": [langfuse_handler]})
+ 
+    span.update_trace(output={"response": response.content})
+```
+
+**Python SDK v2:**
+
+Pass `metadata` as a keyword argument:
 
 ```python
 handler = CallbackHandler(

--- a/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
+++ b/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
@@ -39,7 +39,7 @@ Trace IDs in Langfuse:
 
 ## Usage
 
-<Tabs items={["Python SDK (v3)", "Python SDK (v2)", "JS/TS", "OpenTelemetry", "OpenAI (Python v2)", "OpenAI (JS/TS)", "Langchain (Python v2)", "Langchain (JS/TS)", "LiteLLM"]}>
+<Tabs items={["Python SDK (v3)", "Python SDK (v2)", "JS/TS", "OpenTelemetry", "OpenAI (Python v2)", "OpenAI (JS/TS)", "Langchain (Python)", "Langchain (JS/TS)", "LiteLLM"]}>
 <Tab>
 The Python SDK v3 uses W3C Trace Context IDs by default, which are:
 
@@ -298,9 +298,47 @@ const completion = await openai.chat.completions.create({
 </Tab>
 <Tab>
 
-When using Langchain with Langfuse, you have two options for working with trace IDs:
+**Python SDK v3:**
 
-1. Using the [CallbackHandler](/integrations/frameworks/langchain) and langchain run config:
+To pass a custom trace ID to a Langchain execution, you can wrap the execution in a span that sets a predefined trace ID. You can also retrieve the last trace ID a callback handler has created via `langfuse_handler.last_trace_id`.
+
+```python
+from langfuse import get_client, Langfuse
+from langfuse.langchain import CallbackHandler
+ 
+langfuse = get_client()
+ 
+# Generate deterministic trace ID from external system
+external_request_id = "req_12345"
+predefined_trace_id = Langfuse.create_trace_id(seed=external_request_id)
+ 
+langfuse_handler = CallbackHandler()
+ 
+# Use the predefined trace ID with trace_context
+with langfuse.start_as_current_span(
+    name="langchain-request",
+    trace_context={"trace_id": predefined_trace_id}
+) as span:
+    span.update_trace(
+        user_id="user_123",
+        input={"person": "Ada Lovelace"}
+    )
+ 
+    # LangChain execution will be part of this trace
+    response = chain.invoke(
+        {"person": "Ada Lovelace"},
+        config={"callbacks": [langfuse_handler]}
+    )
+ 
+    span.update_trace(output={"response": response})
+ 
+print(f"Trace ID: {predefined_trace_id}")  # Use this for scoring later
+print(f"Trace ID: {langfuse_handler.last_trace_id}") # Care needed in concurrent environments where handler is reused
+```
+
+**Python SDK v2:**
+
+Option 1: Using the [CallbackHandler](/integrations/frameworks/langchain) and langchain run config:
 
 ```python
 from langfuse.callback import CallbackHandler
@@ -320,7 +358,7 @@ chain.invoke(
 )
 ```
 
-2. Using the [`@observe()` decorator](/docs/sdk/python/decorators) for automatic trace management:
+Option 2: Using the [`@observe()` decorator](/docs/sdk/python/decorators) for automatic trace management:
 
 ```python
 from langfuse.decorators import langfuse_context, observe

--- a/pages/docs/observability/features/url.mdx
+++ b/pages/docs/observability/features/url.mdx
@@ -81,6 +81,14 @@ trace.getTraceUrl()
 </Tab>
 <Tab>
 
+<Callout type="info">
+
+When using the **Python SDK v3**, the trace URL is available via the `langfuse.get_trace_url()`.
+
+See the Python SDK v3 tab for more details.
+
+</Callout>
+
 Use the interoperability of the Langfuse Python `@observe()` Decorator with the Langchain integration to get the URL of a trace ([interop docs](/integrations/frameworks/langchain#interoperability)).
 
 ```python


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates documentation to include Langchain support for Python SDK v3 across features like masking, metadata, trace IDs, and trace URLs.
> 
>   - **Documentation Updates**:
>     - Adds Langchain support for Python SDK v3 in `masking.mdx`, `metadata.mdx`, `trace-ids-and-distributed-tracing.mdx`, and `url.mdx`.
>     - Updates tab labels to "Langchain (Python)" in `metadata.mdx` and `trace-ids-and-distributed-tracing.mdx`.
>   - **Masking**:
>     - Removes specific mention of Langchain in `masking.mdx` to generalize the usage of `mask` keyword argument.
>   - **Metadata**:
>     - Adds examples for setting metadata via chain invocation and enclosing span for Python SDK v3 in `metadata.mdx`.
>   - **Trace IDs**:
>     - Provides examples for using custom trace IDs with Langchain in Python SDK v3 in `trace-ids-and-distributed-tracing.mdx`.
>   - **Trace URLs**:
>     - Adds note about obtaining trace URLs using Python SDK v3 in `url.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 32184442f355b5d427140acd314dae034a077147. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->