### PR TITLE
fix(agent-graphs): add docs to show graph via observation types

### DIFF
--- a/pages/docs/observability/features/agent-graphs.mdx
+++ b/pages/docs/observability/features/agent-graphs.mdx
@@ -22,10 +22,15 @@ _Example trace with agent graph view ([public link](https://cloud.langfuse.com/p
 
 <Callout type="info">
 
-The graph view is currently in beta and supports LangGraph. We are working on a more generalized implementation and expanding support for other frameworks in the future.
+The graph view is currently in beta, please feel free to share feedback.
 
 </Callout>
 
+There are currently two ways to display the graph.
+First, have an observation with any observation type except for `span`, `event` or `generation` in your trace. Then, Langfuse interprets the trace as agentic and will show a graph. The graph is automatically inferred from the observation timings as well as their nesting.
+Second, when you use the LangGraph integration the graph automatically shows in Langfuse.
+
+**Observation Types**: See all available [Observation Types](/docs/observability/features/observation-types) and how to set them.
 **LangGraph**: See the [LangGraph integration guide](/guides/cookbook/integration_langgraph) for an end-to-end example on how to natively integrate LangGraph with Langfuse for LLM Agent tracing.
 
 ## GitHub Discussions


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `agent-graphs.mdx` to document graph display via observation types and clarify beta note.
> 
>   - **Documentation Update**:
>     - In `agent-graphs.mdx`, added instructions for displaying graphs using observation types, excluding `span`, `event`, or `generation`.
>     - Clarified that graphs are inferred from observation timings and nesting.
>     - Updated beta note to remove specific mention of LangGraph support.
>   - **Links**:
>     - Added link to [Observation Types](/docs/observability/features/observation-types).
>     - Retained link to [LangGraph integration guide](/guides/cookbook/integration_langgraph).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 66c08be108acfa5c7ecec68d282f13f94a6d823b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->