### PR TITLE
Claude agents Langfuse integration

### DIFF
--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -455,6 +455,11 @@
     "isGuide": false
   },
   {
+    "notebook": "js_integration_claude_agent_sdk.ipynb",
+    "docsPath": null,
+    "isGuide": true
+  },
+  {
     "notebook": "integration_cerebras.ipynb",
     "docsPath": "integrations/model-providers/cerebras",
     "isGuide": false

--- a/cookbook/js_integration_claude_agent_sdk.ipynb
+++ b/cookbook/js_integration_claude_agent_sdk.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- NOTEBOOK_METADATA source: \"⚠️ Jupyter Notebook\" title: \"Observability for Claude Agent SDK (JS/TS) with Langfuse\" sidebarTitle: \"Claude Agent SDK (JS/TS)\" description: \"Learn how to trace Claude Agent SDK applications in JavaScript/TypeScript with Langfuse via OpenTelemetry\" category: \"Integrations\" -->\n",
+    "\n",
+    "# Integrate Langfuse with Claude Agent SDK (JS/TS)\n",
+    "\n",
+    "This notebook demonstrates how to capture detailed traces from the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-js) in **JavaScript/TypeScript** with **[Langfuse](https://langfuse.com)** using OpenTelemetry.\n",
+    "\n",
+    "> **What is Claude Agent SDK?**  \n",
+    "> The [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) is Anthropic's open-source framework for building AI agents. It provides a clean API for creating tool-using agents, including native support for MCP.\n",
+    "\n",
+    "> **What is Langfuse?**  \n",
+    "> [Langfuse](https://langfuse.com) is the open source LLM engineering platform. It provides detailed tracing, monitoring, and analytics for every prompt, model response, and tool call in your agent, making it easy to debug, evaluate, and iterate on LLM applications."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- STEPS_START -->\n",
+    "## Step 1: Set Up Environment\n",
+    "\n",
+    "Get your Langfuse API keys by signing up for [Langfuse Cloud](https://cloud.langfuse.com/) or [self-hosting Langfuse](https://langfuse.com/self-hosting). You'll also need your Anthropic API key from the [Anthropic Console](https://console.anthropic.com/).\n",
+    "\n",
+    "> **Note**: This cookbook uses **Deno.js** for execution, which requires different syntax for importing packages and setting environment variables. For Node.js applications, the setup process is similar but uses standard `npm` packages and `process.env`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Langfuse authentication keys\n",
+    "Deno.env.set(\"LANGFUSE_PUBLIC_KEY\", \"pk-lf-***\");\n",
+    "Deno.env.set(\"LANGFUSE_SECRET_KEY\", \"sk-lf-***\");\n",
+    "\n",
+    "// Langfuse host configuration\n",
+    "// For US data region, set this to \"https://us.cloud.langfuse.com\"\n",
+    "Deno.env.set(\"LANGFUSE_BASE_URL\", \"https://cloud.langfuse.com\");\n",
+    "\n",
+    "// Set Anthropic API key\n",
+    "Deno.env.set(\"ANTHROPIC_API_KEY\", \"sk-ant-***\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Initialize OpenTelemetry with Langfuse\n",
+    "\n",
+    "We use the `@langfuse/otel` package to initialize the OpenTelemetry SDK with the Langfuse span processor. This processor will automatically send all OpenTelemetry spans to Langfuse for visualization and analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Import required dependencies\n",
+    "import 'npm:dotenv/config';\n",
+    "import { NodeSDK } from \"npm:@opentelemetry/sdk-node\";\n",
+    "import { LangfuseSpanProcessor } from \"npm:@langfuse/otel\";\n",
+    " \n",
+    "// Export the processor to be able to flush it later\n",
+    "// This is important for ensuring all spans are sent to Langfuse\n",
+    "export const langfuseSpanProcessor = new LangfuseSpanProcessor({\n",
+    "    publicKey: Deno.env.get(\"LANGFUSE_PUBLIC_KEY\")!,\n",
+    "    secretKey: Deno.env.get(\"LANGFUSE_SECRET_KEY\")!,\n",
+    "    baseUrl: Deno.env.get(\"LANGFUSE_BASE_URL\") ?? 'https://cloud.langfuse.com',\n",
+    "    environment: Deno.env.get(\"NODE_ENV\") ?? 'development',\n",
+    "  });\n",
+    " \n",
+    "// Initialize the OpenTelemetry SDK with our Langfuse processor\n",
+    "const sdk = new NodeSDK({\n",
+    "  spanProcessors: [langfuseSpanProcessor],\n",
+    "});\n",
+    " \n",
+    "// Start the SDK to begin collecting telemetry\n",
+    "sdk.start();\n",
+    "\n",
+    "console.log(\"OpenTelemetry SDK initialized with Langfuse\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Configure Claude Agent SDK Instrumentation\n",
+    "\n",
+    "Use [LangSmith's Claude Agent SDK instrumentation library](https://docs.langchain.com/langsmith/trace-claude-agent-sdk) to automatically instrument the Claude Agent SDK and emit OpenTelemetry spans. This instrumentation captures:\n",
+    "\n",
+    "- Model API calls with input/output content\n",
+    "- Tool definitions and tool call executions\n",
+    "- Agent turns and conversation flow\n",
+    "- Token usage and latency metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { wrapClaudeAgentSDK } from \"npm:@langchain/otel-claude-agent-sdk\";\n",
+    "\n",
+    "// Configure the Claude Agent SDK with OpenTelemetry instrumentation\n",
+    "// This wraps the SDK to automatically emit spans for all agent operations\n",
+    "wrapClaudeAgentSDK();\n",
+    "\n",
+    "console.log(\"Claude Agent SDK instrumentation configured\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Build a Hello World Agent\n",
+    "\n",
+    "Let's create a simple agent with a weather tool. Every tool call and model completion will be automatically captured as an OpenTelemetry span and forwarded to Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { Agent, tool } from \"npm:@anthropic-ai/claude-agent-sdk\";\n",
+    "\n",
+    "// Define a simple weather tool\n",
+    "const getWeatherTool = tool({\n",
+    "  name: \"get_weather\",\n",
+    "  description: \"Gets the current weather for a given city\",\n",
+    "  parameters: {\n",
+    "    type: \"object\",\n",
+    "    properties: {\n",
+    "      city: {\n",
+    "        type: \"string\",\n",
+    "        description: \"The city to get the weather for\",\n",
+    "      },\n",
+    "    },\n",
+    "    required: [\"city\"],\n",
+    "  },\n",
+    "  execute: async ({ city }) => {\n",
+    "    // Simulated weather data\n",
+    "    const weatherData: Record<string, string> = {\n",
+    "      \"Berlin\": \"Cloudy, 59°F\",\n",
+    "      \"New York\": \"Sunny, 75°F\",\n",
+    "      \"San Francisco\": \"Foggy, 62°F\",\n",
+    "      \"Tokyo\": \"Clear, 68°F\",\n",
+    "    };\n",
+    "    \n",
+    "    const weather = weatherData[city] || \"Weather data not available\";\n",
+    "    return `Weather in ${city}: ${weather}`;\n",
+    "  },\n",
+    "});\n",
+    "\n",
+    "// Create the agent with the weather tool\n",
+    "const agent = new Agent({\n",
+    "  model: \"claude-sonnet-4-20250514\",\n",
+    "  apiKey: Deno.env.get(\"ANTHROPIC_API_KEY\"),\n",
+    "  systemPrompt: \"You are a friendly travel assistant who helps with weather information. Always use the get_weather tool to check the weather for cities the user asks about.\",\n",
+    "  tools: [getWeatherTool],\n",
+    "});\n",
+    "\n",
+    "console.log(\"Agent created with weather tool\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Run the Agent\n",
+    "\n",
+    "Now let's run the agent with a query. All interactions will be automatically traced to Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Run the agent with a user query\n",
+    "const response = await agent.run(\"What's the weather like in Berlin and New York?\");\n",
+    "\n",
+    "console.log(\"Agent Response:\");\n",
+    "console.log(response.content);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Flush Traces\n",
+    "\n",
+    "To ensure all spans are sent to Langfuse before the notebook ends, we flush the span processor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Flush the span processor to ensure all traces are sent\n",
+    "await langfuseSpanProcessor.forceFlush();\n",
+    "\n",
+    "console.log(\"All traces flushed to Langfuse\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: View the Trace in Langfuse\n",
+    "\n",
+    "Head over to your **Langfuse dashboard → Traces**. You should see traces including all tool calls and model inputs/outputs.\n",
+    "\n",
+    "![Claude Agent SDK example trace in Langfuse](https://langfuse.com/images/cookbook/integration_claude_agent_sdk/claude-agent-sdk-example-trace.png)\n",
+    "\n",
+    "[Link to example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/097f1d8982fa909b8cffb14a166ec272?timestamp=2025-12-22T10:46:15.528Z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example: Adding Custom Trace Metadata\n",
+    "\n",
+    "You can enrich your traces with custom metadata like user IDs, session IDs, and tags for better organization and filtering in Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { context, trace } from \"npm:@opentelemetry/api\";\n",
+    "\n",
+    "// Get the current tracer\n",
+    "const tracer = trace.getTracer(\"claude-agent-example\");\n",
+    "\n",
+    "// Create a span with custom attributes for the agent call\n",
+    "await tracer.startActiveSpan(\"weather-assistant-request\", async (span) => {\n",
+    "  // Add Langfuse-specific attributes\n",
+    "  span.setAttribute(\"langfuse.user.id\", \"user-123\");\n",
+    "  span.setAttribute(\"langfuse.session.id\", \"session-456\");\n",
+    "  span.setAttribute(\"langfuse.tags\", JSON.stringify([\"weather\", \"demo\"]));\n",
+    "  span.setAttribute(\"langfuse.metadata\", JSON.stringify({ env: \"notebook\", version: \"1.0\" }));\n",
+    "\n",
+    "  try {\n",
+    "    const response = await agent.run(\"What's the weather in Tokyo?\");\n",
+    "    console.log(\"Response:\", response.content);\n",
+    "    \n",
+    "    // Record successful completion\n",
+    "    span.setAttribute(\"langfuse.output\", response.content);\n",
+    "  } catch (error) {\n",
+    "    span.recordException(error);\n",
+    "    throw error;\n",
+    "  } finally {\n",
+    "    span.end();\n",
+    "  }\n",
+    "});\n",
+    "\n",
+    "// Flush to ensure the trace is sent\n",
+    "await langfuseSpanProcessor.forceFlush();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example: Streaming Responses\n",
+    "\n",
+    "The Claude Agent SDK also supports streaming responses. All streaming events are automatically traced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Run the agent with streaming\n",
+    "const stream = await agent.stream(\"Tell me about the weather in San Francisco.\");\n",
+    "\n",
+    "console.log(\"Streaming response:\");\n",
+    "for await (const chunk of stream) {\n",
+    "  if (chunk.type === \"text\") {\n",
+    "    Deno.stdout.writeSync(new TextEncoder().encode(chunk.text));\n",
+    "  }\n",
+    "}\n",
+    "console.log(\"\\n\");\n",
+    "\n",
+    "// Flush traces\n",
+    "await langfuseSpanProcessor.forceFlush();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- STEPS_END -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Node.js Setup\n",
+    "\n",
+    "For Node.js applications, the setup is similar. Here's how you would configure it:\n",
+    "\n",
+    "```typescript\n",
+    "// 1. Install dependencies\n",
+    "// npm install @anthropic-ai/claude-agent-sdk @langfuse/otel @opentelemetry/sdk-node @langchain/otel-claude-agent-sdk\n",
+    "\n",
+    "// 2. Initialize OpenTelemetry (run this before importing the Claude Agent SDK)\n",
+    "import { NodeSDK } from \"@opentelemetry/sdk-node\";\n",
+    "import { LangfuseSpanProcessor } from \"@langfuse/otel\";\n",
+    "\n",
+    "const langfuseSpanProcessor = new LangfuseSpanProcessor({\n",
+    "  publicKey: process.env.LANGFUSE_PUBLIC_KEY!,\n",
+    "  secretKey: process.env.LANGFUSE_SECRET_KEY!,\n",
+    "  baseUrl: process.env.LANGFUSE_BASE_URL ?? \"https://cloud.langfuse.com\",\n",
+    "});\n",
+    "\n",
+    "const sdk = new NodeSDK({\n",
+    "  spanProcessors: [langfuseSpanProcessor],\n",
+    "});\n",
+    "\n",
+    "sdk.start();\n",
+    "\n",
+    "// 3. Configure Claude Agent SDK instrumentation\n",
+    "import { wrapClaudeAgentSDK } from \"@langchain/otel-claude-agent-sdk\";\n",
+    "wrapClaudeAgentSDK();\n",
+    "\n",
+    "// 4. Use the Claude Agent SDK as normal\n",
+    "import { Agent, tool } from \"@anthropic-ai/claude-agent-sdk\";\n",
+    "// ... your agent code\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- MARKDOWN_COMPONENT name: \"LearnMore\" path: \"@/components-mdx/integration-learn-more.mdx\" -->"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
+  "language_info": {
+   "codemirror_mode": "typescript",
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nb_converter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add a Deno-based Jupyter notebook to demonstrate integrating the JavaScript Claude Agent SDK with Langfuse using OpenTelemetry.

This addresses the current lack of a JavaScript/TypeScript guide for integrating the Claude Agent SDK with Langfuse, providing a direct equivalent to the existing Python guide. It utilizes the LangSmith OTel instrumentation library as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-5453c75e-a3af-447b-8e7a-435edfab13c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5453c75e-a3af-447b-8e7a-435edfab13c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

