### PR TITLE
docs: update anthropic page

### DIFF
--- a/cookbook/integration_anthropic.ipynb
+++ b/cookbook/integration_anthropic.ipynb
@@ -11,8 +11,8 @@
         "Anthropic provides advanced language models like Claude, known for their safety, helpfulness, and strong reasoning capabilities. By combining Anthropic's models with **Langfuse**, you can trace, monitor, and analyze your AI workloads in development and production.\n",
         "\n",
         "This notebook demonstrates **two** different ways to use Anthropic models with Langfuse:\n",
-        "1. **Anthropic SDK:** Use Langfuse decorators to wrap Anthropic SDK calls for automatic tracing.\n",
-        "2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via Langfuse's OpenAI SDK wrapper.\n",
+        "1. **OpenTelemetry Instrumentation:** Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse.\n",
+        "2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via [Langfuse's OpenAI SDK wrapper](https://langfuse.com/integrations/model-providers/openai-py).\n",
         "\n",
         "> **What is Anthropic?**  \n",
         "Anthropic is an AI safety company that develops Claude, a family of large language models designed to be helpful, harmless, and honest. Claude models excel at complex reasoning, analysis, and creative tasks.\n",
@@ -28,11 +28,7 @@
         "<!-- STEPS_START -->\n",
         "## Step 1: Install Dependencies\n",
         "\n",
-        "Before you begin, install the necessary packages in your Python environment:\n",
-        "\n",
-        "- **anthropic**: The official Anthropic Python SDK for using Claude models.\n",
-        "- **openai**: Needed to call Anthropic's OpenAI-compatible endpoints.\n",
-        "- **langfuse**: Required for sending trace data to the Langfuse platform.\n"
+        "Before you begin, install the necessary packages in your Python environment:\n"
       ]
     },
     {
@@ -41,7 +37,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install anthropic openai langfuse"
+        "%pip install anthropic openai langfuse opentelemetry-instrumentation-anthropic"
       ]
     },
     {
@@ -81,9 +77,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Langfuse client is authenticated and ready!\n"
+          ]
+        }
+      ],
       "source": [
         "from langfuse import get_client\n",
         "\n",
@@ -100,13 +104,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Approach 1: Using Native Anthropic SDK with Langfuse Decorators\n",
+        "## Approach 1: OpenTelemetry Instrumentation\n",
         "\n",
-        "Langfuse decorators provide a simple way to trace function calls and automatically capture input/output data. This approach allows you to use the native Anthropic SDK while getting full observability through Langfuse.\n",
+        "Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor\n",
         "\n",
-        "<!-- CALLOUT_START type: \"info\" emoji: \"ℹ️\" -->\n",
-        "**Note:** For more examples on using Langfuse decorators, see the [Langfuse Python SDK documentation](https://langfuse.com/docs/sdk/python/decorators).\n",
-        "<!-- CALLOUT_END -->"
+        "AnthropicInstrumentor().instrument()"
       ]
     },
     {
@@ -115,63 +126,39 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from langfuse import observe\n",
         "from anthropic import Anthropic\n",
         "\n",
         "# Initialize the Anthropic client\n",
-        "anthropic = Anthropic(\n",
+        "client = Anthropic(\n",
         "    api_key=os.environ.get(\"ANTHROPIC_API_KEY\")\n",
         ")\n",
         "\n",
-        "@observe()\n",
-        "def chat_with_claude(messages: list, model: str = \"claude-3-5-sonnet-20241022\", max_tokens: int = 1024):\n",
-        "    \"\"\"Chat with Claude using the Anthropic SDK and trace with Langfuse.\"\"\"\n",
-        "    \n",
-        "    # Make the API call to Anthropic\n",
-        "    response = anthropic.messages.create(\n",
-        "        model=model,\n",
-        "        max_tokens=max_tokens,\n",
-        "        messages=messages\n",
-        "    )\n",
-        "    \n",
-        "    # Update Langfuse observation with model details and usage\n",
-        "    langfuse.update_current_generation(\n",
-        "        model=model,\n",
-        "        input=messages,\n",
-        "        output=response.content[0].text,\n",
-        "        usage_details={\n",
-        "            \"input\": response.usage.input_tokens,\n",
-        "            \"output\": response.usage.output_tokens,\n",
-        "            \"total\": response.usage.input_tokens + response.usage.output_tokens\n",
-        "        },\n",
-        "        metadata={\n",
-        "            \"stop_reason\": response.stop_reason\n",
+        "# Make the API call to Anthropic\n",
+        "message = client.messages.create(\n",
+        "    model=\"claude-opus-4-20250514\",\n",
+        "    max_tokens=1000,\n",
+        "    temperature=1,\n",
+        "    system=\"You are a world-class poet. Respond only with short poems.\",\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": [\n",
+        "                {\n",
+        "                    \"type\": \"text\",\n",
+        "                    \"text\": \"Why is the ocean salty?\"\n",
+        "                }\n",
+        "            ]\n",
         "        }\n",
-        "    )\n",
-        "    \n",
-        "    return response"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Example usage with decorator\n",
-        "messages = [\n",
-        "    {\"role\": \"user\", \"content\": \"What is Langfuse and how does it help with LLM observability?\"}\n",
-        "]\n",
-        "\n",
-        "response = chat_with_claude(messages)\n",
-        "print(response.content[0].text)"
+        "    ]\n",
+        ")\n",
+        "print(message.content)"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Approach 2: Using the Langfuse OpenAI SDK Drop-in Replacement\n",
+        "## Approach 2: OpenAI SDK Drop-in Replacement\n",
         "\n",
         "Anthropic provides [OpenAI-compatible endpoints](https://docs.anthropic.com/en/api/openai-sdk) that allow you to use the OpenAI SDK to interact with Claude models. This is particularly useful if you have existing code using the OpenAI SDK that you want to switch to Claude."
       ]
@@ -211,12 +198,14 @@
         "\n",
         "![Langfuse Trace](https://langfuse.com/images/cookbook/integration_anthropic/anthropic-example-trace.png)\n",
         "\n",
-        "You can also view the public trace here: \n",
+        "You can also view the trace in Langfuse here: \n",
         "\n",
-        "- [Approach 1](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/c0265bd14c1142294bbbb50759cec2f9?timestamp=2025-07-22T15:59:24.590Z&display=details)\n",
-        "- [Approach 2](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)\n",
+        "- [Approach 1: OpenTelemetry Instrumentation](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/308aca9bc430ad872d474fc545889ee2?timestamp=2025-07-25T07:35:01.172Z&display=details)\n",
+        "- [Approach 2: OpenAI SDK](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)\n",
         "\n",
-        "<!-- STEPS_END -->"
+        "<!-- STEPS_END -->\n",
+        "\n",
+        "<!-- MARKDOWN_COMPONENT name: \"LearnMore\" path: \"@/components-mdx/integration-learn-more.mdx\" -->"
       ]
     }
   ],

