### PR TITLE
docs(claude-code): add token usage tracking to Langfuse hook

### DIFF
--- a/pages/integrations/other/claude-code.mdx
+++ b/pages/integrations/other/claude-code.mdx
@@ -299,6 +299,27 @@ def get_message_id(msg: Dict[str, Any]) -> Optional[str]:
             return mid
     return None
 
+def get_usage(msg: Dict[str, Any]) -> Dict[str, int]:
+    m = msg.get("message")
+    if not isinstance(m, dict):
+        return {}
+    u = m.get("usage")
+    if not isinstance(u, dict):
+        return {}
+    result: Dict[str, int] = {}
+    for key in ("input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"):
+        val = u.get(key)
+        if isinstance(val, int):
+            result[key] = val
+    return result
+
+def aggregate_usage(assistant_msgs: List[Dict[str, Any]]) -> Dict[str, int]:
+    totals: Dict[str, int] = {}
+    for msg in assistant_msgs:
+        for key, val in get_usage(msg).items():
+            totals[key] = totals.get(key, 0) + val
+    return totals
+
 # ----------------- Incremental reader -----------------
 @dataclass
 class SessionState:
@@ -462,6 +483,16 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
 
     tool_calls = _tool_calls_from_assistants(turn.assistant_msgs)
 
+    raw_usage = aggregate_usage(turn.assistant_msgs)
+    usage_details: Optional[Dict[str, int]] = None
+    if raw_usage:
+        usage_details = {
+            "input": raw_usage.get("input_tokens", 0),
+            "output": raw_usage.get("output_tokens", 0),
+            "cache_creation_input_tokens": raw_usage.get("cache_creation_input_tokens", 0),
+            "cache_read_input_tokens": raw_usage.get("cache_read_input_tokens", 0),
+        }
+
     # attach tool outputs
     for c in tool_calls:
         if c["id"] and c["id"] in turn.tool_results_by_id:
@@ -496,6 +527,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
                 model=model,
                 input={"role": "user", "content": user_text},
                 output={"role": "assistant", "content": assistant_text},
+                usage_details=usage_details,
                 metadata={
                     "assistant_text": assistant_text_meta,
                     "tool_count": len(tool_calls),


### PR DESCRIPTION
## Summary

- Add `get_usage` helper to extract token usage from assistant messages in the Claude Code transcript
- Add `aggregate_usage` helper to sum token usage across multiple assistant messages in a turn
- Pass `usage_details` (input, output, cache_creation_input_tokens, cache_read_input_tokens) to the Langfuse generation span in `emit_turn`

This enables token-level cost tracking in Langfuse when using the Claude Code hook integration.