### PR TITLE
docs(experiments): add FAQ for data export

### DIFF
--- a/pages/faq/all/retrieve-experiment-scores.mdx
+++ b/pages/faq/all/retrieve-experiment-scores.mdx
@@ -15,68 +15,11 @@ Langfuse supports two types of experiment scores:
 1. **Experiment-level scores**: Overall metrics for the entire experiment run (e.g., precision, recall, F1-scores). These scores are immutable and represent aggregate performance. [Learn more about run-level scores](/changelog/2025-05-07-run-level-scores).
 2. **Experiment-item-level scores**: Scores for individual items within an experiment (e.g., per-generated-output evaluations).
 
-## Via UI Export
-
-The Langfuse UI provides export functionality for experiment scores.
-
-**Export locations:**
-- **Dataset runs page**: Export dataset run metrics across multiple experiments
-- **Dataset detail page**: Export dataset run metrics for a specific dataset's experiments
-
-{/* <Frame fullWidth>
-  ![Export experiments from UI](/images/faq/export-experiment-scores-ui.png)
-</Frame> */}
-
-The exported data includes both experiment-level and experiment-item-level scores.
-
 ## Via API/SDK
 
 ### Experiment-Level Scores
 
-Fetch experiment-level scores using the Langfuse SDK or scores API with the `datasetRunId` parameter:
-
-<LangTabs items={["Python SDK", "JS/TS SDK", "API"]}>
-<Tab>
-
-```python
-from langfuse import Langfuse
-
-langfuse = Langfuse()
-
-# Fetch experiment-level scores
-scores = langfuse.list_scores(
-    data_type="NUMERIC",  # optional: filter by score type
-    dataset_run_id="<experiment_run_id>"
-)
-```
-
-</Tab>
-<Tab>
-
-```ts
-import { LangfuseClient } from "@langfuse/client";
-
-const langfuse = new LangfuseClient();
-
-// Fetch experiment-level scores
-const scores = await langfuse.score.list({
-  dataType: "NUMERIC",  // optional: filter by score type
-  datasetRunId: "<experiment_run_id>"
-});
-```
-
-</Tab>
-<Tab>
-
-```bash
-GET https://api.langfuse.com/api/public/v2/scores?datasetRunId=<experiment_run_id>
-```
-
-[API Reference](https://api.reference.langfuse.com/#tag/scorev2/get/api/public/v2/scores)
-
-</Tab>
-</LangTabs>
-
+Support coming soon: Fetch experiment-level scores using the Langfuse SDK or scores API with the `datasetRunId` parameter.
 See the [Scores Data Model](/docs/evaluation/evaluation-methods/data-model) for details on score properties.
 
 ### Experiment-Item-Level Scores


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds FAQ on retrieving experiment scores via UI or API/SDK, detailing methods for experiment-level and item-level scores, and recommends using the Experiment Runner SDK.
> 
>   - **New FAQ Document**:
>     - Adds `retrieve-experiment-scores.mdx` to explain retrieving experiment scores via UI or API/SDK.
>     - Covers both experiment-level and experiment-item-level scores.
>   - **API/SDK Instructions**:
>     - Details steps to fetch experiment run and scores using Python SDK, JS/TS SDK, and API.
>     - Provides a workaround for retrieving experiment-item-level scores.
>   - **Recommendations**:
>     - Suggests using the Experiment Runner SDK for direct access to scores.
>   - **Terminology Note**:
>     - Clarifies interchangeable use of "experiment" and "dataset run" terms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for e4c71cbc50a71bcff781c0b776cdd774517c694b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->