### PR TITLE
feat: add 524 API  error FAQ

### DIFF
--- a/pages/faq/all/api-524-http-errors.mdx
+++ b/pages/faq/all/api-524-http-errors.mdx
@@ -9,14 +9,14 @@ The 524 error class on Langfuse Cloud indicates that your request timed out beca
 This typically occurs when queries scan too much data due to overly broad filter conditions.
 The main patch for those errors is adding narrow time-frame conditions to reduce the amount of data to be scanned.
 
-## General Solutions
+## General Approaches
 
 To prevent 524 errors across all API endpoints:
 
 1. **Always use timestamp filters**: Add `fromTimestamp` and `toTimestamp` parameters to limit the time range
 2. **Add specific filters**: Use `userId`, `sessionId`, `name`, `tags`, or other filters to narrow your query
 
-## Specific Guidance for GET /api/public/traces
+## Optimizations for GET /api/public/traces
 
 The [`GET /api/public/traces`](https://api.reference.langfuse.com/#tag/trace/get/api/public/traces) endpoint is particularly susceptible to 524 errors.
 Follow these best practices:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds FAQ document to address 524 API errors in Langfuse, with general strategies and specific optimizations for `GET /api/public/traces`.
> 
>   - **New FAQ Document**:
>     - Adds `api-524-http-errors.mdx` to `pages/faq/all/` to address 524 errors on Langfuse API calls.
>   - **Content**:
>     - Explains 524 errors as timeouts due to ClickHouse resource exhaustion.
>     - Recommends using `fromTimestamp` and `toTimestamp` to limit data scanned.
>     - Suggests additional filters like `userId`, `sessionId`, `name`, `tags`.
>     - Provides specific optimizations for `GET /api/public/traces` endpoint, including using `fields` parameter to avoid expensive joins.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 65d417eca99b03f52685e3041611574e56f5cf76. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->