### PR TITLE
fix: change broken LLM-Guard URL

### DIFF
--- a/pages/docs/security-and-guardrails.mdx
+++ b/pages/docs/security-and-guardrails.mdx
@@ -72,7 +72,7 @@ To read more about other security risks, including prompt injection, banned topi
 
 ### Install packages
 
-In this example we use the open source library [LLM Guard](https://llm-guard.com/) for run-time security checks. All examples easily translate to other libraries such as [Prompt Armor](https://promptarmor.com), [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails), [Microsoft Azure AI Content Safety](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety), and [Lakera](https://www.lakera.ai).
+In this example we use the open source library [LLM Guard](https://protectai.github.io/llm-guard/) for run-time security checks. All examples easily translate to other libraries such as [Prompt Armor](https://promptarmor.com), [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails), [Microsoft Azure AI Content Safety](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety), and [Lakera](https://www.lakera.ai).
 
 First, import the security packages and Langfuse tools.
 


### PR DESCRIPTION
- Fix broken LLM Guard URL
  - https://llm-guard.com/ -> https://protectai.github.io/llm-guard/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken `LLM Guard` URL in `security-and-guardrails.mdx`.
> 
>   - **Documentation**:
>     - Update broken URL for `LLM Guard` in `security-and-guardrails.mdx` from `https://llm-guard.com/` to `https://protectai.github.io/llm-guard/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7d0b8f6fc55669c2f6499067d813a0d78b240d04. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->