### PR TITLE
docs: clarify trace-level evaluators can target any data within trace

### DIFF
--- a/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/pages/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -95,7 +95,15 @@ Evaluating live production traffic allows you to monitor the performance of your
 
 </Callout>
 
-Run evaluators on complete traces. This approach:
+Run evaluators on complete traces. This approach evaluates at the trace level, but can **target any data within the trace** when mapping variables:
+
+- **Trace input/output**: The top-level input and output of the entire trace
+- **Specific observation outputs**: Target the output of a particular LLM call, tool invocation, or agent step within the trace using JSONPath expressions
+- **Nested data**: Access deeply nested fields within any observation's input, output, or metadata
+
+This flexibility means you can evaluate specific parts of your trace (e.g., the output of a particular tool call) while still using trace-level filtering to select which traces to evaluate. However, for more granular filtering and better performance, consider using observation-level evaluators.
+
+**Limitations**
 
 - Evaluates entire trace execution
 - Limited to trace-level filtering


### PR DESCRIPTION
Improve the Live Traces section to explain that while evaluation runs at the trace level, variable mapping can target any data within the trace including specific observation outputs, tool calls, and nested fields via JSONPath expressions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies in documentation that trace-level evaluators can target any data within a trace using JSONPath expressions.
> 
>   - **Documentation Update**:
>     - Clarifies that trace-level evaluators can target any data within a trace using JSONPath expressions in `llm-as-a-judge.mdx`.
>     - Explains targeting of trace input/output, specific observation outputs, and nested data.
>     - Suggests using observation-level evaluators for more granular filtering and performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 7242328ae9b5c64752f9c82ef13e63f8f8daee86. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->