### PR TITLE
docs: update dataset fetching instructions and clarify URL encoding requirements

### DIFF
--- a/pages/docs/evaluation/experiments/datasets.mdx
+++ b/pages/docs/evaluation/experiments/datasets.mdx
@@ -52,19 +52,16 @@ Use the Langfuse UI or SDK to create and fetch a dataset in a folder by adding a
 <Tab>
 
 ```python
-from urllib.parse import quote
-
 dataset_name = "evaluation/qa-dataset"
-encoded_name = quote(dataset_name, safe="")  # "evaluation%2Fqa-dataset"
 
 # When creating a dataset, use the full dataset name
 langfuse.create_dataset(
     name=dataset_name,
 )
 
-# When fetching a dataset in a folder, use the encoded name
+# When fetching a dataset in a folder, use the full dataset name
 langfuse.get_dataset(
-    name=encoded_name
+    name=dataset_name
 )
 
 ```
@@ -101,8 +98,7 @@ In the UI, create a dataset and use a slash (`/`) in the name field to organize 
 
 <Callout type="info">
   **URL Encoding**: When using dataset names with slashes as path parameters in
-  the API, use URL encoding. For example, in Python: `urllib.parse.quote(name,
-  safe="")`, in TypeScript: `encodeURIComponent(name)`.
+  the API or JS/TS SDK, use URL encoding. For example, in TypeScript: `encodeURIComponent(name)`.
 </Callout>
 
 ## Schema Enforcement

--- a/pages/faq/all/retrieve-experiment-scores.mdx
+++ b/pages/faq/all/retrieve-experiment-scores.mdx
@@ -79,7 +79,7 @@ const runName = "your-run-name";
 const encodedDatasetName = encodeURIComponent(datasetName);
 const encodedRunName = encodeURIComponent(runName);
 
-// Fetch experiment run
+// Fetch experiment run; must use encoded names for fetching runs
 const run = await langfuse.dataset.getRun({
   datasetName: encodedDatasetName,
   runName: encodedRunName


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update dataset fetching instructions to use full names and clarify URL encoding requirements in documentation.
> 
>   - **Documentation Updates**:
>     - In `datasets.mdx`, update instructions to use the full dataset name for fetching datasets instead of the encoded name.
>     - Clarify URL encoding requirements in `datasets.mdx` and `retrieve-experiment-scores.mdx` for API and SDK usage.
>   - **Code Examples**:
>     - Remove `quote()` usage in Python example in `datasets.mdx`.
>     - Add comment in TypeScript example in `retrieve-experiment-scores.mdx` to emphasize the need for encoded names when fetching runs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7e6e850dde4f8898fb2eef89525f6c41e3f3c296. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->