### PR TITLE
docs: add server-side sampling configuration to scaling guide

### DIFF
--- a/pages/self-hosting/configuration/scaling.mdx
+++ b/pages/self-hosting/configuration/scaling.mdx
@@ -43,6 +43,29 @@ You can set `LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE` to
 Please note that any S3/blob storage deletion lifecycle rules in combination with late updates to events may cause duplicates in the event history.
 If you use the default integration methods with the Langfuse SDKs or OpenTelemetry this should not affect you.
 
+### Server-side sampling per project
+
+Server-side sampling allows you to reduce ingestion processing load by configuring Langfuse to process only a percentage of traces for specific projects. This is useful for high-volume projects where full trace capture may not be necessary, or for cost control in scenarios where trace volume exceeds your infrastructure capacity.
+
+Configure sampling rates per project using the `LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS` environment variable:
+
+```bash
+LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS="project-id-1:0.5,project-id-2:0.2"
+```
+
+The format is a comma-separated list of `projectId:sampleRate` pairs, where:
+- `projectId` is the Langfuse project identifier
+- `sampleRate` is a decimal between 0 and 1 (e.g., 0.5 = keep 50% of traces, 0.2 = keep 20% of traces)
+
+**Key behaviors:**
+- Sampling is **deterministic and hash-based**: the same trace ID will always result in the same sampling decision, ensuring consistency across related events
+- Sampling operates at the **trace level**: when a trace is sampled out, all associated observations, spans, generations, and scores are also dropped
+- Sampling happens after S3 upload but before Redis queue processing, reducing load on ClickHouse and Redis
+
+This is **server-side sampling** that occurs during ingestion processing. For sampling at the client before data is sent to Langfuse, see [client-side sampling](/docs/observability/features/sampling). Client-side sampling is generally preferred as it reduces network bandwidth and S3 storage costs, while server-side sampling is useful for emergency load reduction or when client configuration is not feasible.
+
+Note that server-side sampling means accepting partial observability data for the configured projects. Consider this tradeoff when deciding on appropriate sample rates.
+
 ### Separating ingestion and user interface
 
 When the ingestion load is high, the Langfuse web interface and API calls may become slow or unresponsive.


### PR DESCRIPTION
## Summary

Adds documentation for the `LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS` environment variable to the self-hosting scaling guide.

## Changes

- Added new "Server-side sampling per project" section to `/pages/self-hosting/configuration/scaling.mdx`
- Positioned under "Ingestion Throughput" section for natural discoverability
- Includes:
  - Configuration format and practical example
  - Explanation of deterministic hash-based sampling behavior
  - Trace-level sampling details
  - Comparison with client-side sampling
  - Link to existing client-side sampling documentation

## Documentation approach

- Positioned as a standard performance optimization tool (not emergency-only)
- Moderate technical detail level (deterministic, hash-based, trace-level)
- Brief but comprehensive (~200 words)
- Follows established patterns from other sections in the scaling guide
- Links to related client-side sampling docs for complete picture

## Location rationale

The scaling page was chosen because:
- Feature is specifically for ingestion performance optimization
- Page already documents similar advanced performance features
- Listed under "Essential" in navigation for good discoverability
- Users optimizing performance will naturally find it here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds server-side sampling configuration documentation to the Langfuse scaling guide.
> 
>   - **Documentation**:
>     - Adds "Server-side sampling per project" section to `scaling.mdx`.
>     - Details `LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS` environment variable for configuring sampling rates.
>     - Explains deterministic hash-based sampling, trace-level sampling, and comparison with client-side sampling.
>     - Positioned under "Ingestion Throughput" for discoverability.
>     - Links to client-side sampling documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for f016262b899937e8690004212e9eee993d9ee08a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->