### PR TITLE
Update API docs

### DIFF
--- a/pages/docs/api-and-data-platform/features/public-api.mdx
+++ b/pages/docs/api-and-data-platform/features/public-api.mdx
@@ -52,7 +52,7 @@ There are 3 different groups of APIs:
 
 - This page -> Project-level APIs: CRUD traces/evals/prompts/configuration within a project
 - [Organization-level APIs](/docs/administration/scim-and-org-api): provision projects, users (SCIM), and permissions
-- [Management API](/self-hosting/administration/instance-management-api): administer organizations on self-hosted installations
+- [Instance Management API](/self-hosting/administration/instance-management-api): administer organizations on self-hosted installations
 
 </Callout>
 
@@ -170,7 +170,11 @@ try {
 
 ## Ingest Traces via the API
 
-It is recommended to use the OpenTelemetry Endpoint to ingest traces. Please refer to the [OpenTelemetry docs](/integrations/native/opentelemetry) for more information.
+<Callout type="info">
+  The OpenTelemetry Endpoint will replace the Ingestion API in the future. Therefore, it is strongly recommended to switch to the OpenTelemetry Endpoint for trace ingestion. Please refer to the [OpenTelemetry docs](/integrations/native/opentelemetry) for more information.
+</Callout>
+
+The (legacy) [Ingestion API](https://api.reference.langfuse.com/#tag/ingestion/POST/api/public/ingestion) allows trace ingestion using an API.
 
 ## Alternatives
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update API documentation to rename "Management API" to "Instance Management API" and recommend switching to OpenTelemetry for trace ingestion.
> 
>   - **Documentation Updates**:
>     - Renames "Management API" to "Instance Management API" in `public-api.mdx`.
>     - Adds a callout in `public-api.mdx` recommending the switch to the OpenTelemetry Endpoint for trace ingestion, as it will replace the Ingestion API in the future.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7c281f0e32ff78572ea99145ad4d037a86ef1ca9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->