### PR TITLE
fix: remove image placeholder

### DIFF
--- a/pages/docs/evaluation/evaluation-methods/custom-scores.mdx
+++ b/pages/docs/evaluation/evaluation-methods/custom-scores.mdx
@@ -285,9 +285,7 @@ In some cases, you want to prevent this behavior or update an existing score. Th
 
 ### Enforcing a Score Config
 
-Score configs are helpful when you want to standardize your scores for future analysis.
-
-_[Image placeholder: Score config creation in Langfuse UI]_
+Score configs are helpful when you want to standardize your scores for future analysis. 
 
 To enforce a score config, you can provide a `configId` when creating a score to reference a `ScoreConfig` that was previously created. `Score Configs` can be defined in the Langfuse UI or via our API. [See our guide on how to create and manage score configs](/faq/all/manage-score-configs).
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed image placeholder text from `custom-scores.mdx` documentation.
> 
>   - **Content Update**:
>     - Removed image placeholder text from `custom-scores.mdx` under the section "Enforcing a Score Config".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 75b409bf0f641f62a7378881f10e2406b319b599. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->