### PR TITLE
Add title heading to experiments data model page

### DIFF
--- a/pages/docs/evaluation/experiments/data-model.mdx
+++ b/pages/docs/evaluation/experiments/data-model.mdx
@@ -4,6 +4,8 @@ description: This page describes the evaluation data model including Datasets, D
 sidebarTitle: Data Model
 ---
 
+# Data Model
+
 This page describes the data model for evaluation-related objects in Langfuse. For an overview of how these objects work together, see the [Concepts](/docs/evaluation/core-concepts) page.
 
 For detailed reference please refer to 


### PR DESCRIPTION
## Summary
- Adds missing `# Data Model` title heading to the experiments data model page for consistency with other documentation pages

## Test plan
- [ ] Verify page renders correctly with the new heading at https://langfuse.com/docs/evaluation/experiments/data-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `# Data Model` heading to `data-model.mdx` for consistency.
> 
>   - **Documentation**:
>     - Adds `# Data Model` heading to `data-model.mdx` for consistency with other documentation pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for deb7c4e94a7f34589895643d989c86688a554129. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->