### PR TITLE
fix: add callout about liveness and readiness probes with custom base path

### DIFF
--- a/pages/self-hosting/configuration/custom-base-path.mdx
+++ b/pages/self-hosting/configuration/custom-base-path.mdx
@@ -53,6 +53,14 @@ docker build -t langfuse/langfuse --build-arg NEXT_PUBLIC_BASE_PATH=/langfuse-ba
 
 When Deploying Langfuse according to one of the deployment guides, replace the prebuilt image for the web container (`langfuse/langfuse`) with the image you built from source.
 
+<Callout type="warning">
+  **Kubernetes/Helm deployments:** When using a custom base path with
+  Kubernetes/Helm, you must update the liveness and readiness probe paths to
+  include the custom base path. Update these in your Helm
+  `values.yaml` file under `langfuse.web.livenessProbe.path` and
+  `langfuse.web.readinessProbe.path`.
+</Callout>
+
 ### Connect to Langfuse
 
 Once your Langfuse instance is running, you can access both the API and console through your configured custom base path. When connecting via SDKs, make sure to include the custom base path in the hostname.


### PR DESCRIPTION
fixes https://github.com/langfuse/langfuse-docs/issues/2165
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning in `custom-base-path.mdx` to update liveness and readiness probe paths for Kubernetes/Helm with custom base paths.
> 
>   - **Documentation**:
>     - Adds a warning callout in `custom-base-path.mdx` about updating liveness and readiness probe paths in `values.yaml` for Kubernetes/Helm deployments when using a custom base path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a8e995186fe7260f01c7b203e6e6f8f87e54ab33. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->