### PR TITLE
docs: add pipecat video example

### DIFF
--- a/pages/integrations/frameworks/pipecat.mdx
+++ b/pages/integrations/frameworks/pipecat.mdx
@@ -48,18 +48,23 @@ This organization helps you track conversation-to-conversation and turn-to-turn.
 
 Learn more about Pipecat span attributes in the [Pipecat documentation](https://docs.pipecat.ai/server/utilities/opentelemetry).
 
-## End-to-end example
+## End-to-end Examples
 
-We've created an end-to-end example of how to trace a Pipecat agent with Langfuse. You can find the code in the [Pipecat Examples repository](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse).
+import { FileCode } from "lucide-react";
 
-```bash filename="pipecat/examples/open-telemetry-tracing-langfuse"
-.
-├── README.md
-├── bot.py
-├── env.example
-├── requirements.txt
-└── run.py
-```
+<Cards num={2}>
+  <Card
+    title="Video guide"
+    href="https://github.com/langfuse/langfuse-examples/tree/main/applications/langchat"
+    icon={<FileCode />}
+  />
+  <Card
+    title="End-to-end example"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse"
+    icon={<FileCode />}
+  />
+</Cards>
+
 
 ## Get Started
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a video guide example to the Pipecat documentation in `pipecat.mdx`.
> 
>   - **Documentation**:
>     - Adds a video guide example to `pipecat.mdx` under the "End-to-end Examples" section.
>     - Replaces the previous single example with a card layout featuring two examples: a video guide and an end-to-end example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5dd10ed58e1201e76a69d968ff1ff8d9e3579bc7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->