### PR TITLE
Faq for gemini region

### DIFF
--- a/pages/faq/all/gemini-3-preview-models-global-region.mdx
+++ b/pages/faq/all/gemini-3-preview-models-global-region.mdx
@@ -1,0 +1,16 @@
+---
+title: Why don't Gemini 3 preview models work in the Playground?
+tags: [platform, product]
+---
+
+# Why don't Gemini 3 preview models work in the Playground?
+
+Gemini 3 preview models are only available in the **`global`** region. If your LLM connection is set to another region, model calls from the Playground will fail.
+
+## How to fix it
+
+1. Go to `Project Settings` → `LLM Connections`.
+2. Edit (or create) your Google LLM connection.
+3. Set the **region** to **`global`** and save.
+
+See [LLM Connections](/docs/administration/llm-connection) for setup details.


### PR DESCRIPTION
Add a new FAQ page explaining why Gemini 3 preview models require the "global" region and how to configure it.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7752213-257b-4f23-9c10-f1b17d4964e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7752213-257b-4f23-9c10-f1b17d4964e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

