### PR TITLE
feat: add middleware to track AI coding agent traffic

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,9 @@
+import { withAIAnalytics } from "2027-track/next";
+
+export default withAIAnalytics();
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://docs.langfuse.com",
   "dependencies": {
+    "2027-track": "^0.1.0",
     "@ai-sdk/openai": "^2.0.14",
     "@ai-sdk/react": "^2.0.8",
     "@calcom/embed-react": "^1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      2027-track:
+        specifier: ^0.1.0
+        version: 0.1.0(next@15.2.8(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@ai-sdk/openai':
         specifier: ^2.0.14
         version: 2.0.14(zod@4.0.15)
@@ -281,6 +284,14 @@ importers:
         version: 0.6.2
 
 packages:
+
+  2027-track@0.1.0:
+    resolution: {integrity: sha512-qcgJT/ryXo2xan2M3G10u/eO/7wSYK+wnvcPIdYDIFrH2nehCQXTHaG7XbeyiMsbjdqAJd8SJo1navFBGGzYmg==}
+    peerDependencies:
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   '@ai-sdk/gateway@1.0.4':
     resolution: {integrity: sha512-1roLdgMbFU3Nr4MC97/te7w6OqxsWBkDUkpbCcvxF3jz/ku91WVaJldn/PKU8feMKNyI5W9wnqhbjb1BqbExOQ==}
@@ -6056,6 +6067,10 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  2027-track@0.1.0(next@15.2.8(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    optionalDependencies:
+      next: 15.2.8(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@ai-sdk/gateway@1.0.4(zod@4.0.15)':
     dependencies:


### PR DESCRIPTION
## Summary

Adds Next.js middleware to detect and track AI coding agents (Claude Code, Codex, OpenCode, etc.) visiting the docs.

Uses the `2027-track` npm package:

```ts
import { withAIAnalytics } from "2027-track/next";
export default withAIAnalytics();
```

## How it works

AI coding agents send `Accept: text/markdown` header when fetching documentation - browsers never do this. The middleware detects this signal and sends anonymized events to an external analytics API.

**Detection signals:**
- `Accept: text/markdown` (primary - browsers never send this)
- `axios` user-agent → Claude Code
- `text/markdown` with `q=` weights → OpenCode
- `ChatGPT-User` user-agent → Codex

## Configuration

**No configuration needed.** The middleware sends events to an external tracking API - no env vars or secrets required in this repo.

**Optional:** Set `AI_ANALYTICS_ENDPOINT=""` to disable tracking entirely.

## Data collected

- Host (docs.langfuse.com)
- Path (/docs/tracing)
- Agent type (claude-code, opencode, codex, etc.)
- Country (from Vercel headers)
- Timestamp

**Privacy:** Events are sent server-side from Vercel Edge. Visitor IP addresses never reach the analytics endpoint.

## Dashboard

See collected data: [screenshot](https://github.com/caffeinum/ai-docs-analytics/blob/main/dashboard-screenshot.png)

Package: https://www.npmjs.com/package/2027-track
Source: https://github.com/caffeinum/ai-docs-analytics
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add middleware in `middleware.ts` to track AI coding agents using `2027-track`, with route configuration and dependency update in `package.json`.
> 
>   - **Middleware**:
>     - Adds `middleware.ts` to track AI coding agents using `2027-track` package.
>     - Detects agents via `Accept: text/markdown` header and specific user-agents.
>     - Configures route matching to exclude static assets and images.
>   - **Dependencies**:
>     - Adds `2027-track` to `dependencies` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 67670817026eb6ce37ad5d6c2c4a5ef5eb491f4f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->