### PR TITLE
docs: add guide for connecting LLM gateways

### DIFF
--- a/pages/blog/2026-02-13-will-you-be-my-cli.mdx
+++ b/pages/blog/2026-02-13-will-you-be-my-cli.mdx
@@ -213,29 +213,20 @@ In the main Langfuse Skill (see above) we include a reference that teaches AI ag
 ## Install
 
 ```bash
-# Run directly (recommended)
-npx langfuse-cli api <resource> <action>
+npx langfuse-cli api <resource> <action>   ## Run directly (recommended)
 bunx langfuse-cli api <resource> <action>
 
-# Or install globally
-npm i -g langfuse-cli
+npm i -g langfuse-cli                      ## Or install globally
 langfuse api <resource> <action>
 ```
 
 ## Discovery
 
 ```bash
-# List all resources and auth info
-langfuse api __schema
-
-# List actions for a resource
-langfuse api <resource> --help
-
-# Show args/options for a specific action
-langfuse api <resource> <action> --help
-
-# Preview the curl command without executing
-langfuse api <resource> <action> --curl
+langfuse api __schema                      ## List all resources and auth info
+langfuse api <resource> --help             ## List actions for a resource
+langfuse api <resource> <action> --help    ## Show args/options for a specific action
+langfuse api <resource> <action> --curl    ## Preview the curl command without executing
 ```
 
 ...[redacted for brevity]


### PR DESCRIPTION
- Replaces the "Connecting via proxies" section with a "Connecting via a gateway" section in the LLM Connections docs
- Adds a step-by-step guide for configuring an OpenAI-compatible gateway (e.g. LiteLLM, OpenRouter, Portkey) as an LLM connection