### PR TITLE
Customize browser tab and pdf filenames

### DIFF
--- a/pages/api/md-to-pdf.ts
+++ b/pages/api/md-to-pdf.ts
@@ -95,12 +95,19 @@ export default async function handler(
     // Process Callout components in the HTML
     htmlContent = processCallouts(htmlContent);
 
+    // Extract filename for title and later use
+    const pathname = markdownUrl.pathname;
+    const filename = pathname.split("/").pop() || "document.md";
+    const baseFilename = filename.replace(/\.mdx?$/i, "");
+    const documentTitle = `Langfuse - ${baseFilename}`;
+
     // Create a complete HTML document with styling
     const fullHtml = `
       <!DOCTYPE html>
       <html>
         <head>
           <meta charset="UTF-8">
+          <title>${documentTitle}</title>
           <style>
             body {
               font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -269,10 +276,8 @@ export default async function handler(
         },
       });
 
-      // Extract filename from URL
-      const pathname = markdownUrl.pathname;
-      const filename = pathname.split("/").pop() || "document.md";
-      const pdfFilename = filename.replace(/\.mdx?$/i, ".pdf");
+      // Use the filename extracted earlier
+      const pdfFilename = `${documentTitle}.pdf`;
 
       // Determine content disposition (default to inline)
       const contentDisposition =


### PR DESCRIPTION
Customize the browser tab title and PDF filename for markdown exports to include the "Langfuse - " prefix.

---
<a href="https://cursor.com/background-agent?bcId=bc-12d33180-c3ac-444e-b821-22a099b99c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12d33180-c3ac-444e-b821-22a099b99c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Customize browser tab title and PDF filename in `md-to-pdf.ts` to include "Langfuse - " prefix.
> 
>   - **Behavior**:
>     - Customize browser tab title and PDF filename in `md-to-pdf.ts` to include "Langfuse - " prefix.
>     - Extracts base filename from markdown URL and constructs `documentTitle` with prefix.
>     - Sets HTML `<title>` to `documentTitle`.
>     - Sets PDF filename to `documentTitle.pdf`.
>   - **Misc**:
>     - Refactor to use extracted `documentTitle` for both HTML title and PDF filename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 38844b8979a64d509424c2742a457617521c8c35. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->