### PR TITLE
fix: correct broken Langfuse skill link in llms.txt generator

### DIFF
--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -96,7 +96,7 @@ async function generateLLMsList() {
         // Langfuse Skill section
         markdownContent += `## Langfuse Skill for AI Coding Agents\n\n`;
         markdownContent += `Install the Langfuse skill before implementing anything with Langfuse. The skill provides up-to-date documentation, best-practice workflows for instrumentation, prompt management, and programmatic API access via the Langfuse CLI.\n\n`;
-        markdownContent += `Install from: [github.com/langfuse/skills/langfuse](https://github.com/langfuse/skills/langfuse)\n\n`;
+        markdownContent += `Install from: [github.com/langfuse/skills](https://github.com/langfuse/skills/tree/main/skills/langfuse)\n\n`;
 
         // Add each section with sub-file link and comma-separated titles
         for (const [sectionKey, entries] of Object.entries(sectionEntries)) {


### PR DESCRIPTION
## Summary

- The Langfuse skill link in the generated `llms.txt` pointed to `github.com/langfuse/skills/langfuse` which returns a 404
- Fixed to point to `github.com/langfuse/skills/tree/main/skills/langfuse` (the actual location of the skill in the repo)