### PR TITLE
docs: update openai agents cookbook

### DIFF
--- a/cookbook/integration_openai-agents.ipynb
+++ b/cookbook/integration_openai-agents.ipynb
@@ -301,9 +301,7 @@
         "\n",
         "**Example**: [Langfuse Trace](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019593c7523686ff7667b85673d033bf?timestamp=2025-03-14T08%3A31%3A08.342Z&observation=d69e377f62b1d331)\n",
         "\n",
-        "Each child call is represented as a sub-span under the top-level **Joke workflow** span, making it easy to see the entire conversation or sequence of calls.\n",
-        "\n",
-        "<!-- MARKDOWN_COMPONENT name: \"LearnMore\" path: \"@/components-mdx/integration-learn-more.mdx\" -->"
+        "Each child call is represented as a sub-span under the top-level **Joke workflow** span, making it easy to see the entire conversation or sequence of calls."
       ]
     },
     {
@@ -389,7 +387,9 @@
       "source": [
         "## Resources\n",
         "\n",
-        "- [Example notebook on evaluating agents](https://langfuse.com/guides/cookbook/example_evaluating_openai_agents) with Langfuse. "
+        "- [Example notebook on evaluating agents](https://langfuse.com/guides/cookbook/example_evaluating_openai_agents) with Langfuse. \n",
+        "\n",
+        "<!-- MARKDOWN_COMPONENT name: \"LearnMore\" path: \"@/components-mdx/integration-learn-more.mdx\" -->"
       ]
     }
   ],

--- a/pages/guides/cookbook/integration_openai-agents.mdx
+++ b/pages/guides/cookbook/integration_openai-agents.mdx
@@ -211,10 +211,6 @@ await loop.create_task(main())
 
 Each child call is represented as a sub-span under the top-level **Joke workflow** span, making it easy to see the entire conversation or sequence of calls.
 
-import LearnMore from "@/components-mdx/integration-learn-more.mdx";
-
-<LearnMore />
-
 ## Link Langfuse Prompt
 
 If you manage your prompt with [Langfuse Prompt Management](https://langfuse.com/docs/prompt-management/overview), you can link the used prompt to the trace by setting up an OTel Span processor.
@@ -278,3 +274,7 @@ prompt_info_var.set({
 ## Resources
 
 - [Example notebook on evaluating agents](https://langfuse.com/guides/cookbook/example_evaluating_openai_agents) with Langfuse. 
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />

--- a/pages/integrations/frameworks/openai-agents.mdx
+++ b/pages/integrations/frameworks/openai-agents.mdx
@@ -211,10 +211,6 @@ await loop.create_task(main())
 
 Each child call is represented as a sub-span under the top-level **Joke workflow** span, making it easy to see the entire conversation or sequence of calls.
 
-import LearnMore from "@/components-mdx/integration-learn-more.mdx";
-
-<LearnMore />
-
 ## Link Langfuse Prompt
 
 If you manage your prompt with [Langfuse Prompt Management](https://langfuse.com/docs/prompt-management/overview), you can link the used prompt to the trace by setting up an OTel Span processor.
@@ -278,3 +274,7 @@ prompt_info_var.set({
 ## Resources
 
 - [Example notebook on evaluating agents](https://langfuse.com/guides/cookbook/example_evaluating_openai_agents) with Langfuse. 
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `LearnMore` component to the end of the OpenAI agents cookbook documentation files.
> 
>   - **Documentation**:
>     - Move `LearnMore` component to the end of `integration_openai-agents.mdx` and `openai-agents.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for fca9d1398c612f4a023bd04fd4336c222594e9c4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->