### PR TITLE
Fix evaluation overview link to llm-as-a-judge

### DIFF
--- a/pages/docs/evaluation/overview.mdx
+++ b/pages/docs/evaluation/overview.mdx
@@ -59,7 +59,7 @@ import { Lightbulb, SquarePercent, ClipboardPen} from "lucide-react";
   <Card
     icon={<Lightbulb size="24" />}
     title="LLM-as-a-Judge"
-    href="/docs/evaluation/dataset-runs/datasets"
+    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
     arrow
   />
   <Card


### PR DESCRIPTION
Update the 'LLM-as-a-Judge' link on the evaluation overview page to point to the correct documentation.

---
[Slack Thread](https://langfuse.slack.com/archives/C0995RY6SAF/p1754558593530429%3Fthread_ts=1754558593.530429