### PR TITLE
docs: restore get-started FAQ tags removed in #2525

### DIFF
--- a/pages/docs/observability/get-started.mdx
+++ b/pages/docs/observability/get-started.mdx
@@ -351,7 +351,7 @@ After running your application, visit the Langfuse interface to view the trace y
 #### Not seeing what you expected?
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["observability"]} />
+<FaqPreview tags={["observability-get-started"]} />
 
 ## Next steps
 

--- a/pages/docs/prompt-management/get-started.mdx
+++ b/pages/docs/prompt-management/get-started.mdx
@@ -32,7 +32,7 @@ import PromptUse from "@/components-mdx/prompt-use.mdx";
 #### Not seeing what you expected?
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["prompt-management"]} />
+<FaqPreview tags={["prompt-management-get-started"]} />
 
 ## Next steps
 

--- a/pages/faq/all/empty-trace-input-and-output.mdx
+++ b/pages/faq/all/empty-trace-input-and-output.mdx
@@ -1,7 +1,7 @@
 ---
 title: Why are the input and output of a trace empty?
 description: This article explains why the input and output of a trace might be empty and how to fix it.
-tags: [observability]
+tags: [observability, observability-get-started]
 ---
 
 # Why are the input and output of my trace empty?

--- a/pages/faq/all/missing-traces.mdx
+++ b/pages/faq/all/missing-traces.mdx
@@ -1,6 +1,6 @@
 ---
 title: I have setup Langfuse, but I do not see any traces in the dashboard. How to solve this?
-tags: [evaluation, observability]
+tags: [evaluation, observability, observability-get-started]
 ---
 
 # I have setup Langfuse, but I do not see any traces in the dashboard ("Tracing Pending"). How to solve this?

--- a/pages/faq/all/old-prompt-version-caching.mdx
+++ b/pages/faq/all/old-prompt-version-caching.mdx
@@ -1,7 +1,7 @@
 ---
 title: I'm not seeing the latest version of my prompt. Why?
 description: Learn why you might see outdated prompt versions in Langfuse and how to resolve caching-related issues in both the SDK client cache and the server-side Redis cache.
-tags: [prompt-management]
+tags: [prompt-management, prompt-management-get-started]
 ---
 
 # I'm not seeing the latest version of my prompt. Why?


### PR DESCRIPTION
## Summary
- Restores `observability-get-started` and `prompt-management-get-started` tags to FAQ pages that had them before #2525
- Restores the get-started pages to query these specific tags instead of the broader category tags

This ensures the observability and prompt management get-started pages show only the curated FAQs relevant to getting started, rather than all FAQs for the entire category.

## Test plan
- [ ] Verify `/docs/observability/get-started` shows the correct FAQ entries
- [ ] Verify `/docs/prompt-management/get-started` shows the correct FAQ entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores specific FAQ tags and updates get-started pages to query these tags for relevant FAQs.
> 
>   - **Behavior**:
>     - Restores `observability-get-started` and `prompt-management-get-started` tags to relevant FAQ pages.
>     - Updates `get-started.mdx` files in `observability` and `prompt-management` to query specific tags instead of broader category tags.
>   - **Files Affected**:
>     - `get-started.mdx` in `observability` and `prompt-management` directories.
>     - `empty-trace-input-and-output.mdx`, `missing-traces.mdx`, and `old-prompt-version-caching.mdx` in `faq/all` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for c9d7272d46be4a78414ce5e74bd8bcbe1a1359ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->