### PR TITLE
docs: change instrumentation of ADK

### DIFF
--- a/cookbook/integration_google_adk.ipynb
+++ b/cookbook/integration_google_adk.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install langfuse google-adk -q"
+    "%pip install langfuse google-adk openinference-instrumentation-google-adk -q"
    ]
   },
   {
@@ -44,34 +44,23 @@
    "source": [
     "## Step 2: Set up environment variables\n",
     "\n",
-    "Fill in the **Langfuse** and **OpenTelemetry** credentials for your project. Also set your **Gemini API key**."
+    "Fill in the **Langfuse** and your **Gemini API key**."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "59bda6ea",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import base64\n",
     "\n",
     "# Get keys for your project from the project settings page: https://cloud.langfuse.com\n",
     "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"pk-lf-...\" \n",
     "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\" \n",
     "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
     "# os.environ[\"LANGFUSE_HOST\"] = \"https://us.cloud.langfuse.com\" # 🇺🇸 US region\n",
-    "\n",
-    "# Build Basic Auth header.\n",
-    "LANGFUSE_AUTH = base64.b64encode(\n",
-    "    f\"{os.environ.get('LANGFUSE_PUBLIC_KEY')}:{os.environ.get('LANGFUSE_SECRET_KEY')}\".encode()\n",
-    ").decode()\n",
-    " \n",
-    "# Configure OpenTelemetry endpoint & headers\n",
-    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = os.environ.get(\"LANGFUSE_HOST\") + \"/api/public/otel\"\n",
-    "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {LANGFUSE_AUTH}\"\n",
-    "\n",
     "\n",
     "# Gemini API Key (Get from Google AI Studio: https://aistudio.google.com/app/apikey)\n",
     "os.environ[\"GOOGLE_API_KEY\"] = \"...\" "
@@ -113,6 +102,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1e83b860",
+   "metadata": {},
+   "source": [
+    "## Step 3: OpenTelemetry Instrumentation\n",
+    "\n",
+    "Use the [`GoogleADKInstrumentor`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-google-adk) library to wrap ADK calls and send OpenTelemetry spans to Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "395937fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openinference.instrumentation.google_adk import GoogleADKInstrumentor\n",
+    "\n",
+    "GoogleADKInstrumentor().instrument()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "96b60fd5",
    "metadata": {},
    "source": [
@@ -126,23 +137,7 @@
    "execution_count": null,
    "id": "f2631d97",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: there are non-text parts in the response: ['function_call'], returning concatenated text result from text parts. Check the full candidates.content.parts accessor to get the full model response.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Langfuse 👋!\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from google.adk.agents import Agent\n",
     "from google.adk.runners import Runner\n",
@@ -186,7 +181,7 @@
     "\n",
     "![Google ADK example trace in Langfuse](https://langfuse.com/images/cookbook/integration-google-adk/google-adk-trace.png)\n",
     "\n",
-    "[Link to trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/e59666703bedc7090229c4b7357e5ef3?timestamp=2025-08-19T08%3A59%3A53.529Z&display=details)\n",
+    "[Link to trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/b82a0bdc1994fc5d1c8576ca032543f7?timestamp=2025-08-28T07:32:30.303Z&display=details)\n",
     "\n",
     "<!-- STEPS_END -->"
    ]

--- a/pages/integrations/frameworks/google-adk.mdx
+++ b/pages/integrations/frameworks/google-adk.mdx
@@ -22,33 +22,22 @@ This notebook demonstrates how to capture detailed traces from a [Google Agent D
 
 
 ```python
-%pip install langfuse google-adk -q
+%pip install langfuse google-adk openinference-instrumentation-google-adk -q
 ```
 
 ## Step 2: Set up environment variables
 
-Fill in the **Langfuse** and **OpenTelemetry** credentials for your project. Also set your **Gemini API key**.
+Fill in the **Langfuse** and your **Gemini API key**.
 
 
 ```python
 import os
-import base64
 
 # Get keys for your project from the project settings page: https://cloud.langfuse.com
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..." 
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..." 
 os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" # 🇺🇸 US region
-
-# Build Basic Auth header.
-LANGFUSE_AUTH = base64.b64encode(
-    f"{os.environ.get('LANGFUSE_PUBLIC_KEY')}:{os.environ.get('LANGFUSE_SECRET_KEY')}".encode()
-).decode()
- 
-# Configure OpenTelemetry endpoint & headers
-os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_HOST") + "/api/public/otel"
-os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
-
 
 # Gemini API Key (Get from Google AI Studio: https://aistudio.google.com/app/apikey)
 os.environ["GOOGLE_API_KEY"] = "..." 
@@ -71,6 +60,17 @@ else:
 
     Langfuse client is authenticated and ready!
 
+
+## Step 3: OpenTelemetry Instrumentation
+
+Use the [`GoogleADKInstrumentor`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-google-adk) library to wrap ADK calls and send OpenTelemetry spans to Langfuse.
+
+
+```python
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+GoogleADKInstrumentor().instrument()
+```
 
 ## Step 3: Build a hello world agent
 
@@ -109,20 +109,13 @@ for event in runner.run(user_id=USER_ID, session_id=SESSION_ID, new_message=user
         print(event.content.parts[0].text)
 ```
 
-    Warning: there are non-text parts in the response: ['function_call'], returning concatenated text result from text parts. Check the full candidates.content.parts accessor to get the full model response.
-
-
-    Hello Langfuse 👋!
-    
-
-
 ## Step 4: View the trace in Langfuse
 
 Head over to your **Langfuse dashboard → Traces**. You should see traces including all tool calls and model inputs/outputs.
 
 ![Google ADK example trace in Langfuse](https://langfuse.com/images/cookbook/integration-google-adk/google-adk-trace.png)
 
-[Link to trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/e59666703bedc7090229c4b7357e5ef3?timestamp=2025-08-19T08%3A59%3A53.529Z&display=details)
+[Link to trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/b82a0bdc1994fc5d1c8576ca032543f7?timestamp=2025-08-28T07:32:30.303Z&display=details)
 </Steps>
 
 import LearnMore from "@/components-mdx/integration-learn-more.mdx";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Google ADK documentation to include OpenTelemetry instrumentation with `GoogleADKInstrumentor` and remove unnecessary environment variable configurations.
> 
>   - **Dependencies**:
>     - Add `openinference-instrumentation-google-adk` to the installation command in `google-adk.mdx`.
>   - **Environment Variables**:
>     - Remove OpenTelemetry credentials and Basic Auth header setup from `google-adk.mdx`.
>   - **Instrumentation**:
>     - Add `GoogleADKInstrumentor` usage for OpenTelemetry spans in `google-adk.mdx`.
>   - **Misc**:
>     - Update Langfuse trace link in `google-adk.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f9de92c2a784ac2c9c25bfb62d8f49baec998d6c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->