### PR TITLE
docs: improve OTEL docs discoverability

### DIFF
--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -120,9 +120,10 @@ This guide helps you get started with Langfuse tracing manually.
 
 ### Ingest your first trace
 
-Choose your framework or SDK to get started:
+Choose your framework, SDK, or OpenTelemetry setup to get started. If your
+application already emits OTEL spans, start with the OpenTelemetry guide.
 
-<LangTabs items={["OpenAI SDK (Python)", "OpenAI SDK (JS/TS)", "Vercel AI SDK", "LangChain (Python)", "LangChain (JS/TS)", "Python SDK", "JS/TS SDK", "More integrations"]}>
+<LangTabs items={["OpenAI SDK (Python)", "OpenAI SDK (JS/TS)", "Vercel AI SDK", "LangChain (Python)", "LangChain (JS/TS)", "Python SDK", "JS/TS SDK", "OpenTelemetry (OTEL)", "More integrations"]}>
 
 <Tab>
 {/* PYTHON - OPENAI*/}
@@ -303,11 +304,56 @@ Use the Langfuse JS/TS SDK to wrap any LLM or Agent
 </Tab>
 
 <Tab>
+{/* OTEL */}
+
+If your app, framework, or collector already emits OpenTelemetry (OTEL) spans,
+use the Langfuse OpenTelemetry integration to send OTLP traces to Langfuse.
+This is the right entry point for custom OTEL setups and languages beyond the
+Langfuse SDKs.
+
+<Cards num={2}>
+  <Card
+    icon={
+      <div className="w-6 h-6 dark:bg-white rounded-sm p-0.5 flex items-center justify-center">
+        <img
+          src="/images/integrations/opentelemetry_icon.svg"
+          className="w-full h-full object-contain"
+        />
+      </div>
+    }
+    title="OpenTelemetry (OTEL) guide"
+    href="/integrations/native/opentelemetry"
+    arrow
+  />
+  <Card
+    icon={<BookOpen />}
+    title="Attribute propagation"
+    href="/integrations/native/opentelemetry#propagating-attributes"
+    arrow
+  />
+</Cards>
+
+</Tab>
+
+<Tab>
 {/* MORE INTEGRATIONS */}
 
 Explore all integrations and frameworks that Langfuse supports.
 
 <Cards num={2}>
