### PR TITLE
docs: re-order links in menu

### DIFF
--- a/pages/docs/evaluation/dataset-runs/_meta.tsx
+++ b/pages/docs/evaluation/dataset-runs/_meta.tsx
@@ -1,6 +1,6 @@
 export default {
-  "data-model": "Data Model",
   datasets: "Datasets",
   "native-run": "Native Run",
   "remote-run": "Remote Run",
+  "data-model": "Data Model",
 };

--- a/pages/docs/evaluation/evaluation-methods/_meta.tsx
+++ b/pages/docs/evaluation/evaluation-methods/_meta.tsx
@@ -1,6 +1,6 @@
 export default {
-  "data-model": "Data Model",
   "llm-as-a-judge": "LLM-as-a-Judge",
   annotation: "Human Annotations",
   "custom-scores": "Custom Scores",
+  "data-model": "Data Model",
 };


### PR DESCRIPTION
Data Model pages are more reference pages than docs, and are better at the bottom of the menu. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorder menu links to move 'Data Model' to the bottom in `_meta.tsx` files.
> 
>   - **Menu Reordering**:
>     - Move `"data-model": "Data Model"` to the bottom in `dataset-runs/_meta.tsx` and `evaluation-methods/_meta.tsx`.
>     - Reflects a change in categorization, treating 'Data Model' as a reference page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 410ebcf60dd4393cb3d98188f2ebadb1aebce4e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->