### PR TITLE
Add private channel note to Slack Connect setup guide

### DIFF
--- a/content/handbook/tools-and-processes/using-slack.mdx
+++ b/content/handbook/tools-and-processes/using-slack.mdx
@@ -51,6 +51,9 @@ All support/sales communication in `ext-*` channels happens via Pylon.
 - When creating an `ext-*` channel (customers):
   - Invite external members
   - Invite internal members explicitly, do not make the channel a default channel for everyone. Only invite Clemens and Akio who want to be a member of all external channels. Everyone else can help out in this channel via the Pylon integration, the App automatically joins all `ext-*` channels.
+  - **Private channels:** The Pylon app cannot automatically join private channels. You need to manually:
+    1. Add the Pylon app to the channel (in Slack, open the channel → click the channel name → *Integrations* → *Add apps* → search for Pylon).
+    2. Add the Slack channel as an account in Pylon: [app.usepylon.com/customers/accounts/add](https://app.usepylon.com/customers/accounts/add).
   - Optionally: once you see that the external members joined, share a welcome message in the channel and then mute the channel on Slack. From then on, you can help out in this channel via the Pylon integration.
 
 ### Configure Slack for external channels


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a note to the handbook's Slack Connect channel setup section documenting that private channels require two manual steps:

1. Adding the Pylon app to the channel (since it cannot auto-join private channels).
2. Registering the Slack channel as an account in Pylon at [app.usepylon.com/customers/accounts/add](https://app.usepylon.com/customers/accounts/add).

Resolves INT-1014.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca0b68eb-5459-433f-90d5-f40d534229f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca0b68eb-5459-433f-90d5-f40d534229f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

