### PR TITLE
fix (mcp): correct claude code us host 

### DIFF
--- a/pages/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/pages/docs/api-and-data-platform/features/mcp-server.mdx
@@ -127,7 +127,11 @@ The MCP server provides five tools for comprehensive prompt management.
        --header "Authorization: Basic {your-base64-token}"
 
    # Langfuse Cloud (US)
-   claude mcp add --transport http langfuse https://us.langfuse.com/api/public/mcp \
+   claude mcp add --transport http langfuse https://us.cloud.langfuse.com/api/public/mcp \
+       --header "Authorization: Basic {your-base64-token}"
+
+   # Langfuse Cloud (HIPAA)
+   claude mcp add --transport http langfuse https://hipaa.cloud.langfuse.com/api/public/mcp \
        --header "Authorization: Basic {your-base64-token}"
 
    # Self-Hosted (HTTPS required)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes US Langfuse Cloud endpoint URL and adds HIPAA endpoint in `mcp-server.mdx`.
> 
>   - **Documentation**:
>     - Corrects the US Langfuse Cloud endpoint URL in `mcp-server.mdx` from `https://us.langfuse.com/api/public/mcp` to `https://us.cloud.langfuse.com/api/public/mcp`.
>     - Adds a new endpoint for Langfuse Cloud (HIPAA) in `mcp-server.mdx` as `https://hipaa.cloud.langfuse.com/api/public/mcp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7e2237daa30f620400aa4b49470e47b2db0de0ac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->