### PR TITLE
chore: default to "All" in inkeep search

### DIFF
--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -48,7 +48,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
   const posthog = usePostHog();
   const router = useRouter();
 
-  const currentTab = useMemo(() => {
+  const tabOfCurrentDocsSection = useMemo(() => {
     return inkeepCustomTabsToSlugs.find((t) => {
       const slugs = Array.isArray(t.slug) ? t.slug : [t.slug];
       return slugs.some((slug) => router.pathname.startsWith(slug));
@@ -93,15 +93,11 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     placeholder: "Search...",
     tabs: inkeepCustomTabsToSlugs
       .map((t) => t.tab)
-      .concat(["GitHub", "All"])
-      // show current tab first
-      .sort((a, b) => {
-        if (a === currentTab) return -1;
-        if (b === currentTab) return 1;
-        return 0;
-      })
-      // add isAlwaysVisible to current tab
-      .map((t) => (t === currentTab ? [t, { isAlwaysVisible: true }] : t)),
+      .concat(["All", "GitHub"])
+      // add isAlwaysVisible to current website section
+      .map((t) =>
+        t === tabOfCurrentDocsSection ? [t, { isAlwaysVisible: true }] : t
+      ),
   };
 
   const disclaimerSettings: AIChatDisclaimerSettings = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default tab order to prioritize "All" and rename variable for clarity in `useInkeepSettings`.
> 
>   - **Behavior**:
>     - Default tab order in `searchSettings` changed to prioritize "All" over "GitHub" in `useInkeepSettings`.
>   - **Refactoring**:
>     - Renamed `currentTab` to `tabOfCurrentDocsSection` in `useInkeepSettings` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1c5acd6799abad9dfda1fa1287d7e79808b247bd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->