### PR TITLE
Add youtube embed to changelog page

### DIFF
--- a/pages/changelog/2025-08-28-typescript-sdk-v4-ga.mdx
+++ b/pages/changelog/2025-08-28-typescript-sdk-v4-ga.mdx
@@ -10,6 +10,16 @@ import { Plug, BookOpen } from "lucide-react";
 
 <ChangelogHeader />
 
+<iframe
+  width="100%"
+  src="https://www.youtube-nocookie.com/embed/BjEXs13KyV4?si=AR7e4r3vIlD2ydiO"
+  title="TypeScript SDK v4 (GA)"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  className="aspect-video rounded border mt-6"
+  allowFullScreen
+></iframe>
+
 Langfuse TypeScript SDK v4 is now GA. Rebuilt on OpenTelemetry JS v2, it brings modular packages, automatic tracing for OpenAI and LangChain, and a smoother developer experience across tracing, prompts, datasets, and scores.
 
 ## Highlights


### PR DESCRIPTION
Embed the TypeScript SDK v4 GA YouTube video on its changelog page using the no-cookie domain.

---
<a href="https://cursor.com/background-agent?bcId=bc-21bf287a-63f2-4774-ad96-5131ad717123">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21bf287a-63f2-4774-ad96-5131ad717123">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Embed YouTube video in `2025-08-28-typescript-sdk-v4-ga.mdx` using no-cookie domain.
> 
>   - **Embed Video**:
>     - Adds an `<iframe>` to `2025-08-28-typescript-sdk-v4-ga.mdx` to embed a YouTube video using the no-cookie domain.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 28ee157de76098836c369df59029aa3808daa81b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->