### PR TITLE
Update posthog integration documentation

### DIFF
--- a/pages/integrations/analytics/posthog.mdx
+++ b/pages/integrations/analytics/posthog.mdx
@@ -101,6 +101,7 @@ Is there any additional information that would be helpful? You can request more 
 - `timestamp`: The start time of the generation.
 - `langfuse_generation_name`: The name of the generation.
 - `langfuse_trace_name`: Name of the trace related to the generation.
+- `langfuse_trace_id`: The unique identifier of the trace related to the generation.
 - `langfuse_url`: The URL of the generation on the host platform.
 - `langfuse_id`: Unique identifier of the generation.
 - `langfuse_cost_usd`: Computed total cost of the generation.
@@ -130,6 +131,7 @@ Is there any additional information that would be helpful? You can request more 
 - `langfuse_score_comment`: Any comments attached with the score.
 - `langfuse_score_metadata`: Any metadata attached with the score.
 - `langfuse_trace_name`: The name of the trace associated with the score.
+- `langfuse_trace_id`: The unique identifier of the trace associated with the score.
 - `langfuse_id`: The unique identification of the score.
 - `langfuse_session_id`: The session identification related to the score's trace.
 - `langfuse_project_id`: The project identification linked with the score's trace.


### PR DESCRIPTION
Update PostHog integration documentation to include `langfuse_trace_id` for generation and score events.

---
<a href="https://cursor.com/background-agent?bcId=bc-d01d723d-3603-4bed-acf5-997347267408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d01d723d-3603-4bed-acf5-997347267408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