+  <Card
+    icon={
+      <div className="w-6 h-6 dark:bg-white rounded-sm p-0.5 flex items-center justify-center">
+        <img
+          src="/images/integrations/opentelemetry_icon.svg"
+          className="w-full h-full object-contain"
+        />
+      </div>
+    }
+    title="OpenTelemetry (OTEL)"
+    href="/integrations/native/opentelemetry"
+    arrow
+  />
   <Card
     icon={
       <div className="w-6 h-6 dark:bg-white rounded-sm p-0.5 flex items-center justify-center">

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -17,6 +17,15 @@ As the [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attrib
 
 > **Using other OTEL-based tools?** If you're using Langfuse alongside other OpenTelemetry-based tools, you may run into conflicts. See [Using Langfuse with an Existing OpenTelemetry Setup](/faq/all/existing-otel-setup) for configuration guidance.
 
+<Callout type="info">
+  **Using Python or JS/TS?** Prefer the Langfuse SDKs instead of wiring raw
+  OpenTelemetry exporters directly. Start with the
+  [Python SDK v3](/docs/sdk/python/sdk-v3) or the
+  [JS/TS SDK](/docs/sdk/typescript/guide). This OpenTelemetry page is most
+  useful for existing OTEL setups, collector-based ingestion, and unsupported
+  languages.
+</Callout>
+
 <Callout type="warning">
   **Important:** If you want to filter and aggregate by `userId`, `sessionId`,
   `metadata`, `version`, `release`, or `tags`, you need to propagate these

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -1,19 +1,29 @@
 ---
-title: Open Source LLM Observability via OpenTelemetry
-description: How to connect Langfuse with OpenTelemetry to observe LLM applications.
+title: OpenTelemetry (OTEL) for LLM Observability
+description: Connect Langfuse to OpenTelemetry (OTEL) and send OTLP traces from your application or collector to Langfuse.
 sidebarTitle: OpenTelemetry
 logo: /images/integrations/opentelemetry_icon.svg
 ---
 
-# LLM Observability via OpenTelemetry
+# OpenTelemetry (OTEL) for LLM Observability
 
-[OpenTelemetry](https://opentelemetry.io/) is a [CNCF](https://www.cncf.io/) project that provides a set of specifications, APIs, libraries that define a standard way to collect distributed traces and metrics from your application.
+[OpenTelemetry (OTEL)](https://opentelemetry.io/) is a [CNCF](https://www.cncf.io/) project that provides a set of specifications, APIs, and libraries that define a standard way to collect distributed traces and metrics from your application.
+
+Use this page if your application, framework, or collector already emits OpenTelemetry (OTEL) traces and you want to send them to Langfuse.
 
 Langfuse can operate as an OpenTelemetry Backend to receive traces on the `/api/public/otel` (OTLP) endpoint. In addition to the [Langfuse SDKs](/docs/sdk/overview) and [native integrations](/integrations), this OpenTelemetry endpoint is designed to increase compatibility with frameworks, libraries, and languages beyond the SDKs and native integrations. Popular OpenTelemetry libraries include OpenLLMetry and OpenLIT which extend Language support of Langfuse tracing to Java and Go and cover frameworks such as AutoGen, Semantic Kernel, and more.
 
-As the [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) for GenAI attributes on traces are still evolving, Langfuse maps the received OTel traces to the [Langfuse data model](/docs/observability/data-model) and supports additional attributes that are popular in the OTel GenAI ecosystem ([property mapping](#property-mapping)). Please contribute to the discussion on [GitHub](https://github.com/orgs/langfuse/discussions/2509) if an integration does not work as expected or does not parse the correct attributes.
+As the [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) for GenAI attributes on traces are still evolving, Langfuse maps the received OTel traces to the [Langfuse data model](/docs/observability/data-model) and supports additional attributes that are popular in the OTel GenAI ecosystem ([attribute mapping](#property-mapping)). Please contribute to the discussion on [GitHub](https://github.com/orgs/langfuse/discussions/2509) if an integration does not work as expected or does not parse the correct attributes.
 
 > **Using other OTEL-based tools?** If you're using Langfuse alongside other OpenTelemetry-based tools, you may run into conflicts. See [Using Langfuse with an Existing OpenTelemetry Setup](/faq/all/existing-otel-setup) for configuration guidance.
+
+<Callout type="warning">
+  **Important:** If you want to filter and aggregate by `userId`, `sessionId`,
+  `metadata`, `version`, `release`, or `tags`, you need to propagate these
+  trace-level attributes to every span in the trace. Start with
+  [Propagating Trace Attributes to All Spans](#propagating-attributes) before
+  wiring this up in production.
+</Callout>
 
 ```mermaid
 flowchart LR
@@ -33,6 +43,60 @@ flowchart LR
   classDef subgraphBox fill:none,stroke:#888,stroke-width:2px;
   class App,Langfuse subgraphBox;
 ```
+
+## Important: Propagating Trace Attributes to All Spans [#propagating-attributes]
+
+When using OpenTelemetry (OTEL) instrumentation to send traces to Langfuse,
+certain trace-level attributes should be propagated to **all spans** within a
+trace to enable accurate aggregations and filtering in Langfuse. These
+attributes include:
+
+- `userId` (via `langfuse.user.id` or `user.id`)
+- `sessionId` (via `langfuse.session.id` or `session.id`)
+- `metadata` (via `langfuse.trace.metadata.*` for top-level metadata keys)
+- `version` (via `langfuse.version`)
+- `release` (via `langfuse.release`)
+- `tags` (via `langfuse.trace.tags`)
+
+Langfuse filters and aggregations increasingly operate across individual
+observations rather than only at the trace level. If you want to reliably
+filter or aggregate by these attributes, they need to be present on each span
+in the trace, not only on the root span.
+
+### Recommended: Use OpenTelemetry Baggage for Propagation
+
+The recommended approach for propagating these attributes across all spans is
+to use [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/)
+with a `BaggageSpanProcessor`. Baggage is a built-in OpenTelemetry mechanism
+for context propagation that automatically copies specified key-value pairs to
+all spans within a trace context.
+
+To implement this pattern:
+
+1. Set the desired attributes as baggage entries at the beginning of your trace.
+2. Set the attributes on the currently active span.
+3. Configure a `BaggageSpanProcessor` in your OpenTelemetry setup to automatically copy baggage entries to span attributes.
+4. The processor will ensure all downstream spans in the trace context receive these attributes.
+
+For implementation details and code examples, refer to the OpenTelemetry
+documentation for
+[Python](https://pypi.org/project/opentelemetry-processor-baggage/) and
+[JavaScript](https://www.npmjs.com/package/@opentelemetry/baggage-span-processor).
+
+<Callout type="warning">
+  **Security Consideration:** OpenTelemetry baggage is propagated across
+  service boundaries and to third-party APIs. **Do not include sensitive
+  information** (passwords, API keys, personal data, etc.) in baggage when
+  using this approach, as it will be transmitted to all downstream services.
+</Callout>
+
+### Alternative: Use Langfuse SDK Helpers
+
+If you're using the [Langfuse SDKs](/docs/observability/sdk/overview) with
+OpenTelemetry integration, you can use the convenience methods
+`propagate_attributes()` (Python) or `propagateAttributes()` (TypeScript),
+which handle attribute propagation automatically. These methods provide a
+simpler interface and are the recommended approach when using Langfuse SDKs.
 
 ## Ingestion Options
 
@@ -303,40 +367,6 @@ OpenTelemetry spans can carry arbitrary attributes. Langfuse handles these attri
 - **Langfuse SDKs** provide utility functions (like `update()` with a `metadata` parameter) that automatically set the `langfuse.*.metadata.*` prefixed attributes. This means custom metadata appears at the first level and is filterable.
 - **Standard OpenTelemetry SDKs** set attributes directly on spans. Unless you explicitly use the `langfuse.trace.metadata.*` or `langfuse.observation.metadata.*` prefix, these attributes end up in the `metadata.attributes` catch-all and are not directly filterable in Langfuse.
 </Callout>
-
-### Propagating Trace Attributes to All Spans [#propagating-attributes]
-
-When using OpenTelemetry instrumentation to send traces to Langfuse, certain trace-level attributes should be propagated to **all spans** within a trace to enable accurate aggregations and filtering in Langfuse. These attributes include:
-
-- `userId` (via `langfuse.user.id` or `user.id`)
-- `sessionId` (via `langfuse.session.id` or `session.id`)
-- `metadata` (via `langfuse.trace.metadata.*` for top-level metadata keys)
-- `version` (via `langfuse.version`)
-- `release` (via `langfuse.release`)
-- `tags` (via `langfuse.trace.tags`)
-
-Starting in a future release, Langfuse aggregation queries and filters will operate across individual observations (spans) rather than just at the trace level. This means that if you want to filter or aggregate by these attributes, they must be present on each span in the trace. We strongly recommend implementing this propagation now to ensure compatibility with future versions of Langfuse.
-
-#### Using OpenTelemetry Baggage for Propagation
-
-The recommended approach for propagating these attributes across all spans is to use [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) with a `BaggageSpanProcessor`. Baggage is a built-in OpenTelemetry mechanism for context propagation that automatically copies specified key-value pairs to all spans within a trace context.
-
-To implement this pattern:
-
-1. Set the desired attributes as baggage entries at the beginning of your trace
-2, Set the attributes on the currently active span
-3. Configure a `BaggageSpanProcessor` in your OpenTelemetry setup to automatically copy baggage entries to span attributes
-4. The processor will ensure all downstream spans in the trace context receive these attributes
-
-For implementation details and code examples, refer to the OpenTelemetry documentation for [Python](https://pypi.org/project/opentelemetry-processor-baggage/) and [JavaScript](https://www.npmjs.com/package/@opentelemetry/baggage-span-processor).
-
-<Callout type="warning">
-  **Security Consideration**: OpenTelemetry baggage is propagated across service boundaries and to third-party APIs. **Do not include sensitive information** (passwords, API keys, personal data, etc.) in baggage when using this approach, as it will be transmitted to all downstream services.
-</Callout>
-
-#### Alternative: Using Langfuse SDKs
-
-If you're using the [Langfuse SDKs](/docs/observability/sdk/overview) with OpenTelemetry integration, you can use the convenience methods `propagate_attributes()` (Python) or `propagateAttributes()` (TypeScript) which handle attribute propagation automatically. These methods provide a simpler interface and are the recommended approach when using Langfuse SDKs. 
 
 ### Trace-Level Attributes
 


### PR DESCRIPTION
## What changed

This PR improves how the OpenTelemetry docs are surfaced and navigated.

- updated the OpenTelemetry page title, description, H1, and intro to explicitly include `OTEL`
- promoted attribute propagation from a buried subsection into a prominent top-of-page warning and dedicated section
- added a dedicated `OpenTelemetry (OTEL)` entry to the tracing get-started page
- added direct links from get-started to the OTEL guide and the attribute propagation anchor
- added OpenTelemetry to the `More integrations` grid so it is easier to discover from the tracing entry point

## Why it changed

We received feedback that:

- the OpenTelemetry docs were not surfacing well for the `otel` query
- the OTEL guide was missing from the `Start tracing` page
- attribute propagation is an important detail but was too hard to find on the OTEL page

The root issue was discoverability in two places: search-facing page copy and in-product docs navigation.

## User impact

Users looking for OTEL setup should now find the right page more easily, reach it directly from the tracing get-started flow, and see the attribute propagation requirement much earlier before shipping instrumentation.

## Validation

- `git diff --check origin/main...HEAD`
- manual review of the updated MDX structure and links

## Notes

I did not run a full `pnpm` / Next.js docs build in this environment because `pnpm` is available but `node` is not on `PATH` here (`pnpm exec node -v` fails with `Command "node" not found`).