### PR TITLE
Update SDK install count to 50M+ and link to /careers#public-metrics

### DIFF
--- a/components/CredibilitySentence.tsx
+++ b/components/CredibilitySentence.tsx
@@ -31,7 +31,7 @@ export const CredibilitySentence = ({
           </li>
           <li>
             <Metric className={metricClassName}>
-              {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(1)}M+
+              {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+
             </Metric>{" "}
             SDK installs per month
           </li>
@@ -59,7 +59,7 @@ export const CredibilitySentence = ({
       </Metric>
       ,{" "}
       <Metric className={metricClassName}>
-        {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(1)}M+ SDK installs per
+        {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+ SDK installs per
         month
       </Metric>
       , and{" "}

--- a/components/home/Enterprise.tsx
+++ b/components/home/Enterprise.tsx
@@ -16,7 +16,7 @@ const architecture = [
 ];
 
 const openApis = [
-  { label: "23M+ SDK installs/month", href: "/docs/observability/sdk/overview" },
+  { label: "50M+ SDK installs/month", href: "/careers#public-metrics" },
   { label: "10+ billion observations processed per month" },
   { label: "2300+ customers" },
   { label: "99.9% uptime" },

--- a/components/home/Usage.tsx
+++ b/components/home/Usage.tsx
@@ -4,7 +4,7 @@ import { getGitHubStars } from "@/lib/github-stars";
 import { cn } from "@/lib/utils";
 
 // Export usage stats constants
-export const SDK_INSTALLS_PER_MONTH = 23_100_000;
+export const SDK_INSTALLS_PER_MONTH = 50_000_000;
 export const DOCKER_PULLS = 6_000_000;
 export const FORTUNE_500_COMPANIES = 63;
 export const FORTUNE_50_COMPANIES = 19;

--- a/components/home/WhyLangfuse.tsx
+++ b/components/home/WhyLangfuse.tsx
@@ -43,7 +43,7 @@ const reasons = [
   },
   {
     title: "Production-proven",
-    body: "Billions of events processed per month. 23M installs/month. Fortune 50 deployments.",
+    body: "Billions of events processed per month. 50M+ SDK installs/month. Fortune 50 deployments.",
   },
   {
     title: "Shipping Velocity",

--- a/components/watchOrBookDemo/index.tsx
+++ b/components/watchOrBookDemo/index.tsx
@@ -108,7 +108,7 @@ function TalkToUsContent() {
         </strong>
         ,{" "}
         <strong className="font-[580]">
-          {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(1)}M+ SDK installs per
+          {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+ SDK installs per
           month
         </strong>
         , and{" "}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves MKT-2058

## Changes

- **`components/home/Usage.tsx`**: Updated the central `SDK_INSTALLS_PER_MONTH` constant from `23_100_000` to `50_000_000` — this propagates to all components that reference it (`CredibilitySentence`, `Usage`, `JpCloudSocialProof`, `watchOrBookDemo`)
- **`components/home/Enterprise.tsx`**: Updated label text from "23M+" to "50M+" and changed link href from `/docs/observability/sdk/overview` to `/careers#public-metrics`
- **`components/home/WhyLangfuse.tsx`**: Updated "23M installs/month" to "50M+ SDK installs/month" in "Production-proven" body text
- **`components/CredibilitySentence.tsx`**: Changed `.toFixed(1)` → `.toFixed(0)` (2 places) so it displays "50M+" instead of "50.0M+"
- **`components/watchOrBookDemo/index.tsx`**: Changed `.toFixed(1)` → `.toFixed(0)` so it displays "50M+" instead of "50.0M+"
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MKT-2058](https://linear.app/langfuse/issue/MKT-2058/23m-download-link-should-go-to-metrics-section-on-why)

<div><a href="https://cursor.com/agents/bc-8ed69f33-dd8c-4bc5-a04c-b38017beb035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed69f33-dd8c-4bc5-a04c-b38017beb035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates two marketing copy strings across the home page components to reflect the latest SDK install metric (23M → 50M+) and redirects the related link in `Enterprise.tsx` from the SDK overview docs to `/careers#public-metrics` for better discoverability of public metrics.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic content updates with no logic changes.

Both changes are straightforward copy updates with no logic, no new dependencies, and no structural modifications. The updated number and link are consistent across both files as described in the PR.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/home/Enterprise.tsx | Updated "23M+" → "50M+" for SDK installs/month stat and changed link href from `/docs/observability/sdk/overview` to `/careers#public-metrics` |
| components/home/WhyLangfuse.tsx | Updated "23M installs/month" → "50M+ SDK installs/month" in the "Production-proven" reason body text; no structural changes |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Home Page"] --> B["Enterprise.tsx\n'Reliability at Scale' section"]
    A --> C["WhyLangfuse.tsx\n'Production-proven' reason"]
    B --> D["BulletList item\n50M+ SDK installs/month\nhref: /careers#public-metrics"]
    C --> E["Body text\n50M+ SDK installs/month\n(plain text, no link)"]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/update-s..."](https://github.com/langfuse/langfuse-docs/commit/44da57b590d9099fda2fd1b6f1306d41eb510d5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29129847)</sub>

<!-- /greptile_comment -->