### PR TITLE
Update Amazon Bedrock instructions with disabling ADOT

### DIFF
--- a/pages/faq/all/existing-otel-setup.mdx
+++ b/pages/faq/all/existing-otel-setup.mdx
@@ -631,18 +631,18 @@ When deploying to [AWS Bedrock AgentCore](/integrations/frameworks/amazon-agentc
 
 **Solution:**
 
-Instead of relying on Langfuse SDK callbacks, configure the ADOT collector to send traces directly to Langfuse. Pass these environment variables when launching your AgentCore agent:
+Instead of relying on Langfuse SDK callbacks, disable ADOT and configure your own OTEL exporter to send traces to Langfuse. Pass these environment variables when launching your AgentCore agent:
 
 ```bash
+# 1. Disable AgentCore's built-in ADOT tracing
+DISABLE_ADOT_OBSERVABILITY=true
+
+# 2. Configure your own OTEL exporter to Langfuse
 OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n 'pk-xxx:sk-xxx' | base64)"
 ```
 
-To filter out health check spans and other unwanted instrumentation:
-
-```bash
-OTEL_PYTHON_EXCLUDED_URLS="/ping,/health"
-```
+For US region, use `https://us.cloud.langfuse.com/api/public/otel` as the endpoint.
 
 This applies regardless of which framework (LangChain, LlamaIndex, Strands, etc.) you use on AgentCore.
 

--- a/pages/integrations/frameworks/amazon-agentcore.mdx
+++ b/pages/integrations/frameworks/amazon-agentcore.mdx
@@ -151,6 +151,7 @@ runtime.configure(
 
 launch_result = runtime.launch(
     env_vars={
+        "DISABLE_ADOT_OBSERVABILITY": "true",  # Required: disable ADOT to use Langfuse
         "BEDROCK_MODEL_ID": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
         "OTEL_EXPORTER_OTLP_ENDPOINT": os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"],
         "OTEL_EXPORTER_OTLP_HEADERS": os.environ["OTEL_EXPORTER_OTLP_HEADERS"],
@@ -192,6 +193,45 @@ After running your agent, log in to [Langfuse](https://cloud.langfuse.com) to ex
 The traces provide comprehensive visibility into your agent's behavior in production.
 
 </Steps>
+
+## Using AgentCore with Other Frameworks
+
+If you're using LangChain, LlamaIndex, or another framework on AgentCore: Langfuse SDK callbacks alone won't work on AgentCore. The AgentCore runtime manages telemetry at a level that can bypass SDK HTTP calls.
+
+Pass these environment variables when launching your AgentCore runtime:
+
+```bash
+# Disable AWS's built-in tracing
+DISABLE_ADOT_OBSERVABILITY=true
+
+# Configure OTEL to export to Langfuse
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n 'pk-xxx:sk-xxx' | base64)"
+```
+
+For US region, use `https://us.cloud.langfuse.com/api/public/otel` as the endpoint.
+
+Here's an example of how to launch an AgentCore runtime with the required environment variables:
+
+```python
+import base64
+
+# Prepare auth header
+langfuse_auth = base64.b64encode(
+    f"{LANGFUSE_PUBLIC_KEY}:{LANGFUSE_SECRET_KEY}".encode()
+).decode()
+
+# Launch with required env vars
+launch_result = agentcore_runtime.launch(
+    env_vars={
+        "DISABLE_ADOT_OBSERVABILITY": "true",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": f"{LANGFUSE_BASE_URL}/api/public/otel",
+        "OTEL_EXPORTER_OTLP_HEADERS": f"Authorization=Basic {langfuse_auth}",
+    }
+)
+```
+
+For more troubleshooting, see [Using Langfuse with an Existing OpenTelemetry Setup](/faq/all/existing-otel-setup#aws-bedrock-agentcore-adot).
 
 ## Example repository: Continuous Evaluation with AgentCore and Langfuse
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Amazon Bedrock integration instructions to disable ADOT and configure OTEL exporter for Langfuse.
> 
>   - **Behavior**:
>     - Update instructions to disable ADOT and configure OTEL exporter for Langfuse in `existing-otel-setup.mdx` and `amazon-agentcore.mdx`.
>     - For US region, specify `https://us.cloud.langfuse.com/api/public/otel` as the endpoint.
>   - **Instructions**:
>     - Add environment variable `DISABLE_ADOT_OBSERVABILITY=true` to disable ADOT in `amazon-agentcore.mdx`.
>     - Provide example code for launching AgentCore runtime with required environment variables in `amazon-agentcore.mdx`.
>   - **Misc**:
>     - Remove outdated instructions for filtering health check spans in `existing-otel-setup.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1e8d4d68a3492a20eb6b95eaa3f38caef228109e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->