### PR TITLE
docs: update comparison pages

### DIFF
--- a/pages/faq/all/best-braintrustdata-alternatives.mdx
+++ b/pages/faq/all/best-braintrustdata-alternatives.mdx
@@ -10,10 +10,6 @@ This article compares **Langfuse** and **Braintrust**, two platforms designed to
 
 ## What is Braintrust?
 
-<Frame>
-  ![Braintrust](/images/blog/faq/braintrust/braintrust-example-screen.png)
-</Frame>
-
 [Braintrust](https://www.braintrust.dev/) is an LLM logging and experimentation platform. It provides tools for model evaluation, performance insights, real-time monitoring, and human review. They offer an LLM proxy to log application data and an in-UI playground for rapid prototyping.
 
 <Callout type="info">
@@ -22,20 +18,6 @@ This article compares **Langfuse** and **Braintrust**, two platforms designed to
 </Callout>
 
 ## What is Langfuse?
-
-<Video
-  src="https://static.langfuse.com/docs-videos/trace-page-light.mp4"
-  aspectRatio={1.516}
-  gifStyle
-  className="block dark:hidden"
-/>
-<Video
-  src="https://static.langfuse.com/docs-videos/trace-page-dark.mp4"
-  aspectRatio={1.516}
-  gifStyle
-  className="hidden dark:block"
-/>
-_Example trace in our [public demo](/docs/demo)_
 
 [Langfuse](https://github.com/langfuse/langfuse) is an **open-source** LLM observability platform that offers comprehensive tracing, prompt management, evaluations, and human annotation queues. It empowers teams to understand and debug complex LLM applications, evaluate and iterate them in production, and maintain full control over their data.
 

--- a/pages/faq/all/best-phoenix-arize-alternatives.mdx
+++ b/pages/faq/all/best-phoenix-arize-alternatives.mdx
@@ -54,11 +54,7 @@ _Numbers refresh automatically via [shields.io](https://shields.io)_
 
 _Numbers refresh automatically via [shields.io](https://shields.io)_
 
-## Arize Phoenix
-
-![Arize Phoenix UI](/images/blog/faq/phoenix-arize/phoenix-arize-screen.png)
-
-### What is Arize Phoenix?
+## What is Arize Phoenix?
 
 Arize Phoenix is an open-source observability tool designed for experimentation, evaluation, and troubleshooting of LLM apps. Built by [Arize AI](https://arize.com), Phoenix enables AI engineers and data scientists to visualize data, evaluate performance, track down issues, and export data for improvements.
 
@@ -67,15 +63,7 @@ Arize Phoenix is an open-source observability tool designed for experimentation,
 - **Integration with Arize AI**: Share data when discovering insights to the Arize platform so the data science team can perform further investigation or kickoff retraining workflows.
 - **Development and Experimentation**: Arize Phoenix is focused on the experimental and development stages of LLM applications, providing tools for model evaluation and troubleshooting.
 
-## Langfuse
-
-<Video
-  src="https://static.langfuse.com/docs-videos/trace-page-dark.mp4"
-  gifStyle
-/>
-_Example trace in our [public demo](/docs/demo)_
-
-### What is Langfuse?
+## What is Langfuse?
 
 Langfuse is an LLM observability platform that provides a comprehensive tracing and logging solution for LLM applications. Langfuse helps teams to understand and debug complex LLM applications and evaluate and iterate on them in production.
 

--- a/pages/faq/all/langsmith-alternative.mdx
+++ b/pages/faq/all/langsmith-alternative.mdx
@@ -25,9 +25,7 @@ LangSmith and Langfuse are broadly similar products. They provide LLM observabil
 
 Langfuse is an open source LLM engineering platform that provides a comprehensive tracing solution for AI agents and LLM applications. Langfuse helps teams to understand and debug complex LLM applications and evaluate and iterate them in production.
 
-This is a [LangGraph example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/23338c52-350d-4efb-89ca-82d759828b1d?observation=b9374ddc-6485-4b01-b3b5-64a46607f05b):
-
-<Video src="https://static.langfuse.com/docs-videos/langgraph-overview.mp4" gifStyle />
+[Here is a LangGraph example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/23338c52-350d-4efb-89ca-82d759828b1d?observation=b9374ddc-6485-4b01-b3b5-64a46607f05b)
 
 ## Is Langfuse related to LangSmith and Langchain?
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed media elements from comparison pages for Langfuse against Braintrust, Arize Phoenix, and LangSmith.
> 
>   - **Media Removal**:
>     - Removed image and video elements from `best-braintrustdata-alternatives.mdx`.
>     - Removed image and video elements from `best-phoenix-arize-alternatives.mdx`.
>     - Removed video element from `langsmith-alternative.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 4e1cff9ad8bfb41a2cb7ec809caa89ed6eeb98d9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->