### PR TITLE
docs: add 'NONE' role as value for LANGFUSE_DEFAULT_ORG_ROLE

### DIFF
--- a/pages/self-hosting/administration/automated-access-provisioning.mdx
+++ b/pages/self-hosting/administration/automated-access-provisioning.mdx
@@ -25,6 +25,6 @@ Set up the following environment variables on the application containers:
 | Variable                        | Required / Default | Description                                                                                                                                           |
 | ------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `LANGFUSE_DEFAULT_ORG_ID`       |                    | Configure optional default organization for new users. When users create an account they will be automatically added to this organization.            |
-| `LANGFUSE_DEFAULT_ORG_ROLE`     | `VIEWER`           | Role of the user in the default organization (if set). Possible values are `OWNER`, `ADMIN`, `MEMBER`, `VIEWER` and 'NONE'. See [roles](/docs/rbac) for details. |
+| `LANGFUSE_DEFAULT_ORG_ROLE`     | `VIEWER`           | Role of the user in the default organization (if set). Possible values are `OWNER`, `ADMIN`, `MEMBER`, `VIEWER` and `NONE`. See [roles](/docs/rbac) for details. |
 | `LANGFUSE_DEFAULT_PROJECT_ID`   |                    | Configure optional default project for new users. When users create an account they will be automatically added to this project.                      |
 | `LANGFUSE_DEFAULT_PROJECT_ROLE` | `VIEWER`           | Role of the user in the default project (if set). Possible values are `OWNER`, `ADMIN`, `MEMBER`, `VIEWER`. See [roles](/docs/rbac) for details.      |


### PR DESCRIPTION
as mentioned in roles doc, there is a 'None' role. so it is expected to be  a value for default org role settings. and actually it is as i tried.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'NONE' as a valid role for `LANGFUSE_DEFAULT_ORG_ROLE` in documentation.
> 
>   - **Documentation**:
>     - Update `LANGFUSE_DEFAULT_ORG_ROLE` description in `automated-access-provisioning.mdx` to include 'NONE' as a valid role option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 230877ee375a58e202c9e88d377f703c5c3a5318. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->