### PR TITLE
Fix handbook team resource links

### DIFF
--- a/components/handbook/TeamsIndex.tsx
+++ b/components/handbook/TeamsIndex.tsx
@@ -1,6 +1,6 @@
 import { Cards } from "nextra/components";
 import { Users } from "lucide-react";
-import { TEAMS_PATHS } from "@/pages/handbook/_meta";
+import { TEAMS_PATHS, TEAMS_FIRST_PAGES } from "@/pages/handbook/_meta";
 
 export const TeamsIndex = () => {
   return (
@@ -8,7 +8,7 @@ export const TeamsIndex = () => {
       <Cards num={3}>
         {Object.entries(TEAMS_PATHS).map(([path, title]) => (
           <Cards.Card
-            href={`/handbook/${path}`}
+            href={`/handbook/${path}/${TEAMS_FIRST_PAGES[path]}`}
             key={path}
             title={title}
             icon={<Users size={20} />}

--- a/pages/handbook/_meta.tsx
+++ b/pages/handbook/_meta.tsx
@@ -6,6 +6,12 @@ export const TEAMS_PATHS = {
   operations: "Operations",
 };
 
+export const TEAMS_FIRST_PAGES = {
+  "product-engineering": "documentation",
+  gtm: "overview",
+  operations: "entity-structure",
+};
+
 export default {
   "-- Main Handbook": {
     type: "separator",


### PR DESCRIPTION
Update handbook team resource links to point to the first page within each folder to resolve 404 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-20a859ae-e433-4928-aac1-283e3b102d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20a859ae-e433-4928-aac1-283e3b102d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update handbook team links in `TeamsIndex.tsx` to use `TEAMS_FIRST_PAGES` for correct first page redirection, preventing 404 errors.
> 
>   - **Behavior**:
>     - Update team resource links in `TeamsIndex.tsx` to use `TEAMS_FIRST_PAGES` for first page redirection.
>     - Prevents 404 errors by ensuring links point to the first page within each team folder.
>   - **Data**:
>     - Add `TEAMS_FIRST_PAGES` in `_meta.tsx` to map each team to its first page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for fbad397428acf37fb439c44b6584f15861448a72. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->