### PR TITLE
chore: add troubleshoot postgres owner change

### DIFF
--- a/pages/self-hosting/troubleshooting.mdx
+++ b/pages/self-hosting/troubleshooting.mdx
@@ -62,6 +62,40 @@ Langfuse is engineered to run in the UTC timezone and expects that all infrastru
 Especially Postgres and ClickHouse settings that overwrite the UTC default are not supported and may lead to unexpected behavior.
 If you would like us to consider supporting other timezones, please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046).
 
+## PostgreSQL: Table Ownership and Migration Failures
+
+If you encounter permission errors during PostgreSQL migrations like the following, it typically occurs when the database user running migrations has changed,
+as new users won't own existing tables and therefore cannot modify them.
+
+```
+DbError { severity: "ERROR", code: SqlState(E42501), message: "permission denied for table projects" }
+```
+
+You can verify mixed ownership by checking table owners:
+
+```sql
+\dt public.*
+```
+
+### Solutions
+
+**Option 1: Transfer table ownership**
+
+```sql
+-- Replace 'new_user' with your current migration user
+ALTER TABLE table_name OWNER TO new_user;
+```
+
+**Option 2: Use dedicated migration user**
+
+Set the `DIRECT_URL` environment variable to use a superuser or table owner specifically for migrations:
+
+```bash
+DIRECT_URL=postgresql://migration_user:password@host:port/database
+```
+
+This allows Prisma to use different credentials for migrations while keeping your regular `DATABASE_URL` for application operations.
+
 ## Clickhouse: Handling Failed Migrations
 
 If you encounter a migration error, the migration tool will prevent you from running additional migrations on the same database. You'll see an error message like "Dirty database version 1. Fix and force version" even after fixing the erred migration. This means your database has been marked as 'dirty'. You need to investigate whether the migration was partially applied or not applied at all. After determining the actual state, force your database to the version that accurately reflects its current state. Once you've forced the correct version and fixed the migration, your database will be 'clean' again, allowing you to proceed with subsequent migrations.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds PostgreSQL table ownership and migration failure troubleshooting to `troubleshooting.mdx`, with solutions for permission errors.
> 
>   - **PostgreSQL Troubleshooting**:
>     - Adds section on table ownership and migration failures in `troubleshooting.mdx`.
>     - Describes permission error scenario with `DbError` example.
>     - Provides solutions: transfer table ownership or use a dedicated migration user with `DIRECT_URL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 58c8d561fcbfe1f6173c25ab06b9e669ba99ea9e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->