### PR TITLE
fix: add troubleshooting help for data retention timeouts

### DIFF
--- a/pages/faq/all/data-retention-timeouts-and-errors.mdx
+++ b/pages/faq/all/data-retention-timeouts-and-errors.mdx
@@ -1,0 +1,13 @@
+---
+title: Why is my data retention job running into timeouts?
+tags: [self-hosting]
+---
+
+# Why is my data retention job running into timeouts?
+
+The data retention job uses the `blob_storage_file_log` table to remove event data from S3/blob storage when the corresponding events expire.
+This is a potentially long-running query that may timeout.
+
+If you use a lifecycle policy on your blob storage buckets _and_ have a [TTL configured](https://clickhouse.com/docs/guides/developer/ttl)  on the
+`blob_storage_file_log` table, you can skip this processing step.
+You can set `LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=false` to disable this functionality.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds FAQ page for troubleshooting data retention job timeouts with configuration options.
> 
>   - **Documentation**:
>     - Adds `data-retention-timeouts-and-errors.mdx` to FAQ, explaining data retention job timeouts.
>     - Describes use of `blob_storage_file_log` table for event data removal from S3/blob storage.
>     - Suggests using lifecycle policies and TTL on `blob_storage_file_log` to skip processing.
>     - Advises setting `LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=false` to disable the functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d1ea8de01660fbac878117e43cdf37f4f8d97979. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->