### PR TITLE
feat: add wordpress SSO docs

### DIFF
--- a/pages/self-hosting/security/authentication-and-sso.mdx
+++ b/pages/self-hosting/security/authentication-and-sso.mdx
@@ -188,6 +188,18 @@ Notes:
 - Without specifying `AUTH_WORKOS_ORGANIZATION_ID` or `AUTH_WORKOS_CONNECTION_ID`, users will see two login options and must provide their organization or connection ID.
 - If you specify either variable, only one login button appears with that default setting. You cannot specify both variables simultaneously.
 
+### WordPress
+
+[NextAuth WordPress Provider Docs](https://next-auth.js.org/providers/wordpress)
+
+| Configuration      | Value                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| Required Variables | `AUTH_WORDPRESS_CLIENT_ID`<br/>`AUTH_WORDPRESS_CLIENT_SECRET`            |
+| Optional Variables | See [additional configuration](#additional-configuration) section below. |
+| OAuth Redirect URL | `/api/auth/callback/wordpress`                                           |
+
+Provider: `WORDPRESS`
+
 ### Custom OAuth Provider
 
 [NextAuth Custom OAuth Provider Docs](https://next-auth.js.org/configuration/providers/oauth#using-a-custom-provider) ([source](https://github.com/langfuse/langfuse/blob/main/web/src/server/auth.ts))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add WordPress SSO provider documentation to `authentication-and-sso.mdx` with configuration details.
> 
>   - **Documentation**:
>     - Adds WordPress SSO provider documentation to `authentication-and-sso.mdx`.
>     - Lists required variables: `AUTH_WORDPRESS_CLIENT_ID`, `AUTH_WORDPRESS_CLIENT_SECRET`.
>     - Specifies OAuth Redirect URL: `/api/auth/callback/wordpress`.
>     - Links to [NextAuth WordPress Provider Docs](https://next-auth.js.org/providers/wordpress).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 74504e9ce2329a3b34b4f0ba54d98982d56105cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->