### PR TITLE
feat: add /.md via rewrite and move the copy as markdown button to this logic

### DIFF
--- a/.cursor/rules/_general-rules.mdc
+++ b/.cursor/rules/_general-rules.mdc
@@ -1,8 +1,16 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
+
 # General rules
+
+- This is the documentation for the Langfuse website.
+- We use Nextra.site, v3, docs: https://nextra-v2-7hslbun8z-shud.vercel.app/
+- All pages are in the /pages folder and rendered by Nextra.site.
+- Reusable markdown components are in the /components-mdx folder.
+
+## Frontend
 
 - When using tailwindcss, never use explicit colors, always use the default semantic color tokens introduced by shadcn/ui.

--- a/.cursor/rules/documentation-pages.mdc
+++ b/.cursor/rules/documentation-pages.mdc
@@ -1,23 +1,24 @@
 ---
-description: 
-globs: 
+alwaysApply: true
 ---
+
 Here's a continuation and elaboration of the guidelines for creating documentation pages for Langfuse, based on the existing documentation structure and content style observed across various files:
 
 ### Langfuse Documentation Creation Guide
 
 #### General Structure
+
 Each documentation page typically follows a structured format to ensure consistency and ease of understanding. Here’s a breakdown of the common elements:
 
 1. **Metadata Block**: At the top of each document, include YAML front matter that specifies metadata such as title, description, and category. This helps in SEO optimization and categorizing the content.
 
-    ```markdown
-    ---
-    title: Title of the Document
-    description: A brief description of what the document covers.
-    category: Category Name
-    ---
-    ```
+   ```markdown
+   ---
+   title: Title of the Document
+   description: A brief description of what the document covers.
+   category: Category Name
+   ---
+   ```
 
 2. **Introduction**: Start with a brief introduction that outlines what the document will cover and why it’s important. This section sets the context for the readers.
 
@@ -27,42 +28,45 @@ Each documentation page typically follows a structured format to ensure consiste
 
 5. **Code Snippets**: Include code examples where necessary. Use syntax highlighting to improve readability. Ensure that any placeholders are clearly indicated.
 
-    ```python
-    import langfuse
+   ```python
+   import langfuse
 
-    # Replace 'your_api_key' with your actual API key
-    langfuse.configure(api_key='your_api_key')
-    ```
+   # Replace 'your_api_key' with your actual API key
+   langfuse.configure(api_key='your_api_key')
+   ```
 
 6. **Images and Diagrams**: Use images and diagrams to explain concepts that are difficult to convey through text alone. Wrap images in a `<Frame>` component to maintain styling consistency.
 
-    ```markdown
-    <Frame className="my-10" fullWidth>
-        ![Alt text for image](mdc:path/to/image.png)
-    </Frame>
-    ```
+   ```markdown
+   <Frame className="my-10" fullWidth>
+       ![Alt text for image](mdc:path/to/image.png)
+   </Frame>
+   ```
 
 7. **Tips and Notes**: Use callouts to highlight tips, warnings, or important notes. This can be done using markdown syntax or specific components if available.
 
-    ```markdown
-    > **Tip:** This is a helpful tip.
-    ```
+   ```markdown
+   > **Tip:** This is a helpful tip.
+   ```
 
 8. **FAQs and Troubleshooting**: End the document with a FAQ or troubleshooting section to address common issues or questions related to the topic.
 
 9. **Further Resources**: Provide links to related documents, external resources, or further reading to help users deepen their understanding.
 
 #### Writing Style
+
 - **Clarity and Conciseness**: Use clear and concise language. Avoid jargon unless it is commonly understood in the context of the documentation.
 - **Active Voice**: Use active voice to make the content more engaging.
 - **Second Person**: Address the reader directly using second person ("you") to make the text more user-friendly.
 
 #### Formatting
+
 - **Headers**: Use headers to organize content into logical sections. Headers should be hierarchical (`#`, `##`, `###`).
 - **Lists**: Use bullet points for unordered lists and numbers for ordered lists.
 - **Links**: Always use descriptive link texts instead of generic texts like "click here".
 
 #### Accessibility
+
 - **Alt Texts for Images**: Provide descriptive alt texts for all images to improve accessibility.
 - **Readable Fonts and Colors**: Ensure that the text is readable by using sufficient contrast between text and background colors.
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 public/robots.txt
 public/sitemap*.xml
 public/llms.txt
+public/md-src
 
 # we use pnpm
 package-lock.json

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -95,6 +95,14 @@ const nextraConfig = withNextra({
           },
         ],
       },
