### PR TITLE
chore: show changelog in main menu on desktop

### DIFF
--- a/pages/_meta.tsx
+++ b/pages/_meta.tsx
@@ -102,6 +102,13 @@ export default {
     title: "Handbook",
     // hidden from main menu via overrides.css, nextra display:hidden otherwise breaks type:page
   },
+  changelog: {
+    type: "page",
+    title: "Changelog",
+    theme: {
+      layout: "full",
+    },
+  },
   pricing: {
     title: "Pricing",
     type: "page",
@@ -112,14 +119,6 @@ export default {
   "pricing-self-host": {
     title: "Pricing (self-hosted)",
     type: "page",
-    theme: {
-      layout: "full",
-    },
-    display: "hidden",
-  },
-  changelog: {
-    type: "page",
-    title: "Changelog",
     theme: {
       layout: "full",
     },

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -32,6 +32,12 @@
   display: none !important;
 }
 
+@media (max-width: 1024px) {
+  .nextra-nav-container>nav>div>a[href="/changelog"] {
+    display: none !important;
+  }
+}
+
 /* Less gap in desktop menu */
 .nextra-menu-desktop {
   gap: 0.1rem;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Show changelog in main menu on desktop and hide it on mobile via `_meta.tsx` and `overrides.css` changes.
> 
>   - **Menu Changes**:
>     - In `pages/_meta.tsx`, the `changelog` entry is moved to be visible in the main menu on desktop.
>     - The `pricing` and `pricing-self-host` entries are reordered.
>   - **CSS Adjustments**:
>     - In `overrides.css`, added media query to hide `changelog` link on screens smaller than 1024px.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d69217c70fd5ea4c3fad5da220c92fbd9ca9a8e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->