### PR TITLE
Implement hover effect for website navigation

### DIFF
--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -18,6 +18,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Dialog, DialogContent } from "./ui/dialog";
 import { CustomerStoryCTA } from "./customers/CustomerStoryCTA";
+import { NavHoverEnhancer } from "./NavHoverEnhancer";
 
 const pathsWithoutFooterWidgets = [
   "/imprint",
@@ -162,6 +163,7 @@ export const MainContentWrapper = (props) => {
 
   return (
     <>
+      <NavHoverEnhancer />
       {(versionLabel || shouldShowCopyButton) && (
         <div className="flex items-center gap-2 flex-wrap mt-5">
           {versionLabel && (

--- a/components/NavHoverEnhancer.tsx
+++ b/components/NavHoverEnhancer.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function NavHoverEnhancer() {
+  useEffect(() => {
+    // Function to add hover behavior to menu items
+    const addHoverBehavior = () => {
+      // Find all menu buttons (Product and Resources)
+      const menuButtons = document.querySelectorAll(
+        '.nextra-nav-container button[aria-haspopup="menu"]'
+      );
+
+      menuButtons.forEach((button) => {
+        const htmlButton = button as HTMLButtonElement;
+        let hoverTimeout: NodeJS.Timeout | null = null;
+        let isMenuOpen = false;
+
+        // Function to open menu
+        const openMenu = () => {
+          if (htmlButton.getAttribute("aria-expanded") === "false") {
+            htmlButton.click();
+            isMenuOpen = true;
+          }
+        };
+
+        // Function to close menu
+        const closeMenu = () => {
+          if (htmlButton.getAttribute("aria-expanded") === "true") {
+            htmlButton.click();
+            isMenuOpen = false;
+          }
+        };
+
+        // Add hover listener to button
+        button.addEventListener("mouseenter", () => {
+          if (hoverTimeout) clearTimeout(hoverTimeout);
+          openMenu();
+        });
+
+        // Add mouseleave listener to button
+        button.addEventListener("mouseleave", (e) => {
+          const relatedTarget = e.relatedTarget as HTMLElement;
+          
+          // Check if mouse is moving to the dropdown content
+          const isMovingToDropdown = relatedTarget?.closest('[role="menu"]');
+          
+          if (!isMovingToDropdown) {
+            // Add a small delay before closing
+            hoverTimeout = setTimeout(() => {
+              closeMenu();
+            }, 100);
+          }
+        });
+
+        // Find the associated dropdown menu
+        const findDropdown = () => {
+          // Headless UI renders the dropdown in a portal, so we need to find it
+          const buttonId = htmlButton.getAttribute("id");
+          if (buttonId) {
+            return document.querySelector(`[aria-labelledby="${buttonId}"]`);
+          }
+          return null;
+        };
+
+        // Add listeners to the dropdown content
+        const addDropdownListeners = () => {
+          setTimeout(() => {
+            const dropdown = findDropdown();
+            if (dropdown) {
+              dropdown.addEventListener("mouseenter", () => {
+                if (hoverTimeout) clearTimeout(hoverTimeout);
+              });
+
+              dropdown.addEventListener("mouseleave", (e) => {
+                const relatedTarget = e.relatedTarget as HTMLElement;
+                
+                // Check if mouse is moving back to the button
+                const isMovingToButton = relatedTarget === htmlButton || htmlButton.contains(relatedTarget);
+                
+                if (!isMovingToButton) {
+                  hoverTimeout = setTimeout(() => {
+                    closeMenu();
+                  }, 100);
+                }
+              });
+            }
+          }, 50); // Small delay to ensure dropdown is rendered
+        };
+
+        // Watch for dropdown opening to add listeners
+        const observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            if (
+              mutation.type === "attributes" &&
+              mutation.attributeName === "aria-expanded" &&
+              htmlButton.getAttribute("aria-expanded") === "true"
+            ) {
+              addDropdownListeners();
+            }
+          });
+        });
+
+        observer.observe(htmlButton, { attributes: true });
+      });
+    };
+
+    // Wait for the navigation to be fully rendered
+    const timeoutId = setTimeout(addHoverBehavior, 500);
+
+    // Also try to add behavior when navigation updates
+    const observer = new MutationObserver(() => {
+      addHoverBehavior();
+    });
+
+    const navContainer = document.querySelector(".nextra-nav-container");
+    if (navContainer) {
+      observer.observe(navContainer, { childList: true, subtree: true });
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+      observer.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -145,3 +145,34 @@ li:has(> .subseparator) {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+/* Enable hover for navigation menu dropdowns */
+.nextra-nav-container nav > div > button[aria-expanded="false"]:hover + div[data-radix-popper-content-wrapper],
+.nextra-nav-container nav > div > button[aria-expanded="true"] + div[data-radix-popper-content-wrapper],
+.nextra-nav-container nav > div > div[data-radix-popper-content-wrapper]:hover {
+  display: block !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+/* Show dropdown on button hover */
+.nextra-nav-container nav > div:has(> button[aria-expanded]):hover > div[data-radix-popper-content-wrapper] {
+  display: block !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+/* Keep button highlighted when dropdown is visible */
+.nextra-nav-container nav > div:hover > button[aria-expanded] {
+  background-color: var(--tw-gray-100);
+}
+
+/* Dark mode button highlight */
+.dark .nextra-nav-container nav > div:hover > button[aria-expanded] {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Ensure smooth transitions */
+.nextra-nav-container nav > div > div[data-radix-popper-content-wrapper] {
+  transition: opacity 150ms ease, visibility 150ms ease;
+}

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -145,34 +145,3 @@ li:has(> .subseparator) {
   margin: 0 !important;
   padding: 0 !important;
 }
-
-/* Enable hover for navigation menu dropdowns */
-.nextra-nav-container nav > div > button[aria-expanded="false"]:hover + div[data-radix-popper-content-wrapper],
-.nextra-nav-container nav > div > button[aria-expanded="true"] + div[data-radix-popper-content-wrapper],
-.nextra-nav-container nav > div > div[data-radix-popper-content-wrapper]:hover {
-  display: block !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-}
-
-/* Show dropdown on button hover */
-.nextra-nav-container nav > div:has(> button[aria-expanded]):hover > div[data-radix-popper-content-wrapper] {
-  display: block !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-}
-
-/* Keep button highlighted when dropdown is visible */
-.nextra-nav-container nav > div:hover > button[aria-expanded] {
-  background-color: var(--tw-gray-100);
-}
-
-/* Dark mode button highlight */
-.dark .nextra-nav-container nav > div:hover > button[aria-expanded] {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-/* Ensure smooth transitions */
-.nextra-nav-container nav > div > div[data-radix-popper-content-wrapper] {
-  transition: opacity 150ms ease, visibility 150ms ease;
-}


### PR DESCRIPTION
Enable navigation menu dropdowns to open on hover instead of click, addressing LFE-6970.

---
Linear Issue: [LFE-6970](https://linear.app/langfuse/issue/LFE-6970/make-website-nav-react-on-hover)

<a href="https://cursor.com/background-agent?bcId=bc-e52350a2-382a-448a-9f53-470a0e2c4b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e52350a2-382a-448a-9f53-470a0e2c4b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

