### PR TITLE
Fix evaluation overview human annotation link

### DIFF
--- a/pages/docs/evaluation/overview.mdx
+++ b/pages/docs/evaluation/overview.mdx
@@ -65,7 +65,7 @@ import { Lightbulb, SquarePercent, ClipboardPen} from "lucide-react";
   <Card
     icon={<ClipboardPen size="24" />}
     title="Human Annotations"
-    href="/docs/evaluation/dataset-runs/native-run"
+    href="/docs/evaluation/evaluation-methods/annotation"
     arrow
   />
     <Card


### PR DESCRIPTION
## Review Needed? Checklist
[ ] Did you create or **move a section with headline** (h2, h3, etc...) → *review by Jannik or Felix required*
[ ] Does this include a **changelog post** →  *review by Jannik or Felix required*
[ ] Do you feel having a review would be good → *review by Jannik or Felix required*

Fixes an incorrect link on `/docs/evaluation/overview`. The "Human Annotations" card previously linked to the "Datasets" page; it now correctly points to the "Evaluation Methods / Annotation" page.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff4497fe-c097-4499-b070-bbfa381e9e54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff4497fe-c097-4499-b070-bbfa381e9e54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

