### PR TITLE
docs: reorder guides video

### DIFF
--- a/pages/guides/index.mdx
+++ b/pages/guides/index.mdx
@@ -16,12 +16,6 @@ import { WatchDemoCards } from "@/components/WatchDemo";
 
 <WatchDemoCards />
 
-## Video Tutorials
-
-import { VideoIndex } from "@/components/VideoIndex";
-
-<VideoIndex />
-
 ## Cookbook
 
 You can find the `ipynb` files in the [`cookbook`](https://github.com/langfuse/langfuse-docs/tree/main/cookbook) directory of the repository.
@@ -29,3 +23,9 @@ You can find the `ipynb` files in the [`cookbook`](https://github.com/langfuse/l
 import { CookbookIndex } from "@/components/CookbookIndex";
 
 <CookbookIndex />
+
+## Video Tutorials
+
+import { VideoIndex } from "@/components/VideoIndex";
+
+<VideoIndex />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reordered 'Video Tutorials' section below 'Cookbook' section in `index.mdx`.
> 
>   - **Reordering**:
>     - Moved 'Video Tutorials' section below 'Cookbook' section in `index.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 6bf4f5553723e7ef628875832c8779f29cf2405c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->