### PR TITLE
Center user bubble text on small screens

### DIFF
--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -1724,7 +1724,7 @@ export default function Pricing({
                   {variant === "cloud" &&
                     (tier.name === "Core" || tier.name === "Pro") && (
                       <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
-                        <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium">
+                        <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium text-center">
                           Unlimited Users
                         </div>
                       </div>

--- a/components/home/Pricing.tsx
+++ b/components/home/Pricing.tsx
@@ -1724,7 +1724,7 @@ export default function Pricing({
                   {variant === "cloud" &&
                     (tier.name === "Core" || tier.name === "Pro") && (
                       <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
-                        <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium text-center">
+                        <div className="bg-primary text-primary-foreground text-xs px-3 py-1 rounded-full font-medium text-center whitespace-nowrap inline-block">
                           Unlimited Users
                         </div>
                       </div>


### PR DESCRIPTION
Center the 'Unlimited Users' text within its bubble to fix misalignment on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7a12c3e-1513-41dd-932b-1745ab44f618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7a12c3e-1513-41dd-932b-1745ab44f618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Center 'Unlimited Users' text within its bubble for better alignment on small screens in `Pricing.tsx`.
> 
>   - **UI Update**:
>     - Center 'Unlimited Users' text within its bubble for better alignment on small screens in `Pricing.tsx`.
>     - Applies to 'Core' and 'Pro' tiers when `variant` is 'cloud'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5023a075c40934fddae1b4dc5671ec2d3654fe62. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->