### PR TITLE
Update github actions docs with workaround

### DIFF
--- a/data/generated/contributors.json
+++ b/data/generated/contributors.json
@@ -5,12 +5,16 @@
   "/docs/administration/authentication-and-sso": [
     "marcklingen"
   ],
+  "/docs/administration/billable-units": [
+    "Lotte-Verheyden"
+  ],
   "/docs/administration/data-deletion": [
     "FroeMic",
     "marcklingen",
     "jannikmaierhoefer"
   ],
   "/docs/administration/data-retention": [
+    "Steffen911",
     "marcklingen",
     "nimarb"
   ],
@@ -43,10 +47,15 @@
   "/docs/api-and-data-platform/features/fine-tuning": [
     "marcklingen"
   ],
-  "/docs/api-and-data-platform/features/public-api": [
-    "daaain",
+  "/docs/api-and-data-platform/features/mcp-server": [
     "jannikmaierhoefer",
     "marcklingen",
+    "FroeMic"
+  ],
+  "/docs/api-and-data-platform/features/public-api": [
+    "marcklingen",
+    "daaain",
+    "jannikmaierhoefer",
     "felixkrrr"
   ],
   "/docs/api-and-data-platform/features/query-via-sdk": [
@@ -55,13 +64,16 @@
     "felixkrrr"
   ],
   "/docs/api-and-data-platform/overview": [
+    "FroeMic",
     "marcklingen"
   ],
   "/docs/ask-ai": [
+    "Lotte-Verheyden",
     "marcklingen",
     "jannikmaierhoefer"
   ],
   "/docs/demo": [
+    "Lotte-Verheyden",
     "marcklingen",
     "jannikmaierhoefer",
     "clemra",
@@ -77,9 +89,9 @@
     "jannikmaierhoefer"
   ],
   "/docs/evaluation/evaluation-methods/custom-scores": [
+    "jannikmaierhoefer",
     "hassiebp",
     "marliessophie",
-    "jannikmaierhoefer",
     "maxdeichmann",
     "marcklingen",
     "felixkrrr"
@@ -96,18 +108,21 @@
     "AkioNuernberger",
     "jannikmaierhoefer"
   ],
+  "/docs/evaluation/evaluation-methods/score-analytics": [
+    "FroeMic"
+  ],
   "/docs/evaluation/experiments/data-model": [
     "hassiebp"
   ],
   "/docs/evaluation/experiments/datasets": [
+    "marliessophie",
     "hassiebp",
     "marcklingen",
-    "marliessophie",
     "AkioNuernberger"
   ],
   "/docs/evaluation/experiments/experiments-via-sdk": [
-    "jannikmaierhoefer",
     "marcklingen",
+    "jannikmaierhoefer",
     "hassiebp"
   ],
   "/docs/evaluation/experiments/experiments-via-ui": [
@@ -151,6 +166,7 @@
     "marcklingen"
   ],
   "/docs/observability/data-model": [
+    "Lotte-Verheyden",
     "marcklingen",
     "hassiebp",
     "nimarb"
@@ -165,33 +181,33 @@
     "marcklingen"
   ],
   "/docs/observability/features/environments": [
+    "jannikmaierhoefer",
     "hassiebp",
     "felixkrrr",
-    "jannikmaierhoefer",
     "marcklingen"
   ],
   "/docs/observability/features/log-levels": [
+    "jannikmaierhoefer",
     "hassiebp",
-    "marcklingen",
-    "jannikmaierhoefer"
+    "marcklingen"
   ],
   "/docs/observability/features/masking": [
-    "marcklingen",
     "jannikmaierhoefer",
+    "marcklingen",
     "hassiebp"
   ],
   "/docs/observability/features/mcp-tracing": [
     "aabedraba"
   ],
   "/docs/observability/features/metadata": [
-    "hassiebp",
     "jannikmaierhoefer",
+    "hassiebp",
     "Steffen911",
     "marcklingen"
   ],
   "/docs/observability/features/multi-modality": [
-    "hassiebp",
     "jannikmaierhoefer",
+    "hassiebp",
     "dminhvu",
     "Athroniaeth",
     "marcklingen"
@@ -202,14 +218,14 @@
     "nimarb"
   ],
   "/docs/observability/features/queuing-batching": [
-    "jannikmaierhoefer",
     "hassiebp",
+    "jannikmaierhoefer",
     "marcklingen"
   ],
   "/docs/observability/features/releases-and-versioning": [
+    "jannikmaierhoefer",
     "hassiebp",
-    "marcklingen",
-    "jannikmaierhoefer"
+    "marcklingen"
   ],
   "/docs/observability/features/sampling": [
     "hassiebp",
@@ -217,20 +233,20 @@
     "marcklingen"
   ],
   "/docs/observability/features/sessions": [
+    "jannikmaierhoefer",
     "hassiebp",
-    "marcklingen",
-    "jannikmaierhoefer"
+    "marcklingen"
   ],
   "/docs/observability/features/tags": [
-    "hassiebp",
     "jannikmaierhoefer",
+    "hassiebp",
     "marcklingen",
     "Steffen911"
   ],
   "/docs/observability/features/token-and-cost-tracking": [
     "hassiebp",
-    "marcklingen",
     "jannikmaierhoefer",
+    "marcklingen",
     "nimarb"
   ],
   "/docs/observability/features/trace-ids-and-distributed-tracing": [
@@ -243,17 +259,22 @@
     "marcklingen",
     "hassiebp"
   ],
+  "/docs/observability/features/user-feedback": [
+    "aabedraba"
+  ],
   "/docs/observability/features/users": [
+    "jannikmaierhoefer",
     "hassiebp",
     "marcklingen",
-    "jannikmaierhoefer",
     "felixkrrr"
   ],
   "/docs/observability/get-started": [
+    "Lotte-Verheyden",
     "jannikmaierhoefer",
     "marcklingen"
   ],
   "/docs/observability/overview": [
+    "Lotte-Verheyden",
     "marcklingen",
     "DrRinkiArya"
   ],
@@ -267,13 +288,13 @@
     "nimarb"
   ],
   "/docs/observability/sdk/python/evaluation": [
-    "hassiebp",
-    "jannikmaierhoefer"
+    "jannikmaierhoefer",
+    "hassiebp"
   ],
   "/docs/observability/sdk/python/instrumentation": [
+    "jannikmaierhoefer",
     "marcklingen",
-    "hassiebp",
-    "jannikmaierhoefer"
+    "hassiebp"
   ],
   "/docs/observability/sdk/python/overview": [
     "hassiebp",
@@ -287,8 +308,8 @@
     "marcklingen"
   ],
   "/docs/observability/sdk/python/upgrade-path": [
-    "hassiebp",
-    "jannikmaierhoefer"
+    "jannikmaierhoefer",
+    "hassiebp"
   ],
   "/docs/observability/sdk/typescript/advanced-usage": [
     "hassiebp",
@@ -341,6 +362,7 @@
     "marcklingen"
   ],
   "/docs/prompt-management/features/github-integration": [
+    "mfcabrera",
     "maxdeichmann"
   ],
   "/docs/prompt-management/features/guaranteed-availability": [
@@ -353,6 +375,7 @@
     "jannikmaierhoefer"
   ],
   "/docs/prompt-management/features/mcp-server": [
+    "FroeMic",
     "marcklingen"
   ],
   "/docs/prompt-management/features/message-placeholders": [
@@ -392,9 +415,9 @@
     "jannikmaierhoefer"
   ],
   "/docs/roadmap": [
+    "marcklingen",
     "nimarb",
     "maxdeichmann",
-    "marcklingen",
     "jannikmaierhoefer",
     "Steffen911",
     "clemra",
@@ -417,6 +440,7 @@
     "Steffen911"
   ],
   "/faq/all/api-limits": [
+    "sumerman",
     "jannikmaierhoefer",
     "marcklingen",
     "Steffen911",
@@ -470,6 +494,7 @@
     "marcklingen"
   ],
   "/faq/all/cutting-costs": [
+    "Lotte-Verheyden",
     "AkioNuernberger",
     "FroeMic",
     "Steffen911",
@@ -490,6 +515,7 @@
     "clemra"
   ],
   "/faq/all/empty-trace-input-and-output": [
+    "Lotte-Verheyden",
     "jannikmaierhoefer"
   ],
   "/faq/all/enable-disable-tracing": [
@@ -572,6 +598,7 @@
   ],
   "/faq/all/missing-traces": [
     "jannikmaierhoefer",
+    "Lotte-Verheyden",
     "marcklingen"
   ],
   "/faq/all/monitoring-ai-generated-content": [
@@ -649,10 +676,6 @@
   "/faq/all/upgrade-langfuse": [
     "marcklingen",
     "clemra"
-  ],
-  "/faq/all/user-feedback": [
-    "marcklingen",
-    "jannikmaierhoefer"
   ],
   "/faq/all/what-is-LCEL": [
     "marcklingen",
@@ -753,6 +776,7 @@
     "omahs"
   ],
   "/guides/cookbook/example_intent_classification_pipeline": [
+    "Lotte-Verheyden",
     "jannikmaierhoefer",
     "marcklingen",
     "omahs",
@@ -784,6 +808,7 @@
     "aabedraba"
   ],
   "/guides/cookbook/example_synthetic_datasets": [
+    "pawelsierant",
     "aabedraba",
     "jannikmaierhoefer"
   ],
@@ -942,6 +967,7 @@
   ],
   "/guides/index": [
     "marcklingen",
+    "aabedraba",
     "jannikmaierhoefer"
   ],
   "/guides/videos/beginners-guide-to-rag-evaluation": [
@@ -1005,19 +1031,30 @@
     "marcklingen"
   ],
   "/handbook/chapters/why": [
-    "felixkrrr",
-    "marcklingen"
-  ],
-  "/handbook/how-we-hire": [
+    "marcklingen",
     "felixkrrr"
+  ],
+  "/handbook/devrel/community-hour": [
+    "jannikmaierhoefer"
+  ],
+  "/handbook/how-we-hire/engineering-super-day": [
+    "maxdeichmann"
+  ],
+  "/handbook/how-we-hire/hiring-process": [
+    "maxdeichmann"
+  ],
+  "/handbook/how-we-hire/philosophy": [
+    "maxdeichmann"
   ],
   "/handbook/how-we-work/meetings": [
-    "felixkrrr"
+    "felixkrrr",
+    "maxdeichmann"
   ],
   "/handbook/how-we-work/ownership": [
     "felixkrrr"
   ],
   "/handbook/how-we-work/principles": [
+    "maxdeichmann",
     "marcklingen",
     "felixkrrr"
   ],
