### PR TITLE
fix hiring badge width on short text

### DIFF
--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -19,8 +19,17 @@ export function HiringBadge() {
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setIsHovered(true)}
       onBlur={() => setIsHovered(false)}
+      style={{ width: "max-content" }}
     >
-      {isHovered ? "Looking for 🐐s!" : "Hiring in Berlin and SF"}
+      <span className={cn(isHovered && "invisible")}>Hiring in Berlin and SF</span>
+      <span
+        className={cn(
+          "absolute",
+          !isHovered && "invisible"
+        )}
+      >
+        Looking for 🐐s!
+      </span>
     </Link>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `HiringBadge` width by setting `max-content` and toggling text visibility on hover.
> 
>   - **Behavior**:
>     - Sets `style={{ width: "max-content" }}` on `Link` in `HiringBadge` to adjust width based on text content.
>     - Uses `span` elements with `invisible` class to toggle text visibility on hover.
>   - **UI**:
>     - Displays "Hiring in Berlin and SF" by default, changes to "Looking for 🐐s!" on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for dedd7777e9bfe91537d80ee25bb86d69c6ec1bfe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->