### PR TITLE
Fix github discussions widget top padding

### DIFF
--- a/components/gh-discussions/GhDiscussionsPreviewInternal.tsx
+++ b/components/gh-discussions/GhDiscussionsPreviewInternal.tsx
@@ -108,7 +108,7 @@ const GhDiscussionsPreviewInternal = ({
 
     return (
       <>
-        <ul className="space-y-3 pt-1">
+        <ul className="space-y-3">
           {displayedDiscussions.map((discussion) => (
             <li
               key={discussion.number}


### PR DESCRIPTION
Remove `pt-1` class from GitHub Discussions widget to fix incorrect top padding on the first row.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8d602b7-8005-43c7-a22f-c5c88b0d1ea2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8d602b7-8005-43c7-a22f-c5c88b0d1ea2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

