### PR TITLE
Fix mobile header overlap on /handbook and /security pages

### DIFF
--- a/components/layout/DocsSecondaryNav.tsx
+++ b/components/layout/DocsSecondaryNav.tsx
@@ -46,14 +46,18 @@ export function DocsSecondaryNavMobile() {
 
   const activeSection = SECTIONS.find((s) => pathname?.startsWith(s.path));
 
+  const sectionTitle =
+    activeSection?.title ?? pageNameFromPath("/" + (pathname?.split("/")[1] ?? ""));
+
   // Prefer tree path for page name (gives the authored title), fall back to slug
   const treeNode = treePath.length > 0 ? treePath[treePath.length - 1] : null;
   const pageName =
     (treeNode && "name" in treeNode ? treeNode.name : null) ??
     pageNameFromPath(pathname);
 
-  // Don't show breadcrumb arrow if we're on the section root
-  const isRoot = activeSection && pathname === activeSection.path;
+  const isRoot =
+    (activeSection && pathname === activeSection.path) ||
+    (!activeSection && pathname?.split("/").filter(Boolean).length === 1);
 
   return (
     <div
@@ -67,8 +71,8 @@ export function DocsSecondaryNavMobile() {
       >
         {open ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
       </button>
-      {activeSection && (
-        <span className="text-sm text-text-tertiary">{activeSection.title}</span>
+      {sectionTitle && (
+        <span className="text-sm text-text-tertiary">{sectionTitle}</span>
       )}
       {pageName && !isRoot && (
         <>

--- a/components/layout/SharedDocsLayout.tsx
+++ b/components/layout/SharedDocsLayout.tsx
@@ -42,9 +42,11 @@ export function SharedDocsLayout({
             ? "docs-chrome flex min-h-screen flex-col"
             : "docs-chrome docs-chrome-compact flex min-h-screen flex-col"
         }
-        style={{
-          "--lf-nav-docs-secondary-height": showSecondaryNav ? "40px" : "0px",
-        } as React.CSSProperties}
+        style={
+          showSecondaryNav
+            ? ({ "--lf-nav-docs-secondary-height": "40px" } as React.CSSProperties)
+            : undefined
+        }
       >
         <DocsPatternTracker />
         <NavbarDocs />

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -22,12 +22,22 @@
 }
 
 /*
- * Compact variant (SharedDocsLayout showSecondaryNav={false}): primary
- * navbar only. Used by sections that aren't in the DocsSecondaryNav tabs
- * (e.g. handbook, security).
+ * Compact variant (SharedDocsLayout showSecondaryNav={false}): sections
+ * that aren't in the DocsSecondaryNav tabs (e.g. handbook, security).
+ * On mobile the hamburger/breadcrumb bar still needs 40px; on desktop
+ * no secondary row is shown so collapse to primary only.
  */
 .docs-chrome.docs-chrome-compact {
-  --fd-nav-height: var(--lf-nav-primary-height);
+  --lf-nav-docs-secondary-height: 40px;
+  --fd-nav-height: calc(
+    var(--lf-nav-primary-height) + var(--lf-nav-docs-secondary-height)
+  );
+}
+@media (min-width: 768px) {
+  .docs-chrome.docs-chrome-compact {
+    --lf-nav-docs-secondary-height: 0px;
+    --fd-nav-height: var(--lf-nav-primary-height);
+  }
 }
 
 /* ─── Pattern-bg on docs main content area only ──────────────────────────── */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `/handbook` and `/security` pages, the Langfuse primary header (`NavbarDocs`) and the Fumadocs mobile breadcrumb bar (`DocsSecondaryNavMobile`) overlap on mobile viewports. This doesn't happen on core docs pages like `/docs` or `/integrations`.

**Root cause:** When `showSecondaryNav={false}` (handbook, security), the CSS variable `--lf-nav-docs-secondary-height` was set to `0px` via an inline style. This collapsed the mobile hamburger/breadcrumb bar to zero height, but the bar's content (hamburger icon, section title, page breadcrumb) still rendered and overflowed, visually overlapping with the primary navbar above it.

On `/docs`, the variable is `40px`, so the bar has real height and stacks cleanly below the primary header.

## Fix

**3 files changed:**

1. **`src/overrides.css`** — Made the compact variant (`docs-chrome-compact`) responsive:
   - Mobile (`<768px`): `--lf-nav-docs-secondary-height: 40px` — keeps the hamburger bar visible
   - Desktop (`>=768px`): `--lf-nav-docs-secondary-height: 0px` — no secondary row needed (desktop tabs are hidden for these sections)

2. **`components/layout/SharedDocsLayout.tsx`** — Removed the inline `--lf-nav-docs-secondary-height: 0px` style for compact mode, letting the CSS handle it responsively instead.

3. **`components/layout/DocsSecondaryNav.tsx`** — Improved `DocsSecondaryNavMobile` to derive section titles from the URL path for sections not in the `SECTIONS` array (e.g., "Handbook", "Security"), so the mobile breadcrumb bar shows meaningful content on these pages.

## Resolves

MKT-2061
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MKT-2061](https://linear.app/langfuse/issue/MKT-2061/langfuse-header-fuma-header-css-is-not-ideal-as-they-overlap-here)

<div><a href="https://cursor.com/agents/bc-74d1c237-13d7-46c8-b211-dc51dfa8ce82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74d1c237-13d7-46c8-b211-dc51dfa8ce82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a mobile header overlap on `/handbook` and `/security` pages by making the `--lf-nav-docs-secondary-height` CSS variable responsive in the compact variant: `40px` on mobile (keeping the hamburger bar visible) and `0px` on desktop (collapsing the unused secondary row). The inline style that previously hard-coded `0px` is removed from `SharedDocsLayout`, and `DocsSecondaryNavMobile` is updated to derive readable section titles (e.g. "Handbook", "Security") from the URL path for sections not listed in the `SECTIONS` array.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is contained to CSS variable scoping and a small UI helper; no logic or data paths are affected.

All three changes are correct and well-scoped. The CSS media-query approach cleanly replaces the hard-coded inline style, the `md:hidden` on `DocsSecondaryNavMobile` aligns perfectly with the desktop `0px` variable, and the section-title derivation handles edge cases (null pathname, root pages) properly. The only remaining finding is a P2 readability suggestion.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/overrides.css | Added responsive `.docs-chrome-compact` block: 40px secondary height on mobile, 0px on desktop — correctly fixes the overlap without affecting desktop. |
| components/layout/SharedDocsLayout.tsx | Removed the inline `--lf-nav-docs-secondary-height: 0px` style for compact mode, delegating responsive behaviour to CSS — clean and correct. |
| components/layout/DocsSecondaryNav.tsx | Added `pageNameFromPath` helper and improved `DocsSecondaryNavMobile` to derive section titles (e.g. "Handbook", "Security") for pages outside SECTIONS. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SharedDocsLayout] -->|showSecondaryNav=true| B["docs-chrome\nstyle: --lf-nav-docs-secondary-height: 40px"]
    A -->|showSecondaryNav=false| C["docs-chrome docs-chrome-compact\nno inline style"]
    B --> D["DocsSecondaryNav desktop tabs 40px"]
    B --> E["DocsSecondaryNavMobile h-40px on mobile"]
    C --> F["CSS .docs-chrome-compact"]
    F -->|less than 768px mobile| G["--lf-nav-docs-secondary-height 40px\n--fd-nav-height 100px"]
    F -->|768px and above desktop| H["--lf-nav-docs-secondary-height 0px\n--fd-nav-height 60px"]
    C --> I["DocsSecondaryNavMobile md-hidden on desktop"]
    I --> J["sectionTitle from SECTIONS or derived from URL path"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: components/layout/DocsSecondaryNav.tsx
Line: 49-50

Comment:
**Indirect use of `pageNameFromPath` for section title**

`pageNameFromPath` is designed to extract the *last* segment of a path, but here it's called with `"/" + firstSegment` specifically to extract the *first* segment. It works because there is only one segment, but it's easy to misread. Passing the segment directly makes the intent clearer:

```suggestion
  const sectionTitle =
    activeSection?.title ??
    (pathname?.split("/")[1]
      ? pathname!
          .split("/")[1]
          .split("-")
          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
          .join(" ")
      : null);
```
Alternatively, a brief comment on the existing line would also suffice.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix mobile header overlap on /handbook a..."](https://github.com/langfuse/langfuse-docs/commit/0d6ed535549c11668fda64330673108ebe139b7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29126657)</sub>

<!-- /greptile_comment -->