### PR TITLE
feat: add dedicated agent skill docs page

### DIFF
--- a/content/docs/api-and-data-platform/features/agent-skill.mdx
+++ b/content/docs/api-and-data-platform/features/agent-skill.mdx
@@ -1,0 +1,52 @@
+---
+title: Agent Skill
+sidebarTitle: Agent Skill
+description: Install the Langfuse agent skill to give your coding agent access to Langfuse tracing, prompt management, datasets, and documentation — right from the editor.
+---
+
+# Langfuse Agent Skill
+
+The Langfuse agent skill helps AI coding agents use Langfuse effectively. It follows the open [Agent Skills](https://github.com/anthropics/skills) standard and works with Claude Code, Cursor, Windsurf, and other compatible agents. The skill is open source on [GitHub](https://github.com/langfuse/skills).
+
+## Why use it [#why-use-it]
+
+Coding agents produce significantly better results with the skill installed, because they are conditioned to follow best practices. A coding agent with access to the skill has an opinionated view on what good looks like, based on Langfuse's knowledge.
+
+The skill is a self-contained folder with a `SKILL.md` entrypoint describing general rules and instructions on using documentation, plus reference docs for specific workflows that are filled with specific best practices:
+
+import { FileTree } from "@/components/docs";
+
+<div className="[&_.nextra-filetree>ul]:block [&_.nextra-filetree>ul]:w-full">
+  <FileTree>
+    <FileTree.File name="SKILL.md" />
+    <FileTree.Folder name="references" defaultOpen>
+      <FileTree.File name="cli.md" />
+      <FileTree.File name="instrumentation.md" />
+      <FileTree.File name="prompt-migration.md" />
+      <FileTree.File name="..." />
+    </FileTree.Folder>
+  </FileTree>
+</div>
+
+The skill uses a progressive disclosure model: the frontmatter is always loaded into the agent's context so it knows when the skill is relevant, but the full instructions and reference docs are only loaded on demand. This keeps context usage low while giving agents access to specialized knowledge.
+
+## Install [#install]
+
+import AutoInstall from "@/components-mdx/get-started/auto-install.mdx";
+
+<AutoInstall />
+
+Once installed, you can prompt your agent with what you want to do. A couple of examples:
+
+- *Show me the last 10 traces with a score below 0.5*
+- *Create a dataset called "edge-cases" and add these 3 items to it*
+- *Migrate the system prompt in src/agent.ts to Langfuse prompt management*
+
+## Resources [#resources]
+
+- [Langfuse Skills on GitHub](https://github.com/langfuse/skills)
+- [Langfuse CLI](/docs/api-and-data-platform/features/cli) — the CLI the skill uses under the hood
+- [MCP Server](/docs/api-and-data-platform/features/mcp-server) — alternative protocol-based approach for agents
+- [Making Agents fall in love with Langfuse](/blog/2026-02-13-will-you-be-my-cli) — the full story behind the skill, CLI, and agent platform
+- [Using Agent Skills to Improve your Prompts](/blog/2026-02-16-prompt-improvement-claude-skills)
+- [Evaluating AI Agent Skills](/blog/2026-02-26-evaluate-ai-agent-skills)

--- a/content/docs/api-and-data-platform/features/cli.mdx
+++ b/content/docs/api-and-data-platform/features/cli.mdx
@@ -41,4 +41,4 @@ It dynamically wraps the full OpenAPI spec, so every endpoint (traces, prompts, 
 
 ## Pairs with Agent Skills
 
-The CLI is designed to work together with [Agent Skills](https://github.com/langfuse/skills). The main Langfuse skill teaches agents how to discover endpoints, follow common workflows, and access documentation, all through the CLI. Read more about Skills and the full agent story in [the blog post](/blog/2026-02-13-will-you-be-my-cli).
+The CLI is designed to work together with [Agent Skills](/docs/api-and-data-platform/features/agent-skill). The skill teaches agents how to discover endpoints, follow common workflows, and access documentation, all through the CLI. Read more about the full agent story in [the blog post](/blog/2026-02-13-will-you-be-my-cli).

--- a/content/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/content/docs/api-and-data-platform/features/mcp-server.mdx
@@ -16,6 +16,14 @@ This is the authenticated MCP server for the Langfuse data platform. There is al
 
 </Callout>
 
+<Callout type="info">
+
+Alternatively you can also work with the [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill). Many use cases that aren't supported by the MCP server can be achieved using the skill. 
+
+</Callout>
+
+
+
 ## Configuration
 
 The Langfuse MCP server uses a stateless architecture where each API key is scoped to a specific project. Use the following configuration to connect to the MCP server:

--- a/content/docs/api-and-data-platform/features/meta.json
+++ b/content/docs/api-and-data-platform/features/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Features",
   "pages": [
+    "agent-skill",
     "cli",
     "export-from-ui",
     "export-to-blob-storage",


### PR DESCRIPTION
## Summary
- New docs page at `/docs/api-and-data-platform/features/agent-skill` explaining what the Langfuse agent skill is, why it improves coding agent results, and how to install it
- Cross-links from CLI and MCP server pages to the new page
- Added to sidebar navigation under API & Data Platform > Features