### PR TITLE
fix: remove broken link to RESEARCH-LLM-FEATURES.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The docs site includes four interconnected features designed to make documentati
    - `getLangfuseDocsPage`: Fetches specific page markdown from `.md` URLs
    - `getLangfuseOverview`: Returns `llms.txt` overview
 
-All three user-facing features (Copy, PDF, MCP) depend on the same foundation of pre-built static markdown files, making them fast, cacheable, and reliable. See [RESEARCH-LLM-FEATURES.md](./RESEARCH-LLM-FEATURES.md) for detailed implementation details.
+All three user-facing features (Copy, PDF, MCP) depend on the same foundation of pre-built static markdown files, making them fast, cacheable, and reliable.
 
 ## Bundle analysis
 


### PR DESCRIPTION
## Summary
- Removed broken reference to `RESEARCH-LLM-FEATURES.md` in the README, as the file no longer exists in the repo

## Test plan
- [x] Verified that `RESEARCH-LLM-FEATURES.md` does not exist in the repository
- [x] Confirmed the surrounding content in the README is still accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove broken link to `RESEARCH-LLM-FEATURES.md` in `README.md`.
> 
>   - **README.md**:
>     - Removed broken link to `RESEARCH-LLM-FEATURES.md` as the file no longer exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse-docs&utm_source=github&utm_medium=referral)<sup> for 8f76fd51f29f58ce84063fbd099fc6aafb209ea2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->