### PR TITLE
Make Hiring Badge pop

### DIFF
--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "./ui/button";
+
+export function HiringBadge() {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <Link
+      href="/careers"
+      className={cn(
+        buttonVariants({ variant: "cta", size: "pill" }),
+        "hidden lg:inline-flex h-6 px-2.5 text-[11px] font-medium"
+      )}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onFocus={() => setIsHovered(true)}
+      onBlur={() => setIsHovered(false)}
+    >
+      {isHovered ? "Looking for 🐐s!" : "Hiring in Berlin and SF"}
+    </Link>
+  );
+}
+

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -1,9 +1,9 @@
+"use client";
+
 import Image from "next/image";
-import { useState } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { cn } from "@/lib/utils";
-import { buttonVariants } from "./ui/button";
+import { useState } from "react";
 
 const ContextMenu = dynamic(() => import("./LogoContextMenu"), {
   ssr: false,
@@ -11,10 +11,9 @@ const ContextMenu = dynamic(() => import("./LogoContextMenu"), {
 
 export function Logo() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [badgeHover, setBadgeHover] = useState(false);
   return (
     <>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center">
         <Link
           href="/"
           onContextMenu={(e) => {
@@ -54,19 +53,6 @@ export function Logo() {
               }
             `}</style>
           </div>
-        </Link>
-        <Link
-          href="/careers"
-          className={cn(
-            buttonVariants({ variant: "cta", size: "pill" }),
-            "ml-2 hidden lg:inline-flex h-6 px-2.5 text-[11px] font-medium"
-          )}
-          onMouseEnter={() => setBadgeHover(true)}
-          onMouseLeave={() => setBadgeHover(false)}
-          onFocus={() => setBadgeHover(true)}
-          onBlur={() => setBadgeHover(false)}
-        >
-          {badgeHover ? "Looking for 🐐s!" : "Hiring in Berlin and SF"}
         </Link>
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { DocsThemeConfig, useConfig } from "nextra-theme-docs";
-import { Cards, Steps, Tabs, Callout } from "nextra/components";
 import { Logo } from "@/components/logo";
+import { Cards, Steps, Tabs, Callout } from "nextra/components";
 import { useRouter } from "next/router";
 import { MainContentWrapper } from "./components/MainContentWrapper";
 import { Frame } from "./components/Frame";
@@ -13,13 +13,19 @@ import { GeistSans } from "geist/font/sans";
 import FooterMenu from "./components/FooterMenu";
 import Link from "next/link";
 import { AvailabilityBanner } from "./components/availability";
-import { Video } from "./components/Video";
 import InkeepSearchBar from "./components/inkeep/InkeepSearchBar";
 import { LangTabs } from "./components/LangTabs";
+import { Video } from "./components/Video";
+import { HiringBadge } from "@/components/HiringBadge";
 // import IconYoutube from "./components/icons/youtube";
 
 const config: DocsThemeConfig = {
-  logo: <Logo />,
+  logo: (
+    <div className="flex items-center gap-4">
+      <Logo />
+      <HiringBadge />
+    </div>
+  ),
   logoLink: false,
   main: MainContentWrapper,
   search: {


### PR DESCRIPTION
I hear in too many hiring first calls "I didnt know for a long time that langfuse is based in Berlin" - I want to mitigate this by making the hiring badge be more verbose about this.

![CleanShot 2025-11-11 at 20 53 30](https://github.com/user-attachments/assets/6a5a0107-b965-4f34-90ec-a2b6c1a20a0b)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `HiringBadge` component with hover effect to replace old hiring link and update `theme.config.tsx` to display it next to the logo.
> 
>   - **Components**:
>     - Add `HiringBadge` component in `components/HiringBadge.tsx` with hover effect changing text from "Hiring in Berlin and SF" to "Looking for 🐐s!".
>     - Remove old hiring link from `Logo` component in `components/logo.tsx`.
>   - **Configuration**:
>     - Update `theme.config.tsx` to include `HiringBadge` next to `Logo` in the `logo` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 04fbd617606aa7a08ea809d74efaced59f0f32da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

