### PR TITLE
data retention via api

### DIFF
--- a/pages/docs/administration/data-retention.mdx
+++ b/pages/docs/administration/data-retention.mdx
@@ -16,6 +16,9 @@ sidebarTitle: Data Retention
 />
 
 With Langfuse's Data Retention feature, you can control how long your event data (Traces, Observations, Scores, and Media Assets) is stored in Langfuse.
+
+## Configuration
+
 Data retention is configured on a project level, and we accept a number of days with a minimum of 3 days.
 Project owners and administrators can change the data retention setting within the Project Settings view.
 
@@ -27,6 +30,8 @@ Project owners and administrators can change the data retention setting within t
 <Frame className="my-10" fullWidth>
   ![Configure data retention in Langfuse](/images/docs/data-retention.png)
 </Frame>
+
+Data retention can also be configured via the [projects API](/docs/administration/scim-and-org-api).
 
 ## Details
 

--- a/pages/docs/administration/scim-and-org-api.mdx
+++ b/pages/docs/administration/scim-and-org-api.mdx
@@ -56,6 +56,8 @@ Those include the following routes:
 - `PUT /api/public/projects/{projectId}/memberships`
 - `DELETE /api/public/projects/{projectId}/memberships`
 
+See [API Reference](https://api.reference.langfuse.com) for more details.
+
 ## User Management via SCIM
 
 In addition, we implement the following [SCIM](https://datatracker.ietf.org/doc/html/rfc7642) compliant endpoints.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for configuring data retention via API and updates SCIM and Org API docs with a reference link.
> 
>   - **Documentation**:
>     - Adds a section on configuring data retention via the [projects API](/docs/administration/scim-and-org-api) in `data-retention.mdx`.
>     - Updates `scim-and-org-api.mdx` to include a link to the [API Reference](https://api.reference.langfuse.com) for more details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 932fa661e95fdd5fe662a77ccb311b23cfe373cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->