### PR TITLE
chroe: idempotent scores section should mention out timestamp bounded limitations

### DIFF
--- a/pages/docs/evaluation/evaluation-methods/custom-scores.mdx
+++ b/pages/docs/evaluation/evaluation-methods/custom-scores.mdx
@@ -283,6 +283,8 @@ By default, Langfuse allows for multiple scores of the same `name` on the same t
 
 In some cases, you want to prevent this behavior or update an existing score. This can be achieved by creating an **idempotency key** on the score and add this as an `id` (JS/TS) / `score_id` (Python) when creating the score, e.g. `<trace_id>-<score_name>`.
 
+Note that if you expect API calls for the same score to be 60+ days apart, you should also use the same timestamp. See [How to update traces, observations, and scores](/faq/all/tracing-data-updates#updating-traces-observations-and-scores) for more details.
+
 ### Enforcing a Score Config
 
 Score configs are helpful when you want to standardize your scores for future analysis.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `custom-scores.mdx` about timestamp limitations for idempotent scores when API calls are 60+ days apart.
> 
>   - **Documentation Update**:
>     - In `custom-scores.mdx`, added a note about timestamp limitations for idempotent scores when API calls are 60+ days apart.
>     - References the section on updating traces, observations, and scores for more details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5b8385fa0e64c8a3ee565c39a2a4ffa86d8511e8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->