### PR TITLE
Add faq for evaluating sessions

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -7,3 +7,4 @@ Please check the following:
 - Code blocks in core documentation include all imports to be self-contained (does not apply to notebooks/cookbooks)
 - If blocks of text or code are largely repeated on multiple documentation pages, suggest to consolidate them in `components-mdx` to improve maintainability and consistency.
 - When embedding videos from youtube, make sure to embed from `https://www.youtube-nocookie.com` instead of `https://www.youtube.com` to avoid cookies and tracking.
+- Use one H1 per markdown file, with subsections in order (`##`, `###`, etc.)—do not skip heading levels.

--- a/pages/faq/all/evaluating-sessions-conversations.mdx
+++ b/pages/faq/all/evaluating-sessions-conversations.mdx
@@ -1,0 +1,128 @@
+---
+title: How to evaluate sessions or conversations using LLM-as-a-Judge?
+tags: [evaluation, observability]
+---
+
+# How to evaluate sessions or conversations using LLM-as-a-Judge?
+
+This guide explains how to evaluate entire sessions or conversations in Langfuse using LLM-as-a-Judge, rather than just individual traces.
+
+## Understanding the Challenge
+
+Currently, Langfuse's LLM-as-a-Judge evaluators can only be applied to **single traces**, not to full sessions directly. This is because Langfuse cannot automatically determine when a session actually concludes - sessions are ongoing conversational threads that may span multiple interactions over time.
+
+## Recommended Approach: Evaluate the Final Trace
+
+The recommended approach is to **evaluate a single trace that contains the complete conversation history**. This can be implemented in two main ways:
+
+### Method 1: Manual Span with Full Conversation
+
+Create a manual span that captures the entire conversation history:
+
+```python
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+
+# Create a trace with the full conversation context
+trace = langfuse.trace(
+    name="conversation-evaluation",
+    session_id="your-session-id",
+    input={
+        "conversation_history": [
+            {"role": "user", "content": "Hello, I need help with..."},
+            {"role": "assistant", "content": "I'd be happy to help..."},
+            {"role": "user", "content": "Thanks, but I also need..."},
+            {"role": "assistant", "content": "Of course! Here's how..."}
+        ]
+    },
+    output={
+        "final_response": "The complete conversation concluded successfully",
+        "conversation_summary": "User received comprehensive help with their query"
+    }
+)
+```
+
+### Method 2: Include Message History in LLM Calls
+
+When making the final LLM call in your conversation, include the full message history as input:
+
+```python
+# Your final LLM call that includes the complete conversation
+completion = openai.chat.completions.create(
+    model="gpt-4",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, I need help with..."},
+        {"role": "assistant", "content": "I'd be happy to help..."},
+        {"role": "user", "content": "Thanks, but I also need..."},
+        {"role": "assistant", "content": "Of course! Here's how..."}
+    ],
+    # Langfuse will automatically capture this full message history
+    metadata={"langfuse_session_id": "your-session-id"}
+)
+```
+
+## Key Implementation Details
+
+### 1. Session Context is Preserved
+
+Since you're using `session_id` when creating traces, **the message history of the session is already captured within each trace**. The conversation context exists in:
+
+- The `input` and `output` fields of your traces
+- The message history passed to LLM calls
+- Manual spans that you create to log conversation state
+
+### 2. Evaluate the Final Trace
+
+Set up your LLM-as-a-Judge evaluator to run on traces that represent the end of a conversation:
+
+1. **Tag final traces**: Add a specific tag like `conversation_end` to the final trace of each session
+2. **Configure evaluator filters**: Set up your evaluator to only run on traces with this tag
+3. **Run evaluation once**: The evaluator will process the complete conversation context from that final trace
+
+### 3. Example Evaluator Setup
+
+When configuring your LLM-as-a-Judge evaluator in the Langfuse UI:
+
+- **Filter by tags**: Set the evaluator to only run on traces tagged with `conversation_end`
+- **Map variables**: Map the conversation history from the trace input to your evaluation prompt
+- **Evaluation prompt example**:
+  ```
+  Please evaluate this complete conversation between a user and an AI assistant.
+  
+  Conversation: {{input}}
+  
+  Rate the overall conversation quality on a scale of 1-5 considering:
+  - Helpfulness across all interactions
+  - Coherence and consistency
+  - Problem resolution effectiveness
+  - User satisfaction throughout the conversation
+  ```
+
+## Alternative: Session-Level Scores
+
+For evaluating sessions as a whole, you can also use [session-level scores](/docs/evaluation/evaluation-methods/custom-scores):
+
+```python
+# Create a score at the session level
+langfuse.score(
+    session_id="your-session-id",  # Score the entire session
+    name="conversation_quality",
+    value=4.5,
+    comment="Overall conversation was helpful and resolved user's issues"
+)
+```
+
+## Best Practices
+
+1. **Consistent tagging**: Always tag your final conversation traces consistently
+2. **Include full context**: Ensure your final trace contains or references the complete conversation
+3. **One evaluation per session**: Run the evaluator only once per session on the final trace
+4. **Clear evaluation criteria**: Design your evaluation prompt to assess conversation-level qualities
+
+## What About Session-Level Evaluation?
+
+While Langfuse supports session-level scores, LLM-as-a-Judge evaluators currently only work at the trace level. However, since the conversation history is captured within traces (especially the final trace), this approach effectively evaluates the entire session's content.
+
+The session serves as a grouping mechanism, but the actual evaluation happens on the trace that contains the full conversational context.

