### PR TITLE
fix: use correct env flag for custom CH cluster name

### DIFF
--- a/pages/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/pages/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -37,7 +37,7 @@ They need to be provided for the Langfuse Web and Langfuse Worker containers.
 Langfuse uses `default` as the cluster name if CLICKHOUSE_CLUSTER_ENABLED is set to `true`.
 You can overwrite this by setting `CLICKHOUSE_CLUSTER_NAME` to a different value.
 In that case, the database migrations will not apply correctly as they cannot run dynamically for different clusters.
-You must set `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED = false` and run ClickHouse migrations manually.
+You must set `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED = true` and run ClickHouse migrations manually.
 Clone the Langfuse repository, adjust the cluster name in `./packages/shared/clickhouse/migrations/clustered/*.sql` and run `cd ./packages/shared && sh ./clickhouse/scripts/up.sh`
 to manually apply the migrations.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED` value to `true` in documentation for manual ClickHouse migrations.
> 
>   - **Documentation**:
>     - Corrects the value of `LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED` from `false` to `true` in `clickhouse.mdx` for manual ClickHouse migrations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 28360d8f862ec6dc402d4edf49775707ac659751. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->