### PR TITLE
docs(self-hosting): document ClickHouse system log table opt-out and TTLs

### DIFF
--- a/content/faq/all/reduce-clickhouse-disk-size.mdx
+++ b/content/faq/all/reduce-clickhouse-disk-size.mdx
@@ -1,0 +1,29 @@
+---
+title: How do I reduce ClickHouse disk size on self-hosted Langfuse?
+tags: [self-hosting]
+---
+
+# How do I reduce ClickHouse disk size on self-hosted Langfuse?
+
+On self-hosted Langfuse, disk usage is frequently dominated by ClickHouse's built-in system log tables rather than Langfuse's own tables. There are two levers, in order of recommendation:
+
+1. **Langfuse-owned data** — configure a [data retention policy](/docs/administration/data-retention) to drop old traces, observations, scores, and their blob-storage payloads. This is the primary lever for trimming application data.
+2. **ClickHouse system log tables** — by default, ClickHouse writes to `trace_log`, `text_log`, `opentelemetry_span_log`, `asynchronous_metric_log`, `metric_log`, and `latency_log` with no TTL, and runs the query profiler continuously. Langfuse does not read from these, so you can either opt out of the unused ones or attach aggressive TTLs. See [ClickHouse system log tables](/self-hosting/configuration/scaling#clickhouse-system-log-tables) in the scaling docs for concrete `config.d` snippets.
+
+Use this query inside ClickHouse to identify the largest tables:
+
+```sql
+SELECT table, formatReadableSize(size) as size, rows FROM (
+    SELECT
+        table,
+        database,
+        sum(bytes) AS size,
+        sum(rows) AS rows
+    FROM system.parts
+    WHERE active
+    GROUP BY table, database
+    ORDER BY size DESC
+)
+```
+
+Related: [langfuse/langfuse#13123](https://github.com/langfuse/langfuse/issues/13123), [langfuse-terraform-aws#26](https://github.com/langfuse/langfuse-terraform-aws/pull/26).

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -148,7 +148,7 @@ On the Bitnami ClickHouse Helm chart, you can ship the same block via `clickhous
         <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 7 DAY</engine>
     </trace_log>
     <opentelemetry_span_log>
-        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(finish_date) ORDER BY (finish_date, finish_time_unix_nano) TTL finish_date + INTERVAL 7 DAY</engine>
+        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(finish_date) ORDER BY (finish_date, finish_time_us) TTL finish_date + INTERVAL 7 DAY</engine>
     </opentelemetry_span_log>
     <query_log>
         <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 30 DAY</engine>

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -97,11 +97,6 @@ To automatically remove data within ClickHouse, you can use the [TTL](https://cl
 See the ClickHouse documentation for more details on how to configure it.
 This is applicable for the `traces`, `observations`, `scores`, and `event_log` table within ClickHouse.
 
-In addition, the `system.trace_log` and `system.text_log` tables within ClickHouse may grow large, even on smaller deployments.
-You can modify your ClickHouse settings to set a TTL on both tables.
-It is also safe to manually prune them from time to time.
-Check the [ClickHouse documentation](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#trace_log) for details on how to configure a TTL on those tables.
-
 The following query helps to identify the largest tables in Clickhouse:
 
 ```sql
@@ -117,6 +112,63 @@ SELECT table, formatReadableSize(size) as size, rows FROM (
     ORDER BY size DESC
 )
 ```
+
+#### ClickHouse system log tables [#clickhouse-system-log-tables]
+
+On default ClickHouse configurations, the system log tables (`trace_log`, `text_log`, `opentelemetry_span_log`, `asynchronous_metric_log`, `metric_log`, `latency_log`) can dominate disk usage.
+They have no TTL by default, and the query profiler writes to `system.trace_log` continuously.
+Langfuse does not read from these tables, so you can safely reduce them. Two options:
+
+**Option 1 — Disable unused system log tables.** Mount a file into `/etc/clickhouse-server/config.d/` that opts out of the tables Langfuse never reads. This is the approach taken by default in the [Langfuse Terraform AWS module](https://github.com/langfuse/langfuse-terraform-aws/pull/26):
+
+```xml
+<clickhouse>
+    <trace_log remove="1"/>
+    <text_log remove="1"/>
+    <opentelemetry_span_log remove="1"/>
+    <asynchronous_metric_log remove="1"/>
+    <metric_log remove="1"/>
+    <latency_log remove="1"/>
+</clickhouse>
+```
+
+On the Bitnami ClickHouse Helm chart, you can ship the same block via `clickhouse.extraOverrides`. Keep `query_log`, `part_log`, and `error_log` enabled — they are useful for debugging and remain small.
+
+**Option 2 — Aggressive TTLs.** If you want to keep the tables around for debugging, attach short TTLs and disable the query profiler instead:
+
+```xml
+<clickhouse>
+    <profiles>
+        <default>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+        </default>
+    </profiles>
+    <trace_log>
+        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 7 DAY</engine>
+    </trace_log>
+    <opentelemetry_span_log>
+        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(finish_date) ORDER BY (finish_date, finish_time_unix_nano) TTL finish_date + INTERVAL 7 DAY</engine>
+    </opentelemetry_span_log>
+    <query_log>
+        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 30 DAY</engine>
+    </query_log>
+</clickhouse>
+```
+
+<Callout type="info">
+
+TTL directives only apply when the system table is first created. On an existing install, after deploying the config you also need to retrofit the tables — for example, for `system.trace_log`:
+
+```sql
+SET max_table_size_to_drop = 0;
+TRUNCATE TABLE system.trace_log;
+ALTER TABLE system.trace_log MODIFY TTL event_date + INTERVAL 7 DAY;
+```
+
+Repeat for each table you want to cap. See the upstream discussion in [langfuse/langfuse#13123](https://github.com/langfuse/langfuse/issues/13123).
+
+</Callout>
 
 ## High Redis CPU Load
 

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -500,3 +500,5 @@ All self-hosted deployments must include a ClickHouse instance.
 ### How do I manage ClickHouse storage growth?
 
 Langfuse has a built-in [Data Retention](/docs/administration/data-retention) feature that automatically deletes traces, observations, scores, and media assets older than a configured number of days. This runs nightly and handles cleanup across both ClickHouse and blob storage. You do not need to set ClickHouse TTLs manually.
+
+If ClickHouse disk usage keeps growing despite retention being configured, the cause is often system log tables (`trace_log`, `text_log`, `opentelemetry_span_log`, etc.) that ship without a TTL. See [Scaling › ClickHouse system log tables](/self-hosting/configuration/scaling#clickhouse-system-log-tables) for how to disable or cap them.


### PR DESCRIPTION
## Summary

- Self-hosters frequently hit large ClickHouse disks because system log tables (`trace_log`, `text_log`, `opentelemetry_span_log`, `asynchronous_metric_log`, `metric_log`, `latency_log`) run with no TTL by default and the query profiler writes to `trace_log` continuously. Langfuse does not read from these tables.
- Expand the `ClickHouse Disk Usage` section in `content/self-hosting/configuration/scaling.mdx` with a new `ClickHouse system log tables` subsection covering two concrete remedies: opting out of unused tables via `remove=\"1\"` (matching the default taken in [langfuse-terraform-aws#26](https://github.com/langfuse/langfuse-terraform-aws/pull/26)) and attaching aggressive TTLs + disabling the query profiler. Includes the `TRUNCATE` / `ALTER TABLE ... MODIFY TTL` retrofit note for existing installs.
- Add a new `self-hosting`-tagged FAQ entry `content/faq/all/reduce-clickhouse-disk-size.mdx` that surfaces the two-lever summary and deep-links to the scaling anchor.

Refs: Linear **LFE-9229**, GitHub issue [langfuse/langfuse#13123](https://github.com/langfuse/langfuse/issues/13123).

## Follow-up (separate PR)

The `langfuse-k8s` Helm chart currently sets no ClickHouse system-table overrides, so users get Bitnami defaults — the same configuration that causes the bloat in #13123. Worth mirroring the terraform-aws approach in that chart's `values.yaml` (behind a values-level toggle, default opt-out) and adding a short paragraph + docs link to the chart README. Out of scope for this repo.

## Test plan

- [ ] \`pnpm dev\` and visit \`http://127.0.0.1:3333/self-hosting/configuration/scaling#clickhouse-system-log-tables\` — anchor resolves, XML/SQL code blocks render, Callout renders.
- [ ] Visit \`http://127.0.0.1:3333/faq/all/reduce-clickhouse-disk-size\` — page renders with correct frontmatter title.
- [ ] Visit \`http://127.0.0.1:3333/faq/tag/self-hosting\` — new FAQ appears in the list.
- [ ] Visit \`http://127.0.0.1:3333/self-hosting/configuration/scaling\` — bottom \`<FaqPreview tags={[\"self-hosting\"]} />\` now includes the new entry.
- [ ] \`pnpm run link-check\` — new deep link and external GitHub links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR expands the ClickHouse Disk Usage section in the scaling docs with a new subsection covering two concrete remedies for system log table bloat (opt-out via `remove="1"` and aggressive TTLs), and adds a companion FAQ entry that surfaces the two-lever summary with a deep-link to the scaling anchor.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only documentation changes with two minor P2 findings that do not affect correctness of Option 1.

Both findings are P2: Option 2's TTL snippet is incomplete (missing 3 of 6 tables) and the misleading SET max_table_size_to_drop before TRUNCATE. Neither causes incorrect behavior for users who follow the recommended Option 1, and neither affects the new FAQ page.

content/self-hosting/configuration/scaling.mdx — Option 2 TTL snippet and the retrofit SQL block.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/self-hosting/configuration/scaling.mdx | Adds a detailed "ClickHouse system log tables" subsection with two remediation options (opt-out via remove="1" and TTL config), plus a retrofit Callout; minor gaps: Option 2 TTL snippet omits 3 of the 6 listed tables, and SET max_table_size_to_drop is misleading before a TRUNCATE. |
| content/faq/all/reduce-clickhouse-disk-size.mdx | New FAQ entry with correct frontmatter, self-hosting tag, and deep-link to the scaling anchor; SQL diagnostic query and external issue links are accurate. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClickHouse disk usage growing] --> B{Identify largest tables}
    B --> C[system log tables dominating?]
    B --> D[Langfuse app tables dominating?]
    D --> E[Configure data retention policy]
    C --> F{Keep tables for debugging?}
    F -- No --> G[Option 1: Disable via remove=1\nMount config.d override]
    F -- Yes --> H[Option 2: Attach TTLs\nDisable query profiler]
    H --> I{Existing install?}
    I -- Yes --> J[Retrofit: TRUNCATE + ALTER TABLE MODIFY TTL]
    I -- No --> K[TTL applied on next table creation]
    G --> L[Disk reclaimed on restart]
    J --> L
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/self-hosting/configuration/scaling.mdx
Line: 139-157

Comment:
**Option 2 TTL config is incomplete**

The intro lists six problematic tables (`trace_log`, `text_log`, `opentelemetry_span_log`, `asynchronous_metric_log`, `metric_log`, `latency_log`), but the Option 2 XML snippet only attaches TTLs to `trace_log`, `opentelemetry_span_log`, and `query_log`. A user who follows Option 2 to "keep tables for debugging" will still have unbounded `text_log`, `asynchronous_metric_log`, `metric_log`, and `latency_log` growing without limit — potentially defeating the purpose.

Consider adding the missing entries, e.g.:

```xml
    <text_log>
        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 7 DAY</engine>
    </text_log>
    <asynchronous_metric_log>
        <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time) TTL event_date + INTERVAL 7 DAY</engine>
    </asynchronous_metric_log>
    <metric_log>
        <engine>ENGINE = MergeTree PARTITION BY toDate(event_time) ORDER BY event_time TTL toDate(event_time) + INTERVAL 7 DAY</engine>
    </metric_log>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/self-hosting/configuration/scaling.mdx
Line: 163-167

Comment:
**`max_table_size_to_drop` does not apply to TRUNCATE**

`SET max_table_size_to_drop = 0` only affects `DROP TABLE` and `DROP PARTITION` commands — ClickHouse does not check that limit for `TRUNCATE TABLE`. Placing it here implies it is a prerequisite for the TRUNCATE, which it isn't. Readers may be confused about why it's needed, or copy it blindly into scripts that only run TRUNCATE. Removing it (or replacing it with a brief comment explaining it is only needed if you later want to `DROP` the table) would reduce confusion.

```suggestion
TRUNCATE TABLE system.trace_log;
ALTER TABLE system.trace_log MODIFY TTL event_date + INTERVAL 7 DAY;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document ClickHouse ..."](https://github.com/langfuse/langfuse-docs/commit/6945fd040c92d911ddeb836f104aef5ec4498d7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29002453)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->