### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -93,3 +93,12 @@ Please check the following:
 - We never use `.gif` files, only `.mp4` files uploaded to `static.langfuse.com/docs-videos` to optimize for size and performance.
 - When deep-linking to a section via a link that uses the `#` anchor, make sure the anchor is explicitly defined in the source page via `[#anchor]` at the end of the header line, e.g. `## Get Started [#get-started]`.
 - If a page/route includes a top-of-file comment that points to an `md-override` source, verify both files are kept in sync whenever either side is edited.
+
+## Cursor Cloud specific instructions
+
+- **Single service**: This is a Next.js website (not a monorepo). The only service to run is `pnpm dev` on port 3333. No databases, Docker, or external services are required for local development.
+- **Dev server bind address**: The dev script binds to `127.0.0.1` (`-H 127.0.0.1`), so use `http://127.0.0.1:3333` (not `localhost`) when curling or testing.
+- **First page load is slow**: After `pnpm dev` starts ("Ready in ~1s"), the first HTTP request compiles on-demand and can take 20-40 seconds. Subsequent pages are much faster.
+- **Langfuse SDK warnings are expected**: The dev server logs `[Langfuse SDK] [WARN] No exporter configured…` on startup. These are harmless — the SDK keys are only needed for optional demo API routes and are not required for the docs site itself.
+- **No env file needed**: All external integrations (OpenAI, Supabase, PostHog, etc.) degrade gracefully when keys are absent. You do not need a `.env` file for routine development.
+- **postinstall runs agent shim sync**: `pnpm install` triggers `scripts/postinstall.sh`, which syncs agent config shims. This is expected and idempotent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment notes for future cloud agents:

- Single-service architecture (Next.js only, no external deps needed)
- Dev server binds to `127.0.0.1` (not `localhost`)
- First page load takes 20-40s due to on-demand compilation
- Langfuse SDK warnings on startup are expected/harmless
- No `.env` file needed for routine development
- `postinstall` agent shim sync is expected behavior

### Demo

[langfuse_dev_server_demo.mp4](https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flangfuse_dev_server_demo.mp4)

Homepage, docs, get-started, and changelog pages all load correctly on `http://127.0.0.1:3333`.

[Homepage](https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Docs page](https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_page.webp)
[Get Started page](https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fget_started_page.webp)
[Changelog page](https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchangelog_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f8e647-13ad-42a4-b98a-6ba3b1498beb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

