### PR TITLE
Update public-api with OTEL Enpoint

### DIFF
--- a/pages/docs/api-and-data-platform/features/public-api.mdx
+++ b/pages/docs/api-and-data-platform/features/public-api.mdx
@@ -174,7 +174,8 @@ try {
   The OpenTelemetry Endpoint will replace the Ingestion API in the future. Therefore, it is strongly recommended to switch to the OpenTelemetry Endpoint for trace ingestion. Please refer to the [OpenTelemetry docs](/integrations/native/opentelemetry) for more information.
 </Callout>
 
-The (legacy) [Ingestion API](https://api.reference.langfuse.com/#tag/ingestion/POST/api/public/ingestion) allows trace ingestion using an API.
+- [OpenTelemetry Traces Ingestion Endpoint](https://api.reference.langfuse.com/#tag/opentelemetry/POST/api/public/otel/v1/traces) implements the OTLP/HTTP specification for trace ingestion, providing native OpenTelemetry integration for Langfuse Observability.
+- (Legacy) [Ingestion API](https://api.reference.langfuse.com/#tag/ingestion/POST/api/public/ingestion) allows trace ingestion using an API.
 
 ## Alternatives
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `public-api.mdx` to include OpenTelemetry Traces Ingestion Endpoint, recommending transition from legacy API.
> 
>   - **Documentation Update**:
>     - Adds `OpenTelemetry Traces Ingestion Endpoint` to `public-api.mdx`, implementing OTLP/HTTP for trace ingestion.
>     - Recommends switching from legacy Ingestion API to OpenTelemetry Endpoint for future compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 45d06a23ad1e0138968d6e0e9e5b37c533fe41b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->