### PR TITLE
chore: remove license key trial

### DIFF
--- a/pages/faq/all/self-hosting-langfuse.mdx
+++ b/pages/faq/all/self-hosting-langfuse.mdx
@@ -9,7 +9,7 @@ tags: [product]
 
 Langfuse is an open source project. The core of Langfuse is MIT-licensed and can easily be [self-hosted](/self-hosting).
 
-The self-hosted version of Langfuse is also available as an Enterprise Edition (EE) which is paid and includes access to certain commercially-licensed features and services that require a [license key](/self-hosting/license-key) ([get trial key](/request-trial)).
+The self-hosted version of Langfuse is also available as an Enterprise Edition (EE) which is paid and includes access to certain commercially-licensed features and services that require a [license key](/self-hosting/license-key).
 
 | Langfuse | Cloud            | Self Hosted           |
 | -------- | ---------------- | --------------------- |

--- a/pages/self-hosting/administration/organization-creators.mdx
+++ b/pages/self-hosting/administration/organization-creators.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "Organization Creators (EE)"
 
 <Callout type="info">
 
-This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) to activate it.
 
 </Callout>
 

--- a/pages/self-hosting/administration/organization-management-api.mdx
+++ b/pages/self-hosting/administration/organization-management-api.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "Management API (EE)"
 
 <Callout type="info">
 
-This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) to activate it.
 
 </Callout>
 

--- a/pages/self-hosting/administration/ui-customization.mdx
+++ b/pages/self-hosting/administration/ui-customization.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "UI Customization (EE)"
 
 <Callout type="info">
 
-This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) ([get trial key](/request-trial)) to activate it.
+This is only available in the Enterprise Edition. Please add your [license key](/self-hosting/license-key) to activate it.
 
 </Callout>
 

--- a/pages/self-hosting/index.mdx
+++ b/pages/self-hosting/index.mdx
@@ -15,7 +15,7 @@ import { Callout } from "nextra/components";
 
 Langfuse is open source and can be self-hosted using Docker.
 This section contains guides for different deployment scenarios.
-Some add-on features require a [license key](/self-hosting/license-key) ([get trial key](/request-trial)).
+Some add-on features require a [license key](/self-hosting/license-key).
 
 When self-hosting Langfuse, you run the same infrastructure that powers Langfuse Cloud. Read ["Why Langfuse?"](/why) to learn more about why this is important to us.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove references to trial license key from Langfuse self-hosting documentation.
> 
>   - **Documentation**:
>     - Remove references to "get trial key" from `self-hosting-langfuse.mdx`, `organization-creators.mdx`, `organization-management-api.mdx`, `ui-customization.mdx`, and `index.mdx`.
>     - Simplifies the documentation by removing the option to request a trial license key for the Enterprise Edition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8de0c0656f5cdbcbb0e85bd39acd2a2bba816fe4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->