### PR TITLE
docs: move llm connection page

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -502,6 +502,7 @@ const nonPermanentRedirects = [
   ["/docs/evaluation/features/evaluation-methods/user-feedback", "/faq/all/user-feedback"],
   ["/docs/evaluation/features/security-and-guardrails", "/docs/security-and-guardrails"],
   ["/docs/evaluation/get-started/online", "/docs/observability/overview"],
+  ["/faq/all/llm-connection", "/docs/administration/llm-connection"],
   // END OF MOVED MAIN DOCS INTO SUBMODULES
 
   // Redirect old webhooks path to new webhooks/slack integrations path

--- a/pages/docs/administration/llm-connection.mdx
+++ b/pages/docs/administration/llm-connection.mdx
@@ -1,10 +1,10 @@
 ---
-title: How to set up an LLM connection?
+title: LLM Connections
 description: How to set up an LLM connection in Langfuse to use in the Playground or for LLM-as-a-Judge evaluations.
-tags: ["LLM-as-a-Judge", "Playground"]
+sidebarTitle: LLM Connections
 ---
 
-# How to set up an LLM connection?
+# LLM Connections
 
 LLM connections are used to call models in the Langfuse Playground or for LLM-as-a-Judge evaluations.
 

--- a/pages/docs/evaluation/dataset-runs/native-run.mdx
+++ b/pages/docs/evaluation/dataset-runs/native-run.mdx
@@ -147,7 +147,7 @@ In this example:
 
 ### Configure LLM connection
 
-As your prompt will be executed for each dataset item, you need to configure an LLM connection in the project settings. [How to configure an LLM connection?](/faq/all/llm-connection)
+As your prompt will be executed for each dataset item, you need to configure an LLM connection in the project settings. [How to configure an LLM connection?](/docs/administration/llm-connection)
 
 ### Optional: Set up LLM-as-a-judge
 

--- a/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -34,7 +34,7 @@ Next, you'll define the default model used for conducting the evaluations. The d
   ![Evaluator default model](/images/docs/evaluator-default-model.png)
 </Frame>
 
-This step requires an LLM Connection to be set up. Please see [LLM Connections](/faq/all/llm-connection) for more information.
+This step requires an LLM Connection to be set up. Please see [LLM Connections](/docs/administration/llm-connection) for more information.
 
 - **Setup**: This default model needs to be set up once, though it can be changed at any point if needed.
 - **Change**: Existing evaluators keep evaluating with the new model—historic results stay preserved.

--- a/pages/docs/prompt-management/features/playground.mdx
+++ b/pages/docs/prompt-management/features/playground.mdx
@@ -81,7 +81,7 @@ You can add prompt variables in the playground to simulate different inputs to y
 
 ### Use your favorite model
 
-You can use your favorite model by adding the API key for the model you want to use in the Langfuse project settings. You can learn how to set up an LLM connection [here](/faq/all/llm-connection).
+You can use your favorite model by adding the API key for the model you want to use in the Langfuse project settings. You can learn how to set up an LLM connection [here](/docs/administration/llm-connection).
 
 <Frame border fullWidth>
   ![Select the model you want to

--- a/pages/faq/all/delete-account-langfuse.mdx
+++ b/pages/faq/all/delete-account-langfuse.mdx
@@ -3,7 +3,7 @@ title: I want to delete / cancel / close my Langfuse account
 tags: [platform, auth]
 ---
 
-# How to delete a Langfuse Account
+# How to delete a Langfuse Account?
 
 ## Langfuse Cloud
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move LLM connection documentation to administration section, update redirects and references, and fix title punctuation in account deletion FAQ.
> 
>   - **Documentation Relocation**:
>     - Move `llm-connection.mdx` from `faq/all` to `docs/administration`.
>     - Update title and sidebar title in `llm-connection.mdx` to "LLM Connections".
>   - **Redirects**:
>     - Add redirect in `next.config.mjs` from `/faq/all/llm-connection` to `/docs/administration/llm-connection`.
>   - **Reference Updates**:
>     - Update LLM connection links in `native-run.mdx`, `llm-as-a-judge.mdx`, and `playground.mdx` to new path `/docs/administration/llm-connection`.
>   - **Misc**:
>     - Fix title punctuation in `delete-account-langfuse.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ec295303b0c542236e2adbff9571af193da8a4ff. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->