### PR TITLE
Fix redirect loop for dataset-runs/data-model

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -811,7 +811,6 @@ const mainDocsReorder202507 = [
     "/docs/evaluation/features/prompt-experiments",
     "/docs/evaluation/dataset-runs/native-run",
   ],
-  ["/docs/evaluation/experiments/data-model", "/docs/evaluation/dataset-runs/data-model"],
   [
     "/guides/cookbook/integration_mirascope",
     "/integrations/frameworks/mirascope",


### PR DESCRIPTION
## Summary
- Removes conflicting redirect that caused `ERR_TOO_MANY_REDIRECTS` for `/docs/evaluation/dataset-runs/data-model`
- The redirect from the old URL to `/docs/evaluation/experiments/data-model` remains intact for external links

## Problem
Two redirects were creating a loop:
1. `/docs/evaluation/dataset-runs/data-model` → `/docs/evaluation/experiments/data-model` ✅ (correct)
2. `/docs/evaluation/experiments/data-model` → `/docs/evaluation/dataset-runs/data-model` ❌ (removed)

## Test plan
- [ ] Visit https://langfuse.com/docs/evaluation/dataset-runs/data-model and verify it redirects correctly without looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes redirect loop for `/docs/evaluation/dataset-runs/data-model` by removing conflicting redirect in `lib/redirects.js`.
> 
>   - **Behavior**:
>     - Removes conflicting redirect in `lib/redirects.js` that caused a loop for `/docs/evaluation/dataset-runs/data-model`.
>     - Ensures correct redirection to `/docs/evaluation/experiments/data-model` without looping.
>   - **Test Plan**:
>     - Verify that visiting `/docs/evaluation/dataset-runs/data-model` redirects correctly without looping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for b0f1077daf79baf92815d90960386d772ee1b016. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->