### PR TITLE
improve styling of tutorial cards

### DIFF
--- a/components/TutorialCard.tsx
+++ b/components/TutorialCard.tsx
@@ -23,19 +23,20 @@ export function TutorialCard({
     <Link href={href} className="block h-full">
       <Card
         className={cn(
-          "h-full transition-all hover:shadow-md border bg-card",
+          "h-full transition-all duration-200 border bg-transparent hover:bg-muted/40 hover:border-gray-300 dark:hover:border-gray-600 group",
           className
         )}
       >
-        <CardContent className="p-6 flex flex-col h-full">
-          <div className="flex items-start gap-3 mb-4">
-            <div className="text-muted-foreground mt-0.5">{icon}</div>
+        <CardContent className="p-4 flex flex-col h-full">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="text-muted-foreground flex items-center group-hover:text-primary transition-colors">
+              {icon}
+            </div>
             <h3 className="font-semibold text-lg leading-tight flex-1">
               {title}
             </h3>
-            <ArrowRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
           </div>
-          <p className="text-sm text-muted-foreground mt-auto leading-relaxed">
+          <p className="text-sm text-muted-foreground leading-relaxed">
             {description}
           </p>
         </CardContent>
@@ -51,7 +52,9 @@ interface TutorialCardsProps {
 
 export function TutorialCards({ children, className }: TutorialCardsProps) {
   return (
-    <div className={cn("grid grid-cols-1 md:grid-cols-2 gap-4 mt-6", className)}>
+    <div
+      className={cn("grid grid-cols-1 md:grid-cols-2 gap-4 mt-6", className)}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved styling and layout of `TutorialCard` and `TutorialCards` components with enhanced hover effects and layout adjustments.
> 
>   - **Styling Improvements**:
>     - Updated `TutorialCard` hover effects: added `hover:bg-muted/40`, `hover:border-gray-300`, and `dark:hover:border-gray-600`.
>     - Changed `CardContent` padding from `p-6` to `p-4`.
>     - Modified icon styling to include `group-hover:text-primary` and `transition-colors`.
>   - **Layout Adjustments**:
>     - Removed `ArrowRight` icon from `TutorialCard`.
>     - Adjusted `TutorialCards` grid container to ensure consistent layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for d8f06975936d322cfe2aaba273245777a51e57da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->