### PR TITLE
fix/Attempt to avoid 3rd level of "overview" page

### DIFF
--- a/pages/docs/evaluation/experiments/_meta.tsx
+++ b/pages/docs/evaluation/experiments/_meta.tsx
@@ -1,5 +1,5 @@
 export default {
-  overview: "Overview",
+  configurations: "Configurations",
   datasets: "Datasets",
   "experiments-via-sdk": "Experiments via SDK",
   "experiments-via-ui": "Experiments via UI",

--- a/pages/docs/evaluation/experiments/configurations.mdx
+++ b/pages/docs/evaluation/experiments/configurations.mdx
@@ -1,19 +1,13 @@
 ---
-title: Experiments Overview
-description: Experiments Overview
+title: Experiment Configurations
+description: Experiment Configurations
 ---
 
-# Experiments Overview
+# Experiment Configurations
 
-Experiments allow you to systematically test your LLM application using a dataset, enabling you to evaluate and compare its performance. 
+Experiments can be setup in different ways using Langfuse. The different experiment configurations are based on [1] where your [Datasets](/docs/evaluation/experiments/datasets) are hosted and [2] where the experiment execution takes place (either locally or on the Langfuse platform).
 
-Each experiment is based on a [Dataset](/docs/evaluation/experiments/datasets) containing inputs and, optionally, expected outputs. This Dataset can be either local or hosted on Langfuse. For each input, the experiment runs a task function—this could be your LLM application when using [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk), or a prompt sent to a model when using [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui). 
-
-The results can be assessed and scored using various [Evaluation Methods](/docs/evaluation/evaluation-methods/llm-as-a-judge).
-
-## Running experiments
-
-The matrix below shows the different experiment configurations based on where your data is hosted and where the experiment execution takes place:
+The matrix below shows the different experiment configurations that are available and how they can be run (UI vs SDK).
 
 <div className="my-6">
   <div className="grid grid-cols-3 gap-2">


### PR DESCRIPTION
I would try to avoid creating a third level of "overview" just for experiments. I suggest using the evals overview to explain people how all concepts are linked together and use the pages below "experiments" folder as technical explanations how it works in detail.

I think Experiments are explained really well on [Evals Overview](https://langfuse-docs-git-add-experiment-docs-langfuse.vercel.app/docs/evaluation/overview#experiments) - I think having a page to help users navigate how to best run experiments is fair enough as it is a very detailed / technical topic

<img width="3526" height="1998" alt="CleanShot 2025-09-18 at 20 39 31@2x" src="https://github.com/user-attachments/assets/a94ff588-e6fa-4de6-881b-842a37676ac4" />
