### PR TITLE
Comment out incident banner in theme config

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -217,24 +217,24 @@ const config: DocsThemeConfig = {
     Callout,
     Video,
   },
-  banner: {
-    key: "cloudflare-incident",
-    dismissible: false,
-    content: (
-      <Link href="https://status.langfuse.com/">
-        {/* mobile */}
-        <span className="sm:hidden">
-          Incident: Langfuse Cloud is affected by the global Cloudflare outage.
-          Currently, services are recovering, see status page for more details.
-        </span>
-        {/* desktop */}
-        <span className="hidden sm:inline">
-          Incident: Langfuse Cloud is affected by the global Cloudflare outage.
-          Currently, services are recovering, see status page for more details.
-        </span>
-      </Link>
-    ),
-  },
+  // banner: {
+  //   key: "cloudflare-incident",
+  //   dismissible: false,
+  //   content: (
+  //     <Link href="https://status.langfuse.com/">
+  //       {/* mobile */}
+  //       <span className="sm:hidden">
+  //         Incident: Langfuse Cloud is affected by the global Cloudflare outage.
+  //         Currently, services are recovering, see status page for more details.
+  //       </span>
+  //       {/* desktop */}
+  //       <span className="hidden sm:inline">
+  //         Incident: Langfuse Cloud is affected by the global Cloudflare outage.
+  //         Currently, services are recovering, see status page for more details.
+  //       </span>
+  //     </Link>
+  //   ),
+  // },
 };
 
 export default config;


### PR DESCRIPTION
Comment out the incident banner in `theme.config.tsx` to prevent it from displaying on the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-76451072-3f82-4192-bd51-7d6947f9612a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76451072-3f82-4192-bd51-7d6947f9612a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

