### PR TITLE
chore: add v2 API references to changelog and documentation

### DIFF
--- a/pages/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
+++ b/pages/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-16
+date: 2025-12-17
 title: "v2 Metrics and Observations API (Beta)"
 description: New high-performance v2 APIs for metrics and observations with cursor-based pagination, selective field retrieval, and optimized data architecture.
 author: Valeriy
@@ -72,6 +72,10 @@ The v2 APIs are additive - v1 endpoints remain available and unchanged. When rea
 
 ## Learn more
 
+For full documentation, see the [Metrics API docs](/docs/analytics/metrics-api#v2) and [Observations API docs](/docs/api-and-data-platform/features/observations-api#v2).
+
+---
+
 <iframe
   width="100%"
   style={{ aspectRatio: "16/9" }}
@@ -82,9 +86,11 @@ The v2 APIs are additive - v1 endpoints remain available and unchanged. When rea
   allowFullScreen
 />
 
-import { Book } from "lucide-react";
+import { Book, FileCode } from "lucide-react";
 
 <Cards num={2}>
   <Card title="Metrics API Documentation" href="/docs/analytics/metrics-api#v2" icon={<Book />} />
   <Card title="Observations API Documentation" href="/docs/api-and-data-platform/features/observations-api" icon={<Book />} />
+  <Card title="v2 Metrics API Reference" href="https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics" icon={<FileCode />} />
+  <Card title="v2 Observations API Reference" href="https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations" icon={<FileCode />} />
 </Cards>

--- a/pages/docs/api-and-data-platform/features/observations-api.mdx
+++ b/pages/docs/api-and-data-platform/features/observations-api.mdx
@@ -212,7 +212,11 @@ With all fields included
 }
 ```
 
-See the [API Reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for full documentation.
+<Callout type="info">
+
+**API Reference:** See the full [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for all available parameters, response schemas, and interactive examples.
+
+</Callout>
 
 ## Observations API v1 [#v1]
 

--- a/pages/docs/metrics/features/metrics-api.mdx
+++ b/pages/docs/metrics/features/metrics-api.mdx
@@ -67,7 +67,11 @@ curl \
   https://cloud.langfuse.com/api/public/v2/metrics
 ```
 
-See the [API Reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics) for full documentation.
+<Callout type="info">
+
+**API Reference:** See the full [v2 Metrics API Reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics) for all available parameters, response schemas, and interactive examples.
+
+</Callout>
 
 ## Metrics API v1 [#v1]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add v2 API documentation links to changelog and update API documentation with reference links.
> 
>   - **Changelog Update**:
>     - Adds links to the v2 Metrics and Observations API documentation in `2025-12-17-v2-metrics-and-observations-api.mdx`.
>     - Updates changelog date from 2025-12-16 to 2025-12-17.
>   - **Documentation Update**:
>     - Adds a callout with a link to the v2 Observations API Reference in `observations-api.mdx`.
>     - Adds a callout with a link to the v2 Metrics API Reference in `metrics-api.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 23c7e07b8f6002ee23df9c2899909c936fe1e255. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->