### PR TITLE
Add langfuse shipper to documentation

### DIFF
--- a/pages/integrations/no-code/n8n.mdx
+++ b/pages/integrations/no-code/n8n.mdx
@@ -32,3 +32,5 @@ Currently, there is no native n8n tracing integration. Please upvote the related
 </Frame>
 
 [@rorubyy](https://github.com/rorubyy) has created a n8n node for that wraps OpenAI models and sends tracing data to Langfuse. You can find it here: [rorubyy/n8n-nodes-openai-langfuse](https://github.com/rorubyy/n8n-nodes-openai-langfuse)
+
+Alternatively, [@rwb-truelime](https://github.com/rwb-truelime) has developed [n8n-langfuse-shipper](https://github.com/rwb-truelime/n8n-langfuse-shipper), a Python project that ships n8n execution data to Langfuse using the OTEL (OpenTelemetry) API. This approach provides a broader integration by capturing workflow execution data from n8n and forwarding it to Langfuse for observability and tracing.


### PR DESCRIPTION
Add a community-maintained Langfuse integration option to the n8n documentation page to provide users with an alternative for tracing n8n workflow execution data.

---
<a href="https://cursor.com/background-agent?bcId=bc-e40a1ecd-8d56-411f-b85f-5b7c4f6426a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e40a1ecd-8d56-411f-b85f-5b7c4f6426a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

