### PR TITLE
Set up Cloudflare proxy for Langfuse handbook

### DIFF
--- a/pages/handbook/product-engineering/architecture.mdx
+++ b/pages/handbook/product-engineering/architecture.mdx
@@ -51,7 +51,7 @@ flowchart LR
 
 ## Production environments
 
-Our production infrastructure is deployed across multiple AWS regions with a fully automated CI/CD pipeline. All infrastructure is managed using Terraform. Cloudflare WAF (Web Application Firewall) serves as a central proxy in front of AWS, providing DDoS protection, security filtering, and traffic management.
+Our production infrastructure is deployed across multiple AWS regions with a fully automated CI/CD pipeline. All infrastructure is managed using Terraform. Cloudflare WAF (Web Application Firewall) serves as a central proxy in front of AWS.
 
 ```mermaid
 ---


### PR DESCRIPTION
Add Cloudflare WAF as a central proxy in front of AWS to the architecture page, including a diagram update.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ba79cb8-c4a3-4c0c-8dd2-c66c49f03d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ba79cb8-c4a3-4c0c-8dd2-c66c49f03d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Cloudflare WAF as a central proxy in front of AWS to the architecture documentation, including a diagram update.
> 
>   - **Architecture Update**:
>     - Adds Cloudflare WAF as a central proxy in front of AWS in `architecture.mdx`.
>     - Updates diagram to include Cloudflare WAF and Proxy components.
>   - **Security**:
>     - Describes Cloudflare WAF providing DDoS protection, security filtering, and traffic management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1ca1e24b4be8fb25484f11d92cd758c20c14428a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->