### PR TITLE
Add pricing faq usage alerts

### DIFF
--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -33,6 +33,11 @@ const faqs = [
       "You get one bill each month. We charge your Core, Pro, or Team plan at the start of the month. We charge for your usage at the end of the month. The bill you get at the start of the month shows two things: the plan cost for the new month and the usage from last month.",
   },
   {
+    question: "Can I set up alerts on the usage fees?",
+    answer:
+      "Yes, you can configure spend alerts to receive email notifications when your organization's spending exceeds predefined monetary thresholds. This helps you monitor costs and take action before unexpected charges occur. Navigate to your organization settings and the Billing tab to configure spend alerts. Learn more in our <a class='underline' href='/docs/administration/spend-alerts'>spend alerts documentation</a>.",
+  },
+  {
     question: "How can I manage my subscription?",
     answer:
       "You can manage your subscription through the organization settings in Langfuse Cloud or by using this <a class='underline' href='/billing-portal'>Customer Portal</a>.",


### PR DESCRIPTION
Add pricing FAQ item about usage fee alerts to clarify spend alert functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-865638b5-3c73-4868-98dc-5472f8113d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-865638b5-3c73-4868-98dc-5472f8113d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new FAQ item in `PricingFAQ.tsx` about configuring spend alerts for usage fees.
> 
>   - **Behavior**:
>     - Adds a new FAQ item in `PricingFAQ.tsx` about setting up alerts on usage fees.
>     - Provides instructions on configuring spend alerts to receive email notifications when spending exceeds thresholds.
>     - Includes a link to the spend alerts documentation for further details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 88d82c329eeba1eb110487c09b98208a377e0b30. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->