### PR TITLE
docs: Update missing-traces.mdx

### DIFF
--- a/pages/faq/all/missing-traces.mdx
+++ b/pages/faq/all/missing-traces.mdx
@@ -8,7 +8,7 @@ tags: [evaluation, datasets, observability]
 Langfuse runs all tracing integrations asynchronously ([learn more](/docs/tracing#queuing-batching)). Here are a few steps to resolve this issue:
 
 1. **Verify Integration**: Ensure that your application is correctly integrated with Langfuse. Follow the [quickstart guide](/docs/get-started) to verify your setup.
-2. **Check API Credentials**: Make sure that the API credentials used in your application match those created in your Langfuse project settings. They need to be set before importing/instantiating the Langfuse SDKs. If you use Jupyter Notebook, try restarting the session. 
+2. **Check API Credentials**: Ensure that the API credentials used in your application match those configured in your Langfuse project settings. Set them before importing or instantiating the Langfuse SDKs. If you’re using Jupyter Notebook, try restarting the kernel or session.
 3. **Inspect Tracing Configuration**: Ensure that your tracing configuration is correctly set up. For example, verify that the `LANGFUSE_HOST` (Python) or `LANGFUSE_BASEURL` (JS/TS) is set to the correct endpoint.
 4. **Review Logs**: Check the logs of your application to see if there are any errors related to Langfuse. This can help identify issues with the integration or network connectivity. Optionally, you can enable debug logging to get more detailed information.
 5. **Manual Flushing**: If you are using short-lived applications like serverless functions, local batch scripts or Jupyter Notebooks, ensure that you are manually flushing the events before the application exits. This is important to avoid losing events. Read more on this [here](/docs/tracing).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies API credential setup timing in `missing-traces.mdx`, especially for Jupyter Notebook users.
> 
>   - **Documentation Update**:
>     - In `missing-traces.mdx`, clarifies that API credentials must be set before importing/instantiating Langfuse SDKs.
>     - Adds a note for Jupyter Notebook users to restart the session if needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 42a8790dca0e542d9d1c48438635ebf2dd8e45c8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->