### PR TITLE
Add shutdown to SDK get started

### DIFF
--- a/pages/docs/observability/sdk/overview.mdx
+++ b/pages/docs/observability/sdk/overview.mdx
@@ -81,7 +81,7 @@ Create an `instrumentation.ts` to register the Langfuse span processor so traces
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 
-const sdk = new NodeSDK({
+export const sdk = new NodeSDK({
   spanProcessors: [new LangfuseSpanProcessor()],
 });
 
@@ -97,7 +97,7 @@ Instrumentation means adding code that records what’s happening in your applic
 In this example we will use the [context manager](/docs/observability/sdk/instrumentation#context-manager). You can also use the [decorator](/docs/observability/sdk/instrumentation#observe-wrapper) or create [manual observations](/docs/observability/sdk/instrumentation#manual-observations).
 
 ```ts filename="index.ts" /startActiveObservation/
-import "./instrumentation";
+import { sdk } from "./instrumentation";
 import { startActiveObservation } from "@langfuse/tracing";
 
 async function main() {
@@ -109,8 +109,10 @@ async function main() {
   });
 }
 
-main();
+// Shutdown flushes events and is required for short-lived applications
+main().finally(() => sdk.shutdown());
 ```
+_[When do I need to use `shutdown()`?](/docs/observability/data-model#background-processing)_
 
 **5. Run your application and see the trace in Langfuse:**
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates Langfuse SDK setup to include `sdk.shutdown()` for event flushing in short-lived applications.
> 
>   - **Behavior**:
>     - Updates `instrumentation.ts` to export `sdk` for use in other modules.
>     - Modifies `index.ts` to import `sdk` and ensure `sdk.shutdown()` is called after `main()` to flush events in short-lived applications.
>   - **Documentation**:
>     - Adds a note on when to use `shutdown()` with a link to more information in `overview.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 6b8c6b0eded5624040e828452ef3f4a74887244e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->