### PR TITLE
docs: enhance guidance for dataset run prompts in experiments

### DIFF
--- a/pages/docs/evaluation/experiments/experiments-via-ui.mdx
+++ b/pages/docs/evaluation/experiments/experiments-via-ui.mdx
@@ -202,7 +202,7 @@ Dataset Runs are currently started from the detail page of a dataset.
 
 1. **Set** a Dataset Run name
 2. **Select** the prompt you want to use
-   - If you only have one piece of dynamic content, we recommend a static chat prompt with a system prompt and a dynamic user message (e.g., full user message as a variable). This ensures you can map your dynamic content as the user message. 
+   - If you only have one piece of dynamic content, we recommend a chat prompt with a static system prompt and a dynamic user message (e.g., full user message as a variable). This ensures you can map your dynamic content as the user message. 
    - If you have multiple pieces of dynamic content, we recommend creating a variable in the prompt for each piece of dynamic content. This ensures you can map your dynamic content to the corresponding variable.
 3. **Set up or select** the LLM connection you want to use
 4. **Select** the dataset you want to use


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `experiments-via-ui.mdx` with guidance on handling dynamic content in prompts for dataset runs.
> 
>   - **Documentation Update**:
>     - Adds guidance in `experiments-via-ui.mdx` for handling dynamic content in prompts during dataset runs.
>     - Recommends using a chat prompt with a static system prompt and dynamic user message for single dynamic content.
>     - Suggests creating a variable for each piece of dynamic content when multiple are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4a2ca3e27a670065087d998c4725915b4d534ff3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->