### PR TITLE
docs: note reserved OTel attribute key segments are silently dropped

### DIFF
--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -357,6 +357,10 @@ Furthermore, Langfuse uses attributes within the `langfuse.*` namespace to map O
   not work as expected or does not parse the correct attributes.
 </Callout>
 
+<Callout type="warning">
+  **Reserved attribute key segments:** Attribute keys that contain `__proto__`, `constructor`, or `prototype` as a path segment (e.g. `gen_ai.prompt.__proto__.foo`) are silently dropped during ingestion. This is a security measure to prevent prototype pollution. If you notice missing attributes, check that your keys do not include these reserved segments.
+</Callout>
+
 Langfuse distinguishes between trace-level attributes and observation-level attributes.
 - [Trace-level attributes](#trace-level-attributes) represent shared context for an entire interaction. If Langfuse detects these attributes on a specific span, it will treat them as properties of the whole trace.
 - [Observation-level attributes](#observation-level-attributes) describe individual steps within a trace. Langfuse keeps them on the observation level.


### PR DESCRIPTION
## Summary
- Adds a warning callout to the OpenTelemetry attribute mapping docs noting that attribute keys containing `__proto__`, `constructor`, or `prototype` as a path segment are silently dropped during ingestion
- Documents the behavior introduced in langfuse/langfuse#13201 (prototype pollution prevention)

## Test plan
- [ ] Verify the callout renders correctly on the OTel integration page (`/integrations/native/opentelemetry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a single `<Callout type="warning">` block to the OpenTelemetry integration docs, informing users that attribute keys containing `__proto__`, `constructor`, or `prototype` as a path segment are silently dropped during ingestion as a prototype-pollution safeguard. The callout is well-placed within the Attribute Mapping section, uses correct American English, and provides a concrete example and actionable guidance.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, accurate documentation addition with no code logic.

Single callout block added to docs; content is factually correct per the linked backend PR, grammar and formatting are correct, placement is appropriate, and no P0/P1 issues were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/integrations/native/opentelemetry.mdx | Adds a warning callout under the Attribute Mapping section documenting that keys containing `__proto__`, `constructor`, or `prototype` segments are silently dropped; content is accurate, well-placed, and grammatically correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTel Span Attribute Key] --> B{Contains reserved segment?}
    B -- "yes (__proto__ / constructor / prototype)" --> C[Silently dropped during ingestion]
    B -- no --> D{Matches langfuse.* namespace?}
    D -- yes --> E[Mapped directly to Langfuse data model]
    D -- no --> F{Matches OTel GenAI conventions?}
    F -- yes --> G[Mapped per semantic conventions]
    F -- no --> H[Stored under metadata.attributes catch-all]
```

<sub>Reviews (1): Last reviewed commit: ["docs: note that reserved OTel attribute ..."](https://github.com/langfuse/langfuse-docs/commit/e93852297f87e1e4a0fc23d68d75bc14273502e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28626092)</sub>

<!-- /greptile_comment -->