### PR TITLE
chore: otel grpc note

### DIFF
--- a/pages/integrations/native/opentelemetry.mdx
+++ b/pages/integrations/native/opentelemetry.mdx
@@ -55,6 +55,8 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://cloud.langfuse.com/api/public/otel/v
 
 </Callout>
 
+Please note that Langfuse does not support `gRPC` for the OpenTelemetry endpoint. Please use `HTTP/protobuf` instead.
+
 ## Custom via OpenTelemetry SDKs
 
 You can use the OpenTelemetry SDKs to directly export traces to Langfuse with the configuration mentioned above. Thereby, Language support of Langfuse is extended to other languages than the ones supported by the [Langfuse SDKs](/docs/sdk/overview) (Python and JS/TS).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `opentelemetry.mdx` that Langfuse does not support `gRPC` for the OpenTelemetry endpoint, recommending `HTTP/protobuf` instead.
> 
>   - **Documentation**:
>     - Adds a note in `opentelemetry.mdx` that Langfuse does not support `gRPC` for the OpenTelemetry endpoint.
>     - Recommends using `HTTP/protobuf` instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4083d157df8c490bfdfd0d60166f89b89cec364c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->