### PR TITLE
fix: tighter trace deletion API limits

### DIFF
--- a/pages/faq/all/api-limits.mdx
+++ b/pages/faq/all/api-limits.mdx
@@ -18,6 +18,10 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 5MB per request and 5MB per response
 
+### Request Constraints
+
+- **Trace Deletion**: We advise strongly against trying to send more than 30-50 trace ids in a single DELETE request. Consider using [data retention](/docs/administration/data-retention) to automatically delete old traces instead of manual deletion.
+
 ### Rate Limits
 
 Rate limits are applied per-organization.
@@ -26,6 +30,7 @@ Rate limits are applied per-organization.
 | ------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
 | **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces. | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
 | **Legacy Tracing**. Legacy ingestion endpoints.                                                         | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace Deletion**. DELETE APIs used to delete traces.                                                  | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
 | **Prompts**. GET APIs used to fetch prompts for use in applications.                                    | No limit           | No limit           | No limit            |
 | **Metrics**. GET APIs used to fetch analytics data, e.g. [metrics api](/docs/analytics/metrics-api).    | 100&nbsp;req/day   | 200&nbsp;req/day   | 2000&nbsp;req/day   |
 | **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                        | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces tighter limits on trace deletion API requests and rate limits in `api-limits.mdx`.
> 
>   - **Trace Deletion Limits**:
>     - Advises against sending more than 30-50 trace IDs in a single DELETE request in `api-limits.mdx`.
>     - Adds rate limits for trace deletion: 50 req/day for Hobby, 200 req/day for Core, and 1,000 req/day for Pro/Team/Enterprise in `api-limits.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 9964cb6840e88748ab369c1b8b07a9bb0e381ced. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->