### PR TITLE
Prevent ios safari input zoom

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 sm:text-sm",
       className
     )}
     {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm",
         className
       )}
       ref={ref}

--- a/data/generated/contributors.json
+++ b/data/generated/contributors.json
@@ -75,6 +75,7 @@
     "felixkrrr"
   ],
   "/docs/evaluation/evaluation-methods/annotation": [
+    "felixkrrr",
     "marliessophie",
     "jannikmaierhoefer"
   ],

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 15234;
+export const GITHUB_STARS = 15283;

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -141,3 +141,10 @@ li:has(> .subseparator) {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+/* Prevent iOS Safari auto-zoom on focus by enforcing >=16px */
+@supports (-webkit-touch-callout: none) {
+  input, select, textarea {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
Prevent iOS Safari input zoom by enforcing `text-base` on inputs at mobile breakpoints.

iOS Safari automatically zooms inputs with a font-size below 16px. This PR ensures input font-size is `text-base` (16px) on mobile and `text-sm` (14px) from the `sm` breakpoint upwards, resolving the zoom issue without affecting desktop styles. A defensive global CSS rule is also added as a safeguard.

---
Linear Issue: [LFE-6307](https://linear.app/langfuse/issue/LFE-6307/prevent-ios-safari-input-zoom-by-enforcing-text-base-on-inputs-at)

<a href="https://cursor.com/background-agent?bcId=bc-b67d20ca-ea49-4d98-8f93-2992dbb6af39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b67d20ca-ea49-4d98-8f93-2992dbb6af39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