@@ -1039,24 +1076,51 @@
     "felixkrrr"
   ],
   "/handbook/product-engineering/analytics": [
+    "maxdeichmann",
     "felixkrrr"
   ],
-  "/handbook/product-engineering/documentation": [
-    "felixkrrr",
-    "marcklingen"
+  "/handbook/product-engineering/architecture": [
+    "marcklingen",
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/how-we-work/code-review": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/how-we-work/onboarding": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/how-we-work/product-ops": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/how-we-work/roadmapping": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/how-we-work/workflow": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/infrastructure/clickhouse": [
+    "Steffen911"
+  ],
+  "/handbook/product-engineering/playbooks/code-structure": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/playbooks/documentation": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/playbooks/releases": [
+    "maxdeichmann"
+  ],
+  "/handbook/product-engineering/playbooks/vulnerability-handling": [
+    "maxdeichmann"
   ],
   "/handbook/product-engineering/principles": [
+    "maxdeichmann",
     "marcklingen",
     "felixkrrr"
   ],
-  "/handbook/product-engineering/product-ops": [
-    "marcklingen"
-  ],
-  "/handbook/product-engineering/releases": [
-    "marcklingen"
-  ],
-  "/handbook/product-engineering/roadmapping": [
-    "marcklingen"
+  "/handbook/product-engineering/tech-stack": [
+    "Steffen911",
+    "maxdeichmann"
   ],
   "/handbook/sales-and-cs/customer-success": [
     "felixkrrr"
@@ -1068,9 +1132,11 @@
     "felixkrrr"
   ],
   "/handbook/support/support": [
+    "maxdeichmann",
     "felixkrrr"
   ],
   "/handbook/support/using-plain": [
+    "maxdeichmann",
     "felixkrrr"
   ],
   "/handbook/tools-and-processes/spending-money": [
@@ -1080,9 +1146,11 @@
     "felixkrrr"
   ],
   "/handbook/tools-and-processes/using-linear": [
+    "maxdeichmann",
     "felixkrrr"
   ],
   "/handbook/tools-and-processes/using-slack": [
+    "marcklingen",
     "felixkrrr"
   ],
   "/integrations/analytics/coval": [
@@ -1219,9 +1287,9 @@
     "jannikmaierhoefer"
   ],
   "/integrations/frameworks/vercel-ai-sdk": [
+    "jannikmaierhoefer",
     "hassiebp",
     "aabedraba",
-    "jannikmaierhoefer",
     "marcklingen"
   ],
   "/integrations/frameworks/voltagent": [
@@ -1234,6 +1302,9 @@
   "/integrations/gateways/anannas": [
     "jannikmaierhoefer",
     "Haleshot"
+  ],
+  "/integrations/gateways/kong-ai-plugin": [
+    "Ramtinboreili"
   ],
   "/integrations/gateways/litellm": [
     "marcklingen",
@@ -1343,9 +1414,9 @@
     "marcklingen"
   ],
   "/integrations/native/opentelemetry": [
+    "Steffen911",
     "jannikmaierhoefer",
-    "marcklingen",
-    "Steffen911"
+    "marcklingen"
   ],
   "/integrations/no-code/dify": [
     "marcklingen",
@@ -1457,8 +1528,8 @@
     "marcklingen"
   ],
   "/security/index": [
-    "AkioNuernberger",
-    "marcklingen"
+    "marcklingen",
+    "AkioNuernberger"
   ],
   "/security/iso27001": [
     "marcklingen"
@@ -1484,9 +1555,10 @@
     "Steffen911"
   ],
   "/security/responsible-disclosure": [
+    "Steffen911",
     "maxdeichmann",
-    "marliessophie",
-    "marcklingen"
+    "marcklingen",
+    "marliessophie"
   ],
   "/security/security-faq": [
     "marcklingen",
@@ -1510,6 +1582,7 @@
     "marcklingen"
   ],
   "/self-hosting/administration/automated-access-provisioning": [
+    "MEgooneh",
     "marcklingen"
   ],
   "/self-hosting/administration/headless-initialization": [
@@ -1518,10 +1591,10 @@
   "/self-hosting/administration/index": [
     "marcklingen"
   ],
-  "/self-hosting/administration/organization-creators": [
+  "/self-hosting/administration/instance-management-api": [
     "marcklingen"
   ],
-  "/self-hosting/administration/instance-management-api": [
+  "/self-hosting/administration/organization-creators": [
     "marcklingen"
   ],
   "/self-hosting/administration/ui-customization": [
@@ -1544,6 +1617,7 @@
     "marcklingen"
   ],
   "/self-hosting/configuration/index": [
+    "Steffen911",
     "marcklingen"
   ],
   "/self-hosting/configuration/observability": [
@@ -1571,6 +1645,7 @@
     "marcklingen"
   ],
   "/self-hosting/deployment/infrastructure/cache": [
+    "Steffen911",
     "marcklingen"
   ],
   "/self-hosting/deployment/infrastructure/clickhouse": [

--- a/pages/docs/prompt-management/features/github-integration.mdx
+++ b/pages/docs/prompt-management/features/github-integration.mdx
@@ -6,7 +6,7 @@ description: Integrate Langfuse prompts with GitHub using webhooks for version c
 
 There are two methods to integrate Langfuse prompts with GitHub:
 
-- [**GitHub Actions Webhook**](#trigger-github-actions) - Trigger CI/CD workflows when prompts change. This does not require additional infrastructure.
+- [**GitHub Actions Webhook**](#trigger-github-actions) - Trigger CI/CD workflows when prompts change. Requires a webhook proxy to transform payloads.
 - [**Sync Langfuse Prompts to a repository**](#sync-langfuse-prompts-to-a-repository) - Store prompts in a specific file in your repository. This involves a webhook server that listens for prompt version changes and commits them to the repository.
 
 ---
@@ -19,15 +19,19 @@ Trigger GitHub Actions workflows when Langfuse prompts change using `repository_
 sequenceDiagram
     participant User as User/Team
     participant LF as Langfuse
+    participant Proxy as Webhook Proxy
     participant GH as GitHub API
     participant Actions as GitHub Actions
 
     User->>LF: Update prompt in Langfuse
-    LF->>GH: POST /repos/owner/repo/dispatches
+    LF->>Proxy: POST webhook payload
+    Proxy->>GH: POST /repos/owner/repo/dispatches (transformed)
     GH->>Actions: Trigger repository_dispatch event
     Actions->>Actions: Run CI workflow (tests, deploy, etc.)
     Note over User,Actions: Prompt changes trigger automated workflows
 ```
+
+> **Note:** GitHub's `repository_dispatch` API requires a specific payload format with `event_type` and `client_payload` fields. Since Langfuse webhooks send the prompt data directly, you need an intermediate webhook proxy to transform the payload into the correct format for GitHub.
 
 ### 1. Create GitHub Workflow
 
@@ -92,22 +96,151 @@ jobs:
 | Personal Access Token (classic) | `repo` scope (public repos) or `public_repo` scope (private repos) |
 | Fine-grained PAT or GitHub App | `read` and `write` to `actions` |
 
-### 3. Configure Langfuse Webhook for Actions
+### 3. Deploy Webhook Proxy
+
+Since GitHub's `repository_dispatch` API expects a payload with `event_type` and `client_payload` fields, you need an intermediate service to transform Langfuse webhook payloads. Below are examples using Cloudflare Workers (serverless) and a Python server.
+
+<Tabs items={["Cloudflare Workers", "Python Server"]}>
+<Tab>
+
+Deploy this Cloudflare Worker to transform Langfuse webhooks into GitHub `repository_dispatch` format:
+
+```javascript
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    try {
+      const langfusePayload = await request.json();
+
+      // Transform to GitHub repository_dispatch format
+      const githubPayload = {
+        event_type: "langfuse-prompt-update",
+        client_payload: langfusePayload,
+      };
+
+      const response = await fetch(
+        `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/dispatches`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+            "Content-Type": "application/json",
+            "User-Agent": "Langfuse-Webhook-Proxy",
+          },
+          body: JSON.stringify(githubPayload),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await response.text();
+        return new Response(`GitHub API error: ${error}`, {
+          status: response.status,
+        });
+      }
+
+      return new Response(JSON.stringify({ status: "dispatched" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch (error) {
+      return new Response(`Error: ${error.message}`, { status: 500 });
+    }
+  },
+};
+```
+
+**Environment variables required:**
+- `GITHUB_OWNER`: Your GitHub username or organization
+- `GITHUB_REPO`: Your repository name
+- `GITHUB_TOKEN`: Your GitHub Personal Access Token
+
+</Tab>
+<Tab>
+
+Deploy this Python server as a webhook proxy:
+
+```python
+from fastapi import FastAPI, HTTPException, Request
+import httpx
+import os
+
+app = FastAPI(title="Langfuse GitHub Actions Proxy")
+
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+GITHUB_OWNER = os.environ["GITHUB_OWNER"]
+GITHUB_REPO = os.environ["GITHUB_REPO"]
+
+@app.post("/webhook")
+async def proxy_webhook(request: Request):
+    """Transform Langfuse webhook to GitHub repository_dispatch format."""
+    langfuse_payload = await request.json()
+    
+    # Transform to GitHub repository_dispatch format
+    github_payload = {
+        "event_type": "langfuse-prompt-update",
+        "client_payload": langfuse_payload
+    }
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/dispatches",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {GITHUB_TOKEN}",
+                "Content-Type": "application/json",
+                "User-Agent": "Langfuse-Webhook-Proxy"
+            },
+            json=github_payload
+        )
+        
+        if response.status_code not in (200, 204):
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"GitHub API error: {response.text}"
+            )
+    
+    return {"status": "dispatched"}
+
+@app.get("/health")
+async def health():
+    return {"healthy": True}
+```
+
+**Install dependencies:**
+
+```bash
+pip install fastapi uvicorn httpx
+```
+
+**Run the server:**
+
+```bash
+GITHUB_TOKEN=your_token GITHUB_OWNER=owner GITHUB_REPO=repo uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+Deploy to Render, Fly.io, Railway, or any platform that supports Python web apps.
+
+</Tab>
+</Tabs>
+
+### 4. Configure Langfuse Webhook
 
 1. Go to **Prompts > Automations** in your Langfuse project
 2. Click **Create Webhook**
-3. Set endpoint URL: `https://api.github.com/repos/{owner}/{repo}/dispatches`
-4. Add headers:
-   - `Accept: application/vnd.github+json`
-   - `Authorization: Bearer {your_github_token}`
+3. Set endpoint URL to your webhook proxy:
+   - Cloudflare Workers: `https://your-worker.your-subdomain.workers.dev`
+   - Python Server: `https://your-server.example.com/webhook`
 
-**Important:** Store your GitHub token securely in the Authorization header. Langfuse encrypts webhook headers and stores them securely.
-
-### 4. Test GitHub Actions Integration
+### 5. Test GitHub Actions Integration
 
 1. **Update a prompt** in Langfuse with the `production` label
-2. **Check GitHub Actions** tab for triggered workflow
-3. **Verify** that both test and deploy jobs run successfully
+2. **Check your webhook proxy logs** to verify the request was received
+3. **Check GitHub Actions** tab for triggered workflow
+4. **Verify** that both test and deploy jobs run successfully
 
 ---
 

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 18043;
+export const GITHUB_STARS = 18961;


### PR DESCRIPTION
Update GitHub Actions integration documentation to include a webhook proxy workaround for `repository_dispatch` payload format incompatibility.

The original documentation implied a direct integration, but GitHub's `repository_dispatch` API requires `event_type` and `client_payload` fields, which Langfuse webhooks do not provide directly. This PR adds a necessary intermediate webhook proxy step with code examples (Cloudflare Workers, Python FastAPI) to transform the payload, resolving the issue where direct integration failed.

---
Linear Issue: [LF-2078](https://linear.app/langfuse/issue/LF-2078/update-github-actions-docs-with-workaround)

<a href="https://cursor.com/background-agent?bcId=bc-40dbb0da-8fdf-45c5-817e-6e0e79436d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40dbb0da-8fdf-45c5-817e-6e0e79436d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

