### PR TITLE
docs: add changelog entry for triggering remote custom experiments from UI

### DIFF
--- a/pages/changelog/2025-07-24-remote-experiment-triggers.mdx
+++ b/pages/changelog/2025-07-24-remote-experiment-triggers.mdx
@@ -37,7 +37,7 @@ Your remote experiment service will receive:
 - Dataset name and ID
 - Custom payload (if configured)
 
-Ideally, your experiment runner uses [Langfuse SDKs](/docs/sdk/overview) to push dataset run and evaluation results back to Langfuse for complete experiment tracking.
+Ideally, your experiment runner uses [Langfuse SDKs/API](/docs/evaluation/get-started/offline) to push the dataset run and evaluation results back to Langfuse for complete experiment tracking.
 
 ## Questions or Feedback?
 

--- a/pages/changelog/2025-07-24-remote-experiment-triggers.mdx
+++ b/pages/changelog/2025-07-24-remote-experiment-triggers.mdx
@@ -1,0 +1,46 @@
+---
+date: 2025-07-24
+title: Trigger Remote Custom Experiments from UI  
+description: Enable non-technical users to trigger external experiment pipelines directly from the Langfuse UI on datasets.
+author: Marlies
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+You can now trigger external experiment pipelines directly from the Langfuse UI. This feature enables non-technical users to run experiments on [Datasets](/docs/datasets) without requiring code changes or manual setup.
+
+Configure a remote experiment URL at the dataset level, and team members can trigger experiments with a single click. Langfuse will send the dataset name, ID, and any custom payload to your experiment service, then wait up to 10 seconds for a response.
+
+## Features
+
+- **Dataset-level configuration**: Set up experiment URLs and custom payloads per dataset
+- **Simple triggering**: One-click experiment execution from the UI
+- **Custom payloads**: Send additional context or parameters to your experiment service
+- **Response handling**: 10-second timeout with status feedback
+
+## Setup
+
+1. Navigate to your **Dataset** in Langfuse. In the top right corner of your **Dataset Runs** page, click **New Experiment**
+2. Configure the **Remote Experiment URL** where your experiment service is hosted
+3. Add any **Custom Payload** (JSON format) needed by your experiment runner
+
+## Triggering an experiment
+
+1. Click **New Experiment** in the top right corner of the dataset runs page. Click the **Run** button
+2. Confirm your payload, and click **Run** again to send dataset details to your service
+
+## Integration
+
+Your remote experiment service will receive:
+- Dataset name and ID
+- Custom payload (if configured)
+
+Ideally, your experiment runner uses [Langfuse SDKs](/docs/sdk/overview) to push dataset run and evaluation results back to Langfuse for complete experiment tracking.
+
+## Questions or Feedback?
+
+Share your remote experiment workflows and use cases in our [GitHub Discussions](https://github.com/orgs/langfuse/discussions).
+
+Please open a [GitHub issue](/issues) if you encounter any problems or have suggestions for improvements.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds changelog entry for new feature enabling remote custom experiment triggers from Langfuse UI with dataset-level configuration and custom payloads.
> 
>   - **Changelog Entry**: Adds `2025-07-24-remote-experiment-triggers.mdx` to document new feature for triggering remote custom experiments from the Langfuse UI.
>   - **Features**:
>     - Allows non-technical users to trigger experiments via UI with dataset-level configuration.
>     - Supports custom payloads and provides a 10-second response timeout.
>   - **Setup and Usage**:
>     - Users configure a remote experiment URL and custom payloads in JSON format.
>     - Experiments are triggered with a single click, sending dataset name, ID, and payload to the service.
>   - **Integration**:
>     - Encourages use of Langfuse SDKs/API for tracking results back to Langfuse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 67063e50a831a5d53fd5de15590dcd043ca3b984. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->