### PR TITLE
docs: correct LLM-as-a-Judge page

### DIFF
--- a/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -141,7 +141,7 @@ You now need to teach Langfuse _which properties_ of your trace or dataset item 
 
 As our system evaluates your data it writes the results as [scores](/docs/evaluation/evaluation-methods/data-model). You can then:
 
-- **View Logs**: Check detailed logs for each evaluation, including status, any retry errors, and the full request/response bodies sent to the evaluation model.
+- **View Logs**: Check detailed logs for each evaluation, including status, any retry errors. (Tracing the request/response bodies sent to the evaluation model is on our roadmap: https://github.com/orgs/langfuse/discussions/7166).
 - **Use Dashboards**: Aggregate scores over time, filter by version or environment, and track the performance of your LLM application.
 - **Take Actions**: Pause, resume, or delete an evaluator.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies in `llm-as-a-judge.mdx` that tracing request/response bodies is a future feature.
> 
>   - **Documentation**:
>     - Updates `llm-as-a-judge.mdx` to clarify that tracing request/response bodies is on the roadmap, not currently available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f97c4c4a5aad7142abe2f5b1ddd3eef92a4a2151. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->