### PR TITLE
feat: support static builds via pnpm run build:static

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,9 +2,7 @@ const cookbookRoutes = require("./cookbook/_routes.json");
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-    siteUrl: process.env.STATIC_EXPORT === 'true' ?
-        (process.env.STATIC_SITE_URL || 'https://langfuse.com') :
-        'https://langfuse.com',
+    siteUrl: process.env.CF_PAGES_URL ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ?? 'https://langfuse.com',
     generateRobotsTxt: true,
     changefreq: 'daily',
     additionalPaths: async (config) => [{

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,7 +2,9 @@ const cookbookRoutes = require("./cookbook/_routes.json");
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-    siteUrl: 'https://langfuse.com',
+    siteUrl: process.env.STATIC_EXPORT === 'true' ?
+        (process.env.STATIC_SITE_URL || 'https://langfuse.com') :
+        'https://langfuse.com',
     generateRobotsTxt: true,
     changefreq: 'daily',
     additionalPaths: async (config) => [{
@@ -18,7 +20,9 @@ module.exports = {
             .map(({ notebook }) => `/guides/cookbook/${notebook.replace(".ipynb", "")}`),
         // Exclude _meta files
         '*/_meta',
-        '/events/*'
+        '/events/*',
+        // Exclude API routes for static export
+        ...(process.env.STATIC_EXPORT === 'true' ? ['/api/*'] : [])
     ],
 
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -39,6 +39,13 @@ const withNextra = nextra({
 
 // next config
 const nextraConfig = withNextra({
+  // Enable static export when STATIC_EXPORT env var is set
+  ...(process.env.STATIC_EXPORT === 'true' && {
+    output: 'export',
+    trailingSlash: true,
+    // Disable server-side features for static export
+    distDir: 'out',
+  }),
   experimental: {
     scrollRestoration: true,
   },
@@ -49,6 +56,8 @@ const nextraConfig = withNextra({
   ],
 
   images: {
+    // Disable image optimization for static export
+    ...(process.env.STATIC_EXPORT === 'true' && { unoptimized: true }),
     remotePatterns: [
       {
         protocol: 'https',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prebuild": "node scripts/update-github-stars.js && node scripts/authors/generate-contributors.js && node scripts/copy_md_sources.js",
     "build": "next build",
     "postbuild": "pnpm run postbuild:sitemap && pnpm run postbuild:cleanup && pnpm run postbuild:llms-txt",
+    "build:static": "cross-env STATIC_EXPORT=true pnpm run prebuild && cross-env STATIC_EXPORT=true next build",
+    "postbuild:static": "pnpm run postbuild",
     "start": "next start -p 3333",
     "analyze": "cross-env ANALYZE=true next build",
     "postbuild:sitemap": "next-sitemap",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for static builds with new scripts and configuration changes to enable static export and exclude API routes.
> 
>   - **Build Scripts**:
>     - Adds `build:static` and `postbuild:static` scripts in `package.json` for static builds.
>   - **Configuration**:
>     - Updates `next.config.mjs` to enable static export when `STATIC_EXPORT` is `true`, setting `output: 'export'`, `trailingSlash: true`, and `distDir: 'out'`.
>     - Disables image optimization in `next.config.mjs` for static export.
>   - **Sitemap**:
>     - Modifies `next-sitemap.config.js` to exclude `/api/*` routes when `STATIC_EXPORT` is `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f80ad51e96b44fe7c08b959da33f248b784dd33b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->