### PR TITLE
fix(docs): correct backup storage description in data-regions

### DIFF
--- a/content/security/data-regions.mdx
+++ b/content/security/data-regions.mdx
@@ -55,7 +55,7 @@ Less critical factor:
 | **High Availability**     | Multi‑AZ databases & load‑balanced stateless application layer on AWS.                                                                                          |
 | **Recovery Precision**    | RPO: 10 minutes (PITR for Postgres). RTO: 12 hours.                                                                                                            |
 | **Backup Layers**         | Postgres: 7d retention. Clickhouse: 6-hourly backups (4d retention). S3: 7d versioning retention.                                                              |
-| **Durability**            | Encrypted backups stored cross‑region on AWS/Clickhouse Cloud; tested at least annually for restoration integrity.                                             |
+| **Durability**            | Encrypted backups stored across multiple availability zones within a single region on AWS/Clickhouse Cloud; tested at least annually for restoration integrity. |
 | **Status Page**           | [https://status.langfuse.com](https://status.langfuse.com) with historical uptime and incidents.                                                               | 
 
 


### PR DESCRIPTION
## Summary
- Corrects the **Durability** row in the data-regions reliability table: backups are stored across multiple availability zones within a single region, not cross-region.

## Test plan
- [ ] Verify the data-regions page renders correctly on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)