### PR TITLE
add `/api/search-docs?query=<url-encoded question>`

### DIFF
--- a/pages/api/inkeep-search.ts
+++ b/pages/api/inkeep-search.ts
@@ -1,0 +1,42 @@
+const INKEEP_CHAT_COMPLETIONS_URL = "https://api.inkeep.com/v1/chat/completions";
+const INKEEP_MODEL = "inkeep-rag";
+
+export type InkeepSearchResponse = {
+  answer: string;
+  metadata: unknown;
+};
+
+export const searchLangfuseDocsWithInkeep = async (
+  query: string
+): Promise<InkeepSearchResponse> => {
+  if (!process.env.INKEEP_BACKEND_API_KEY) {
+    throw new Error("Missing INKEEP_BACKEND_API_KEY environment variable");
+  }
+
+  const inkeepRes = await fetch(INKEEP_CHAT_COMPLETIONS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.INKEEP_BACKEND_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: INKEEP_MODEL,
+      messages: [{ role: "user", content: query }],
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!inkeepRes.ok) {
+    throw new Error(`Inkeep API returned ${inkeepRes.status}`);
+  }
+
+  const result = await inkeepRes.json();
+
+  return {
+    answer: result?.choices?.[0]?.message?.content || "No results found",
+    metadata: result,
+  };
+};
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;

--- a/pages/api/search-docs.ts
+++ b/pages/api/search-docs.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { searchLangfuseDocsWithInkeep, isNonEmptyString } from "./inkeep-search";
+
+// Public, unauthenticated GET endpoint that exposes the Inkeep docs search used by MCP.
+// Usage: /api/search-docs?query=<url-encoded question>
+// Returns JSON: { query, answer, metadata } where `metadata` is the raw Inkeep payload.
+const setCorsHeaders = (res: NextApiResponse) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  setCorsHeaders(res);
+
+  if (req.method === "OPTIONS") {
+    return res.status(204).end();
+  }
+
+  if (req.method !== "GET") {
+    return res
+      .status(405)
+      .setHeader("Allow", "GET, OPTIONS")
+      .json({ error: "Method Not Allowed" });
+  }
+
+  const queryParam = req.query.query;
+  const query = Array.isArray(queryParam) ? queryParam[0] : queryParam;
+
+  if (!isNonEmptyString(query)) {
+    return res.status(400).json({
+      error: "Missing or invalid 'query' parameter",
+    });
+  }
+
+  try {
+    const inkeepResult = await searchLangfuseDocsWithInkeep(query);
+
+    return res.status(200).json({
+      query,
+      answer: inkeepResult.answer,
+      metadata: inkeepResult.metadata,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: "Error searching documentation",
+      message: error instanceof Error ? error.message : "Unknown error",
+      query,
+    });
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `/api/search-docs` endpoint for public Inkeep documentation search and refactors Inkeep API call logic.
> 
>   - **New Endpoint**:
>     - Adds `/api/search-docs` in `search-docs.ts` for public, unauthenticated GET requests to search documentation using Inkeep API.
>     - Returns JSON with `query`, `answer`, and `metadata`.
>   - **Refactoring**:
>     - Extracts Inkeep API call logic to `searchLangfuseDocsWithInkeep()` in `inkeep-search.ts`.
>     - Replaces direct Inkeep API calls in `mcp.ts` with `searchLangfuseDocsWithInkeep()`.
>   - **Utilities**:
>     - Adds `isNonEmptyString()` in `inkeep-search.ts` to validate query strings.
>   - **CORS**:
>     - Sets CORS headers in `search-docs.ts` to allow all origins and methods `GET, OPTIONS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8b2c3ee7cce6166a08961dec60d3857827581d79. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->