### PR TITLE
chore: add trace upsert sharding settings

### DIFF
--- a/pages/self-hosting/infrastructure/cache.mdx
+++ b/pages/self-hosting/infrastructure/cache.mdx
@@ -183,7 +183,8 @@ When using Redis cluster mode:
 - Use the same authentication credentials across all cluster nodes
 - Monitor cluster health and handle node failures appropriately
 - Set `maxmemory-policy=noeviction` on all cluster nodes to prevent queue job eviction
-- Set `LANGFUSE_INGESTION_QUEUE_SHARD_COUNT` to a positive integer to enable sharding of the ingestion queue across cluster nodes. We recommend 2-3x of your Redis shard.
+- Set `LANGFUSE_INGESTION_QUEUE_SHARD_COUNT` to a positive integer to enable sharding of the ingestion queue across cluster nodes. We recommend 2-3x of your Redis shards.
+- Set `LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT` to a positive integer to enable sharding of the trace upsert queue across cluster nodes. We recommend 2-3x of your Redis shards.
 
 </Callout>
 

--- a/pages/self-hosting/scaling.mdx
+++ b/pages/self-hosting/scaling.mdx
@@ -125,7 +125,7 @@ If you observe high Redis Engine CPU utilization (above 90%), we recommend to ch
 - Ensure that you have [Redis Cluster mode](/self-hosting/infrastructure/cache#redis-cluster-mode) enabled.
 
 If the high CPU utilization persists, it is possible to shard the queues that Langfuse uses across multiple nodes.
-Set `LANGFUSE_INGESTION_QUEUE_SHARD_COUNT` to a value greater than 1 to enable sharding.
+Set `LANGFUSE_INGESTION_QUEUE_SHARD_COUNT` and `LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT` to a value greater than 1 to enable sharding.
 We recommend a value that is approximately 2-3 times the number of shards you have within your Redis cluster to ensure
 an equal distribution among the nodes, as each queue-shard will be allocated to a random slot in Redis
 (see [Redis Cluster](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/) docs for more details).
@@ -134,7 +134,7 @@ an equal distribution among the nodes, as each queue-shard will be allocated to 
 
 Sharding the queues is an advanced feature and should only be used if you have a high Redis CPU load and have followed the above recommendations.
 Once you have sharded your queue, do _not_ reduce the number of Shards.
-Make sure to scale `LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY` accordingly as it counts _per shard_.
+Make sure to scale `LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY` and `LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY` accordingly as it counts _per shard_.
 Per default, we target a concurrency of 20 per worker, i.e. set it to 2 if you have 10 queue-shards.
 
 </Callout>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT` for sharding trace upsert queue in Redis cluster, with updated concurrency settings in documentation.
> 
>   - **Documentation Updates**:
>     - Add `LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT` to `cache.mdx` and `scaling.mdx` for sharding trace upsert queue across Redis cluster nodes.
>     - Recommend setting `LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT` to 2-3x of Redis shards.
>     - Update concurrency settings: scale `LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY` per shard in `scaling.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for af4a4ec6b43e083fac5948937c3323647f4b16a4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->