### PR TITLE
add /cloud landingpage

### DIFF
--- a/lib/cloud-regions.ts
+++ b/lib/cloud-regions.ts
@@ -1,0 +1,41 @@
+export const cloudRegions = {
+  eu: {
+    url: "https://cloud.langfuse.com",
+    label: "EU region",
+  },
+  us: {
+    url: "https://us.cloud.langfuse.com",
+    label: "US region",
+  },
+  hipaa: {
+    url: "https://hipaa.cloud.langfuse.com",
+    label: "HIPAA region",
+  },
+} as const;
+
+export type CloudRegionKey = keyof typeof cloudRegions;
+
+export const cloudRegionSelectorOrder: CloudRegionKey[] = [
+  "us",
+  "hipaa",
+  "eu",
+];
+
+export const continentHostMapping: Record<string, string> = {
+  AF: cloudRegions.eu.url, // Africa
+  AN: cloudRegions.eu.url, // Antarctica
+  AS: cloudRegions.eu.url, // Asia
+  EU: cloudRegions.eu.url, // Europe
+  NA: cloudRegions.us.url, // North America
+  OC: cloudRegions.eu.url, // Oceania
+  SA: cloudRegions.us.url, // South America
+};
+
+export const createInitialCloudRegionSignInState = () =>
+  Object.fromEntries(
+    Object.keys(cloudRegions).map((key) => [key, false])
+  ) as Record<CloudRegionKey, boolean>;
+
+export const isSignedInSession = (session: unknown) => {
+  return !!session && typeof session === "object" && "user" in session;
+};

--- a/lib/use-cloud-region-sign-in.ts
+++ b/lib/use-cloud-region-sign-in.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import {
+  cloudRegions,
+  type CloudRegionKey,
+  createInitialCloudRegionSignInState,
+  isSignedInSession,
+} from "@/lib/cloud-regions";
+
+export const useCloudRegionSignIn = (
+  enabled = process.env.NODE_ENV === "production"
+) => {
+  const [signedInRegions, setSignedInRegions] = useState<
+    Record<CloudRegionKey, boolean>
+  >(() => createInitialCloudRegionSignInState());
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    Object.entries(cloudRegions).forEach(([key, region]) => {
+      fetch(`${region.url}/api/auth/session`, {
+        credentials: "include",
+        mode: "cors",
+        signal: abortController.signal,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          setSignedInRegions((prev) => ({
+            ...prev,
+            [key]: isSignedInSession(data),
+          }));
+        })
+        .catch((error) => {
+          if (error.name !== "AbortError") {
+            setSignedInRegions((prev) => ({
+              ...prev,
+              [key]: false,
+            }));
+          }
+        });
+    });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [enabled]);
+
+  return signedInRegions;
+};

