### PR TITLE
Add OpenRouter Broadcast as tracing workaround for n8n

### DIFF
--- a/pages/integrations/no-code/n8n.mdx
+++ b/pages/integrations/no-code/n8n.mdx
@@ -24,7 +24,15 @@ Langfuse Prompt Management is available via an n8n node. Learn more in the [n8n 
 
 Currently, there is no native n8n tracing integration. Please upvote the related GitHub discussion [here](https://github.com/orgs/langfuse/discussions/4397) if you are interested in this.
 
-### Community Supported
+### Workarounds
+
+While there is no native integration, there are several ways to trace your n8n AI workflows in Langfuse.
+
+#### Using OpenRouter with Broadcast
+
+You can use [OpenRouter](https://openrouter.ai/) as your LLM provider in n8n, and send traces to Langfuse using OpenRouter's [Broadcast feature](/integrations/gateways/openrouter#broadcast).
+
+#### Community Supported
 
 <Frame>
   ![n8n workflow with OpenAI model traced in


### PR DESCRIPTION
## Summary
- Adds a "Workarounds" section to the n8n integration page for tracing options
- Documents OpenRouter Broadcast as a way to trace n8n AI workflows in Langfuse
- Reorganizes community-supported options under the new hierarchy

## Test plan
- [ ] Verify the page renders correctly at `/integrations/no-code/n8n`
- [ ] Check that links to OpenRouter Broadcast documentation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds OpenRouter Broadcast as a tracing workaround for n8n in the documentation, reorganizing tracing options under a new 'Workarounds' section.
> 
>   - **Documentation**:
>     - Adds 'Workarounds' section to `n8n.mdx` for tracing options.
>     - Documents OpenRouter Broadcast as a tracing workaround for n8n AI workflows.
>     - Reorganizes community-supported options under the new 'Workarounds' hierarchy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5dcb87d0f140b13abaed1613b61f10a1c0e48468. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->