### PR TITLE
Add about page link to titlebar

### DIFF
--- a/components/LogoContextMenu.tsx
+++ b/components/LogoContextMenu.tsx
@@ -6,7 +6,8 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "./ui/dropdown-menu";
-import { Download, ExternalLink } from "lucide-react";
+import { Download, ExternalLink, Info } from "lucide-react";
+import Link from "next/link";
 
 const LogoContextMenu: React.FC<{
   open: boolean;
@@ -39,6 +40,12 @@ const LogoContextMenu: React.FC<{
           <DropdownMenuItem onClick={(e) => handleAction(e, "/", false)}>
             <ExternalLink size={14} className="mr-2" />
             Open in new tab
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/about" onClick={() => setOpen(false)}>
+              <Info size={14} className="mr-2" />
+              About
+            </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem


### PR DESCRIPTION
Add an "About" option to the Langfuse logo context menu to allow users to navigate to the About page.

---
<a href="https://cursor.com/background-agent?bcId=bc-8310135a-facb-403d-8125-9b55fac615b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8310135a-facb-403d-8125-9b55fac615b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add "About" option to `LogoContextMenu` linking to `/about` page in `LogoContextMenu.tsx`.
> 
>   - **Behavior**:
>     - Adds "About" option to `LogoContextMenu` in `LogoContextMenu.tsx`.
>     - "About" option links to `/about` page and closes menu on click.
>   - **Imports**:
>     - Adds `Info` icon from `lucide-react` and `Link` from `next/link`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 328067183bea85209460fb42602dc8bceab55f44. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->