### PR TITLE
Constrain image width on experiment page

### DIFF
--- a/pages/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/pages/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -1300,17 +1300,17 @@ You need to set up a webhook to receive the trigger request from Langfuse.
 - **Navigate to** `Your Project` > `Datasets`
 - **Click on** the dataset you want to set up a remote experiment trigger for
 
-<Frame>![New Experiment Button](/images/docs/navigate-to-dataset.png)</Frame>
+<Frame className="max-w-lg">![New Experiment Button](/images/docs/navigate-to-dataset.png)</Frame>
 
 ### Open the setup page
 
 **Click on** `Start Experiment` to open the setup page
 
-<Frame>![New Experiment Button](/images/docs/trigger-process.png)</Frame>
+<Frame className="max-w-lg">![New Experiment Button](/images/docs/trigger-process.png)</Frame>
 
 **Click on** `⚡` below `Custom Experiment`
 
-<Frame>
+<Frame className="max-w-lg">
   ![New Experiment Button](/images/docs/trigger-remote-experiment-1.png)
 </Frame>
 
@@ -1319,7 +1319,7 @@ You need to set up a webhook to receive the trigger request from Langfuse.
 **Enter** the URL of your external evaluation service that will receive the webhook when experiments are triggered.
 **Specify** a default config that will be sent to your webhook. Users can modify this when triggering experiments.
 
-<Frame>
+<Frame className="max-w-lg">
   ![New Experiment Button](/images/docs/trigger-remote-experiment-2.png)
 </Frame>
 
@@ -1327,7 +1327,7 @@ You need to set up a webhook to receive the trigger request from Langfuse.
 
 Once configured, team members can trigger remote experiments via the `Run` button under the **Custom Experiment** option. Langfuse will send the dataset metadata (ID and name) along with any custom configuration to your webhook.
 
-<Frame>
+<Frame className="max-w-lg">
   ![New Experiment Button](/images/docs/trigger-remote-experiment-3.png)
 </Frame>
 


### PR DESCRIPTION
Add `max-w-lg` to images on the "experiment with SDK" page to constrain their width and match existing styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f1ce74a-6cfc-4908-98ec-ec5fe2b26560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f1ce74a-6cfc-4908-98ec-ec5fe2b26560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

