### PR TITLE
fix: ignore ts build errors for mcp server given zod v3/v4 incompatibility

### DIFF
--- a/pages/api/mcp.ts
+++ b/pages/api/mcp.ts
@@ -44,9 +44,9 @@ const trackMcpToolUsage = async (
 };
 
 // Create the MCP handler using Vercel's adapter
-// @ts-ignore
 const mcpHandler = createMcpHandler(
   (server) => {
+    // @ts-ignore
     server.tool(
       "searchLangfuseDocs",
       "Search Langfuse documentation for relevant information. Whenever there are questions about Langfuse, use this tool to get relevant documentation chunks.",
@@ -123,6 +123,7 @@ const mcpHandler = createMcpHandler(
     );
 
     // Define the getLangfuseDocsPage tool
+    // @ts-ignore
     server.tool(
       "getLangfuseDocsPage",
       "Fetch the Markdown for a single Langfuse docs page. Accepts either a path (e.g. /docs/observability/overview) or a full URL (https://langfuse.com/docs/observability/overview).",
@@ -197,6 +198,7 @@ const mcpHandler = createMcpHandler(
     );
 
     // Define the getLangfuseOverview tool
+    // @ts-ignore
     server.tool(
       "getLangfuseOverview",
       "Get an initial overview of Langfuse documentation and features by fetching the llms.txt file from langfuse.com",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Added `@ts-ignore` comments in `pages/api/mcp.ts` to suppress TypeScript build errors for `server.tool` definitions.
> 
>   - **TypeScript Fixes**:
>     - Added `@ts-ignore` comments to suppress TypeScript errors in `pages/api/mcp.ts` for `server.tool` definitions.
>     - Removed outdated TypeScript check comments at the end of `pages/api/mcp.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ce7102a019d11ea81fc825bc56df320941088447. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->