### PR TITLE
Switch quarkus langchain4j to http transport

### DIFF
--- a/pages/integrations/frameworks/quarkus-langchain4j.mdx
+++ b/pages/integrations/frameworks/quarkus-langchain4j.mdx
@@ -34,7 +34,7 @@ For Maven, add the following to your `pom.xml` (Gradle users can include equival
 **Configure OpenTelemetry exporter** (`application.properties`):
 
 ```properties
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+quarkus.otel.exporter.otlp.traces.protocol=http/json
 ```
 
 With these configurations and dependencies in place, your Quarkus application is ready to produce OpenTelemetry traces. Quarkus LangChain4j internal calls (e.g. when you invoke a chat model) will be recorded as spans.
@@ -78,7 +78,7 @@ Making the following configuration in `application.properties`:
 ```bash
 quarkus.otel.exporter.otlp.headers=Authorization=Basic <base64 of public:key>
 quarkus.otel.exporter.otlp.endpoint=https://cloud.langfuse.com/api/public/otel
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+quarkus.otel.exporter.otlp.traces.protocol=http/json
 ```
 
 </Tab>


### PR DESCRIPTION
Switch Quarkus LangChain4j OpenTelemetry exporter protocol from `http/protobuf` to `http/json` to use HTTP transport.

---
<a href="https://cursor.com/background-agent?bcId=bc-261e3162-d817-4a65-97b5-ddbd0fbe7d32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-261e3162-d817-4a65-97b5-ddbd0fbe7d32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

