### PR TITLE
Pricing page DPA update

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -1147,7 +1147,7 @@ const sections: Section[] = [
         name: "Contracts",
         tiers: {
           cloud: {
-            Hobby: "Standard T&Cs",
+            Hobby: "Standard T&Cs & DPA",
             Core: "Standard T&Cs & DPA",
             Pro: "Standard T&Cs & DPA",
             Enterprise: "Custom with " + YEARLY_COMMITMENT,
@@ -1161,7 +1161,7 @@ const sections: Section[] = [
         name: "Data processing agreement (GDPR)",
         href: "/security/dpa",
         tiers: {
-          cloud: { Hobby: false, Core: true, Pro: true, Enterprise: true },
+          cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": ENTERPRISE },
         },
       },

--- a/data/generated/contributors.json
+++ b/data/generated/contributors.json
@@ -292,6 +292,7 @@
     "jannikmaierhoefer"
   ],
   "/docs/observability/sdk/overview": [
+    "Lotte-Verheyden",
     "jannikmaierhoefer",
     "hassiebp",
     "marcklingen"
@@ -1176,6 +1177,9 @@
   "/integrations/frameworks/beeai": [
     "jannikmaierhoefer"
   ],
+  "/integrations/frameworks/claude-agent-sdk": [
+    "jannikmaierhoefer"
+  ],
   "/integrations/frameworks/crewai": [
     "jannikmaierhoefer",
     "marcklingen"
@@ -1340,7 +1344,13 @@
   "/integrations/model-providers/anthropic": [
     "jannikmaierhoefer"
   ],
+  "/integrations/model-providers/baseten": [
+    "jannikmaierhoefer"
+  ],
   "/integrations/model-providers/byteplus": [
+    "jannikmaierhoefer"
+  ],
+  "/integrations/model-providers/cerebras": [
     "jannikmaierhoefer"
   ],
   "/integrations/model-providers/cleanlab": [
@@ -1410,6 +1420,9 @@
     "jannikmaierhoefer",
     "marcklingen"
   ],
+  "/integrations/model-providers/vllm": [
+    "jannikmaierhoefer"
+  ],
   "/integrations/model-providers/xai-grok": [
     "jannikmaierhoefer",
     "marcklingen"
@@ -1453,8 +1466,14 @@
   "/integrations/no-code/vapi": [
     "marcklingen"
   ],
+  "/integrations/other/claude-code": [
+    "jannikmaierhoefer"
+  ],
   "/integrations/other/cognee": [
     "hande-k"
+  ],
+  "/integrations/other/cursor": [
+    "jannikmaierhoefer"
   ],
   "/integrations/other/exa": [
     "jannikmaierhoefer"
@@ -1508,6 +1527,7 @@
     "marcklingen"
   ],
   "/security/dependencies": [
+    "maxdeichmann",
     "marcklingen"
   ],
   "/security/dpa": [
@@ -1559,8 +1579,8 @@
     "Steffen911"
   ],
   "/security/responsible-disclosure": [
-    "Steffen911",
     "maxdeichmann",
+    "Steffen911",
     "marcklingen",
     "marliessophie"
   ],

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 19603;
+export const GITHUB_STARS = 20176;


### PR DESCRIPTION
Update pricing page to reflect that the Data Processing Agreement (DPA) is available for free accounts.

---
<a href="https://cursor.com/background-agent?bcId=bc-66f0e105-ca23-4df3-b0a2-266fc59584eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66f0e105-ca23-4df3-b0a2-266fc59584eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update pricing page to include DPA for free accounts and update contributors and GitHub stars.
> 
>   - **Pricing Update**:
>     - Update `PricingTable.tsx` to include "Standard T&Cs & DPA" for the Hobby tier under "Contracts".
>     - Change DPA availability for Hobby tier from `false` to `true` in `PricingTable.tsx`.
>   - **Contributors**:
>     - Add new contributors to `contributors.json` for various documentation paths.
>   - **Misc**:
>     - Update `GITHUB_STARS` in `github-stars.ts` from 19603 to 20176.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 04f58aa15da4c906532f557ff3da66b9d5928a06. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->