### PR TITLE
feat: add troubleshooting section to scim guide

### DIFF
--- a/pages/docs/administration/scim-and-org-api.mdx
+++ b/pages/docs/administration/scim-and-org-api.mdx
@@ -171,3 +171,7 @@ To setup user provisioning in Okta, follow these steps:
    - Select the users you want to assign to the Langfuse SCIM application. You can overwrite the role here.
    - Click **Done** and then **Save**.
    - Users should appear as Member within your Langfuse Organization.
+
+#### Troubleshooting
+
+- **Users are provisioned with NONE/VIEWER permissions instead of their intended `role`**: This usually happens if the `roles` attribute has an attribute type `Group` instead of `Personal`.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a troubleshooting section to the SCIM guide addressing user role provisioning issues in `scim-and-org-api.mdx`.
> 
>   - **Documentation**:
>     - Adds a "Troubleshooting" section to `scim-and-org-api.mdx`.
>     - Addresses issue where users are provisioned with `NONE/VIEWER` permissions instead of intended `role` due to `roles` attribute type being `Group` instead of `Personal`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e376bd220055066c7f483c7f5ae461a28d49c6fd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->