### PR TITLE
Add note about metrics api

### DIFF
--- a/pages/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/pages/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -26,6 +26,12 @@ New data is typically available for querying within 15-30 seconds of ingestion, 
 
 Via the [SDKs](/docs/sdk/overview) for Python and JS/TS you can easily query the API without having to write the HTTP requests yourself.
 
+<Callout type="info">
+
+If you need aggregated metrics (e.g., counts, costs, usage) rather than individual entities, consider the [Metrics API](/docs/metrics/features/metrics-api). It is optimized for aggregate queries and higher rate limits.
+
+</Callout>
+
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>
 <Tab title="Python SDK">
 


### PR DESCRIPTION
Add a callout to the "Query via SDK" page to direct users to the more performant Metrics API for aggregate queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd0ee82d-eeb9-4e98-8366-690c2875b559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd0ee82d-eeb9-4e98-8366-690c2875b559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add callout in `query-via-sdk.mdx` to recommend Metrics API for aggregate queries.
> 
>   - **Documentation Update**:
>     - Added a callout in `query-via-sdk.mdx` to recommend the Metrics API for aggregate queries (e.g., counts, costs, usage) due to its optimization for such queries and higher rate limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 6402f0f7c21646cf2f6cda1a4ae128f7957ae7d4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->