### PR TITLE
docs: idp-initiated sso

### DIFF
--- a/pages/changelog/2025-11-04-idp-initiated-sso.mdx
+++ b/pages/changelog/2025-11-04-idp-initiated-sso.mdx
@@ -1,0 +1,29 @@
+---
+date: 2025-11-04
+title: IdP-Initiated SSO Support
+description: Langfuse now supports IdP-initiated SSO, allowing users to start authentication directly from their identity provider (e.g., Okta, Azure AD, Keycloak)
+badge: Launch Week 4 🚀
+author: Marc
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+This enables a more seamless authentication experience where users can click on the Langfuse application tile in their identity provider's dashboard and be automatically authenticated.
+
+## How It Works
+
+When configuring IdP-initiated SSO, you'll set up your identity provider to redirect users to:
+
+```
+<YOUR_LANGFUSE_INSTANCE_URL>/auth/sso-initiate?provider=<PROVIDER>
+```
+
+Langfuse will automatically detect the provider and initiate the SSO authentication flow. Users see a brief loading screen while being redirected to their identity provider for authentication.
+
+## Get Started
+
+**On Langfuse Cloud:** Reach out to [support](/support) to configure IdP-initiated SSO for your identity provider.
+
+**When self-hosting:** See the [self-hosted SSO documentation](/self-hosting/security/authentication-and-sso#idp-initiated-sso) for configuration instructions. IdP-initiated SSO is available on version `>=v3.126.0` of Langfuse.

--- a/pages/self-hosting/security/authentication-and-sso.mdx
+++ b/pages/self-hosting/security/authentication-and-sso.mdx
@@ -245,6 +245,20 @@ Provider: `CUSTOM`
 Langfuse supports HTTP proxy settings for SSO providers.
 Configure `AUTH_HTTPS_PROXY` or `AUTH_HTTP_PROXY` to use a proxy for SSO provider requests.
 
+## IdP-Initiated SSO [#idp-initiated-sso]
+
+Langfuse supports **IdP-initiated SSO** (Identity Provider-initiated Single Sign-On), where users can start the SSO flow directly from their identity provider (e.g., Okta, Azure AD, Keycloak, etc.) instead of starting from Langfuse.
+
+To enable IdP-initiated SSO, configure your identity provider to redirect users to:
+
+```
+https://<YOUR_LANGFUSE_URL>/auth/sso-initiate?provider=<PROVIDER>
+```
+
+- Replace `<YOUR_LANGFUSE_URL>` with your Langfuse instance URL and `<PROVIDER>` with your configured provider name (e.g., `GOOGLE`, `GITHUB`, `AZURE_AD`, etc., see other variables of provider above).
+- Use the `Redirect to app to initiate login (OIDC Compliant)` option in your identity provider's settings.
+- IdP-initiated SSO is available on version `>=v3.126.0` of Langfuse.
+
 ## Additional configuration
 
 These are additional configuration variables. Replace `<PROVIDER>` with the provider name (e.g., `GOOGLE`, `GITHUB`, `AZURE_AD`, etc., see other variables of provider above).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for IdP-initiated SSO support, detailing configuration for both cloud and self-hosted environments.
> 
>   - **Documentation**:
>     - Adds `2025-11-04-idp-initiated-sso.mdx` to changelog for IdP-initiated SSO support.
>     - Updates `authentication-and-sso.mdx` with IdP-initiated SSO setup instructions for self-hosting.
>   - **Features**:
>     - Describes IdP-initiated SSO allowing users to authenticate from identity providers like Okta, Azure AD, Keycloak.
>     - Provides configuration details for redirecting users to `/auth/sso-initiate?provider=<PROVIDER>`.
>     - Specifies availability from version `>=v3.126.0` for self-hosted setups.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for ec44c32421e453d1a36f372e499b10e27f972142. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->