--- a/pages/cloud/[[...path]].tsx
+++ b/pages/cloud/[[...path]].tsx
@@ -1,0 +1,260 @@
+import { useCallback, useMemo, type MouseEvent } from "react";
+import Head from "next/head";
+import Image from "next/image";
+import { useRouter } from "next/router";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowRight,
+  Globe,
+  Shield,
+  ShieldCheck,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  cloudRegionSelectorOrder,
+  cloudRegions,
+  type CloudRegionKey,
+} from "@/lib/cloud-regions";
+import { useCloudRegionSignIn } from "@/lib/use-cloud-region-sign-in";
+
+const regionCards: Record<
+  CloudRegionKey,
+  {
+    title: string;
+    awsRegion: string;
+    awsLocation: string;
+    icon: LucideIcon;
+    flag?: string;
+  }
+> = {
+  us: {
+    title: "US",
+    awsRegion: "us-west-2",
+    awsLocation: "Oregon",
+    icon: Shield,
+    flag: "🇺🇸",
+  },
+  hipaa: {
+    title: "US HIPAA",
+    awsRegion: "us-west-2",
+    awsLocation: "Oregon",
+    icon: ShieldCheck,
+  },
+  eu: {
+    title: "Europe",
+    awsRegion: "eu-west-1",
+    awsLocation: "Ireland",
+    icon: Globe,
+    flag: "🇪🇺",
+  },
+};
+
+const CLOUD_ROUTE_PREFIX = "/cloud";
+
+const stripControlChars = (value: string) =>
+  value.replace(/[\u0000-\u001F\u007F]/g, "");
+
+const getCloudRedirectPartsFromAsPath = (asPath: string) => {
+  const sanitizedAsPath = stripControlChars(asPath || "");
+  const hashStart = sanitizedAsPath.indexOf("#");
+  const pathAndSearch =
+    hashStart === -1 ? sanitizedAsPath : sanitizedAsPath.slice(0, hashStart);
+  const hash = hashStart === -1 ? "" : sanitizedAsPath.slice(hashStart);
+
+  const queryStart = pathAndSearch.indexOf("?");
+  const pathname =
+    queryStart === -1 ? pathAndSearch : pathAndSearch.slice(0, queryStart);
+  const search = queryStart === -1 ? "" : pathAndSearch.slice(queryStart);
+
+  let cloudSubpath = "/";
+  if (
+    pathname.startsWith(`${CLOUD_ROUTE_PREFIX}/`) &&
+    pathname.length > CLOUD_ROUTE_PREFIX.length
+  ) {
+    cloudSubpath = pathname.slice(CLOUD_ROUTE_PREFIX.length);
+  } else if (pathname === CLOUD_ROUTE_PREFIX) {
+    cloudSubpath = "/";
+  }
+
+  return { cloudSubpath, search, hash };
+};
+
+const buildCloudRedirectUrl = ({
+  region,
+  cloudSubpath,
+  search,
+  hash,
+}: {
+  region: CloudRegionKey;
+  cloudSubpath: string;
+  search: string;
+  hash: string;
+}) => {
+  const baseUrl = cloudRegions[region].url.replace(/\/$/, "");
+  const targetPath = cloudSubpath.startsWith("/") ? cloudSubpath : `/${cloudSubpath}`;
+  return `${baseUrl}${targetPath}${search}${hash}`;
+};
+
+const SignedInHint = () => (
+  <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-emerald-700/90 dark:text-emerald-400">
+    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500/90" />
+    Signed in
+  </span>
+);
+
+const getCloudHost = (url: string) => new URL(url).host;
+
+export default function CloudRegionSelectorPage() {
+  const router = useRouter();
+  const signedInRegions = useCloudRegionSignIn();
+
+  const {
+    cloudSubpath,
+    search: fallbackSearch,
+    hash: fallbackHash,
+  } = useMemo(
+    () => getCloudRedirectPartsFromAsPath(router.asPath || ""),
+    [router.asPath]
+  );
+
+  const handleRegionSelect = useCallback(
+    (region: CloudRegionKey, event: MouseEvent<HTMLAnchorElement>) => {
+      const isModifiedClick =
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey;
+      if (isModifiedClick) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const search =
+        typeof window === "undefined"
+          ? fallbackSearch
+          : window.location.search;
+      const hash =
+        typeof window === "undefined" ? fallbackHash : window.location.hash;
+      const targetUrl = buildCloudRedirectUrl({
+        region,
+        cloudSubpath,
+        search,
+        hash,
+      });
+
+      if (typeof window !== "undefined") {
+        window.location.assign(targetUrl);
+      }
+    },
+    [cloudSubpath, fallbackHash, fallbackSearch]
+  );
+
+  return (
+    <>
+      <Head>
+        <title>Select Cloud Region - Langfuse</title>
+        <meta
+          name="description"
+          content="Select the Langfuse Cloud region and continue to your destination."
+        />
+      </Head>
+      <main className="flex min-h-screen items-center bg-background px-4 py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-10 lg:px-8">
+        <div className="w-full max-w-[480px]">
+          <div className="text-center sm:mx-auto sm:w-full">
+            <a href="/" aria-label="Langfuse Home" className="inline-flex">
+              <Image
+                src="/langfuse_logo.svg"
+                alt="Langfuse"
+                width={152}
+                height={20}
+                priority
+                className="h-auto w-36 dark:hidden"
+              />
+              <Image
+                src="/langfuse_logo_white.svg"
+                alt="Langfuse"
+                width={152}
+                height={20}
+                priority
+                className="hidden h-auto w-36 dark:block"
+              />
+            </a>
+            <h1 className="mt-7 text-2xl font-bold leading-9 tracking-tight text-primary">
+              Select your region
+            </h1>
+          </div>
+
+          <Card className="mt-8 overflow-hidden border shadow-sm">
+            <CardContent className="divide-y p-0">
+              {cloudRegionSelectorOrder.map((regionKey) => {
+                const region = cloudRegions[regionKey];
+                const card = regionCards[regionKey];
+                const Icon = card.icon;
+                const host = getCloudHost(region.url);
+                const href = buildCloudRedirectUrl({
+                  region: regionKey,
+                  cloudSubpath,
+                  search: fallbackSearch,
+                  hash: fallbackHash,
+                });
+                const isSignedIn = signedInRegions[regionKey];
+
+                return (
+                  <div
+                    key={regionKey}
+                    className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-4"
+                  >
+                    <div className="flex min-w-0 items-start gap-3">
+                      <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-border/80 bg-muted/25 text-lg">
+                        {card.flag ? (
+                          <span>{card.flag}</span>
+                        ) : (
+                          <Icon className="h-5 w-5 text-muted-foreground" />
+                        )}
+                      </span>
+                      <div className="min-w-0">
+                        <div className="mb-1 flex items-center justify-between gap-2">
+                          <p className="text-base font-semibold">
+                            {card.title}
+                          </p>
+                          {isSignedIn && <SignedInHint />}
+                        </div>
+                        <p className="mt-1.5 text-xs font-medium tracking-wide text-muted-foreground/80">
+                          AWS {card.awsRegion} • {card.awsLocation}
+                        </p>
+                        <code
+                          className="mt-1.5 block max-w-full truncate text-xs text-muted-foreground/90"
+                          title={host}
+                        >
+                          {host}
+                        </code>
+                      </div>
+                    </div>
+                    <div>
+                      <Button
+                        asChild
+                        size="sm"
+                        className="whitespace-nowrap"
+                      >
+                        <a
+                          href={href}
+                          onClick={(event) => handleRegionSelect(regionKey, event)}
+                        >
+                          Continue
+                          <ArrowRight className="h-4 w-4" />
+                        </a>
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add cloud region selection page and refactor region sign-in logic into reusable components and hooks.
> 
>   - **New Feature**:
>     - Adds `CloudRegionSelectorPage` in `pages/cloud/[[...path]].tsx` for selecting cloud regions.
>     - Displays region-specific information and redirects users based on their selection.
>   - **Refactoring**:
>     - Moves cloud region data to `cloud-regions.ts`.
>     - Replaces inline region sign-in logic in `ToAppButton.tsx` with `useCloudRegionSignIn` hook.
>   - **Utilities**:
>     - Adds `useCloudRegionSignIn` hook in `use-cloud-region-sign-in.ts` to manage sign-in state across regions.
>     - Provides utility functions in `cloud-regions.ts` for initial sign-in state and session validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for a6fe3cffcfe92f1845b6463bb97db8ce6d4a0f9b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->