--- a/pages/faq/all/evaluating-sessions-conversations.mdx
+++ b/pages/faq/all/evaluating-sessions-conversations.mdx
@@ -5,124 +5,24 @@ tags: [evaluation, observability]
 
 # How to evaluate sessions or conversations using LLM-as-a-Judge?
 
-This guide explains how to evaluate entire sessions or conversations in Langfuse using LLM-as-a-Judge, rather than just individual traces.
+This guide explains how to evaluate entire [sessions](/docs/observability/features/sessions) (such as conversations, threads, etc.), rather than just individual traces.
+The information here applies to all [evaluation methods](/docs/evaluation/overview) supported by Langfuse.
 
-## Understanding the Challenge
+Scores in Langfuse can be assigned to traces, observations, or sessions (see the [data model](/docs/evaluation/evaluation-methods/data-model)).
 
-Currently, Langfuse's LLM-as-a-Judge evaluators can only be applied to **single traces**, not to full sessions directly. This is because Langfuse cannot automatically determine when a session actually concludes - sessions are ongoing conversational threads that may span multiple interactions over time.
+### Session-level scores
 
-## Recommended Approach: Evaluate the Final Trace
+1. You can add a [custom score](/docs/evaluation/evaluation-methods/custom-scores) that references the session ID.
+2. You can annotate the session using [annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues).
 
-The recommended approach is to **evaluate a single trace that contains the complete conversation history**. This can be implemented in two main ways:
+### Trace-level LLM-as-a-Judge evaluators
 
-### Method 1: Manual Span with Full Conversation
+[LLM-as-a-Judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) can be applied to traces.
+They cannot be applied directly to sessions, as Langfuse does not inherently know when a session has concluded.
 
-Create a manual span that captures the entire conversation history:
+It is recommended to evaluate the session using a trace-level LLM-as-a-Judge evaluator. Ensure that the trace contains the complete conversation history. This is typically the case if the conversation is used as input to an LLM call within a trace (i.e., conversation history or short-term memory).
 
-```python
-from langfuse import Langfuse
+You can either:
 
-langfuse = Langfuse()
-
-# Create a trace with the full conversation context
-trace = langfuse.trace(
-    name="conversation-evaluation",
-    session_id="your-session-id",
-    input={
-        "conversation_history": [
-            {"role": "user", "content": "Hello, I need help with..."},
-            {"role": "assistant", "content": "I'd be happy to help..."},
-            {"role": "user", "content": "Thanks, but I also need..."},
-            {"role": "assistant", "content": "Of course! Here's how..."}
-        ]
-    },
-    output={
-        "final_response": "The complete conversation concluded successfully",
-        "conversation_summary": "User received comprehensive help with their query"
-    }
-)
-```
-
-### Method 2: Include Message History in LLM Calls
-
-When making the final LLM call in your conversation, include the full message history as input:
-
-```python
-# Your final LLM call that includes the complete conversation
-completion = openai.chat.completions.create(
-    model="gpt-4",
-    messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Hello, I need help with..."},
-        {"role": "assistant", "content": "I'd be happy to help..."},
-        {"role": "user", "content": "Thanks, but I also need..."},
-        {"role": "assistant", "content": "Of course! Here's how..."}
-    ],
-    # Langfuse will automatically capture this full message history
-    metadata={"langfuse_session_id": "your-session-id"}
-)
-```
-
-## Key Implementation Details
-
-### 1. Session Context is Preserved
-
-Since you're using `session_id` when creating traces, **the message history of the session is already captured within each trace**. The conversation context exists in:
-
-- The `input` and `output` fields of your traces
-- The message history passed to LLM calls
-- Manual spans that you create to log conversation state
-
-### 2. Evaluate the Final Trace
-
-Set up your LLM-as-a-Judge evaluator to run on traces that represent the end of a conversation:
-
-1. **Tag final traces**: Add a specific tag like `conversation_end` to the final trace of each session
-2. **Configure evaluator filters**: Set up your evaluator to only run on traces with this tag
-3. **Run evaluation once**: The evaluator will process the complete conversation context from that final trace
-
-### 3. Example Evaluator Setup
-
-When configuring your LLM-as-a-Judge evaluator in the Langfuse UI:
-
-- **Filter by tags**: Set the evaluator to only run on traces tagged with `conversation_end`
-- **Map variables**: Map the conversation history from the trace input to your evaluation prompt
-- **Evaluation prompt example**:
-  ```
-  Please evaluate this complete conversation between a user and an AI assistant.
-  
-  Conversation: {{input}}
-  
-  Rate the overall conversation quality on a scale of 1-5 considering:
-  - Helpfulness across all interactions
-  - Coherence and consistency
-  - Problem resolution effectiveness
-  - User satisfaction throughout the conversation
-  ```
-
-## Alternative: Session-Level Scores
-
-For evaluating sessions as a whole, you can also use [session-level scores](/docs/evaluation/evaluation-methods/custom-scores):
-
-```python
-# Create a score at the session level
-langfuse.score(
-    session_id="your-session-id",  # Score the entire session
-    name="conversation_quality",
-    value=4.5,
-    comment="Overall conversation was helpful and resolved user's issues"
-)
-```
-
-## Best Practices
-
-1. **Consistent tagging**: Always tag your final conversation traces consistently
-2. **Include full context**: Ensure your final trace contains or references the complete conversation
-3. **One evaluation per session**: Run the evaluator only once per session on the final trace
-4. **Clear evaluation criteria**: Design your evaluation prompt to assess conversation-level qualities
-
-## What About Session-Level Evaluation?
-
-While Langfuse supports session-level scores, LLM-as-a-Judge evaluators currently only work at the trace level. However, since the conversation history is captured within traces (especially the final trace), this approach effectively evaluates the entire session's content.
-
-The session serves as a grouping mechanism, but the actual evaluation happens on the trace that contains the full conversational context.
+1. Evaluate the session on every trace.
+2. Apply a special [tag](/docs/observability/features/tags) to the final trace of the session (e.g., `conversation_end`) and configure the evaluator to only run on traces with this tag. This approach can help reduce evaluation costs and make metrics more stable.

