### PR TITLE
fix(scripts): restore markdown aliases for PDF downloads

### DIFF
--- a/scripts/copy_md_sources.js
+++ b/scripts/copy_md_sources.js
@@ -42,13 +42,15 @@ function ensureDir(dirPath) {
  * - Map content/foo/bar.mdx -> public/md-src/foo/bar.md
  * - Map content/foo/index.mdx -> public/md-src/foo.md
  */
-function mapDestination(sourceFile) {
-    const rel = path.relative(SOURCE_DIR, sourceFile);
+function mapDestinations(sourceFile, options = {}) {
+    const sourceDir = options.sourceDir ?? SOURCE_DIR;
+    const outputDir = options.outputDir ?? OUTPUT_DIR;
+    const rel = path.relative(sourceDir, sourceFile);
     const base = path.basename(rel);
-    if (base === 'meta.json' || base.startsWith('_')) return null;
+    if (base === 'meta.json' || base.startsWith('_')) return [];
 
     const ext = path.extname(rel).toLowerCase();
-    if (ext !== '.md' && ext !== '.mdx') return null;
+    if (ext !== '.md' && ext !== '.mdx') return [];
 
     const withoutExt = rel.slice(0, -ext.length);
     const parts = withoutExt.split(path.sep);
@@ -57,37 +59,51 @@ function mapDestination(sourceFile) {
         outParts = parts.slice(0, -1);
     }
     const outRel = outParts.length ? outParts.join('/') + '.md' : 'index.md';
-    return path.join(OUTPUT_DIR, outRel);
+    const destinations = [path.join(outputDir, outRel)];
+
+    // Preserve legacy root-level markdown URLs for marketing pages (e.g., /terms.md).
+    if (parts[0] === 'marketing' && parts.length === 2 && parts[1] !== 'index') {
+        destinations.push(path.join(outputDir, `${parts[1]}.md`));
+    }
+
+    return destinations;
 }
 
-function copyAll() {
-    if (!fs.existsSync(SOURCE_DIR)) {
+function copyAll(options = {}) {
+    const sourceDir = options.sourceDir ?? SOURCE_DIR;
+    const outputDir = options.outputDir ?? OUTPUT_DIR;
+
+    if (!fs.existsSync(sourceDir)) {
         console.log('copy_md_sources: content/ not found, skipping');
         return;
     }
-    const allFiles = walkDir(SOURCE_DIR);
+    const allFiles = walkDir(sourceDir);
     let copied = 0;
     for (const file of allFiles) {
-        const dest = mapDestination(file);
-        if (!dest) continue;
-        const dir = path.dirname(dest);
-        ensureDir(dir);
         const originalContent = fs.readFileSync(file, 'utf8');
         const processed = inlineComponentsMdx(originalContent, file);
-        fs.writeFileSync(dest, processed, 'utf8');
-        copied += 1;
+        const destinations = mapDestinations(file, { sourceDir, outputDir });
+        for (const dest of destinations) {
+            const dir = path.dirname(dest);
+            ensureDir(dir);
+            fs.writeFileSync(dest, processed, 'utf8');
+            copied += 1;
+        }
     }
     console.log(`Copied ${copied} markdown source files into public/md-src`);
 }
 
-function cleanOutputDir() {
-    if (fs.existsSync(OUTPUT_DIR)) {
-        fs.rmSync(OUTPUT_DIR, { recursive: true, force: true });
+function cleanOutputDir(options = {}) {
+    const outputDir = options.outputDir ?? OUTPUT_DIR;
+    if (fs.existsSync(outputDir)) {
+        fs.rmSync(outputDir, { recursive: true, force: true });
     }
 }
 
-cleanOutputDir();
-copyAll();
+if (require.main === module) {
+    cleanOutputDir();
+    copyAll();
+}
 
 /**
  * Inline imports of MDX components from the components-mdx directory.
@@ -152,4 +168,11 @@ function resolveComponentPath(rootDir, relImport) {
     return null;
 }
 
+module.exports = {
+    SOURCE_DIR,
+    OUTPUT_DIR,
+    mapDestinations,
+    copyAll,
+    cleanOutputDir,
+};
 

--- a/scripts/copy_md_sources.test.js
+++ b/scripts/copy_md_sources.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { copyAll } = require('./copy_md_sources');
+
+function writeFile(filePath, content) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf8');
+}
+
+test('creates root-level aliases for marketing pages and keeps security paths scoped', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'copy-md-sources-'));
+    const sourceDir = path.join(tempRoot, 'content');
+    const outputDir = path.join(tempRoot, 'public', 'md-src');
+
+    writeFile(path.join(sourceDir, 'marketing', 'terms.mdx'), '# Terms');
+    writeFile(path.join(sourceDir, 'security', 'toms.mdx'), '# TOMS');
+
+    copyAll({ sourceDir, outputDir });
+
+    assert.equal(fs.readFileSync(path.join(outputDir, 'marketing', 'terms.md'), 'utf8'), '# Terms');
+    assert.equal(fs.readFileSync(path.join(outputDir, 'terms.md'), 'utf8'), '# Terms');
+    assert.equal(fs.readFileSync(path.join(outputDir, 'security', 'toms.md'), 'utf8'), '# TOMS');
+    assert.equal(fs.existsSync(path.join(outputDir, 'toms.md')), false);
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+});


### PR DESCRIPTION
### Motivation
- The docs `Download as PDF` feature broke because the site no longer exposed root-level `.md` source URLs like `/terms.md` that the PDF endpoint expects.
- The copy pipeline produced only scoped exports under `public/md-src/marketing/*`, so legacy direct markdown URLs were missing and PDF requests failed.

### Description
- Refactored `scripts/copy_md_sources.js` to return multiple output destinations per source and renamed `mapDestination` to `mapDestinations` to support this behavior.
- Added logic to emit a root-level alias for direct `content/marketing/*` pages (for example, producing both `public/md-src/marketing/terms.md` and `public/md-src/terms.md`).
- Made the script testable by accepting injectable `sourceDir`/`outputDir`, exporting helpers (`mapDestinations`, `copyAll`, `cleanOutputDir`), and guarding execution with `require.main === module` to avoid side effects on import.
- Added `scripts/copy_md_sources.test.js` to validate that marketing pages get root-level aliases while non-marketing docs (e.g., `security/toms`) remain scoped.

### Testing
- Ran the unit test with `node --test scripts/copy_md_sources.test.js`, which verifies the root-level alias for marketing pages and scoped behavior for security pages, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c192e32794832f83d538ac8becd447)