### PR TITLE
Deduplicate handbook meta paths and pages

### DIFF
--- a/components/handbook/TeamsIndex.tsx
+++ b/components/handbook/TeamsIndex.tsx
@@ -1,16 +1,16 @@
 import { Cards } from "nextra/components";
 import { Users } from "lucide-react";
-import { TEAMS_PATHS, TEAMS_FIRST_PAGES } from "@/pages/handbook/_meta";
+import { TEAMS } from "@/pages/handbook/_meta";
 
 export const TeamsIndex = () => {
   return (
     <div className="my-6">
       <Cards num={3}>
-        {Object.entries(TEAMS_PATHS).map(([path, title]) => (
+        {Object.entries(TEAMS).map(([path, team]) => (
           <Cards.Card
-            href={`/handbook/${path}/${TEAMS_FIRST_PAGES[path]}`}
+            href={`/handbook/${path}/${team.firstPage}`}
             key={path}
-            title={title}
+            title={team.name}
             icon={<Users size={20} />}
             arrow
           />

--- a/pages/handbook/_meta.tsx
+++ b/pages/handbook/_meta.tsx
@@ -1,15 +1,18 @@
 import { MenuSubSeparator } from "@/components/MenuSubSeparator";
 
-export const TEAMS_PATHS = {
-  "product-engineering": "Product Engineering",
-  gtm: "GTM",
-  operations: "Operations",
-};
-
-export const TEAMS_FIRST_PAGES = {
-  "product-engineering": "documentation",
-  gtm: "overview",
-  operations: "entity-structure",
+export const TEAMS = {
+  "product-engineering": {
+    name: "Product Engineering",
+    firstPage: "documentation",
+  },
+  gtm: {
+    name: "GTM",
+    firstPage: "overview",
+  },
+  operations: {
+    name: "Operations",
+    firstPage: "entity-structure",
+  },
 };
 
 export default {
@@ -24,5 +27,7 @@ export default {
     type: "separator",
     title: <MenuSubSeparator>Teams</MenuSubSeparator>,
   },
-  ...TEAMS_PATHS,
+  ...Object.fromEntries(
+    Object.entries(TEAMS).map(([key, value]) => [key, value.name])
+  ),
 };


### PR DESCRIPTION
Refactor handbook meta file to consolidate team paths and first pages into a single object, eliminating duplication and improving maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1b496cf-f600-4dc7-839e-8ec03ce8de8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1b496cf-f600-4dc7-839e-8ec03ce8de8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor handbook meta to consolidate team paths and pages into a single `TEAMS` object, improving maintainability.
> 
>   - **Refactor**:
>     - Consolidate `TEAMS_PATHS` and `TEAMS_FIRST_PAGES` into a single `TEAMS` object in `_meta.tsx`.
>     - Update `TeamsIndex` in `TeamsIndex.tsx` to use the new `TEAMS` object for rendering team cards.
>   - **Behavior**:
>     - `TeamsIndex` now maps over `TEAMS` to generate team cards with `team.name` and `team.firstPage`.
>     - `_meta.tsx` exports `TEAMS` and uses it to dynamically generate team entries in the default export.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c7156bda23d9a25abcecfb21f4415825aa15eb29. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->