--- a/pages/faq/all/evaluating-sessions-conversations.mdx
+++ b/pages/faq/all/evaluating-sessions-conversations.mdx
@@ -1,9 +1,9 @@
 ---
-title: How to evaluate sessions or conversations using LLM-as-a-Judge?
+title: How to evaluate sessions/conversations?
 tags: [evaluation, observability]
 ---
 
-# How to evaluate sessions or conversations using LLM-as-a-Judge?
+# How to evaluate sessions/conversations?
 
 This guide explains how to evaluate entire [sessions](/docs/observability/features/sessions) (such as conversations, threads, etc.), rather than just individual traces.
 The information here applies to all [evaluation methods](/docs/evaluation/overview) supported by Langfuse.
@@ -20,9 +20,11 @@ Scores in Langfuse can be assigned to traces, observations, or sessions (see the
 [LLM-as-a-Judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) can be applied to traces.
 They cannot be applied directly to sessions, as Langfuse does not inherently know when a session has concluded.
 
-It is recommended to evaluate the session using a trace-level LLM-as-a-Judge evaluator. Ensure that the trace contains the complete conversation history. This is typically the case if the conversation is used as input to an LLM call within a trace (i.e., conversation history or short-term memory).
+It is recommended to evaluate the session using a trace-level LLM-as-a-Judge evaluator. Ensure that the trace contains the complete conversation history. This is typically the case if the conversation is used as input to an LLM call within a trace (i.e., conversation history or short-term memory). You can select this specific information from the observation when setting up the evaluator.
 
 You can either:
 
 1. Evaluate the session on every trace.
-2. Apply a special [tag](/docs/observability/features/tags) to the final trace of the session (e.g., `conversation_end`) and configure the evaluator to only run on traces with this tag. This approach can help reduce evaluation costs and make metrics more stable.
+2. Or apply a special [tag](/docs/observability/features/tags) to the final trace of the session (e.g., `conversation_end`) and configure the evaluator to only run on traces with this tag. This approach can help reduce evaluation costs and make metrics more stable.
+
+In both cases, the score will be assigned to the trace.

--- a/pages/faq/all/evaluating-sessions-conversations.mdx
+++ b/pages/faq/all/evaluating-sessions-conversations.mdx
@@ -10,12 +10,12 @@ The information here applies to all [evaluation methods](/docs/evaluation/overvi
 
 Scores in Langfuse can be assigned to traces, observations, or sessions (see the [data model](/docs/evaluation/evaluation-methods/data-model)).
 
-### Session-level scores
+## Session-level scores
 
 1. You can add a [custom score](/docs/evaluation/evaluation-methods/custom-scores) that references the session ID.
 2. You can annotate the session using [annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues).
 
-### Trace-level LLM-as-a-Judge evaluators
+## Trace-level LLM-as-a-Judge evaluators
 
 [LLM-as-a-Judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) can be applied to traces.
 They cannot be applied directly to sessions, as Langfuse does not inherently know when a session has concluded.


### PR DESCRIPTION
Add a new FAQ page detailing how to evaluate full sessions or conversations in Langfuse by applying LLM-as-a-Judge to a single trace containing the complete history.

---
<a href="https://cursor.com/background-agent?bcId=bc-76209700-4c7e-43c2-a7f1-afb3604c65dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76209700-4c7e-43c2-a7f1-afb3604c65dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

