### PR TITLE
docs: add 'War room call' section to Incident Response handbook

### DIFF
--- a/content/handbook/product-engineering/incident-response.mdx
+++ b/content/handbook/product-engineering/incident-response.mdx
@@ -23,6 +23,13 @@ The **first engineer to join** the incident channel is the **Incident Lead**. As
 2. **Mitigate** — Restore the system first: rollback, scale up, feature-flag, hotfix. Root cause comes later.
 3. **Stabilize** — Mark as mitigated in incident.io, update the status page, monitor for 15–30 min, then dissolve the call.
 
+### War room call
+
+Keep all incident communication in the incident.io war room call so remote teammates can join quickly and we have a transcript for the post-mortem.
+
+1. Open the incident Slack channel created by incident.io.
+2. Click **☎️ Join the call** in the incident.io message.
+
 ### Status page
 
 Status pages are extremely important — they are our mechanism to show transparency to users, which builds trust. **When in doubt, always set up a status page.**


### PR DESCRIPTION
### Motivation
- Add explicit instructions for joining the incident.io war room call so remote teammates can join quickly and an audio transcript is available for post-mortems.

### Description
- Add a `War room call` section to the Incident Response handbook with two concise steps: open the incident Slack channel and click `☎️ Join the call` from the incident.io message.

### Testing
- This is a documentation-only change; no automated tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcf664d28c832b9dc02b420db81cb5)