### PR TITLE
docs(self-hosting/auth): update optional variables for keycloak config

### DIFF
--- a/pages/self-hosting/security/authentication-and-sso.mdx
+++ b/pages/self-hosting/security/authentication-and-sso.mdx
@@ -146,7 +146,7 @@ Provider: `GOOGLE`
 | Configuration      | Value                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------- |
 | Required Variables | `AUTH_KEYCLOAK_CLIENT_ID`<br/>`AUTH_KEYCLOAK_CLIENT_SECRET`<br/>`AUTH_KEYCLOAK_ISSUER` |
-| Optional Variables | See [additional configuration](#additional-configuration) section below.               |
+| Optional Variables | `AUTH_KEYCLOAK_SCOPE` (defaults to `"openid email profile"`)<br/>`AUTH_KEYCLOAK_ID_TOKEN` (Defaults to `true`, set to `false` if you want to make a request to the `userinfo` endpoint instead of extracting user information from the `id_token` claims)<br/><br/>See [additional configuration](#additional-configuration) section below for more options.               |
 | OAuth Redirect URL | `/api/auth/callback/keycloak`                                                          |
 
 Provider: `KEYCLOAK`


### PR DESCRIPTION
Documentation update for PR https://github.com/langfuse/langfuse/pull/9359
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Keycloak configuration documentation to include optional variables `AUTH_KEYCLOAK_SCOPE` and `AUTH_KEYCLOAK_ID_TOKEN`.
> 
>   - **Documentation**:
>     - Updates `pages/self-hosting/security/authentication-and-sso.mdx` to include `AUTH_KEYCLOAK_SCOPE` and `AUTH_KEYCLOAK_ID_TOKEN` as optional variables for Keycloak configuration.
>     - Specifies default values and behavior for `AUTH_KEYCLOAK_SCOPE` and `AUTH_KEYCLOAK_ID_TOKEN`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 6ce682f0c6e45cd91db5adf382fe81aae247566b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->