### PR TITLE
fix(docs): update llm-guard docs link on masking page

### DIFF
--- a/content/docs/observability/features/masking.mdx
+++ b/content/docs/observability/features/masking.mdx
@@ -212,7 +212,7 @@ langfuse.flush()
 
 In this example, we'll use the `Anonymize` scanner from `llm-guard` to remove personal names and other PII from the data. This is useful for anonymizing user data and protecting privacy.
 
-Find our more about the `llm-guard` library in their [documentation](https://llm-guard.com/).
+Find our more about the `llm-guard` library in their [documentation](https://protectai.github.io/llm-guard/).
 
 **Steps:**
 


### PR DESCRIPTION
### Motivation
- Fix a broken external reference to the `llm-guard` documentation on the masking docs page by pointing to the correct Protect AI docs URL `https://protectai.github.io/llm-guard/`.

### Description
- Replaced the old `llm-guard.com` link with `https://protectai.github.io/llm-guard/` in `content/docs/observability/features/masking.mdx` and committed the change with `fix(docs): update llm-guard docs link on masking page`.

### Testing
- Verified the update by running `rg` to find the occurrence and using `nl | sed` to inspect the file context, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2638d0a8c832fb98a5e9fc253a099)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a broken external link on the masking docs page, replacing the defunct `llm-guard.com` URL with the current Protect AI GitHub Pages URL (`protectai.github.io/llm-guard/`). The change is correct and minimal.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line URL fix with no functional or structural risk.

Only remaining finding is a pre-existing P2 typo on the same line; the URL change itself is correct. No blocking issues.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/docs/observability/features/masking.mdx | Replaces broken `llm-guard.com` URL with the correct Protect AI GitHub Pages URL; pre-existing typo "Find our more" on the same line flagged for cleanup. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["masking.mdx — llm-guard docs link"] -->|"old (broken)"| B["llm-guard.com ❌"]
    A -->|"new (fixed)"| C["protectai.github.io/llm-guard/ ✅"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/docs/observability/features/masking.mdx
Line: 215

Comment:
**Typo: "our" → "out"**

The sentence reads "Find our more" but should be "Find out more."

```suggestion
Find out more about the `llm-guard` library in their [documentation](https://protectai.github.io/llm-guard/).
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): update llm-guard docs link on..."](https://github.com/langfuse/langfuse-docs/commit/8df6eea76dda3e00958719b55c6749f5eefc0db4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28793871)</sub>

<!-- /greptile_comment -->