### PR TITLE
docs: add note on tool call type obs

### DIFF
--- a/pages/docs/prompt-management/features/playground.mdx
+++ b/pages/docs/prompt-management/features/playground.mdx
@@ -57,6 +57,10 @@ You can open a generation from [Langfuse Observability](/docs/observability) in 
 
 The Langfuse Playground supports tool calling and structured output schemas, enabling you to define, test, and validate LLM executions that rely on tool calls and enforce specific response formats.
 
+<Callout type="info">
+  Currently, Langfuse supports opening tool-type observations in the playground only when they are in the OpenAI ChatML format. If you’d like to see support for additional formats, feel free to add your request to our [public roadmap](https://langfuse.com/ideas).
+</Callout>
+
 <iframe
   width="100%"
   className="aspect-[16/9] rounded mt-10"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `playground.mdx` about Langfuse Playground's support for tool-type observations only in OpenAI ChatML format, with a link for requesting additional format support.
> 
>   - **Documentation Update**:
>     - Adds a note in `playground.mdx` about Langfuse Playground's support for tool-type observations only in OpenAI ChatML format.
>     - Encourages users to request support for additional formats via the public roadmap link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8301633be67899739900474bbc525b6c7a705036. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->