### PR TITLE
Deduplicate faq entries

### DIFF
--- a/pages/docs/evaluation/troubleshooting-and-faq.mdx
+++ b/pages/docs/evaluation/troubleshooting-and-faq.mdx
@@ -29,6 +29,5 @@ If you don't find a solution to your issue here, try using [Ask AI](/docs/ask-ai
     "feat-prompt-experiments",
     "feat-scores",
     "feat-annotation",
-    "feat-datasets",
   ]}
 />


### PR DESCRIPTION
Remove duplicate "feat-datasets" label to deduplicate FAQ entries in the GitHub Discussions section.

---
<a href="https://cursor.com/background-agent?bcId=bc-e37b7f77-b286-42c9-9f71-24146751b4e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e37b7f77-b286-42c9-9f71-24146751b4e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

