### PR TITLE
docs: update example to use Langfuse instead of CallbackHandler

### DIFF
--- a/pages/docs/observability/features/environments.mdx
+++ b/pages/docs/observability/features/environments.mdx
@@ -157,6 +157,7 @@ See the Python SDK tab for more details.
 </Callout>
 
 ```python
+import os
 from langfuse import Langfuse
 
 # Either set the environment variable or the constructor parameter. The latter takes precedence.

--- a/pages/docs/observability/features/environments.mdx
+++ b/pages/docs/observability/features/environments.mdx
@@ -157,11 +157,11 @@ See the Python SDK tab for more details.
 </Callout>
 
 ```python
-from langfuse.callback import CallbackHandler
+from langfuse import Langfuse
 
 # Either set the environment variable or the constructor parameter. The latter takes precedence.
 os.environ["LANGFUSE_TRACING_ENVIRONMENT"] = "production"
-handler = CallbackHandler(
+Langfuse(
   environment="production"
 )
 ```


### PR DESCRIPTION
This PR updates the documentation example for environment configuration.

- Replace deprecated `CallbackHandler` with `Langfuse`
- Add missing `import os` for environment variable usage
- Keep environment variable example unchanged

These changes ensure the docs are aligned with the latest Langfuse API and runnable as-is.
