### PR TITLE
docs: self-host env vars for traces API performance

### DIFF
--- a/pages/faq/all/api-524-http-errors.mdx
+++ b/pages/faq/all/api-524-http-errors.mdx
@@ -23,3 +23,17 @@ Follow these best practices:
 
 - **Add timestamp filters**: E.g. run `GET /api/public/traces?page=1&limit=10&fromTimestamp=2025-10-16T00:00:00.000Z&toTimestamp=2025-10-17T00:00:00.000Z`.
 - **Use the `fields` parameter**: Request only the data you need to avoid expensive joins (e.g. `GET /api/public/traces?fields=core,io`).
+
+### Additional Self-Host Options
+
+Self-hosters can configure server-side defaults and restrictions for the `GET /api/public/traces` endpoint via environment variables.
+Enforcement order: rejection → default date range → default fields.
+
+| Variable                                      | Type                                      | Description                                                                                                                                                                                                                                                   |
+|-----------------------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE`    | `"true"` / `"false"` (default: `"false"`) | Reject requests that do not include a `fromTimestamp` parameter with HTTP 400.                                                                                                                                                                                |
+| `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS` | Positive integer (optional)               | When no `fromTimestamp` is provided, automatically apply a lookback window of N days from `toTimestamp` (or now). Ignored when rejection is enabled.                                                                                                          |
+| `LANGFUSE_API_TRACES_DEFAULT_FIELDS`          | Comma-separated string (optional)         | Default field groups returned when the caller does not specify a `fields` query parameter. Valid groups: `core`, `io`, `scores`, `observations`, `metrics`. E.g. `"core"` or `"core,io"`. An explicit `fields` query parameter always overrides this default. |
+
+**Recommended starting point for large projects:** set `LANGFUSE_API_TRACES_DEFAULT_FIELDS=core` and `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS=3`.
+This keeps `input`/`output` out of the default response (users can still request them explicitly via `fields=core,io`) and caps the scan window.


### PR DESCRIPTION
## Summary
- Document three new environment variables for self-hosters to control `GET /api/public/traces` performance: `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE`, `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS`, `LANGFUSE_API_TRACES_DEFAULT_FIELDS`
- Added to existing 524 HTTP errors FAQ page under the "Additional Self-Host Options" section
- Refs langfuse/langfuse#12062

## Test plan
- [ ] Verify page renders correctly on dev server
- [ ] Confirm table formatting displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documents new environment variables for self-hosters to optimize `GET /api/public/traces` performance in `api-524-http-errors.mdx`.
> 
>   - **Documentation**:
>     - Adds documentation for three new environment variables: `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE`, `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS`, `LANGFUSE_API_TRACES_DEFAULT_FIELDS`.
>     - Updates `api-524-http-errors.mdx` under "Additional Self-Host Options" to include these variables.
>   - **Environment Variables**:
>     - `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE`: Rejects requests without `fromTimestamp` with HTTP 400.
>     - `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS`: Applies a default lookback window when `fromTimestamp` is missing.
>     - `LANGFUSE_API_TRACES_DEFAULT_FIELDS`: Sets default field groups if `fields` parameter is not specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 5153458da07e180a4324ddd9ed1dcfcdd6745608. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->