### PR TITLE
docs: clarify that experiment run_name must be unique

### DIFF
--- a/pages/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/pages/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -1062,7 +1062,9 @@ Please refer to the [integrations](/docs/integrations/overview) page for details
 
 ### Run experiment on dataset
 
-When running an experiment on a dataset, the application that shall be tested is executed for each item in the dataset. The execution trace is then linked to the dataset item. This allows you to compare different runs of the same application on the same dataset. Each experiment is identified by a `run_name`.
+When running an experiment on a dataset, the application that shall be tested is executed for each item in the dataset. The execution trace is then linked to the dataset item. This allows you to compare different runs of the same application on the same dataset.
+
+Each experiment is identified by a unique `run_name`. If you reuse the same `run_name`, the new run will not appear separately in the Langfuse dataset run UI. As a good practice, include a timestamp in your `run_name` to ensure uniqueness (the [Experiment Runner SDK](#experiment-runner-sdk) does this automatically).
 
 <LangTabs items={["Python SDK", "JS/TS SDK", "Langchain (Python)", "Langchain (JS/TS)", "Vercel AI SDK", "Other frameworks"]}>
 <Tab>
@@ -1070,17 +1072,21 @@ When running an experiment on a dataset, the application that shall be tested is
 You may then execute that LLM-app for each dataset item to create a dataset run:
 
 ```python filename="execute_dataset.py" /for item in dataset.items:/
+from datetime import datetime
 from langfuse import get_client
 from .app import my_llm_application
 
 # Load the dataset
 dataset = get_client().get_dataset("<dataset_name>")
 
+# Include a timestamp to ensure the run_name is unique
+run_name = f"my-experiment-{datetime.now().isoformat()}"
+
 # Loop over the dataset items
 for item in dataset.items:
     # Use the item.run() context manager for automatic trace linking
     with item.run(
-        run_name="<run_name>",
+        run_name=run_name,
         run_description="My first run",
         run_metadata={"model": "llama3"},
     ) as root_span:
@@ -1109,6 +1115,9 @@ import { LangfuseClient } from "@langfuse/client";
 
 const langfuse = new LangfuseClient();
 
+// Include a timestamp to ensure the run_name is unique
+const runName = `my-experiment-${new Date().toISOString()}`;
+
 for (const item of dataset.items) {
   // execute application function and get langfuseObject (trace/span/generation/event, and other observation types: see /docs/observability/features/observation-types)
   // output also returned as it is used to evaluate the run
@@ -1116,7 +1125,7 @@ for (const item of dataset.items) {
   const [span, output] = await myLlmApplication.run(item.input);
 
   // link the execution trace to the dataset item and give it a run_name
-  await item.link(span, "<run_name>", {
+  await item.link(span, runName, {
     description: "My first run", // optional run description
     metadata: { model: "llama3" }, // optional run metadata
   });
@@ -1137,12 +1146,16 @@ await langfuse.flush();
 <Tab>
 
 ```python /for item in dataset.items:/
+from datetime import datetime
 from langfuse import get_client
 from langfuse.langchain import CallbackHandler
 #from .app import my_llm_application
 
 # Load the dataset
 dataset = get_client().get_dataset("<dataset_name>")
+
+# Include a timestamp to ensure the run_name is unique
+run_name = f"my-experiment-{datetime.now().isoformat()}"
 
 # Initialize the Langfuse handler
 langfuse_handler = CallbackHandler()
@@ -1151,7 +1164,7 @@ langfuse_handler = CallbackHandler()
 for item in dataset.items:
     # Use the item.run() context manager for automatic trace linking
     with item.run(
-        run_name="<run_name>",
+        run_name=run_name,
         run_description="My first run",
         run_metadata={"model": "llama3"},
     ) as root_span:
@@ -1182,7 +1195,8 @@ import { CallbackHandler } from "@langfuse/langchain";
 ...
 
 const langfuse = new LangfuseClient()
-const runName = "my-dataset-run";
+// Include a timestamp to ensure the run_name is unique
+const runName = `my-dataset-run-${new Date().toISOString()}`;
 for (const item of dataset.items) {
   const [span, output] = await startActiveObservation('my_llm_application', async (span) => {
     // ... your Langchain code ...
@@ -1214,13 +1228,16 @@ import { LangfuseClient } from "@langfuse/client";
 
 const langfuse = new LangfuseClient();
 
+// Include a timestamp to ensure the run_name is unique
+const runName = `my-experiment-${new Date().toISOString()}`;
+
 // iterate over the dataset items
 for (const item of dataset.items) {
   // run application on the dataset item input
   const [span, output] = await runMyLLMApplication(item.input, trace.id);
 
   // link the execution trace to the dataset item and give it a run_name
-  await item.link(span, "<run_name>", {
+  await item.link(span, runName, {
     description: "My first run", // optional run description
     metadata: { model: "gpt-4o" }, // optional run metadata
   });


### PR DESCRIPTION
## Summary
- Clarify in the low-level SDK methods section that `run_name` must be unique per dataset run
- Explain that reusing the same `run_name` prevents the new run from appearing in the dataset run UI
- Update all code examples (Python, JS/TS, Langchain) to use timestamp-based `run_name` as a good practice

## Test plan
- [ ] Verify the page renders correctly at `/docs/evaluation/experiments/experiments-via-sdk`
- [ ] Check that the Experiment Runner SDK anchor link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies `run_name` uniqueness requirement in documentation and updates code examples to use timestamp-based `run_name`.
> 
>   - **Documentation**:
>     - Clarifies that `run_name` must be unique per dataset run in `experiments-via-sdk.mdx`.
>     - Explains that reusing `run_name` prevents new runs from appearing in the dataset run UI.
>   - **Code Examples**:
>     - Updates Python, JS/TS, and Langchain examples to use timestamp-based `run_name` for uniqueness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1619a88e7894566301cb549efa0b9cb666c45c99. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->