### PR TITLE
fix: links to evaluation methods

### DIFF
--- a/pages/docs/evaluation/overview.mdx
+++ b/pages/docs/evaluation/overview.mdx
@@ -59,19 +59,19 @@ import { Lightbulb, SquarePercent, ClipboardPen} from "lucide-react";
   <Card
     icon={<Lightbulb size="24" />}
     title="LLM-as-a-Judge"
-    href="/docs/evaluation/dataset-runs/datasets"
+    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
     arrow
   />
   <Card
     icon={<ClipboardPen size="24" />}
     title="Human Annotations"
-    href="/docs/evaluation/dataset-runs/native-run"
+    href="/docs/evaluation/evaluation-methods/annotation"
     arrow
   />
     <Card
     icon={<SquarePercent size="24" />}
     title="Custom Scores"
-    href="/docs/evaluation/dataset-runs/data-model"
+    href="/docs/evaluation/evaluation-methods/custom-scores"
     arrow
   />
 </Cards>


### PR DESCRIPTION
When I read the document, I noticed that these links pointed to troubling places, so I tried to fix them, hoping that now they were correct :)