### PR TITLE
Don't preload footer menu links

### DIFF
--- a/components/FooterMenu.tsx
+++ b/components/FooterMenu.tsx
@@ -243,6 +243,7 @@ const FooterMenu = () => {
                     <Link
                       href={item.href}
                       className="text-sm hover:text-primary/80"
+                      prefetch={false}
                     >
                       {item.name}
                     </Link>


### PR DESCRIPTION
Disable Next.js preloading for footer menu links.

This change reduces unnecessary network requests and improves initial page load performance by preventing Next.js from preloading routes for footer links, which are typically not primary navigation paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-f260731e-5ff2-4121-9681-c38e16b36b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f260731e-5ff2-4121-9681-c38e16b36b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

