### PR TITLE
docs: add attribute propagation guidance to OpenTelemetry integration

### DIFF
--- a/pages/integrations/native/opentelemetry.mdx
+++ b/pages/integrations/native/opentelemetry.mdx
@@ -269,25 +269,24 @@ Starting in a future release, Langfuse aggregation queries and filters will oper
 
 #### Using OpenTelemetry Baggage for Propagation
 
-The recommended approach for propagating these attributes across all spans is to use [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) with a [`BaggageSpanProcessor`](https://opentelemetry.io/docs/languages/python/instrumentation/#baggage). Baggage is a built-in OpenTelemetry mechanism for context propagation that automatically copies specified key-value pairs to all spans within a trace context.
+The recommended approach for propagating these attributes across all spans is to use [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) with a `BaggageSpanProcessor`. Baggage is a built-in OpenTelemetry mechanism for context propagation that automatically copies specified key-value pairs to all spans within a trace context.
 
 To implement this pattern:
 
 1. Set the desired attributes as baggage entries at the beginning of your trace
-2. Configure a `BaggageSpanProcessor` in your OpenTelemetry setup to automatically copy baggage entries to span attributes
-3. The processor will ensure all spans in the trace context receive these attributes
+2, Set the attributes on the currently active span
+3. Configure a `BaggageSpanProcessor` in your OpenTelemetry setup to automatically copy baggage entries to span attributes
+4. The processor will ensure all downstream spans in the trace context receive these attributes
 
-For implementation details and code examples, refer to the OpenTelemetry documentation for [Python](https://opentelemetry.io/docs/languages/python/instrumentation/#baggage) and [JavaScript](https://opentelemetry.io/docs/languages/js/instrumentation/#baggage).
+For implementation details and code examples, refer to the OpenTelemetry documentation for [Python](https://pypi.org/project/opentelemetry-processor-baggage/) and [JavaScript](https://www.npmjs.com/package/@opentelemetry/baggage-span-processor).
 
 <Callout type="warning">
   **Security Consideration**: OpenTelemetry baggage is propagated across service boundaries and to third-party APIs. **Do not include sensitive information** (passwords, API keys, personal data, etc.) in baggage when using this approach, as it will be transmitted to all downstream services.
 </Callout>
 
-#### Alternative: Using Langfuse SDK v3
+#### Alternative: Using Langfuse SDKs
 
-If you're using the [Langfuse SDK v3](/docs/sdk/python/sdk-v3) (Python) or TypeScript SDK with OpenTelemetry integration, you can use the convenience methods `propagate_attributes()` (Python) or `propagateAttributes()` (TypeScript) which handle attribute propagation automatically. These methods provide a simpler interface and are the recommended approach when using Langfuse SDK v3. See the [Python instrumentation guide](/docs/observability/sdk/python/instrumentation#propagate-attributes) or [TypeScript instrumentation guide](/docs/observability/sdk/typescript/instrumentation#propagate-attributes) for detailed examples.
-
-Below is a non-exhaustive mapping of Langfuse data model attributes to OpenTelemetry span attributes.
+If you're using the [Langfuse SDKs](/docs/observability/sdk/overview) with OpenTelemetry integration, you can use the convenience methods `propagate_attributes()` (Python) or `propagateAttributes()` (TypeScript) which handle attribute propagation automatically. These methods provide a simpler interface and are the recommended approach when using Langfuse SDKs. 
 
 ### Trace-Level Attributes
 


### PR DESCRIPTION
## Summary

Extends the OpenTelemetry integration documentation to include comprehensive guidance on attribute propagation for trace-level attributes. This documentation builds on the work from #2240 where similar guidance was added to the Python and JS SDK docs.

## Changes

Added a new subsection "Propagating Trace Attributes to All Spans" within the Property Mapping section (`pages/integrations/native/opentelemetry.mdx`) that covers:

- **Why propagation is needed**: Explains that `userId`, `sessionId`, `metadata`, `version`, `release`, and `tags` should be propagated to all spans for accurate filtering and aggregations in future Langfuse versions
- **Recommended approach**: Details using OpenTelemetry Baggage with `BaggageSpanProcessor` as the primary method for users not using Langfuse SDKs
- **Security considerations**: Prominent warning about baggage propagating to third-party services and avoiding sensitive data
- **Alternative option**: References Langfuse SDK v3's `propagate_attributes()` methods for users of the SDK
- **Future compatibility**: Positions as "strongly recommended now" without specifying hard transition date

## Context

This addresses the need to communicate the upcoming change where Langfuse aggregations will operate on individual observations rather than just trace-level data. The OpenTelemetry integration doc is specifically for users who are **not** using the Langfuse SDKs directly, so the focus is on native OpenTelemetry patterns (baggage) rather than SDK-specific methods.

## Related

- #2240 - PR that added similar propagation guidance to Python and JS SDK docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds guidance on propagating trace-level attributes to all spans in OpenTelemetry integration docs for future Langfuse compatibility.
> 
>   - **Documentation Update**:
>     - Adds "Propagating Trace Attributes to All Spans" subsection in `opentelemetry.mdx`.
>     - Explains the need for propagating `userId`, `sessionId`, `metadata`, `version`, `release`, and `tags` to all spans for future Langfuse compatibility.
>     - Recommends using OpenTelemetry Baggage with `BaggageSpanProcessor` for propagation.
>     - Warns against including sensitive data in baggage due to third-party propagation.
>     - Mentions Langfuse SDK v3's `propagate_attributes()` as an alternative for SDK users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5a87297e13f2ff43f77bfa2e52f6565cd3906829. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->