### PR TITLE
docs(score-analytics): update sampling, intervals, and metrics description

### DIFF
--- a/pages/docs/evaluation/evaluation-methods/score-analytics.mdx
+++ b/pages/docs/evaluation/evaluation-methods/score-analytics.mdx
@@ -19,7 +19,7 @@ Score Analytics complements Langfuse's [experiment SDK](/docs/evaluation/overvie
 - **Lightweight Setup**: No configuration needed—start analyzing scores immediately after they're ingested
 - **Quick Validation**: Compare scores from different sources (e.g., GPT-4 vs Gemini as judges) to measure agreement and ensure reliability
 - **Out-of-the-Box Insights**: Visualize distributions, track trends, and discover correlations without custom dashboard configuration
-- **Statistical Rigor**: Access industry-standard metrics like Pearson correlation, Cohen's Kappa, and F1 scores with built-in interpretation
+- **Statistical Rigor**: Access metrics like Pearson correlation, Cohen's Kappa, and F1 scores with built-in interpretation
 
 For advanced analyses requiring custom metrics or complex comparisons, use the [experiment SDK](/docs/evaluation/overview) for deeper investigation.
 
@@ -114,7 +114,7 @@ Score Analytics provides two views for understanding your data:
 ### Time-Based Analysis
 
 The Trend Over Time chart helps you monitor score patterns with:
-- **Configurable intervals**: From seconds to years (1s, 5s, 10s, 30s, 1m, 5m, 15m, 30m, 1h, 6h, 1d, 7d, 30d, 90d, 365d)
+- **Configurable intervals**: From minutes to years (5m, 30m, 1h, 3h, 1d, 7d, 30d, 90d, 1y)
 - **Automatic interval selection**: Smart defaults based on your selected time range
 - **Gap filling**: Missing time periods are filled with zeros for consistent visualization
 - **Average calculations**: Subtitle shows overall average for the time period
@@ -219,7 +219,7 @@ Score Analytics provides industry-standard statistical metrics with interpretati
 **Current Constraints**:
 - **Two scores maximum**: Currently supports comparing up to two scores at a time. For multi-way comparisons, perform pairwise analyses.
 - **Same data type only**: You can only compare scores of the same data type (numeric with numeric, categorical with categorical, boolean with boolean).
-- **Query truncation**: Very large queries (100k+ matched scores) may be truncated to maintain performance. Use time range or object type filters to narrow your analysis if needed.
+- **Sampling**: For performance optimization, queries expecting >100k scores (for either score1 or score2) automatically apply random sampling. This sampling approximates true random sampling and maintains statistical properties of your data. A visible indicator will show when sampling is active, and you can use time range or object type filters to narrow your analysis if you need the complete dataset.
 </Callout>
 
 ## Tips and Best Practices


### PR DESCRIPTION
## Summary
Updates Score Analytics documentation with accurate technical details:
- Add detailed sampling documentation (>100k threshold)
- Update configurable intervals to match actual UI
- Remove "industry-standard" qualifier from metrics description

## Changes Made

### 1. Enhanced Sampling Documentation (line 222)
**Before:** "Query truncation: Very large queries (100k+ matched scores) may be truncated to maintain performance."

**After:** "Sampling: For performance optimization, queries expecting >100k scores (for either score1 or score2) automatically apply random sampling. This sampling approximates true random sampling and maintains statistical properties of your data. A visible indicator will show when sampling is active, and you can use time range or object type filters to narrow your analysis if you need the complete dataset."

### 2. Updated Configurable Intervals (line 117)
**Before:** `1s, 5s, 10s, 30s, 1m, 5m, 15m, 30m, 1h, 6h, 1d, 7d, 30d, 90d, 365d`

**After:** `5m, 30m, 1h, 3h, 1d, 7d, 30d, 90d, 1y`

Updated description from "From seconds to years" to "From minutes to years" to match actual UI.

### 3. Simplified Statistical Rigor Description (line 22)
**Before:** "Access industry-standard metrics like..."

**After:** "Access metrics like..."

## Files Changed
- `pages/docs/evaluation/evaluation-methods/score-analytics.mdx` (3 additions, 3 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Score Analytics documentation to enhance sampling details, update intervals, and simplify metrics description.
> 
>   - **Documentation Updates**:
>     - Enhanced sampling description to clarify random sampling for queries expecting >100k scores, with visible indicator and filter options.
>     - Updated configurable intervals to reflect actual UI options, changing from seconds to years to minutes to years.
>     - Simplified metrics description by removing "industry-standard" qualifier.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 24afc031afcc1c3b548af5f54f8828eb30a89d47. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->