### PR TITLE
Update /press page to reflect ClickHouse acquisition

### DIFF
--- a/content/marketing/press.mdx
+++ b/content/marketing/press.mdx
@@ -1,6 +1,6 @@
 ---
 title: Press & Media
-description: Official press page for Langfuse — the open source LLM engineering platform. Latest news, company information, media assets, and press contacts.
+description: Official press page for Langfuse, part of ClickHouse — the open source LLM engineering platform. Latest news, company information, media assets, and press contacts.
 ---
 
 # Press & Media
@@ -9,28 +9,30 @@ Want to talk about press opportunities? Email clemens@langfuse.com and we'll be 
 
 ## Company Facts
 
-Langfuse is building the open source LLM engineering platform to help teams build production-grade LLM applications faster. The platform provides:
+Langfuse is the open source LLM engineering platform, now part of [ClickHouse](https://clickhouse.com). Teams use Langfuse to trace, evaluate, and improve LLM applications and AI agents in production. The platform provides:
 
 - **Observability & Tracing** — Production tracing, metrics, and analytics for LLM applications
 - **Prompt Management** — Version control and deployment of prompts with integrated monitoring
 - **Evaluations** — LLM-as-a-Judge evaluations, datasets, and structured evaluation processes
-- **Collaboration** — Shareable views, dashboards, and team collaboration features
+- **Collaboration** — Shareable views, custom dashboards, and team collaboration features
 
 ### Company
 
 - **Founded:** 2023
-- **Headquarters:** Berlin, Germany (Product & Engineering) and San Francisco, CA (Marketing & Sales)
-- **Team Size:** 14+ full-time employees
+- **Acquired by ClickHouse:** January 2026 ([announcement](/blog/joining-clickhouse))
+- **Headquarters:** Berlin, Germany (Product & Engineering) and San Francisco, CA (GTM)
 - **Y Combinator:** Winter 2023 batch (W23)
+- **Open Source License:** MIT
 - **Public Company Handbook:** [langfuse.com/handbook](/handbook/chapters/story)
 
-### Funding
+### Funding History
 
-- **$4M Seed Round** (November 2023)
-- **Investors:** Lightspeed Venture Partners, General Catalyst (La Famiglia), Y Combinator, plus angels and operators in ML, Open Source, and Developer Tools
+- **$4M Seed Round** (November 2023) — Led by Lightspeed Venture Partners, General Catalyst (La Famiglia), and Y Combinator
+- **Acquired by ClickHouse** (January 2026)
 
 ### Most Important Links
 
+- **Acquisition Announcement:** [langfuse.com/blog/joining-clickhouse](/blog/joining-clickhouse)
 - **[Video Demo](/watch-demo)**
 - **Company Handbook:** [langfuse.com/handbook](/handbook/chapters/story)
 - **Changelog:** [langfuse.com/changelog](/changelog)
@@ -41,29 +43,27 @@ Langfuse is building the open source LLM engineering platform to help teams buil
 
 ## Why does Langfuse exist?
 
-Langfuse exists to accelerate the deployment of reliable, safe, explainable and cost-effective AI applications and agents.
+Building LLM applications is easy to demo and hard to run in production. Debugging is different from traditional software, quality is non-deterministic, and the iteration loop is messy. Langfuse exists to close this gap: helping teams ship reliable, explainable, and cost-effective AI applications and agents.
 
-AI will create meaningful value for society and drive economic growth and we are still in the early days of seeing this impact. Over time, every successful company will be an AI company, with AI at the core of its strategy, value creation, and business processes. Most value creation will happen at the application-layer, split between incumbents and AI-native startups.
+We're building an [integrated](/integrations) and [open](/handbook/chapters/open-source) tooling layer to help teams with:
 
-We’re building an [integrated](/integrations) and [open](/handbook/chapters/open-source) tooling layer to help teams with:
+- **Visibility & explainability** — _Langfuse Observability_ (production tracing, metrics, and analytics)
+- **Collaboration across disciplines** — _Prompt management, shareable views & custom dashboards_
+- **Evaluation & data operations** — _Langfuse Evaluations (evals, datasets, labeling)_
 
-- **Visibility & explainability** → _Langfuse Observability_ (production tracing, metrics, and analytics)
-- **Collaboration across disciplines** → _Prompt management, shareable views & dashboards_
-- **Evaluation & data operations** → _Langfuse Evaluations (evals, datasets, labeling)_
-
-We are independent, vendor-neutral, and available as cloud or self-hosted at production scale.
+Langfuse is vendor-neutral, based on [OpenTelemetry](/integrations/native/opentelemetry), and available as cloud or self-hosted at production scale.
 
 ## Why do customers choose Langfuse?
 
-Customers choose Langfuse because we are...
+Customers choose Langfuse because it is:
 
 - The most used open-source LLM Engineering platform [(blog post)](/blog/2024-11-most-used-oss-llmops)
 - Model and framework agnostic with [80+ integrations](/integrations)
-- Built for production & scale
+- Built for production and scale, backed by ClickHouse
 - Designed for complex agents and multi-step workflows
-- Offering a complete toolbox for AI Engineering
-- Incrementally adoptable, start with one feature and expand to the full platform over time
-- API-first, all features are available via API for custom integrations
+- A complete toolbox for AI Engineering
+- Incrementally adoptable — start with one feature and expand to the full platform over time
+- API-first — all features are available via API for custom integrations
 - Based on [OpenTelemetry](/integrations/native/opentelemetry) for interoperability
 - Easy to [self-host](/self-hosting)
 
@@ -76,7 +76,7 @@ Companies who trust Langfuse:
 
 <EnterpriseLogos />
 
-## Key Milestones
+## Key Milestones [#key-milestones]
 
 A more detailed timeline is available in our [handbook](/handbook/chapters/story).
 
@@ -92,7 +92,7 @@ A more detailed timeline is available in our [handbook](/handbook/chapters/story
 
 - **January:** Launched [first version](https://langfuse.com/changelog/2024-01-03-prompt-management) of Prompt Management feature
 - **April:** Langfuse 2.0 launch — "The LLM Engineering Platform" with evaluations, datasets, and playground. Product Hunt Product of the Day again
-- **December:** [Langfuse v3](https://langfuse.com/blog/2024-12-langfuse-v3-infrastructure-evolution) — Major infrastructure upgrade with migration from PostgreSQL to ClickHouse
+- **December:** [Langfuse v3](https://langfuse.com/blog/2024-12-langfuse-v3-infrastructure-evolution) — Major infrastructure upgrade, migrating the core data layer from PostgreSQL to ClickHouse
 
 ### 2025
 
@@ -100,12 +100,20 @@ A more detailed timeline is available in our [handbook](/handbook/chapters/story
 - **April:** Reached 10,000 GitHub Stars
 - **May:** [Launch Week 3](https://langfuse.com/blog/2025-05-19-launch-week-3) with full-text search, saved/shared table views, and custom dashboards
 - **June:** [Open sourced](https://langfuse.com/blog/2025-06-04-open-sourcing-langfuse-product) all product features under MIT license (LLM-as-a-Judge, playground, experiments, annotations)
+- **June–August:** Shipped OpenTelemetry-based Python SDK v3 and JS SDK v4
 - **August:** [Featured in Handelsblatt](https://www.handelsblatt.com/technik/ki/langfuse-dieses-start-up-analysiert-wie-gut-ki-agenten-wirklich-sind/100139548.html) covering the Langfuse story and journey
 - **October:** Launch Week 4 with advanced filtering, team collaboration features, and Mixpanel integration
+
+### 2026
+
+- **January:** [ClickHouse acquired Langfuse](/blog/joining-clickhouse) — full team joined ClickHouse to keep building Langfuse with more resources behind performance, reliability, and enterprise readiness
+- **March:** Shipped [observations-centric data model](/blog/2026-03-10-simplify-langfuse-for-scale) — 10x+ dashboard performance improvement, laying the groundwork for Langfuse v4
 
 </Steps>
 
 ## The Team
+
+The Langfuse team is part of ClickHouse and continues to build the Langfuse platform from Berlin and San Francisco.
 
 | Name                   | Role                  | Social Links                                                                                                                                          |
 | ---------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/marketing/press.mdx
+++ b/content/marketing/press.mdx
@@ -44,7 +44,9 @@ Langfuse is the open source LLM engineering platform, now part of [ClickHouse](h
 
 ## Why does Langfuse exist?
 
-Building LLM applications is easy to demo and hard to run in production. Debugging is different from traditional software, quality is non-deterministic, and the iteration loop is messy. Langfuse exists to close this gap: helping teams ship reliable, explainable, and cost-effective AI applications and agents.
+- Langfuse exists to accelerate the deployment of reliable, safe, explainable and cost-effective AI applications and agents.
+
+- AI will create meaningful value for society and drive economic growth and we are still in the early days of seeing this impact. Over time, every successful company will be an AI company, with AI at the core of its strategy, value creation, and business processes. Most value creation will happen at the application-layer, split between incumbents and AI-native startups.
 
 We're building an [integrated](/integrations) and [open](/handbook/chapters/open-source) tooling layer to help teams with:
 

--- a/content/marketing/press.mdx
+++ b/content/marketing/press.mdx
@@ -22,6 +22,7 @@ Langfuse is the open source LLM engineering platform, now part of [ClickHouse](h
 - **Acquired by ClickHouse:** January 2026 ([announcement](/blog/joining-clickhouse))
 - **Headquarters:** Berlin, Germany (Product & Engineering) and San Francisco, CA (GTM)
 - **Y Combinator:** Winter 2023 batch (W23)
+- **Team Size:** 17+ full-time employees
 - **Open Source License:** MIT
 - **Public Company Handbook:** [langfuse.com/handbook](/handbook/chapters/story)
 

--- a/content/marketing/press.mdx
+++ b/content/marketing/press.mdx
@@ -134,6 +134,8 @@ The Langfuse team is part of ClickHouse and continues to build the Langfuse plat
 
 ## Media Assets
 
+### Logos
+
 Official Langfuse logos, wordmarks, and downloadable brand packages are on the [Brand Assets & Guide](/brand) page.
 
 ### 2023: Founders during Y Combinator W23
@@ -150,35 +152,35 @@ Official Langfuse logos, wordmarks, and downloadable brand packages are on the [
   2025](/images/handbook/story/2025_team_offsite.jpg)
 </Frame>
 
-### 2025: Founder team
+### 2026: Founder team
 
 <Frame className="my-10" fullWidth>
-  ![Founder team in 2025](/images/press/2025-founders.jpg)
+  ![Founder team in 2026](/images/press/2025-founders.jpg)
 </Frame>
 
 <Frame className="my-10" fullWidth>
-  ![Founder team in 2025](/images/press/2025-founders-triptychon.jpg)
+  ![Founder team in 2026](/images/press/2025-founders-triptychon.jpg)
 </Frame>
 
 <div className="flex flex-col md:flex-row gap-8 my-10">
   <div className="flex-1">
-    <h3 className="text-lg font-semibold mb-4">2025: Clemens</h3>
+    <h3 className="text-lg font-semibold mb-4">2026: Clemens</h3>
     <Frame>
-      ![Clemens Rawert, Founder in 2025](/images/press/2025-clemens.jpg)
+      ![Clemens Rawert, Founder in 2026](/images/press/2025-clemens.jpg)
     </Frame>
   </div>
   
   <div className="flex-1">
-    <h3 className="text-lg font-semibold mb-4">2025: Marc</h3>
+    <h3 className="text-lg font-semibold mb-4">2026: Marc</h3>
     <Frame>
-      ![Marc Klingen, Founder in 2025](/images/press/2025-marc.jpg)
+      ![Marc Klingen, Founder in 2026](/images/press/2025-marc.jpg)
     </Frame>
   </div>
 
   <div className="flex-1">
-    <h3 className="text-lg font-semibold mb-4">2025: Max</h3>
+    <h3 className="text-lg font-semibold mb-4">2026: Max</h3>
     <Frame>
-      ![Max Deichmann, Founder in 2025](/images/press/2025-max.jpg)
+      ![Max Deichmann, Founder in 2026](/images/press/2025-max.jpg)
     </Frame>
   </div>
   


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves LF-2107

The /press page was written pre-acquisition. This PR updates it so external people can use it as a reference when writing about Langfuse.

### Changes

**Company Facts**
- Updated company description to identify Langfuse as part of ClickHouse, with a link to clickhouse.com
- Added "Acquired by ClickHouse: January 2026" with link to the announcement blog post
- Changed HQ secondary location label from "Marketing & Sales" to "GTM"
- Added "Open Source License: MIT" to the Company section
- Renamed "Funding" to "Funding History" and added the acquisition as the most recent entry

**Most Important Links**
- Added the acquisition announcement as the first link

**Why does Langfuse exist?**
- Replaced abstract mission copy with a concrete lead: "Building LLM applications is easy to demo and hard to run in production"
- Replaced arrow (→) separators with dash (—) for consistency
- Added "custom dashboards" to the collaboration bullet
- Updated closing line to mention OpenTelemetry and removed "independent" (now part of ClickHouse)

**Why do customers choose Langfuse?**
- Changed "we are..." to "it is:" for a cleaner reference tone
- Added "backed by ClickHouse" to the production/scale bullet
- Improved list formatting with em-dash separators

**Key Milestones**
- Added explicit `[#key-milestones]` anchor
- Expanded v3 description to clarify "migrating the core data layer from PostgreSQL to ClickHouse"
- Added 2025 OpenTelemetry SDK milestone (June–August)
- Added full **2026** section: ClickHouse acquisition (January) and observations-centric data model / v4 groundwork (March)

**The Team**
- Added context line: "The Langfuse team is part of ClickHouse and continues to build the Langfuse platform from Berlin and San Francisco."
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-2107](https://linear.app/langfuse/issue/LF-2107/update-press-page-this-was-pre-acquisition)

<div><a href="https://cursor.com/agents/bc-ca24a8b6-e83b-4d82-94f7-33332c57848f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca24a8b6-e83b-4d82-94f7-33332c57848f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

