### PR TITLE
Fix capitalization and add missing features in license key doc

### DIFF
--- a/pages/self-hosting/license-key.mdx
+++ b/pages/self-hosting/license-key.mdx
@@ -13,7 +13,7 @@ When running Langfuse self-hosted, you use the same deployment infrastructure as
 Some additional Enterprise features require a license key:
 
 - [Project-level RBAC Roles](/docs/rbac)
-- [Protected Prompt Lables](/docs/prompt-management/features/prompt-version-control#protected-prompt-labels)
+- [Protected Prompt Labels](/docs/prompt-management/features/prompt-version-control#protected-prompt-labels)
 - [Data Retention Policies](/docs/data-retention)
 - [Audit Logs](/changelog/2025-01-21-audit-logs)
 - [UI Customization](/self-hosting/administration/ui-customization)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix capitalization and add missing features in `license-key.mdx` documentation.
> 
>   - **Documentation Updates**:
>     - Fix capitalization of "RBAC Roles" in `license-key.mdx`.
>     - Add missing features: "Protected Prompt Labels" and "Org Management API and SCIM" to the list of features requiring a license key in `license-key.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 37258ea9157f5b299d179a564b2c36b52e908b90. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->