### PR TITLE
Apply text balance to team sentence

### DIFF
--- a/components/home/Usage.tsx
+++ b/components/home/Usage.tsx
@@ -13,7 +13,7 @@ export const Usage = ({ noPadding = false }: { noPadding?: boolean }) => {
 
   return (
     <div className={cn(!noPadding && "py-14")}>
-      <h2 className="text-center text-lg font-semibold leading-8 mb-8">
+      <h2 className="text-center text-lg font-semibold leading-8 mb-8 text-balance">
         Teams building complex LLM apps rely on Langfuse
       </h2>
       <div className="flex flex-col gap-8">

--- a/components/home/UsersMarquee.tsx
+++ b/components/home/UsersMarquee.tsx
@@ -114,7 +114,7 @@ const UserLogo = ({ user }: { user: User }) => {
 export const UsersMarquee = () => {
   return (
     <HomeSection className="pt-2 sm:pt-2 lg:pt-2 xl:pt-2">
-      <h2 className="text-center text-lg font-semibold leading-8 mb-6">
+      <h2 className="text-center text-lg font-semibold leading-8 mb-6 text-balance">
         Teams building complex LLM apps rely on Langfuse
       </h2>
       <div className="relative flex h-full w-full flex-col items-center justify-center gap-4 overflow-hidden">


### PR DESCRIPTION
Add `text-balance` to the heading "Teams building complex LLM apps rely on Langfuse" to improve typography.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fc1a49d-21be-4490-9141-6ea84dd06506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fc1a49d-21be-4490-9141-6ea84dd06506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

