### PR TITLE
chore: remove troubleshooting/faq from self-hosting index

### DIFF
--- a/components-mdx/self-host-help-footer.mdx
+++ b/components-mdx/self-host-help-footer.mdx
@@ -1,5 +1,6 @@
 If you experience any issues when self-hosting Langfuse, please:
 
-1. Use [Ask AI](/ask-ai) to get instant answers to your questions.
-2. Ask the maintainers on [GitHub Discussions](/gh-support).
-3. Create a bug report or feature request on [GitHub](/issues).
+1. Check out [Troubleshooting & FAQ](/self-hosting/troubleshooting-and-faq) page.
+2. Use [Ask AI](/ask-ai) to get instant answers to your questions.
+3. Ask the maintainers on [GitHub Discussions](/gh-support).
+4. Create a bug report or feature request on [GitHub](/issues).

--- a/pages/self-hosting/index.mdx
+++ b/pages/self-hosting/index.mdx
@@ -99,15 +99,3 @@ You can also watch the GitHub releases to get notified about new releases:
 import SelfHostHelpFooter from "@/components-mdx/self-host-help-footer.mdx";
 
 <SelfHostHelpFooter />
-
-## FAQ
-
-import { FaqPreview } from "@/components/faq/FaqPreview";
-
-<FaqPreview tags={["self-hosting"]} />
-
-## GitHub Discussions
-
-import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
-
-<GhDiscussionsPreview labels={["self-hosting"]} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates self-hosting support section by adding a Troubleshooting & FAQ link and removing FAQ and GitHub Discussions previews.
> 
>   - **Support Section Update**:
>     - Adds a link to the `Troubleshooting & FAQ` page in `self-host-help-footer.mdx`.
>     - Removes `FAQ` and `GitHub Discussions` previews from `index.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8a0ba93e971c80c3072c7324480a380cbddba94f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->