### PR TITLE
Fix caching docs link

### DIFF
--- a/pages/changelog/2024-02-05-sdk-level-prompt-caching.mdx
+++ b/pages/changelog/2024-02-05-sdk-level-prompt-caching.mdx
@@ -58,4 +58,4 @@ To benefit from prompt caching, upgrade to the latest version of the Python and 
 
 ### More details
 
-Check out the full [documentation](/docs/prompts#caching-in-client-sdks) for more details on how to use this feature.
+Check out the full [documentation](/docs/prompt-management/features/caching) for more details on how to use this feature.


### PR DESCRIPTION
Update link in changelog to point to the correct caching documentation feature page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b95edc51-97f3-487a-b13c-1012f99b8649">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b95edc51-97f3-487a-b13c-1012f99b8649">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

