### PR TITLE
Add FAQ page to security section

### DIFF
--- a/pages/faq/all/data-encryption-langfuse.mdx
+++ b/pages/faq/all/data-encryption-langfuse.mdx
@@ -1,0 +1,46 @@
+---
+title: How does Langfuse encrypt my data?
+tags: [security]
+---
+
+# How does Langfuse encrypt my data?
+
+Langfuse implements comprehensive encryption to protect your data both at rest and in transit.
+
+## Encryption at Rest
+
+All data stored in Langfuse is encrypted using **AES-256 encryption**, the industry standard for data protection:
+
+- **Database Encryption**: All database records are encrypted before being written to disk
+- **File Storage**: Any uploaded files or artifacts are encrypted using the same AES-256 standard
+- **Backup Encryption**: Database backups are also encrypted to ensure data protection
+
+## Encryption in Transit
+
+All data transmitted to and from Langfuse is protected using **TLS 1.2+** encryption:
+
+- **API Communications**: All API requests and responses are encrypted
+- **Web Interface**: The Langfuse dashboard uses HTTPS with strong cipher suites
+- **Database Connections**: Internal database connections use encrypted channels
+
+## Key Management
+
+- **Key Rotation**: Encryption keys are regularly rotated following security best practices
+- **Hardware Security Modules (HSM)**: Keys are protected using industry-standard HSMs
+- **Access Control**: Encryption keys are accessible only to authorized systems and personnel
+
+## Regional Data Storage
+
+For compliance with data residency requirements:
+- **EU Data**: European customer data is encrypted and stored in EU data centers
+- **US Data**: US customer data is encrypted and stored in US data centers
+- **Custom Regions**: Enterprise customers can specify preferred data regions
+
+## Self-Hosted Encryption
+
+For self-hosted deployments:
+- You maintain full control over encryption keys
+- Support for customer-managed encryption keys (CMEK)
+- Integration with your existing key management infrastructure
+
+For more details about our security practices, visit our [Security Center](/security) or [Encryption documentation](/security/encryption).

--- a/pages/faq/all/langfuse-security-overview.mdx
+++ b/pages/faq/all/langfuse-security-overview.mdx
@@ -1,0 +1,43 @@
+---
+title: How secure is Langfuse?
+tags: [security]
+---
+
+# How secure is Langfuse?
+
+Langfuse is built with security as a core principle. We implement multiple layers of security controls to protect your data and ensure compliance with industry standards.
+
+## Key Security Features
+
+### Data Protection
+- **Encryption at Rest**: All data is encrypted using AES-256 encryption
+- **Encryption in Transit**: All communications use TLS 1.2+ encryption
+- **Data Isolation**: Multi-tenant architecture with strict data isolation
+
+### Access Controls
+- **Authentication**: Support for SSO, SAML, and OAuth integrations
+- **Authorization**: Role-based access control (RBAC) with granular permissions
+- **API Security**: Secure API key management with scoped access
+
+### Infrastructure Security
+- **SOC 2 Type II Compliant**: Independently audited security controls
+- **ISO 27001 Certified**: International security management standards
+- **Regular Security Audits**: Continuous monitoring and vulnerability assessments
+
+### Privacy & Compliance
+- **GDPR Compliant**: Full compliance with European data protection regulations
+- **HIPAA Available**: HIPAA-compliant deployment options for healthcare customers
+- **Data Residency**: Choose your data region (US, EU) for compliance requirements
+
+## Self-Hosting Options
+
+For organizations with strict security requirements, Langfuse offers self-hosting options:
+- Deploy in your own infrastructure
+- Full control over data location and access
+- Enterprise features available with commercial license
+
+## Security Reporting
+
+We take security seriously. If you discover a security vulnerability, please report it through our [responsible disclosure program](/security/responsible-disclosure).
+
+For more detailed information, visit our [Security Center](/security) or contact our security team.

--- a/pages/security/_meta.tsx
+++ b/pages/security/_meta.tsx
@@ -1,5 +1,6 @@
 export default {
   index: "Overview",
+  faq: "FAQ",
   "-- Security": {
     type: "separator",
     title: "Security",

--- a/pages/security/faq.mdx
+++ b/pages/security/faq.mdx
@@ -1,0 +1,25 @@
+---
+title: Security FAQ
+sidebarTitle: FAQ
+description: Frequently asked questions about Langfuse security, compliance, and privacy.
+---
+
+# Security FAQ
+
+import { FaqPreview } from "@/components/faq/FaqPreview";
+
+<FaqPreview tags={["security"]} />
+
+## GitHub Discussions
+
+For additional security questions or to report security concerns, please visit our GitHub Discussions.
+
+import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
+
+<GhDiscussionsPreview
+  labels={[
+    "feat-security",
+    "feat-compliance",
+    "feat-privacy"
+  ]}
+/>

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 13943;
+export const GITHUB_STARS = 14104;


### PR DESCRIPTION
Add a dedicated FAQ page to the security documentation, populated with initial security-related FAQs.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e66ce119-1433-485f-8b2d-a101cbe7bd86) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e66ce119-1433-485f-8b2d-a101cbe7bd86)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)