### PR TITLE
docs(js-sdk): add interop with Sentry

### DIFF
--- a/pages/docs/observability/sdk/typescript/advanced-usage.mdx
+++ b/pages/docs/observability/sdk/typescript/advanced-usage.mdx
@@ -165,7 +165,7 @@ Available log levels are `DEBUG`, `INFO`, `WARN`, and `ERROR`.
 
 **Via environment variable:**
 
-You can also set the log level using the `LANGFUSE_LOG_LEVEL` environment variable to enable the debug mode. 
+You can also set the log level using the `LANGFUSE_LOG_LEVEL` environment variable to enable the debug mode.
 
 ```bash
 export LANGFUSE_LOG_LEVEL="DEBUG"
@@ -451,3 +451,51 @@ await langfuseWeb.score({
 ```
 
 Learn more about [custom scores here](/docs/evaluation/evaluation-methods/custom-scores).
+
+## Setup with Sentry
+
+If you're using both Sentry and Langfuse in your application, you'll need to configure a custom OpenTelemetry setup since both tools use OpenTelemetry for tracing. This guide shows how to send error monitoring data to Sentry while simultaneously capturing LLM observability traces in Langfuse.
+
+To use Langfuse alongside Sentry, configure `skipOpenTelemetrySetup: true` in your Sentry initialization and manually set up the OpenTelemetry components:
+
+<Callout type="info">
+
+**Important:** If you're using Sentry's tracing feature, be aware that Sentry's `tracesSampleRate` will also apply to your Langfuse traces, since both services share the same underlying OpenTelemetry setup.
+
+If you only want to use Sentry for error monitoring (without tracing), omit the `tracesSampleRate` in `Sentry.init()` and remove the `SentrySpanProcessor` from the span processors array.
+
+</Callout>
+
+```ts filename="instrumentation.ts"
+import * as Sentry from "@sentry/node";
+
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import {
+  SentryPropagator,
+  SentrySampler,
+  SentrySpanProcessor,
+} from "@sentry/opentelemetry";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+const sentryClient = Sentry.init({
+  dsn: "<your dsn>",
+  skipOpenTelemetrySetup: true,
+  tracesSampleRate: 1, // <-- must be dropped if Sentry tracing is not used
+  // ...
+});
+
+const provider = new NodeTracerProvider({
+  sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
+  spanProcessors: [
+    new LangfuseSpanProcessor(),
+    new SentrySpanProcessor(), // <-- must be dropped if Sentry tracing is not used
+  ],
+});
+
+provider.register({
+  propagator: new SentryPropagator(),
+  contextManager: new Sentry.SentryContextManager(),
+});
+```
+
+For more details on custom OpenTelemetry setup with Sentry, see the [Sentry documentation](https://docs.sentry.io/platforms/javascript/guides/express/opentelemetry/custom-setup/).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for integrating Sentry with Langfuse using OpenTelemetry in `advanced-usage.mdx`.
> 
>   - **Documentation**:
>     - Adds section "Setup with Sentry" in `advanced-usage.mdx`.
>     - Provides guide for integrating Sentry with Langfuse using OpenTelemetry.
>     - Includes code example for custom OpenTelemetry setup with `skipOpenTelemetrySetup: true` in Sentry.
>   - **Important Considerations**:
>     - Notes that Sentry's `tracesSampleRate` affects Langfuse traces.
>     - Advises to omit `tracesSampleRate` and `SentrySpanProcessor` if not using Sentry tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c8a0476c8402ce49e5362af77ee3d99710f8c070. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->