+      // Mark markdown endpoints as noindex and ensure correct content type
+      {
+        source: "/:path*.md",
+        headers: [
+          { key: "X-Robots-Tag", value: "noindex" },
+          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
+        ],
+      },
     ];
 
     // Do not index Vercel preview deployments
@@ -123,7 +131,17 @@ const nextraConfig = withNextra({
       destination,
       permanent: false,
     })),
-  ]
+  ],
+  async rewrites() {
+    // Serve any ".md" path by mapping to the static copy in public/md-src
+    // Example: /docs.md -> /md-src/docs.md, /docs/observability/overview.md -> /md-src/docs/observability/overview.md
+    return [
+      {
+        source: "/:path*.md",
+        destination: "/md-src/:path*.md",
+      },
+    ];
+  },
 });
 
 const nonPermanentRedirects = [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Langfuse docs",
   "scripts": {
     "dev": "next dev -p 3333",
-    "prebuild": "node scripts/update-github-stars.js && node scripts/authors/generate-contributors.js",
+    "prebuild": "node scripts/update-github-stars.js && node scripts/authors/generate-contributors.js && node scripts/copy_md_sources.js",
     "build": "next build",
     "postbuild": "pnpm run postbuild:sitemap && pnpm run postbuild:cleanup && pnpm run postbuild:llms-txt",
     "start": "next start -p 3333",

--- a/pages/changelog/2025-08-07-markdown-endpoints-and-copy-button.mdx
+++ b/pages/changelog/2025-08-07-markdown-endpoints-and-copy-button.mdx
@@ -1,0 +1,19 @@
+---
+title: Docs now available as Markdown (.md) endpoints
+description: Append .md to any docs URL to fetch the page as Markdown. Built at compile time for fast, reliable access.
+date: 2025-08-07
+author: Marc
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+You can now fetch the Markdown source of any docs page by appending `.md` to the URL.
+
+Example: `/docs` → [`/docs.md`](https://langfuse.com/docs.md)
+
+From now on this powers:
+
+- [Copy as Markdown](/changelog/2025-04-17-copy-as-markdown): now faster and more reliable
+- [Langfuse Docs MCP Server](/docs/docs-mcp): new `getLangfuseDocsPage` tool

--- a/scripts/copy_md_sources.js
+++ b/scripts/copy_md_sources.js
@@ -1,0 +1,156 @@
+/*
+  Copy all Markdown sources from pages/** (md, mdx) into public/md-src/** as .md files.
+  This runs at build time so the static files can be served directly in production.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE_DIR = path.join(process.cwd(), 'pages');
+const OUTPUT_DIR = path.join(process.cwd(), 'public', 'md-src');
+
+/**
+ * Recursively walk a directory collecting file paths.
+ */
+function walkDir(dirPath) {
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...walkDir(fullPath));
+        } else {
+            files.push(fullPath);
+        }
+    }
+    return files;
+}
+
+/**
+ * Ensure a directory exists.
+ */
+function ensureDir(dirPath) {
+    if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, { recursive: true });
+    }
+}
+
+/**
+ * Determine if path within pages/ should be copied and where.
+ * - Accept .md and .mdx files only
+ * - Exclude next special files and api routes (e.g., pages/api/**, _app, _document, _meta, 404)
+ * - Map pages/foo/bar.mdx -> public/md-src/foo/bar.md
+ * - Map pages/foo/index.mdx -> public/md-src/foo.md
+ */
+function mapDestination(sourceFile) {
+    const rel = path.relative(SOURCE_DIR, sourceFile);
+    // Exclude special folders/files
+    if (rel.startsWith('api/')) return null;
+    const base = path.basename(rel);
+    if (base.startsWith('_') || base === '404.mdx' || base === '404.md') return null;
+
+    const ext = path.extname(rel).toLowerCase();
+    if (ext !== '.md' && ext !== '.mdx') return null;
+
+    // Remove extension
+    const withoutExt = rel.slice(0, -ext.length);
+
+    // Handle index files (e.g., docs/index.mdx -> docs.md)
+    const parts = withoutExt.split(path.sep);
+    let outParts = parts.slice();
+    if (parts[parts.length - 1] === 'index') {
+        outParts = parts.slice(0, -1); // drop 'index'
+    }
+    const outRel = outParts.length ? outParts.join('/') + '.md' : 'index.md';
+    return path.join(OUTPUT_DIR, outRel);
+}
+
+function copyAll() {
+    const allFiles = walkDir(SOURCE_DIR);
+    let copied = 0;
+    for (const file of allFiles) {
+        const dest = mapDestination(file);
+        if (!dest) continue;
+        const dir = path.dirname(dest);
+        ensureDir(dir);
+        const originalContent = fs.readFileSync(file, 'utf8');
+        const processed = inlineComponentsMdx(originalContent, file);
+        fs.writeFileSync(dest, processed, 'utf8');
+        copied += 1;
+    }
+    console.log(`Copied ${copied} markdown source files into public/md-src`);
+}
+
+function cleanOutputDir() {
+    if (fs.existsSync(OUTPUT_DIR)) {
+        fs.rmSync(OUTPUT_DIR, { recursive: true, force: true });
+    }
+}
+
+cleanOutputDir();
+copyAll();
+
+/**
+ * Inline imports of MDX components from the components-mdx directory.
+ * Only resolves paths starting with "@/components-mdx/".
+ */
+function inlineComponentsMdx(fileContent, sourceFilePath) {
+    try {
+        const importPattern = /(^|\n)import\s+([A-Za-z0-9_]+)\s+from\s+"@\/components-mdx\/([^"]+)";?\s*(?=\n|$)/g;
+        const componentAliasRoot = path.join(process.cwd(), 'components-mdx');
+
+        // Collect all imports first to avoid interfering with regex iteration during replacements
+        const imports = [];
+        let match;
+        while ((match = importPattern.exec(fileContent)) !== null) {
+            const importedName = match[2];
+            const importedRel = match[3];
+            imports.push({ fullMatch: match[0], importedName, importedRel });
+        }
+
+        if (imports.length === 0) return fileContent;
+
+        let contentWithoutImports = fileContent;
+        for (const imp of imports) {
+            // Remove the import line
+            contentWithoutImports = contentWithoutImports.replace(imp.fullMatch, '\n');
+        }
+
+        // Resolve and inline each component
+        let finalContent = contentWithoutImports;
+        for (const imp of imports) {
+            const resolvedPath = resolveComponentPath(componentAliasRoot, imp.importedRel);
+            if (!resolvedPath) {
+                console.warn(`copy_md_sources: Could not resolve component ${imp.importedRel} imported as ${imp.importedName} in ${sourceFilePath}`);
+                continue;
+            }
+            const rawChild = fs.readFileSync(resolvedPath, 'utf8');
+            const childInlined = inlineComponentsMdx(rawChild, resolvedPath);
+
+            // Replace self-closing and paired tags
+            const selfClosing = new RegExp(`<${imp.importedName}(\\s[^>]*)?\\s*/>`, 'g');
+            const paired = new RegExp(`<${imp.importedName}(\\s[^>]*)?>([\\s\\S]*?)<\/${imp.importedName}>`, 'g');
+
+            finalContent = finalContent.replace(selfClosing, `\n${childInlined}\n`);
+            finalContent = finalContent.replace(paired, `\n${childInlined}\n`);
+        }
+
+        return finalContent;
+    } catch (e) {
+        console.warn(`copy_md_sources: Failed to inline components for ${sourceFilePath}:`, e.message);
+        return fileContent;
+    }
+}
+
+function resolveComponentPath(rootDir, relImport) {
+    // Allow explicit extensions or try .mdx, then .md
+    const explicit = path.join(rootDir, relImport);
+    if (fs.existsSync(explicit)) return explicit;
+    const withMdx = explicit.endsWith('.mdx') ? explicit : explicit + '.mdx';
+    if (fs.existsSync(withMdx)) return withMdx;
+    const withMd = explicit.endsWith('.md') ? explicit : explicit + '.md';
+    if (fs.existsSync(withMd)) return withMd;
+    return null;
+}
+
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds functionality to serve documentation pages as Markdown files by appending `.md` to URLs, updates the `CopyMarkdownButton` to use this feature, and introduces a script to copy Markdown sources for static serving.
> 
>   - **Behavior**:
>     - Serve documentation pages as Markdown by appending `.md` to URLs, handled in `next.config.mjs`.
>     - `CopyMarkdownButton` in `MainContentWrapper.tsx` now fetches Markdown directly from the new endpoints.
>     - New MCP tool `getLangfuseDocsPage` in `mcp.ts` to fetch Markdown for docs pages.
>   - **Scripts**:
>     - Adds `copy_md_sources.js` to copy Markdown sources from `pages` to `public/md-src`.
>     - Updates `prebuild` script in `package.json` to run `copy_md_sources.js`.
>   - **Configuration**:
>     - Adds rewrites in `next.config.mjs` to map `.md` paths to static files in `public/md-src`.
>     - Sets headers for Markdown endpoints to `noindex` and `text/markdown` content type.
>   - **Documentation**:
>     - Adds changelog entry `2025-08-07-markdown-endpoints-and-copy-button.mdx` to document the new feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a9cc024aa1bdf5519bed0bdd0082d3f4c3bc3a98. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->