### PR TITLE
fix(costs): add reference to observation types

### DIFF
--- a/pages/docs/observability/features/token-and-cost-tracking.mdx
+++ b/pages/docs/observability/features/token-and-cost-tracking.mdx
@@ -11,7 +11,7 @@ sidebarTitle: Token & Cost Tracking
   UI](https://static.langfuse.com/250108_model_cost_breakdown.gif)
 </Frame>
 
-Langfuse tracks the usage and costs of your LLM generations and provides breakdowns by usage types.
+Langfuse tracks the usage and costs of your LLM generations and provides breakdowns by usage types. Use and cost can be tracked on observations of type `generation` and `embedding`, see [here](docs/observability/features/observation-types).
 
 - **Usage details**: number of units consumed per usage type
 - **Cost details**: USD cost per usage type
@@ -441,6 +441,7 @@ For more details, see [the OpenAI guide](https://platform.openai.com/docs/guides
 ## Troubleshooting
 
 - If you change the model definition, the updated costs will only be applied to new generations logged to Langfuse.
+- Only observations of type `generation` and `embedding` can track costs and usage.
 
 ## GitHub Discussions
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarified in documentation that usage and cost tracking applies to `generation` and `embedding` observation types.
> 
>   - **Documentation**:
>     - In `token-and-cost-tracking.mdx`, added clarification that usage and cost tracking is applicable to observations of type `generation` and `embedding`.
>     - Added a troubleshooting note that only these observation types can track costs and usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for eb5c0250555047b633df5a47bc2cae47f5bc6196. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->