### PR TITLE
fix: add retries for gtihub api calls in prebuild step

### DIFF
--- a/scripts/update-github-stars.js
+++ b/scripts/update-github-stars.js
@@ -6,10 +6,52 @@ const path = require('path');
 const GITHUB_REPO_API_URL = "https://api.github.com/repos/langfuse/langfuse";
 const STARS_FILE_PATH = path.join(__dirname, '..', 'src', 'github-stars.ts');
 
+// Retry configuration
+const RETRY_CONFIG = {
+  maxRetries: 3,
+  baseDelay: 1000, // 1 second base delay
+  maxDelay: 30000, // 30 seconds max delay
+  backoffMultiplier: 2
+};
+
+// Sleep utility function
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+// Retry wrapper with exponential backoff
+async function withRetry(fn, description) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= RETRY_CONFIG.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === RETRY_CONFIG.maxRetries) {
+        console.error(`❌ ${description} failed after ${RETRY_CONFIG.maxRetries} attempts`);
+        throw error;
+      }
+
+      // Calculate delay with exponential backoff
+      const delay = Math.min(
+        RETRY_CONFIG.baseDelay * Math.pow(RETRY_CONFIG.backoffMultiplier, attempt - 1),
+        RETRY_CONFIG.maxDelay
+      );
+
+      console.warn(`⚠️  ${description} failed (attempt ${attempt}/${RETRY_CONFIG.maxRetries}): ${error.message}`);
+      console.warn(`🔄 Retrying in ${delay}ms...`);
+
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}
+
 async function updateGitHubStars() {
   try {
     console.log('Fetching GitHub stars...');
-    
+
     // Prepare headers for the GitHub API request
     const headers = {
       Accept: "application/vnd.github.v3+json",
@@ -23,25 +65,29 @@ async function updateGitHubStars() {
       console.warn('Warning: GITHUB_ACCESS_TOKEN not set. API requests may be rate limited.');
     }
 
-    // Fetch repository information from GitHub API
-    const response = await fetch(GITHUB_REPO_API_URL, { headers });
-    
-    if (!response.ok) {
-      throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`);
-    }
+    const { starCount } = await withRetry(async () => {
+      // Fetch repository information from GitHub API
+      const response = await fetch(GITHUB_REPO_API_URL, { headers });
 
-    const repoData = await response.json();
-    const starCount = repoData.stargazers_count;
+      if (!response.ok) {
+        throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`);
+      }
 
-    if (typeof starCount !== 'number') {
-      throw new Error('Invalid star count received from GitHub API');
-    }
+      const repoData = await response.json();
+      const starCount = repoData.stargazers_count;
+
+      if (typeof starCount !== 'number') {
+        throw new Error('Invalid star count received from GitHub API');
+      }
+
+      return { starCount };
+    }, 'GitHub API fetch');
 
     console.log(`✅ Fetched ${starCount} GitHub stars`);
 
     // Update the TypeScript file
     const newContent = `export const GITHUB_STARS = ${starCount};`;
-    
+
     fs.writeFileSync(STARS_FILE_PATH, newContent, 'utf8');
     console.log(`✅ Updated ${STARS_FILE_PATH} with ${starCount} stars`);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry logic with exponential backoff for GitHub API calls in `generate-contributors.js`, `load_github_discussions.py`, and `update-github-stars.js`.
> 
>   - **Retry Logic**:
>     - Adds `withRetry` function with exponential backoff to `generate-contributors.js`, `load_github_discussions.py`, and `update-github-stars.js`.
>     - Configures retries with `maxRetries`, `baseDelay`, `maxDelay`, and `backoffMultiplier`.
>   - **Behavior Changes**:
>     - `fetchFromGitHub` in `generate-contributors.js` now uses `withRetry` for API calls.
>     - `run_query` in `load_github_discussions.py` uses `withRetry` for GraphQL queries.
>     - `updateGitHubStars` in `update-github-stars.js` uses `withRetry` for fetching star count.
>   - **Error Handling**:
>     - Logs detailed error messages and retry attempts in all scripts.
>     - Exits with error code on final failure after retries in `load_github_discussions.py` and `update-github-stars.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for aae7d1f5204ab07e2df651acfc53b4391a06db56. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->