### PR TITLE
docs(v4): add rollout timeline for v4 preview

### DIFF
--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -24,7 +24,7 @@ Langfuse is now observations-first. Queries that used to require expensive joins
 
 - **SDK:** Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
 - **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
-- **UI:** Enable the **Preview** toggle (bottom-left) to opt in. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
+- **UI:** If your organization was created before April 14, 2026, 14:00 UTC (15:00 CET), enable the **Preview** toggle (bottom-left) to opt in. Organizations created on/after this cutoff are already on v4 and do not see the toggle. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
 - **Evals:** Migrate evals to the observation level. [See evals migration guide](/faq/all/llm-as-a-judge-migration))
 
 ---
@@ -57,10 +57,10 @@ As agentic applications grow more complex, a single trace can contain hundreds o
 
 ## Preview access and rollout timeline
 
-| Organization creation date (Langfuse Cloud) | Fast Preview (v4) default | "Preview" toggle visibility     |
-| ------------------------------------------- | ------------------------- | ------------------------------- |
-| Before April 14, 2026, 10:00 CEST           | Optional                  | Visible (you can switch on/off) |
-| On/after April 14, 2026, 10:00 CEST         | Enabled by default        | Hidden (already on v4)          |
+| Organization creation date (Langfuse Cloud)    | Fast Preview (v4) default | "Preview" toggle visibility     |
+| ---------------------------------------------- | ------------------------- | ------------------------------- |
+| Before April 14, 2026, 14:00 UTC (15:00 CET)   | Optional                  | Visible (you can switch on/off) |
+| On/after April 14, 2026, 14:00 UTC (15:00 CET) | Enabled by default        | Hidden (already on v4)          |
 
 If you signed up recently and do not see the toggle, your organization is already on the new experience by default.
 For organizations created before the cutoff date, the "Preview" toggle is available in the bottom-left corner of the UI to opt in to v4.

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -3,17 +3,25 @@ title: "Langfuse v4: Faster and Observations-First"
 description: Langfuse v4 delivers faster performance and introduces an observations-first data model. Enable the preview and upgrade SDKs to get started.
 ---
 
-import { BarChart3, Book, Github, LayoutDashboard, Table, Zap } from "lucide-react";
+import {
+  BarChart3,
+  Book,
+  Github,
+  LayoutDashboard,
+  Table,
+  Zap,
+} from "lucide-react";
 
 # Langfuse Cloud: Fast Preview (v4)
 
 ## At a glance
 
-Langfuse is now observations-first. Queries that used to require expensive joins now run an order of magnitude faster. This change was necessary do allow Langfuse scale for agentic applications.
+Langfuse is now observations-first. Queries that used to require expensive joins now run an order of magnitude faster. This change was necessary to let Langfuse scale for agentic applications.
 
 **What changed:** We move from traces and observations as separate entities to observations only. A trace ID remains a correlating identifier for a group of observations. Trace attributes (`user_id`, `session_id`, etc.) must be set on _all_ observations for efficient queries and aggregations. Traces have no longer separate input and output.
 
 **How to adopt:**
+
 - **SDK:** Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
 - **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
 - **UI:** Enable the **Preview** toggle (bottom-left) to opt in. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
@@ -28,7 +36,11 @@ Langfuse now delivers faster product performance at scale. Chart loading is much
 We will keep this page updated as we roll out additional related features and share OSS and self-hosted support updates.
 
 <Callout type="info">
-V4 introduces a **single unified observations table** where all inputs, outputs, and context attributes live directly on observations. See the [guide on working with the observation-centric data model in v4](/faq/all/explore-observations-in-v4) for before/after workflows and saved view setup.
+  V4 introduces a **single unified observations table** where all inputs,
+  outputs, and context attributes live directly on observations. See the [guide
+  on working with the observation-centric data model in
+  v4](/faq/all/explore-observations-in-v4) for before/after workflows and saved
+  view setup.
 </Callout>
 
 ## Why observations-first?
@@ -43,18 +55,22 @@ As agentic applications grow more complex, a single trace can contain hundreds o
   />
 </Cards>
 
-## Get access to the preview
+## Preview access and rollout timeline
 
+| Organization creation date (Langfuse Cloud) | Fast Preview (v4) default | "Preview" toggle visibility     |
+| ------------------------------------------- | ------------------------- | ------------------------------- |
+| Before April 14, 2026, 10:00 CEST           | Optional                  | Visible (you can switch on/off) |
+| On/after April 14, 2026, 10:00 CEST         | Enabled by default        | Hidden (already on v4)          |
 
+If you signed up recently and do not see the toggle, your organization is already on the new experience by default.
+For organizations created before the cutoff date, the "Preview" toggle is available in the bottom-left corner of the UI to opt in to v4.
 
 <Frame className="max-w-xs mx-auto">
-  ![Beta toggle in Langfuse UI](/images/changelog/2026-03-10-v4-preview/v4-beta-togle.png)
+  ![Beta toggle in Langfuse
+  UI](/images/changelog/2026-03-10-v4-preview/v4-beta-togle.png)
 </Frame>
 
-
-In the UI, a "Preview" toggle is available in the bottom left to opt into the new experience. Not all screens have been migrated to the new data model yet.
-
-The toggle is reversible, you can always switch back to the previous experience.
+The toggle remains reversible for organizations created before the cutoff date.
 
 <Callout type="info">
 Data from SDKs `langfuse-js` < `5.0.0`, `langfuse-python` < `4.0.0`, or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes in the new UI. Upgrade to the latest SDKs or set that header on your OTEL span exporter to see new data in real time.
@@ -62,9 +78,7 @@ Data from SDKs `langfuse-js` < `5.0.0`, `langfuse-python` < `4.0.0`, or direct O
 
 ### Migrate to the new experience
 
-
 <Steps>
-
 
 ### Use a v4-compatible ingestion path
 
@@ -109,7 +123,8 @@ The new [Observations API v2](/docs/api-and-data-platform/features/observations-
 ## Under the hood
 
 <Frame fullWidth>
-  ![Langfuse data model overview](/images/changelog/2026-03-10-v4-preview/data-model.png)
+  ![Langfuse data model
+  overview](/images/changelog/2026-03-10-v4-preview/data-model.png)
 </Frame>
 
 This preview is powered by a simplified observation-centric data model. Trace-level attributes such as `user_id`, `session_id`, and `metadata` now propagate automatically to observations, which helps remove expensive joins and keep the product fast at larger scale. Learn more in the [data model docs](/docs/observability/data-model) and [Explore Observations in V4](/faq/all/explore-observations-in-v4).


### PR DESCRIPTION
### Motivation

- Clarify the preview rollout and toggle behavior so organizations know when v4 is enabled by default. 
- Improve copy and readability across the v4 preview docs to reduce confusion during migration. 
- Fix small formatting and import inconsistencies to keep the repository style consistent.

### Description

- Added a new "Preview access and rollout timeline" table and explanatory text describing the cutoff date and toggle visibility for v4 preview. 
- Updated wording and fixed a typo (`do allow` -> `to let`) and reflowed several callout and image text blocks for better readability. 
- Adjusted the `lucide-react` imports to a multi-line format and cleaned up duplicate or outdated UI toggle lines. 
- Performed minor markdown/layout adjustments across `content/docs/v4.mdx` to align the documentation with the new observations-first messaging.

### Testing

- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de10422298832b9df9e1663aeed566)