### PR TITLE
docs: add new Redis TLS configuration options

### DIFF
--- a/pages/self-hosting/deployment/infrastructure/cache.mdx
+++ b/pages/self-hosting/deployment/infrastructure/cache.mdx
@@ -53,6 +53,13 @@ OR
 | `REDIS_TLS_CA_PATH`     |                    | Path to the CA certificate for the Redis connection.                                                                    |
 | `REDIS_TLS_CERT_PATH`   |                    | Path to the certificate for the Redis connection.                                                                       |
 | `REDIS_TLS_KEY_PATH`    |                    | Path to the private key for the Redis connection.                                                                       |
+| `REDIS_TLS_SERVERNAME`  |                    | Server name for SNI (Server Name Indication). Useful when connecting to Redis through a proxy or with custom certificates. |
+| `REDIS_TLS_REJECT_UNAUTHORIZED` | `true`     | Set to `false` to disable certificate validation. Not recommended for production. When not set, defaults to Node.js secure behavior. |
+| `REDIS_TLS_CHECK_SERVER_IDENTITY` |          | Set to `false` to bypass server identity checking. Use with caution in enterprise environments with custom certificate setups. |
+| `REDIS_TLS_SECURE_PROTOCOL` |                 | TLS protocol version specification (e.g., `TLSv1_2_method`, `TLSv1_3_method`). Uses Node.js defaults when not specified. |
+| `REDIS_TLS_CIPHERS`     |                    | Custom cipher suite configuration. Allows specification of allowed TLS ciphers for enhanced security requirements.       |
+| `REDIS_TLS_HONOR_CIPHER_ORDER` |              | Set to `true` to use server's cipher order preference instead of client's. Useful for enforcing security policies.        |
+| `REDIS_TLS_KEY_PASSPHRASE` |                  | Passphrase for encrypted private keys. Required if your TLS private key is password-protected.                           |
 | `REDIS_KEY_PREFIX`           | ``                 | Optional prefix for all Redis keys to avoid key collisions with other applications. Should end with `:`.                     |
 | `REDIS_CLUSTER_ENABLED`      | `false`            | Set to `true` to enable Redis cluster mode. When enabled, you must also provide `REDIS_CLUSTER_NODES`.                       |
 | `REDIS_CLUSTER_NODES`        |                    | Comma-separated list of Redis cluster nodes in the format `host:port`. Required when `REDIS_CLUSTER_ENABLED` is `true`.      |
@@ -173,6 +180,7 @@ REDIS_CLUSTER_ENABLED=true
 REDIS_CLUSTER_NODES=clustercfg.my-redis-cluster.abc123.cache.amazonaws.com:6379
 REDIS_AUTH=your-auth-token
 REDIS_TLS_ENABLED=true
+REDIS_TLS_SERVERNAME=clustercfg.my-redis-cluster.abc123.cache.amazonaws.com
 ```
 
 #### Self-hosted Redis Cluster
@@ -181,6 +189,30 @@ REDIS_TLS_ENABLED=true
 REDIS_CLUSTER_ENABLED=true
 REDIS_CLUSTER_NODES=10.0.1.10:6379,10.0.1.11:6379,10.0.1.12:6379,10.0.1.13:6379,10.0.1.14:6379,10.0.1.15:6379
 REDIS_AUTH=your-cluster-password
+```
+
+#### Enterprise Redis with Custom CA Certificates
+
+For enterprise environments with custom certificate authorities and specific TLS requirements:
+
+```bash
+REDIS_CONNECTION_STRING=redis://username:password@redis.example.com:6379
+REDIS_TLS_ENABLED=true
+REDIS_TLS_CA_PATH=/app/ca/cacertbundle.pem
+REDIS_TLS_CERT_PATH=/app/redis-certs/tls.crt
+REDIS_TLS_KEY_PATH=/app/redis-certs/tls.key
+REDIS_TLS_SERVERNAME=redis.example.com
+REDIS_TLS_REJECT_UNAUTHORIZED=true
+```
+
+This configuration enables:
+- Proper certificate validation against a custom CA
+- SNI support via `REDIS_TLS_SERVERNAME` for proxied connections
+- Secure certificate verification without global workarounds
+
+For encrypted private keys, add:
+```bash
+REDIS_TLS_KEY_PASSPHRASE=your-key-passphrase
 ```
 
 <Callout type="warning">


### PR DESCRIPTION
## Summary

Adds documentation for 7 new Redis TLS environment variables introduced in [langfuse/langfuse#10663](https://github.com/langfuse/langfuse/pull/10663).

## Changes

### New Environment Variables Documented

1. **REDIS_TLS_SERVERNAME** - Server name for SNI (Server Name Indication)
2. **REDIS_TLS_REJECT_UNAUTHORIZED** - Certificate validation control
3. **REDIS_TLS_CHECK_SERVER_IDENTITY** - Server identity checking bypass
4. **REDIS_TLS_SECURE_PROTOCOL** - TLS protocol version specification
5. **REDIS_TLS_CIPHERS** - Custom cipher suite configuration
6. **REDIS_TLS_HONOR_CIPHER_ORDER** - Cipher order preference
7. **REDIS_TLS_KEY_PASSPHRASE** - Support for encrypted private keys

### Enhanced Examples

- **AWS ElastiCache**: Added `REDIS_TLS_SERVERNAME` to demonstrate proper SNI configuration
- **Enterprise TLS**: New comprehensive example showing custom CA certificate setup with all relevant TLS options

## Benefits

✅ Documents solutions for enterprise CA certificate validation issues
✅ Shows how to eliminate `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround
✅ Provides clear examples for proper SNI configuration
✅ Maintains security compliance guidelines
✅ All options are optional and backward compatible

## Modified Files

- `pages/self-hosting/deployment/infrastructure/cache.mdx` - Added TLS options to configuration table and example configurations

## Related

- Implements documentation for langfuse/langfuse#10663
- Fixes documentation gap for enterprise Redis TLS configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for 7 new Redis TLS environment variables and updates examples in `cache.mdx`.
> 
>   - **Documentation**:
>     - Adds 7 new Redis TLS environment variables to `cache.mdx`: `REDIS_TLS_SERVERNAME`, `REDIS_TLS_REJECT_UNAUTHORIZED`, `REDIS_TLS_CHECK_SERVER_IDENTITY`, `REDIS_TLS_SECURE_PROTOCOL`, `REDIS_TLS_CIPHERS`, `REDIS_TLS_HONOR_CIPHER_ORDER`, `REDIS_TLS_KEY_PASSPHRASE`.
>     - Updates configuration table and examples to include new TLS options.
>   - **Examples**:
>     - Adds `REDIS_TLS_SERVERNAME` to AWS ElastiCache example for SNI configuration.
>     - Adds comprehensive enterprise TLS example with custom CA certificate setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for fd7d0cae64c5f2be2215602fd8c51db5a07a74f5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->