### PR TITLE
Remove mcp-use integration prerequisite sentence

### DIFF
--- a/pages/integrations/other/mcp-use.mdx
+++ b/pages/integrations/other/mcp-use.mdx
@@ -20,7 +20,6 @@ category: Integrations
 
 ### Prerequisites
 
-- An mcp-use account and configured agents
 - A Langfuse project (sign up at [cloud.langfuse.com](https://cloud.langfuse.com) or self-host)
 
 ### Setup Langfuse Integration


### PR DESCRIPTION
Remove `mcp-use` account prerequisite from integration page as it is not required.

---
[Slack Thread](https://langfuse.slack.com/archives/C07NSMHKBH8/p1753474400230669?thread_ts=1753474400.230669&cid=C07NSMHKBH8)

<a href="https://cursor.com/background-agent?bcId=bc-e9c11e9b-9993-4f95-ba25-9e6e378413ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9c11e9b-9993-4f95-ba25-9e6e378413ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