--- a/pages/guides/cookbook/integration_anthropic.mdx
+++ b/pages/guides/cookbook/integration_anthropic.mdx
@@ -12,8 +12,8 @@ category: Integrations
 Anthropic provides advanced language models like Claude, known for their safety, helpfulness, and strong reasoning capabilities. By combining Anthropic's models with **Langfuse**, you can trace, monitor, and analyze your AI workloads in development and production.
 
 This notebook demonstrates **two** different ways to use Anthropic models with Langfuse:
-1. **Anthropic SDK:** Use Langfuse decorators to wrap Anthropic SDK calls for automatic tracing.
-2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via Langfuse's OpenAI SDK wrapper.
+1. **OpenTelemetry Instrumentation:** Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse.
+2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via [Langfuse's OpenAI SDK wrapper](https://langfuse.com/integrations/model-providers/openai-py).
 
 > **What is Anthropic?**  
 Anthropic is an AI safety company that develops Claude, a family of large language models designed to be helpful, harmless, and honest. Claude models excel at complex reasoning, analysis, and creative tasks.
@@ -27,14 +27,10 @@ Anthropic is an AI safety company that develops Claude, a family of large langua
 
 Before you begin, install the necessary packages in your Python environment:
 
-- **anthropic**: The official Anthropic Python SDK for using Claude models.
-- **openai**: Needed to call Anthropic's OpenAI-compatible endpoints.
-- **langfuse**: Required for sending trace data to the Langfuse platform.
-
 
 
 ```python
-%pip install anthropic openai langfuse
+%pip install anthropic openai langfuse opentelemetry-instrumentation-anthropic
 ```
 
 ## Step 2: Configure Langfuse SDK
@@ -71,65 +67,51 @@ else:
     print("Authentication failed. Please check your credentials and host.")
 ```
 
-## Approach 1: Using Native Anthropic SDK with Langfuse Decorators
+    Langfuse client is authenticated and ready!
 
-Langfuse decorators provide a simple way to trace function calls and automatically capture input/output data. This approach allows you to use the native Anthropic SDK while getting full observability through Langfuse.
 
-<Callout type="info" emoji="ℹ️">
-**Note:** For more examples on using Langfuse decorators, see the [Langfuse Python SDK documentation](https://langfuse.com/docs/sdk/python/decorators).
-</Callout>
+## Approach 1: OpenTelemetry Instrumentation
+
+Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse.
 
 
 ```python
-from langfuse import observe
+from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+
+AnthropicInstrumentor().instrument()
+```
+
+
+```python
 from anthropic import Anthropic
 
 # Initialize the Anthropic client
-anthropic = Anthropic(
+client = Anthropic(
     api_key=os.environ.get("ANTHROPIC_API_KEY")
 )
 
-@observe()
-def chat_with_claude(messages: list, model: str = "claude-3-5-sonnet-20241022", max_tokens: int = 1024):
-    """Chat with Claude using the Anthropic SDK and trace with Langfuse."""
-    
-    # Make the API call to Anthropic
-    response = anthropic.messages.create(
-        model=model,
-        max_tokens=max_tokens,
-        messages=messages
-    )
-    
-    # Update Langfuse observation with model details and usage
-    langfuse.update_current_generation(
-        model=model,
-        input=messages,
-        output=response.content[0].text,
-        usage_details={
-            "input": response.usage.input_tokens,
-            "output": response.usage.output_tokens,
-            "total": response.usage.input_tokens + response.usage.output_tokens
-        },
-        metadata={
-            "stop_reason": response.stop_reason
+# Make the API call to Anthropic
+message = client.messages.create(
+    model="claude-opus-4-20250514",
+    max_tokens=1000,
+    temperature=1,
+    system="You are a world-class poet. Respond only with short poems.",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Why is the ocean salty?"
+                }
+            ]
         }
-    )
-    
-    return response
+    ]
+)
+print(message.content)
 ```
 
-
-```python
-# Example usage with decorator
-messages = [
-    {"role": "user", "content": "What is Langfuse and how does it help with LLM observability?"}
-]
-
-response = chat_with_claude(messages)
-print(response.content[0].text)
-```
-
-## Approach 2: Using the Langfuse OpenAI SDK Drop-in Replacement
+## Approach 2: OpenAI SDK Drop-in Replacement
 
 Anthropic provides [OpenAI-compatible endpoints](https://docs.anthropic.com/en/api/openai-sdk) that allow you to use the OpenAI SDK to interact with Claude models. This is particularly useful if you have existing code using the OpenAI SDK that you want to switch to Claude.
 
@@ -160,8 +142,13 @@ After executing the application, navigate to your Langfuse Trace Table. You will
 
 ![Langfuse Trace](https://langfuse.com/images/cookbook/integration_anthropic/anthropic-example-trace.png)
 
-You can also view the public trace here: 
+You can also view the trace in Langfuse here: 
 
-- [Approach 1](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/c0265bd14c1142294bbbb50759cec2f9?timestamp=2025-07-22T15:59:24.590Z&display=details)
-- [Approach 2](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)
+- [Approach 1: OpenTelemetry Instrumentation](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/308aca9bc430ad872d474fc545889ee2?timestamp=2025-07-25T07:35:01.172Z&display=details)
+- [Approach 2: OpenAI SDK](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)
 </Steps>
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />
+

--- a/pages/integrations/model-providers/anthropic.mdx
+++ b/pages/integrations/model-providers/anthropic.mdx
@@ -12,8 +12,8 @@ category: Integrations
 Anthropic provides advanced language models like Claude, known for their safety, helpfulness, and strong reasoning capabilities. By combining Anthropic's models with **Langfuse**, you can trace, monitor, and analyze your AI workloads in development and production.
 
 This notebook demonstrates **two** different ways to use Anthropic models with Langfuse:
-1. **Anthropic SDK:** Use Langfuse decorators to wrap Anthropic SDK calls for automatic tracing.
-2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via Langfuse's OpenAI SDK wrapper.
+1. **OpenTelemetry Instrumentation:** Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse.
+2. **OpenAI SDK:** Use Anthropic's OpenAI-compatible endpoints via [Langfuse's OpenAI SDK wrapper](https://langfuse.com/integrations/model-providers/openai-py).
 
 > **What is Anthropic?**  
 Anthropic is an AI safety company that develops Claude, a family of large language models designed to be helpful, harmless, and honest. Claude models excel at complex reasoning, analysis, and creative tasks.
@@ -27,14 +27,10 @@ Anthropic is an AI safety company that develops Claude, a family of large langua
 
 Before you begin, install the necessary packages in your Python environment:
 
-- **anthropic**: The official Anthropic Python SDK for using Claude models.
-- **openai**: Needed to call Anthropic's OpenAI-compatible endpoints.
-- **langfuse**: Required for sending trace data to the Langfuse platform.
-
 
 
 ```python
