### PR TITLE
docs: Add missing OpenTelemetry environment variables and @langfuse/otel package setup for JS/TS OpenAI SDK

### DIFF
--- a/components-mdx/get-started/js-openai-sdk.mdx
+++ b/components-mdx/get-started/js-openai-sdk.mdx
@@ -1,6 +1,9 @@
-**Install package**
+**Install packages**
+
+Install the Langfuse OpenAI wrapper, the official OpenAI SDK, and the Langfuse OpenTelemetry integration required for tracing.
+
 ```sh
-npm install @langfuse/openai
+npm install @langfuse/openai @langfuse/otel
 ```
 
 **Add credentials**

--- a/components-mdx/setup-otel-js.mdx
+++ b/components-mdx/setup-otel-js.mdx
@@ -4,6 +4,27 @@ Install the OpenTelemetry SDK, which the Langfuse integration uses under the hoo
 npm install @opentelemetry/sdk-node
 ```
 
+**Configure OpenTelemetry environment variables**
+
+Before initializing the SDK, you need to set up the OpenTelemetry exporter environment variables. These tell OpenTelemetry where to send the traces and how to authenticate with Langfuse.
+
+Add the following environment variables to your `.env` file or environment:
+
+```bash filename=".env"
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU region
+# OTEL_EXPORTER_OTLP_ENDPOINT="https://us.cloud.langfuse.com/api/public/otel" # 🇺🇸 US region
+
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64_encoded_auth>"
+```
+
+To generate the base64 encoded authentication string, use the following command in your terminal:
+
+```bash
+echo -n "pk-lf-...:sk-lf-..." | base64
+```
+
+Replace `pk-lf-...` and `sk-lf-...` with your actual `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` values. Then replace `<base64_encoded_auth>` in the `OTEL_EXPORTER_OTLP_HEADERS` with the output from the command above.
+
 Next is initializing the Node SDK. You can do that either in a dedicated instrumentation file or directly at the top of your main file.
 
 


### PR DESCRIPTION
## Summary
This PR adds missing documentation for OpenTelemetry setup in the JS/TS OpenAI SDK get-started guide.

## Changes
1. **Added OpenTelemetry environment variables configuration** (`components-mdx/setup-otel-js.mdx`)
   - Added `OTEL_EXPORTER_OTLP_ENDPOINT` configuration
   - Added `OTEL_EXPORTER_OTLP_HEADERS` configuration with base64 authentication
   - Included instructions for generating base64 encoded auth string using terminal command
   - This was already present in Python documentation but missing in JS/TS

2. **Added @langfuse/otel package installation** (`components-mdx/get-started/js-openai-sdk.mdx`)
   - Added `@langfuse/otel` to the required packages list
   - This package is required for `LangfuseSpanProcessor` used in OpenTelemetry setup

## Context
The JS/TS OpenAI SDK integration requires OpenTelemetry environment variables to be configured, similar to the Python version. Without these environment variables, the OpenTelemetry exporter cannot properly authenticate and send traces to Langfuse, and the integration will silently fail without any error messages.

## Testing
- Verified that the documentation matches the Python version structure
- Confirmed that all required packages are now listed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds missing OpenTelemetry setup documentation for JS/TS OpenAI SDK, including environment variables and package installation.
> 
>   - **Documentation**:
>     - Adds OpenTelemetry environment variables `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` to `setup-otel-js.mdx`.
>     - Provides instructions for generating base64 encoded auth string in `setup-otel-js.mdx`.
>     - Adds `@langfuse/otel` package to installation instructions in `get-started/js-openai-sdk.mdx`.
>   - **Context**:
>     - Aligns JS/TS OpenAI SDK documentation with Python version for OpenTelemetry setup.
>     - Ensures proper authentication and trace sending to Langfuse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 54c8df403a40cf4f52d1db57fc0b6ae9f6618a0d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->