### PR TITLE
feat:split-out-quickstarts-in-docs-nav

### DIFF
--- a/pages/docs/_meta.tsx
+++ b/pages/docs/_meta.tsx
@@ -14,20 +14,16 @@ export default {
     title: "Get Started",
   },
   "observability-quickstart": {
-    title: "Trace an Application",
+    title: "Start Tracing",
     href: "/docs/observability/get-started",
   },
   "prompt-management-quickstart": {
-    title: "Fetch a Prompt",
+    title: "Fetch Prompts",
     href: "/docs/prompt-management/get-started",
   },
   "evals-quickstart": {
-    title: "Start Evaluating Traces",
-    href: "/docs/evaluation/evaluation-methods/llm-as-a-judge",
-  },
-  "experiments-quickstart": {
-    title: "Run an Experiment",
-    href: "/docs/evaluation/experiments/experiments-via-ui",
+    title: "Start Evaluating",
+    href: "/docs/evaluation/overview",
   },
 
   "-- Products": {

--- a/pages/docs/_meta.tsx
+++ b/pages/docs/_meta.tsx
@@ -9,6 +9,27 @@ export default {
   demo: "Interactive Demo",
   "ask-ai": "Ask AI",
 
+  "-- Get Started": {
+    type: "separator",
+    title: "Get Started",
+  },
+  "observability-quickstart": {
+    title: "Trace an Application",
+    href: "/docs/observability/get-started",
+  },
+  "prompt-management-quickstart": {
+    title: "Fetch a Prompt",
+    href: "/docs/prompt-management/get-started",
+  },
+  "evals-quickstart": {
+    title: "Start Evaluating Traces",
+    href: "/docs/evaluation/evaluation-methods/llm-as-a-judge",
+  },
+  "experiments-quickstart": {
+    title: "Run an Experiment",
+    href: "/docs/evaluation/experiments/experiments-via-ui",
+  },
+
   "-- Products": {
     type: "separator",
     title: "Products",

--- a/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -124,7 +124,7 @@ You now need to teach Langfuse _which properties_ of your trace or dataset item 
 </Tabs>
 
 ### Trigger the evaluation
-To see you evaluator in action, you need to either [send traces](/docs/observability/get-started) (fastest) or trigger an experiment run (takes longer to setup) via the [UI](/docs/evaluation/experiments/experiments-via-ui) or [SDK](/docs/evaluation/experiments/experiments-via-sdk). Make sure to set the correct target data in the evaluator settings according to how you want to trigger the evaluation.
+To see your evaluator in action, you need to either [send traces](/docs/observability/get-started) (fastest) or trigger an experiment run (takes longer to setup) via the [UI](/docs/evaluation/experiments/experiments-via-ui) or [SDK](/docs/evaluation/experiments/experiments-via-sdk). Make sure to set the correct target data in the evaluator settings according to how you want to trigger the evaluation.
 
 </Steps>
 

--- a/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -123,6 +123,9 @@ You now need to teach Langfuse _which properties_ of your trace or dataset item 
 </Tab>
 </Tabs>
 
+### Trigger the evaluation
+To see you evaluator in action, you need to either [send traces](/docs/observability/get-started) (fastest) or trigger an experiment run (takes longer to setup) via the [UI](/docs/evaluation/experiments/experiments-via-ui) or [SDK](/docs/evaluation/experiments/experiments-via-sdk). Make sure to set the correct target data in the evaluator settings according to how you want to trigger the evaluation.
+
 </Steps>
 
 ✨ Done! You have successfully set up an evaluator which will run on your data.

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -8,6 +8,7 @@ description: Langfuse is an open source LLM engineering platform. It includes ob
 Langfuse is an **open-source LLM engineering platform** ([GitHub](https://github.com/langfuse/langfuse)) that helps teams collaboratively debug, analyze, and iterate on their LLM applications. All platform features are natively integrated to accelerate the development workflow. Langfuse is open, self-hostable, and extensible ([_why langfuse?_](/why)).
 
 import { FeatureOverview } from "@/components/FeatureOverview";
+import { TextQuote, GitPullRequestArrow, ThumbsUp, FlaskConical } from "lucide-react";
 
 <FeatureOverview />
 
@@ -95,6 +96,37 @@ _Simplified lifecycle from PoC to production:_
   ![Langfuse Features along the development
   lifecycle](/images/docs/features-dark.png)
 </Frame>
+
+## Quickstarts
+
+Get up and running with Langfuse in minutes. Choose the path that best fits your current needs:
+
+<Cards num={1}>
+  <Card
+    icon={<TextQuote size="24" />}
+    title="Trace an Application"
+    href="/docs/observability/get-started"
+    arrow
+  />
+  <Card
+    icon={<GitPullRequestArrow size="24" />}
+    title="Fetch a Prompt"
+    href="/docs/prompt-management/get-started"
+    arrow
+  />
+  <Card
+    icon={<ThumbsUp size="24" />}
+    title="Start Evaluating Traces"
+    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
+    arrow
+  />
+  <Card
+    icon={<FlaskConical size="24" />}
+    title="Run an Experiment"
+    href="/docs/evaluation/experiments/experiments-via-ui"
+    arrow
+  />
+</Cards>
 
 ## Why Langfuse?
 

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -116,14 +116,8 @@ Get up and running with Langfuse in minutes. Choose the path that best fits your
   />
   <Card
     icon={<ThumbsUp size="24" />}
-    title="Start Evaluating Traces"
-    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
-    arrow
-  />
-  <Card
-    icon={<FlaskConical size="24" />}
-    title="Run an Experiment"
-    href="/docs/evaluation/experiments/experiments-via-ui"
+    title="Start Evaluating an Application"
+    href="/docs/evaluation/overview"
     arrow
   />
 </Cards>


### PR DESCRIPTION

<img width="2964" height="1736" alt="CleanShot 2025-09-30 at 11 40 32@2x" src="https://github.com/user-attachments/assets/dc445e0d-c6c0-4f15-b7e6-bdf4bdfac027" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances documentation navigation by adding quickstart guides and updating the index page with new sections for tracing, prompt management, and evaluation.
> 
>   - **Navigation Enhancements**:
>     - Added "Get Started" section in `pages/docs/_meta.tsx` with quickstart links for "Start Tracing", "Fetch Prompts", and "Start Evaluating".
>   - **Documentation Index**:
>     - Added "Quickstarts" section in `pages/docs/index.mdx` with cards linking to quickstart guides for tracing, prompt management, and evaluation.
>   - **Content Update**:
>     - Added a new section "Trigger the evaluation" in `llm-as-a-judge.mdx` to guide users on how to activate evaluators.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d9c2d6ffdce8a9bfb601b8acd75d4d934c404ce1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->