### PR TITLE
fix(experiments): update function name from get_dataset_run to get_run in experiment score retrieval

### DIFF
--- a/pages/faq/all/retrieve-experiment-scores.mdx
+++ b/pages/faq/all/retrieve-experiment-scores.mdx
@@ -55,7 +55,7 @@ encoded_dataset_name = quote(dataset_name, safe="")
 encoded_run_name = quote(run_name, safe="")
 
 # Fetch experiment run
-run = langfuse.get_dataset_run(
+run = langfuse.get_run(
     dataset_name=encoded_dataset_name,
     run_name=encoded_run_name
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `get_dataset_run` to `get_run` in `retrieve-experiment-scores.mdx` for correct function reference.
> 
>   - **Documentation**:
>     - Rename `get_dataset_run` to `get_run` in `retrieve-experiment-scores.mdx` to reflect the correct function name in the Langfuse SDK.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 520cb1d92cf54f7ae1e1449aa20eaddfd52df094. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->