### PR TITLE
fix(data-retention): clarify docs

### DIFF
--- a/pages/docs/administration/data-retention.mdx
+++ b/pages/docs/administration/data-retention.mdx
@@ -40,6 +40,9 @@ We use the following properties per entity to decide whether they are outside th
 
 Deleted assets cannot be recovered.
 
+The retention policy applies to the respective data, independent of any references.
+For example, if a dataset references a trace but the trace is e.g. deleted after 30 days, the dataset run item will point to a non-existent trace.
+
 ## Self-hosted Instances
 
 To use the Data Retention feature in a self-hosted environment, you need to grant `s3:DeleteObject` to the Langfuse IAM role on all buckets (see [Blob Storage (S3) docs](/self-hosting/deployment/infrastructure/blobstorage)).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies data retention policy in documentation by adding an example about references to deleted traces.
> 
>   - **Documentation**:
>     - Clarifies data retention policy in `data-retention.mdx`.
>     - Adds example explaining that datasets may reference non-existent traces if traces are deleted after retention period.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9f90a67333bafed80a42e78e52fc79016876d732. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->