### PR TITLE
Add handbook section to about page

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -35,8 +35,6 @@ And angels and operators who work in ML, Open Source, and Developer Tools.
 
 ## Read our Handbook
 
-We publicly document our core principles and processes at Langfuse to align as a team, maintain transparency with our community, and help you determine if you'd enjoy working here.
-
 <ChapterIndex />
 
 ## Join us


### PR DESCRIPTION
Add the handbook section to the `/about` page, mirroring the structure on `/careers`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f550580-e477-4e0c-87dd-495192e76f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f550580-e477-4e0c-87dd-495192e76f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a handbook section to the `/about` page using the `ChapterIndex` component, mirroring the `/careers` page structure.
> 
>   - **Behavior**:
>     - Adds a "Read our Handbook" section to `about.mdx` using the `ChapterIndex` component.
>     - Mirrors the structure of the `/careers` page.
>   - **Components**:
>     - Imports `ChapterIndex` from `@/components/handbook/ChapterIndex` in `about.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8d1f5968ef90ce57d279c58e4c6a70508c49266f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->