### PR TITLE
chore: add cloud-only beta note to v2 Metrics and Observations docs

### DIFF
--- a/pages/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
+++ b/pages/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
@@ -16,6 +16,8 @@ We're releasing new **v2 endpoints** for our Metrics and Observations APIs, desi
 
 The v2 APIs are currently in **beta**. They are stable for production use, but some parameters and behaviors may evolve based on user feedback before general availability.
 
+**Cloud-only (Beta):** The v2 APIs are only available on Langfuse Cloud and currently in beta. We are working on a robust migration path for self-hosted deployments.
+
 **Important:** With current SDK versions, data may take approximately 5 minutes to appear on v2 endpoints. We will be releasing updated SDK versions soon that will make data available immediately on v2 endpoints.
 
 </Callout>

--- a/pages/docs/api-and-data-platform/features/observations-api.mdx
+++ b/pages/docs/api-and-data-platform/features/observations-api.mdx
@@ -16,6 +16,8 @@ For general information about API authentication, base URLs, and SDK access, see
 
 The v2 Observations API is currently in **beta**. The API is stable for production use, but some parameters and behaviors may change based on user feedback before general availability.
 
+**Cloud-only (Beta):** The v2 Observations API is only available on Langfuse Cloud and currently in beta. We are working on a robust migration path for self-hosted deployments.
+
 **Data availability note:** When using current SDK versions, data may take approximately 5 minutes to appear on v2 endpoints. We will be releasing updated SDK versions soon that will make data available immediately.
 
 </Callout>

--- a/pages/docs/metrics/features/metrics-api.mdx
+++ b/pages/docs/metrics/features/metrics-api.mdx
@@ -19,6 +19,8 @@ This endpoint allows you to specify dimensions, metrics, filters, and time granu
 
 The v2 Metrics API is currently in **beta**. The API is stable for production use, but some parameters and behaviors may change based on user feedback before general availability.
 
+**Cloud-only (Beta):** The v2 Metrics API is only available on Langfuse Cloud and currently in beta. We are working on a robust migration path for self-hosted deployments.
+
 **Data availability note:** When using current SDK versions, data may take approximately 5 minutes to appear on v2 endpoints. We will be releasing updated SDK versions soon that will make data available immediately.
 
 </Callout>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add "Cloud-only (Beta)" note to v2 Metrics and Observations API documentation.
> 
>   - **Documentation Updates**:
>     - Added "Cloud-only (Beta)" note to `2025-12-17-v2-metrics-and-observations-api.mdx`, `observations-api.mdx`, and `metrics-api.mdx`.
>     - Note specifies that v2 APIs are only available on Langfuse Cloud and are currently in beta.
>     - Mentions ongoing work on a migration path for self-hosted deployments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8e2b5c81286f9e5290f25b5051bc95eed4268598. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->