-%pip install anthropic openai langfuse
+%pip install anthropic openai langfuse opentelemetry-instrumentation-anthropic
 ```
 
 ## Step 2: Configure Langfuse SDK
@@ -71,65 +67,51 @@ else:
     print("Authentication failed. Please check your credentials and host.")
 ```
 
-## Approach 1: Using Native Anthropic SDK with Langfuse Decorators
+    Langfuse client is authenticated and ready!
 
-Langfuse decorators provide a simple way to trace function calls and automatically capture input/output data. This approach allows you to use the native Anthropic SDK while getting full observability through Langfuse.
 
-<Callout type="info" emoji="ℹ️">
-**Note:** For more examples on using Langfuse decorators, see the [Langfuse Python SDK documentation](https://langfuse.com/docs/sdk/python/decorators).
-</Callout>
+## Approach 1: OpenTelemetry Instrumentation
+
+Use the [`AnthropicInstrumentor`](https://pypi.org/project/opentelemetry-instrumentation-anthropic/) library to wrap Anthropic SDK calls and send OpenTelemetry spans to Langfuse.
 
 
 ```python
-from langfuse import observe
+from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+
+AnthropicInstrumentor().instrument()
+```
+
+
+```python
 from anthropic import Anthropic
 
 # Initialize the Anthropic client
-anthropic = Anthropic(
+client = Anthropic(
     api_key=os.environ.get("ANTHROPIC_API_KEY")
 )
 
-@observe()
-def chat_with_claude(messages: list, model: str = "claude-3-5-sonnet-20241022", max_tokens: int = 1024):
-    """Chat with Claude using the Anthropic SDK and trace with Langfuse."""
-    
-    # Make the API call to Anthropic
-    response = anthropic.messages.create(
-        model=model,
-        max_tokens=max_tokens,
-        messages=messages
-    )
-    
-    # Update Langfuse observation with model details and usage
-    langfuse.update_current_generation(
-        model=model,
-        input=messages,
-        output=response.content[0].text,
-        usage_details={
-            "input": response.usage.input_tokens,
-            "output": response.usage.output_tokens,
-            "total": response.usage.input_tokens + response.usage.output_tokens
-        },
-        metadata={
-            "stop_reason": response.stop_reason
+# Make the API call to Anthropic
+message = client.messages.create(
+    model="claude-opus-4-20250514",
+    max_tokens=1000,
+    temperature=1,
+    system="You are a world-class poet. Respond only with short poems.",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Why is the ocean salty?"
+                }
+            ]
         }
-    )
-    
-    return response
+    ]
+)
+print(message.content)
 ```
 
-
-```python
-# Example usage with decorator
-messages = [
-    {"role": "user", "content": "What is Langfuse and how does it help with LLM observability?"}
-]
-
-response = chat_with_claude(messages)
-print(response.content[0].text)
-```
-
-## Approach 2: Using the Langfuse OpenAI SDK Drop-in Replacement
+## Approach 2: OpenAI SDK Drop-in Replacement
 
 Anthropic provides [OpenAI-compatible endpoints](https://docs.anthropic.com/en/api/openai-sdk) that allow you to use the OpenAI SDK to interact with Claude models. This is particularly useful if you have existing code using the OpenAI SDK that you want to switch to Claude.
 
@@ -160,8 +142,13 @@ After executing the application, navigate to your Langfuse Trace Table. You will
 
 ![Langfuse Trace](https://langfuse.com/images/cookbook/integration_anthropic/anthropic-example-trace.png)
 
-You can also view the public trace here: 
+You can also view the trace in Langfuse here: 
 
-- [Approach 1](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/c0265bd14c1142294bbbb50759cec2f9?timestamp=2025-07-22T15:59:24.590Z&display=details)
-- [Approach 2](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)
+- [Approach 1: OpenTelemetry Instrumentation](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/308aca9bc430ad872d474fc545889ee2?timestamp=2025-07-25T07:35:01.172Z&display=details)
+- [Approach 2: OpenAI SDK](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/8e8da1b2c15036ed9c25b37c604f2d29?timestamp=2025-07-22T16:05:47.602Z&display=details)
 </Steps>
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates Anthropic integration docs to use OpenTelemetry Instrumentation instead of Langfuse decorators for tracing.
> 
>   - **Documentation Update**:
>     - Replaces Langfuse decorators with OpenTelemetry Instrumentation in `integration_anthropic.mdx` and `anthropic.mdx`.
>     - Updates installation instructions to include `opentelemetry-instrumentation-anthropic`.
>     - Provides example code for using `AnthropicInstrumentor` to wrap Anthropic SDK calls.
>   - **Approaches**:
>     - Approach 1: Uses `AnthropicInstrumentor` for OpenTelemetry spans.
>     - Approach 2: Uses OpenAI SDK with Anthropic's OpenAI-compatible endpoints.
>   - **Misc**:
>     - Updates links to Langfuse and Anthropic documentation.
>     - Adds `LearnMore` component at the end of both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 41ace946d4a43d0b1460760f67cbbebee5827dfa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->