### PR TITLE
Fix trace link in Google Vertex AI documentation

### DIFF
--- a/cookbook/integration_google_vertexai.ipynb
+++ b/cookbook/integration_google_vertexai.ipynb
@@ -144,7 +144,7 @@
         "\n",
         "![Langfuse Trace](https://langfuse.com/images/cookbook/integration_vertexai/vertexai-trace.png)\n",
         "\n",
-        "[See trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/308aca9bc430ad872d474fc545889ee2?timestamp=2025-07-25T07:35:01.172Z&display=details)\n",
+        "[See trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/0298935e31d66d7de9487cac935d7d99)\n",
         "\n",
         "<!-- STEPS_END -->\n",
         "\n",

--- a/pages/integrations/model-providers/google-vertex-ai.mdx
+++ b/pages/integrations/model-providers/google-vertex-ai.mdx
@@ -96,8 +96,7 @@ for chunk in model.generate_content("Why is LLM observability important?", strea
 After executing the application, navigate to your Langfuse Trace Table. You will find detailed traces of the application's execution, providing insights into the agent conversations, LLM calls, inputs, outputs, and performance metrics. 
 
 ![Langfuse Trace](https://langfuse.com/images/cookbook/integration_vertexai/vertexai-trace.png)
-
-[See trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/308aca9bc430ad872d474fc545889ee2?timestamp=2025-07-25T07:35:01.172Z&display=details)
+[See trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/0298935e31d66d7de9487cac935d7d99)
 </Steps>
 
 import LearnMore from "@/components-mdx/integration-learn-more.mdx";


### PR DESCRIPTION
Fix incorrect traceid in link.

The current link somehow correspond to an anthropic/claude trace
<img width="491" height="509" alt="image" src="https://github.com/user-attachments/assets/185f5daf-89ac-418c-b47a-53a9d37fc467" />
