### PR TITLE
docs(self-hosting): document migrating to a new ClickHouse instance

### DIFF
--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -251,6 +251,22 @@ CLICKHOUSE_PASSWORD=clickhouse
 CLICKHOUSE_CLUSTER_ENABLED=false
 ```
 
+## Migrating to a New Instance
+
+You may want to move Langfuse to a different ClickHouse instance, e.g. when switching providers or moving from a single-node to a clustered setup.
+We recommend the following approach:
+
+1. Point Langfuse to the new ClickHouse instance so that incoming data is captured there.
+2. Create a backup of the existing instance to blob storage and restore it into the new instance.
+
+A zero-downtime switch where data is written to both instances concurrently is technically possible, but we have not tested it and it is not recommended by ClickHouse.
+Please reach out to Langfuse Support if you want to explore this option.
+
+Refer to the ClickHouse migration guides for backup and restore instructions:
+
+- [ClickHouse to ClickHouse via remoteSecure](https://clickhouse.com/docs/cloud/migration/clickhouse-to-cloud)
+- [ClickHouse to ClickHouse via backup and restore](https://clickhouse.com/docs/cloud/migration/oss-to-cloud-backup-restore)
+
 ## Encryption
 
 ClickHouse supports disk encryption for data at rest, providing an additional layer of security for sensitive data.


### PR DESCRIPTION
## Summary
- Adds a "Migrating to a New Instance" section to the ClickHouse self-hosting guide covering cutover-then-restore, notes on dual-write, and links to the relevant ClickHouse migration guides.

## Test plan
- [ ] Verify the new section renders correctly on the docs site
- [ ] Verify the ClickHouse documentation links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a "Migrating to a New Instance" section to the ClickHouse self-hosting guide, covering the recommended cutover approach, a note discouraging dual-write, and links to ClickHouse migration docs.

- **Step order is backwards and risks data loss or restore failure**: the guide currently says to redirect Langfuse to the new instance *before* restoring the backup. ClickHouse's `RESTORE` will fail by default (`allow_non_empty_tables=false`) on the already-populated table, and enabling the override may cause duplicates. The safe order is backup → restore into empty instance → cut over.
- The two linked guides describe OSS → ClickHouse Cloud migrations; users migrating between self-hosted instances should also be pointed to the [self-hosted Backup & Restore docs](https://clickhouse.com/docs/operations/backup/overview).

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the documented migration step order is backwards and will likely cause restore failures or data loss for users following the guide.

One P1 finding: the cut-over-first, then restore order conflicts with ClickHouse's default restore behaviour and could cause data loss. The one-line suggestion fix is straightforward but should be confirmed before merging.

content/self-hosting/deployment/infrastructure/clickhouse.mdx — migration step ordering at lines 259-260

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/self-hosting/deployment/infrastructure/clickhouse.mdx | Adds "Migrating to a New Instance" section; migration step order (cut over first, then restore) is backwards and likely causes restore failures or data loss. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as Langfuse
    participant O as Old ClickHouse
    participant N as New ClickHouse
    participant B as Blob Storage

    Note over L,O: Current state — Langfuse writes to Old instance

    rect rgb(255, 220, 220)
        Note over L,N: ❌ Documented order (risky)
        L->>N: 1. Redirect traffic to New instance
        Note over N: New data accumulates in New instance
        O->>B: 2a. BACKUP old instance
        B->>N: 2b. RESTORE into New instance (already has data!)
        Note over N: ⚠️ RESTORE fails (allow_non_empty_tables=false) OR overwrites new rows
    end

    rect rgb(220, 255, 220)
        Note over L,N: ✅ Recommended order (safe)
        O->>B: 1. BACKUP old instance
        B->>N: 2. RESTORE into New instance (empty — no conflict)
        L->>N: 3. Redirect traffic to New instance
        Note over N: All historical + new data present
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/self-hosting/deployment/infrastructure/clickhouse.mdx
Line: 259-260

Comment:
**Migration step order risks data loss**

The steps are listed in an order that will likely cause the restore in step 2 to either fail or overwrite data. After step 1 redirects traffic to the new instance, new rows are written there. When step 2 then restores the old instance's backup into that already-populated new instance, ClickHouse's default `RESTORE` behaviour (`allow_non_empty_tables=false`) will fail on existing tables; enabling `allow_non_empty_tables=true` may cause duplicates or silently drop the newly-written rows depending on the table engine.

The safer, conventional order is: backup first, restore into the new empty instance, then cut over. That keeps the new instance empty during restore and avoids the conflict entirely.

```suggestion
1. Create a backup of the existing instance to blob storage.
2. Restore the backup into the new (empty) instance.
3. Point Langfuse to the new ClickHouse instance so that incoming data is captured there.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/self-hosting/deployment/infrastructure/clickhouse.mdx
Line: 267-268

Comment:
**Links target ClickHouse Cloud, not self-hosted-to-self-hosted**

Both linked guides describe migrating *from* OSS ClickHouse *to* ClickHouse Cloud using `remoteSecure` or cloud-backed backup/restore. Langfuse users moving between two self-hosted instances (e.g. single-node → cluster) would follow different docs. Consider also linking the self-hosted [Backup and Restore overview](https://clickhouse.com/docs/operations/backup/overview) which covers `BACKUP TO Disk` / `BACKUP TO S3` for self-managed deployments, or clarifying that these guides are specifically for moves to ClickHouse Cloud.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document migrating t..."](https://github.com/langfuse/langfuse-docs/commit/43a689d454cc040134848c015c0c33bc89d78e93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29089869)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->