### PR TITLE
Update trace properties in OpenAI integration docs

### DIFF
--- a/pages/integrations/model-providers/openai-js.mdx
+++ b/pages/integrations/model-providers/openai-js.mdx
@@ -128,14 +128,14 @@ Tracing of the assistants api is not supported by this integration as OpenAI Ass
 
 You can add the following properties to the `langfuseConfig` of the `observeOpenAI` function to use additional Langfuse features:
 
-| Property             | Description                                                                  |
-| -------------------- | ---------------------------------------------------------------------------- |
-| `generationName`     | Set `generationName` to identify a specific type of generation.              |
-| `langfusePrompt`     | Pass a created or fetched Langfuse prompt to link it with the generations    |
-| `generationMetadata` | Set `metadata` with additional information that you want to see in Langfuse. |
-| `sessionId`          | The current [session](/docs/tracing-features/sessions).                      |
-| `userId`             | The current [user_id](/docs/tracing-features/users).                         |
-| `tags`               | Set [tags](/docs/tracing-features/tags) to categorize and filter traces.     |
+| Property             | Description                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `generationName`     | Set `generationName` to identify a specific type of generation.                        |
+| `langfusePrompt`     | Pass a created or fetched Langfuse prompt to link it with the generations              |
+| `generationMetadata` | Set `generationMetadata` with additional information that you want to see in Langfuse. |
+| `sessionId`          | The current [session](/docs/tracing-features/sessions).                                |
+| `userId`             | The current [user_id](/docs/tracing-features/users).                                   |
+| `tags`               | Set [tags](/docs/tracing-features/tags) to categorize and filter traces.               |
 
 Example:
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `metadata` to `generationMetadata` in OpenAI integration docs for clarity.
> 
>   - **Documentation**:
>     - Rename `metadata` to `generationMetadata` in `openai-js.mdx` to clarify its purpose in the `langfuseConfig` of the `observeOpenAI` function.
>     - Update example code to reflect the property rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 71b09190f1c71e843357b4ef3f5f31b123c9604d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->