### PR TITLE
docs: add FAQ section for empty trace input/output when root span is filtered

### DIFF
--- a/pages/docs/observability/sdk/advanced-features.mdx
+++ b/pages/docs/observability/sdk/advanced-features.mdx
@@ -19,10 +19,9 @@ When third-party libraries create OpenTelemetry spans (through their instrumenta
 You can see the instrumentation scope name for any span in the Langfuse UI under the observation's metadata (`metadata.scope.name`). Use this to identify which scopes you want to filter.
 
 <Callout type="warning" title="Filtering Spans May Break Trace Trees">
-  **Cross-Library Span Relationships:**
   Filtering spans may break the parent-child relationships in your traces. For
   example, if you filter out a parent span but keep its children, you may see
-  "orphaned" observations in the Langfuse UI.
+  "orphaned" observations in the Langfuse UI or [traces without any input or output](/faq/all/empty-trace-input-and-output#3-your-root-span-is-being-filtered-out).
 </Callout>
 
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>

--- a/pages/faq/all/empty-trace-input-and-output.mdx
+++ b/pages/faq/all/empty-trace-input-and-output.mdx
@@ -206,7 +206,26 @@ trace.update({
 
 ---
 
-### 3. You're using the `@observe()` decorator but input/output capture is disabled
+### 3. Your root span is being filtered out
+
+**Symptoms**: Trace input/output is empty when using `shouldExportSpan` to filter spans.
+
+If you're using `shouldExportSpan` in your `LangfuseSpanProcessor` to filter spans, and your root span matches the filter criteria, the trace input/output will be empty. This happens because trace input/output is [derived from the root observation by default](#the-root-observation-rule).
+
+**Solution**: If you want the root span to stay filtered out, use `updateTrace()` to manually set trace input/output from within a child span that is not filtered out:
+
+```typescript
+span.updateTrace({
+  input: yourInputData,
+  output: yourOutputData,
+});
+```
+
+See the [advanced features docs](/docs/observability/sdk/advanced-features#filtering-by-instrumentation-scope) for more details on `shouldExportSpan`.
+
+---
+
+### 4. You're using the `@observe()` decorator but input/output capture is disabled
 
 **Symptoms**: Decorated functions don't show input/output, even though they return values.
 
@@ -240,7 +259,7 @@ def my_function(data):
 
 ---
 
-### 4. You're using an OpenTelemetry-based integration
+### 5. You're using an OpenTelemetry-based integration
 
 **Symptoms**: Traces from OTEL integrations (OpenLLMetry, Logfire, etc.) show empty input/output.
 


### PR DESCRIPTION


- Add new troubleshooting section explaining that filtering root spans via shouldExportSpan causes empty trace input/output
- Document updateTrace() workaround for manually setting trace data
- Update warning callout in advanced-features to link to new FAQ section
- Renumber existing FAQ sections (3→4, 4→5)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add FAQ section for empty trace input/output when root span is filtered, document workaround, and update related documentation.
> 
>   - **Documentation**:
>     - Add new FAQ section in `empty-trace-input-and-output.mdx` explaining empty trace input/output when root span is filtered via `shouldExportSpan`.
>     - Document `updateTrace()` workaround for setting trace data manually.
>     - Update warning callout in `advanced-features.mdx` to link to new FAQ section.
>   - **Misc**:
>     - Renumber existing FAQ sections (3→4, 4→5) in `empty-trace-input-and-output.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 3d0f7aa7d2877dbbf6d276f74f2555d575b4f2a5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->