### PR TITLE
Set caching headers for latest releases API

### DIFF
--- a/pages/api/latest-releases.ts
+++ b/pages/api/latest-releases.ts
@@ -71,11 +71,11 @@ export default async function handler(
       res
         .status(200)
         .setHeader("Content-Type", "application/json")
-        // cache for 5 minutes in the CDN
+        // cache for 1 hour in the browser and CDN
         // cache for 1 day if there is an error with the API response
         .setHeader(
           "Cache-Control",
-          "public, s-maxage=300, max-age=0, stale-if-error=86400"
+          "public, s-maxage=3600, max-age=3600, stale-if-error=86400"
         )
         .json(langfuseReleases)
     );


### PR DESCRIPTION
Update caching headers for `/api/latest-releases` to enable 1-hour browser and CDN caching.

---
<a href="https://cursor.com/background-agent?bcId=bc-8344e14c-f365-402c-a446-797d0e87e5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8344e14c-f365-402c-a446-797d0e87e5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

