### PR TITLE
feat: add Google Colab icon to notebook banner button

### DIFF
--- a/components/NotebookBanner.tsx
+++ b/components/NotebookBanner.tsx
@@ -29,7 +29,15 @@ export const NotebookBanner: React.FC<{ src: string; className?: string }> = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Button size="xs" variant="outline" className="inline-block">
+                <Button size="xs" variant="outline" className="inline-flex items-center gap-1.5">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    className="h-4 w-4 shrink-0"
+                    fill="#F9AB00"
+                  >
+                    <path d="M16.9414 4.9757a7.033 7.033 0 0 0-4.9308 2.0646 7.033 7.033 0 0 0-.1232 9.8068l2.395-2.395a3.6455 3.6455 0 0 1 5.1497-5.1478l2.397-2.3989a7.033 7.033 0 0 0-4.8877-1.9297zM7.07 4.9855a7.033 7.033 0 0 0-4.8878 1.9316l2.3911 2.3911a3.6434 3.6434 0 0 1 5.0227.1271l1.7341-2.9737-.0997-.0802A7.033 7.033 0 0 0 7.07 4.9855zm15.0093 2.1721-2.3892 2.3911a3.6455 3.6455 0 0 1-5.1497 5.1497l-2.4067 2.4068a7.0362 7.0362 0 0 0 9.9456-9.9476zM1.932 7.1674a7.033 7.033 0 0 0-.002 9.6816l2.397-2.397a3.6434 3.6434 0 0 1-.004-4.8916zm7.664 7.4235c-1.38 1.3816-3.5863 1.411-5.0168.1134l-2.397 2.395c2.4693 2.3328 6.263 2.5753 9.0072.5455l.1368-.1115z" />
+                  </svg>
                   Run on Google Colab
                 </Button>
               </a>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a Google Colab icon to the 'Run on Google Colab' button in `NotebookBanner.tsx`.
> 
>   - **UI Enhancement**:
>     - Adds a Google Colab icon to the 'Run on Google Colab' button in `NotebookBanner.tsx`.
>     - Uses an inline SVG for the icon with specific dimensions and color.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 1b595569bb08afc447af46a364950b31f28e6ba7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->