### PR TITLE
simplify langchain distributed tracing example

### DIFF
--- a/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
+++ b/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
@@ -305,7 +305,7 @@ langfuse = get_client()
 external_request_id = "req_12345"
 predefined_trace_id = Langfuse.create_trace_id(seed=external_request_id)
 
-langfuse_handler = CallbackHandler(trace_context={"trace_id": predefined_trace_id)
+langfuse_handler = CallbackHandler(trace_context={"trace_id": predefined_trace_id})
 
 # LangChain execution will be part of this trace
 response = chain.invoke(

--- a/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
+++ b/pages/docs/observability/features/trace-ids-and-distributed-tracing.mdx
@@ -293,7 +293,7 @@ const completion = await openai.chat.completions.create({
 </Tab>
 <Tab>
 
-To pass a custom trace ID to a Langchain execution, you can wrap the execution in a span that sets a predefined trace ID. You can also retrieve the last trace ID a callback handler has created via `langfuse_handler.last_trace_id`.
+To pass a custom trace ID to a Langchain execution, you can add a trace ID to the callback handler using the `trace_context` argument. You can also retrieve the last trace ID a callback handler has created via `langfuse_handler.last_trace_id`.
 
 ```python
 from langfuse import get_client, Langfuse
@@ -305,27 +305,13 @@ langfuse = get_client()
 external_request_id = "req_12345"
 predefined_trace_id = Langfuse.create_trace_id(seed=external_request_id)
 
-langfuse_handler = CallbackHandler()
+langfuse_handler = CallbackHandler(trace_context={"trace_id": predefined_trace_id)
 
-# Use the predefined trace ID with trace_context
-with langfuse.start_as_current_observation(
-    as_type="span",
-    name="langchain-request",
-    trace_context={"trace_id": predefined_trace_id}
-) as span:
-
-    with propagate_attributes(
-    span.update_trace(
-        input={"person": "Ada Lovelace"}
-    )
-
-    # LangChain execution will be part of this trace
-    response = chain.invoke(
-        {"person": "Ada Lovelace"},
-        config={"callbacks": [langfuse_handler]}
-    )
-
-    span.update_trace(output={"response": response})
+# LangChain execution will be part of this trace
+response = chain.invoke(
+    {"person": "Ada Lovelace"},
+    config={"callbacks": [langfuse_handler]}
+)
 
 print(f"Trace ID: {predefined_trace_id}")  # Use this for scoring later
 print(f"Trace ID: {langfuse_handler.last_trace_id}") # Care needed in concurrent environments where handler is reused


### PR DESCRIPTION
I think that the previous example was complicating the solution for just adding a trace id.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies Langchain trace ID handling by using `trace_context` in `CallbackHandler` instead of span wrapping.
> 
>   - **Documentation**:
>     - Simplifies the process of adding a trace ID to Langchain executions in `trace-ids-and-distributed-tracing.mdx`.
>     - Replaces the span wrapping method with a direct `trace_context` argument in `CallbackHandler`.
>     - Removes unnecessary span creation and updates example code accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 447e9cd23104d474d256e5ee5edfa36680a72f81. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->