### PR TITLE
fix: Metabase embed on /careers showing "Message seems corrupt or manipulated"

### DIFF
--- a/app/api/metabase-embed/route.ts
+++ b/app/api/metabase-embed/route.ts
@@ -1,23 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
 
+const METABASE_SITE_URL = "https://langfuse.metabaseapp.com";
+
 export async function GET(request: NextRequest) {
   try {
-    const METABASE_SITE_URL = "https://langfuse.metabaseapp.com";
-    const METABASE_SECRET_KEY = process.env.METABASE_SECRET_KEY;
+    const secretKeyRaw = process.env.METABASE_SECRET_KEY;
 
-    if (!METABASE_SECRET_KEY) {
-      console.error("Missing required environment variables: METABASE_SECRET_KEY");
+    if (!secretKeyRaw) {
+      console.error("Missing required environment variable: METABASE_SECRET_KEY");
       return NextResponse.json(
         { message: "Server configuration error" },
         { status: 500 }
       );
     }
 
+    const secretKey = secretKeyRaw.trim();
+
     const dashboardId = request.nextUrl.searchParams.get("dashboardId")
       ? parseInt(request.nextUrl.searchParams.get("dashboardId")!, 10)
       : 25;
-    const theme = request.nextUrl.searchParams.get("theme") === "day" ? "day" : "night";
+    const theme =
+      request.nextUrl.searchParams.get("theme") === "day" ? "day" : "night";
 
     const payload = {
       resource: { dashboard: dashboardId },
@@ -25,7 +29,7 @@ export async function GET(request: NextRequest) {
       exp: Math.round(Date.now() / 1000) + 10 * 60,
     };
 
-    const token = jwt.sign(payload, METABASE_SECRET_KEY);
+    const token = jwt.sign(payload, secretKey);
     const iframeUrl = `${METABASE_SITE_URL}/embed/dashboard/${token}#theme=${theme}&bordered=false&titled=false`;
 
     return NextResponse.json(
@@ -35,7 +39,7 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: {
-          "Cache-Control": "public, s-maxage=300, max-age=0",
+          "Cache-Control": "no-store, no-cache, must-revalidate",
         },
       }
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Metabase embed on `/careers` (Public Metrics Dashboard) shows "Message seems corrupt or manipulated" after the `METABASE_SECRET_KEY` was rotated in Vercel.

This error occurs when Metabase cannot validate the JWT signature — i.e. the key used to sign the token doesn't match the key Metabase expects.

## Root Cause

Two issues in `app/api/metabase-embed/route.ts`:

1. **Whitespace in env variable** — When pasting the new secret key into Vercel's env variable UI, trailing whitespace or newlines are common. The key was used as-is from `process.env` without trimming, causing the JWT signature to be invalid.

2. **Aggressive CDN caching** — The API response had `Cache-Control: public, s-maxage=300`, meaning Vercel's CDN could serve stale JWTs (signed with the old key) for up to 5 minutes after a key rotation. This could also cause intermittent failures.

## Fix

- **Trim the secret key** before using it to sign the JWT (`secretKeyRaw.trim()`).
- **Disable response caching** (`no-store, no-cache, must-revalidate`) so each request generates a fresh JWT. The client-side component already handles token refresh every 8 minutes, so CDN caching of these short-lived JWTs provides little benefit.

## Verification

After deploying, confirm that `METABASE_SECRET_KEY` is correctly set in Vercel env variables. The embed should load the Metabase dashboard without errors.

Resolves LFE-9403
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9403](https://linear.app/langfuse/issue/LFE-9403/metabase-embed-on-careers-is-not-showing-data-anymore)

<div><a href="https://cursor.com/agents/bc-c0285e6b-60d8-47b3-9ade-da167eb268c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0285e6b-60d8-47b3-9ade-da167eb268c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a broken Metabase embed by trimming whitespace from the `METABASE_SECRET_KEY` env variable before signing the JWT, and by replacing the aggressive `s-maxage=300` CDN cache header with `no-store, no-cache, must-revalidate` so stale tokens can't be served after a key rotation. It also hoists `METABASE_SITE_URL` to module scope — a minor cleanup aligned with the team's import/constant style.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both root causes are correctly addressed and the only remaining finding is a minor hardening suggestion.

All remaining findings are P2. The trim fix directly resolves the reported bug, and disabling CDN caching eliminates the key-rotation race condition. The one open comment (guard against whitespace-only value after trim) is a hardening suggestion and does not block the fix from working in practice.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/metabase-embed/route.ts | Fixes JWT signing failure by trimming whitespace from the secret key and disabling CDN caching of short-lived tokens; also hoists the site URL constant to module scope. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Browser / Next.js Component
    participant API as /api/metabase-embed
    participant Env as Vercel Env
    participant MB as Metabase

    Client->>API: GET /api/metabase-embed?dashboardId=25&theme=night
    API->>Env: read METABASE_SECRET_KEY
    Env-->>API: raw value (may contain whitespace)
    Note over API: trim() the raw value
    Note over API: jwt.sign(payload, trimmedValue, HS256)
    API-->>Client: { iframeUrl, expiresAt } Cache-Control: no-store
    Client->>MB: iframe loads signed URL
    MB-->>Client: Dashboard rendered
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: app/api/metabase-embed/route.ts
Line: 18

Comment:
**Empty string not guarded after trim**

If `METABASE_SECRET_KEY` is set to a whitespace-only string (e.g. `"  \n"`), the `!secretKeyRaw` guard passes because a non-empty string is truthy. After `.trim()`, the value becomes `""`. `jsonwebtoken` accepts an empty string and produces a token, but Metabase will reject it with the same "corrupt or manipulated" error. A post-trim emptiness check would close this gap and surface a clearer error message in the logs.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: trim METABASE\_SECRET\_KEY and disabl..."](https://github.com/langfuse/langfuse-docs/commit/44b5c5e5ca43803f1cffbb9838a919615dd7633e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29115554)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->