### PR TITLE
Add OpenTelemetry get started guide to tracing docs

### DIFF
--- a/components-mdx/get-started/opentelemetry.mdx
+++ b/components-mdx/get-started/opentelemetry.mdx
@@ -1,0 +1,27 @@
+**Configure OpenTelemetry endpoint**
+
+Langfuse exposes an OpenTelemetry (OTLP) endpoint at `/api/public/otel` that can receive traces from any OpenTelemetry-compatible client. If you already have an OpenTelemetry setup in your application, you can configure Langfuse as an additional backend to receive your traces.
+
+Set the following environment variables to point your OpenTelemetry exporter to Langfuse:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+# OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US data region
+
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING}"
+```
+
+**Authenticate with your API keys**
+
+Langfuse uses Basic Auth to authenticate OpenTelemetry requests. Create a base64-encoded string from your Langfuse API keys:
+
+```bash
+echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
+```
+
+Use the output as `AUTH_STRING` in the headers configuration above.
+
+**Start tracing**
+
+Once configured, your OpenTelemetry-instrumented application will automatically send traces to Langfuse. This works with any OpenTelemetry-compatible library including OpenLLMetry, OpenLIT, and framework-specific instrumentations.
+

--- a/pages/docs/observability/get-started.mdx
+++ b/pages/docs/observability/get-started.mdx
@@ -22,12 +22,13 @@ import GetStartedLangchain from "@/components-mdx/get-started/langchain.mdx";
 import GetStartedJsOpenaiSdk from "@/components-mdx/get-started/js-openai-sdk.mdx";
 import GetStartedJsLangchain from "@/components-mdx/get-started/js-langchain.mdx";
 import GetStartedAutoInstall from "@/components-mdx/get-started/auto-install.mdx";
+import GetStartedOpenTelemetry from "@/components-mdx/get-started/opentelemetry.mdx";
 
 import { BookOpen, Code } from "lucide-react";
 
 If you're using one of our supported integrations, following their specific guide will be the fastest way to get started with minimal code changes. For more control, you can instrument your application directly using the Python or JS/TS SDKs.
 
-<LangTabs items={["OpenAI SDK (Python)", "OpenAI SDK (JS/TS)", "LangChain (Python)", "LangChain (JS/TS)", "Python SDK", "JS/TS SDK", "✨ Auto Install", "More integrations"]}>
+<LangTabs items={["OpenAI SDK (Python)", "OpenAI SDK (JS/TS)", "LangChain (Python)", "LangChain (JS/TS)", "Python SDK", "JS/TS SDK", "OpenTelemetry", "✨ Auto Install", "More integrations"]}>
 
 <Tab>
 {/* PYTHON - OPENAI*/}
@@ -183,6 +184,24 @@ Use the Langfuse JS/TS SDK to wrap any LLM or Agent
     icon={<Code />}
     title="Notebook"
     href="/docs/sdk/typescript/example-notebook"
+    arrow
+  />
+</Cards>
+
+</Tab>
+
+<Tab>
+{/* OPENTELEMETRY */}
+
+If you already have OpenTelemetry instrumentation in your application, you can configure Langfuse as an OpenTelemetry backend to receive your traces.
+
+<GetStartedOpenTelemetry />
+
+<Cards num={1}>
+  <Card
+    icon={<BookOpen />}
+    title="Full OpenTelemetry documentation"
+    href="/integrations/native/opentelemetry"
     arrow
   />
 </Cards>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds OpenTelemetry setup guide to tracing docs, detailing Langfuse configuration and authentication.
> 
>   - **New Guide**:
>     - Adds `opentelemetry.mdx` to `components-mdx/get-started/` for OpenTelemetry setup.
>     - Provides instructions to configure Langfuse as an OpenTelemetry backend.
>     - Details environment variable setup for EU and US data regions.
>     - Explains Basic Auth setup using Langfuse API keys.
>   - **Documentation Update**:
>     - Updates `get-started.mdx` in `pages/docs/observability/` to include OpenTelemetry in the integration tabs.
>     - Adds a new tab for OpenTelemetry with a link to full documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1e6abf19a29d4bfa77cc424ed4b98070f62e52ec. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->