### PR TITLE
3y data access on pricing page

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -110,7 +110,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
       href: "https://cloud.langfuse.com",
       featured: true,
       description:
-        "For production projects. Longer data retention and unlimited users.",
+        "For production projects. Longer data access and unlimited users.",
       price: "$29",
       priceDiscountCta: {
         name: "Discounts available",

--- a/pages/startups.mdx
+++ b/pages/startups.mdx
@@ -42,7 +42,7 @@ Your company qualifies if **all** of the following are true:
 ## Benefits 🎁
 
 - **50 % discount** on every line-item (usage, seats, add-ons) for 12 months
-- Full access to **Pro & Teams**-tier features (SSO, HIPAA, 3-year data retention)
+- Full access to **Pro & Teams**-tier features (SSO, HIPAA, 3-year data access)
 - Priority access to dedicated support
 
 ---


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update data retention policy to "3 years" for Pro and Enterprise tiers in `PricingTable.tsx` and `startups.mdx`.
> 
>   - **PricingTable.tsx**:
>     - Change data access for Pro and Enterprise tiers from "Unlimited" to "3 years".
>     - Update main features for Pro tier to "3 years data access".
>   - **startups.mdx**:
>     - Update benefits section to "3-year data retention" instead of "Unlimited data retention" for Pro & Teams-tier features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 651423bc846178867385df4b1572d6509c79948b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->