### PR TITLE
fix: L shortcut works in all scenarios and remove split-button chevron

### DIFF
--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
-import NextLink from "next/link";
-import { Plus, ChevronDown } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -18,16 +17,6 @@ import {
   type CloudRegionKey,
 } from "@/lib/cloud-regions";
 import { useCloudRegionSignIn } from "@/lib/use-cloud-region-sign-in";
-import { HoverCorners } from "./ui/corner-box";
-
-const DEFAULT_BUTTON_TEXT = {
-  signedIn: "Launch App",
-  signUp: "Launch App",
-  dropdown: "Launch App",
-} as const;
-
-const labelClasses =
-  "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] [font-variant-numeric:ordinal] p-0";
 
 function isEditableElement(el: Element | null): boolean {
   if (!el) return false;
@@ -54,12 +43,11 @@ interface ToAppButtonProps {
 }
 
 export const ToAppButton = ({
-  signedInText = DEFAULT_BUTTON_TEXT.signedIn,
-  signUpText = DEFAULT_BUTTON_TEXT.signUp,
-  dropdownText = DEFAULT_BUTTON_TEXT.dropdown,
+  signedInText = "Launch App",
+  signUpText = "Launch App",
+  dropdownText = "Launch App",
 }: ToAppButtonProps = {}) => {
   const signedInRegions = useCloudRegionSignIn();
-  const linkRef = useRef<HTMLAnchorElement>(null);
 
   const signedInCount = Object.values(signedInRegions).filter(Boolean).length;
 
@@ -69,92 +57,24 @@ export const ToAppButton = ({
       )
     : null;
 
-  useEffect(() => {
-    if (signedInCount !== 1 || !signedInRegion) return;
-
-    const handler = (e: KeyboardEvent) => {
-      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.key.toLowerCase() !== "l") return;
-      if (isEditableTarget(e.target)) return;
-      e.preventDefault();
-      linkRef.current?.click();
-    };
-
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [signedInCount, signedInRegion]);
-
   if (signedInCount > 1) {
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="primary"
-            size="small"
-            shortcutKey="L"
-            className="whitespace-nowrap"
-          >
-            {dropdownText}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          {cloudRegionSelectorOrder.map((key) => {
-            const region = cloudRegions[key];
-            return (
-              signedInRegions[key] && (
-                <DropdownMenuItem asChild key={key}>
-                  <Link href={region.url}>{region.label}</Link>
-                </DropdownMenuItem>
-              )
-            );
-          })}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem asChild>
-            <Link href="/cloud" className="flex items-center gap-1.5 text-muted-foreground">
-              <Plus className="h-3.5 w-3.5" />
-              Add region
-            </Link>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <MultiRegionButton
+        signedInRegions={signedInRegions}
+        dropdownText={dropdownText}
+      />
     );
   } else if (signedInCount === 1 && signedInRegion) {
     return (
-      <div className="relative flex items-center p-1 group button-wrapper max-h-[34px]">
-        <HoverCorners />
-        <NextLink
-          ref={linkRef}
-          href={signedInRegion[1].url}
-          className="inline-flex h-[26px] min-w-0 items-center gap-[6px] whitespace-nowrap rounded-[2px] rounded-r-none border border-r-0 border-text-secondary bg-text-primary py-0.75 pl-[10px] pr-[8px] text-surface-bg shadow-sm transition-colors [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)]"
-          aria-keyshortcuts="L"
-        >
-          <span className={labelClasses}>{signedInText}</span>
-          <kbd
-            className="hidden lg:flex justify-center items-center not-italic shrink-0 w-[20px] h-[20px] rounded-px font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] [font-variant-numeric:ordinal] p-0 border border-[rgba(64,61,57,0.30)] bg-[rgba(64,61,57,0.40)]"
-            aria-hidden
-          >
-            L
-          </kbd>
-        </NextLink>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="inline-flex h-[26px] items-center justify-center rounded-[2px] rounded-l-none border border-text-secondary bg-text-primary px-1.5 text-surface-bg shadow-sm transition-colors [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)]"
-              aria-label="More options"
-            >
-              <ChevronDown className="h-3 w-3" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem asChild>
-              <Link href="/cloud" className="flex items-center gap-1.5 text-muted-foreground">
-                <Plus className="h-3.5 w-3.5" />
-                Add region
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <Button
+        variant="primary"
+        size="small"
+        shortcutKey="L"
+        href={signedInRegion[1].url}
+        className="whitespace-nowrap"
+      >
+        {signedInText}
+      </Button>
     );
   } else {
     return (
@@ -170,3 +90,70 @@ export const ToAppButton = ({
     );
   }
 };
+
+function MultiRegionButton({
+  signedInRegions,
+  dropdownText,
+}: {
+  signedInRegions: Record<CloudRegionKey, boolean>;
+  dropdownText: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key.toLowerCase() !== "l") return;
+      if (isEditableTarget(e.target)) return;
+      e.preventDefault();
+      setOpen((prev) => !prev);
+    },
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen} modal>
+      <DropdownMenuTrigger asChild>
+        <Button
+          ref={triggerRef}
+          variant="primary"
+          size="small"
+          shortcutKey="L"
+          className="whitespace-nowrap"
+        >
+          {dropdownText}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        onCloseAutoFocus={(e) => {
+          e.preventDefault();
+          triggerRef.current?.focus();
+        }}
+      >
+        {cloudRegionSelectorOrder.map((key) => {
+          const region = cloudRegions[key];
+          return (
+            signedInRegions[key] && (
+              <DropdownMenuItem asChild key={key}>
+                <Link href={region.url}>{region.label}</Link>
+              </DropdownMenuItem>
+            )
+          );
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/cloud" className="flex items-center gap-1.5 text-muted-foreground">
+            <Plus className="h-3.5 w-3.5" />
+            Add region
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Plus, Loader2 } from "lucide-react";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -66,30 +67,53 @@ export const ToAppButton = ({
     );
   } else if (signedInCount === 1 && signedInRegion) {
     return (
-      <Button
-        variant="primary"
-        size="small"
-        shortcutKey="L"
+      <NavigatingButton
         href={signedInRegion[1].url}
-        className="whitespace-nowrap"
-      >
-        {signedInText}
-      </Button>
+        label={signedInText}
+      />
     );
   } else {
     return (
-      <Button
-        variant="primary"
-        size="small"
-        shortcutKey="L"
+      <NavigatingButton
         href="/cloud"
-        className="whitespace-nowrap"
-      >
-        {signUpText}
-      </Button>
+        label={signUpText}
+      />
     );
   }
 };
+
+function NavigatingButton({ href, label }: { href: string; label: string }) {
+  const [navigating, setNavigating] = useState(false);
+  const router = useRouter();
+  const isExternal = href.startsWith("http");
+
+  const navigate = useCallback(() => {
+    setNavigating(true);
+    if (isExternal) {
+      window.location.href = href;
+    } else {
+      router.push(href);
+    }
+  }, [href, isExternal, router]);
+
+  return (
+    <Button
+      variant="primary"
+      size="small"
+      shortcutKey={navigating ? undefined : "L"}
+      icon={navigating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : undefined}
+      iconPosition="end"
+      href={href}
+      onClick={(e) => {
+        e.preventDefault();
+        navigate();
+      }}
+      className="whitespace-nowrap"
+    >
+      {label}
+    </Button>
+  );
+}
 
 function MultiRegionButton({
   signedInRegions,
@@ -106,10 +130,11 @@ function MultiRegionButton({
       if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key.toLowerCase() !== "l") return;
       if (isEditableTarget(e.target)) return;
+      if (open) return;
       e.preventDefault();
-      setOpen((prev) => !prev);
+      setOpen(true);
     },
-    []
+    [open]
   );
 
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "L" keyboard shortcut for the "Launch App" button did not work when a user was signed into multiple cloud regions. Additionally, the button showed a dropdown chevron element on every page load that caused width-switching layout shift.

Fixes LFE-9411

## Changes

**Multi-region (signed into 2+ regions):**
- Extracted a `MultiRegionButton` component that uses **controlled** `DropdownMenu` state (`open`/`setOpen`)
- The "L" shortcut now opens the dropdown via `setOpen(true)` instead of relying on `.click()`, which Radix DropdownMenu ignores (it listens for `pointerdown`)
- Pressing "L" while the dropdown is already open is a no-op (closing is handled by Escape, natively via Radix)
- Once the dropdown is open, arrow key navigation and Enter selection work natively via Radix's built-in keyboard handling

**Single-region and not-signed-in (navigation cases):**
- Extracted a `NavigatingButton` component that shows a **spinner** (Loader2 icon) replacing the "L" shortcut badge when a navigation is triggered (click or keyboard shortcut)
- Replaced the custom split-button layout (link + chevron dropdown trigger) with the standard `Button` component — completely removes the `ChevronDown` icon

## Result

- All three states (not signed in, single region, multi-region) now render a consistent `Button` — no chevron, no layout shift
- The "L" shortcut works in every scenario
- Navigation feedback via spinner for redirect-based actions
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9411](https://linear.app/langfuse/issue/LFE-9411/the-l-launch-app-shortcut-does-not-work-when-logged-into-multiple)

<div><a href="https://cursor.com/agents/bc-db1e5038-39a2-4dfa-858d-59b6f4590b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db1e5038-39a2-4dfa-858d-59b6f4590b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes the \"L\" keyboard shortcut for the Launch App button across all sign-in states and eliminates the chevron-driven layout shift. The `MultiRegionButton` component correctly uses controlled Radix `DropdownMenu` state (`open`/`setOpen`) and a dedicated `window.keydown` listener so the shortcut reliably opens the dropdown without depending on `.click()`, which Radix ignores. Single-region and signed-out cases are simplified to plain `Button` with `href`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are minor style suggestions with no impact on correctness.

Both P2 comments are non-blocking: one is a code-duplication note and the other is a documentation suggestion. The core logic (controlled dropdown state, dedicated keydown handler, removal of the split-button layout) is sound.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/ToAppButton.tsx | Refactored to fix the "L" shortcut for multi-region users and remove the chevron layout-shift; controlled DropdownMenu state and dedicated keydown handler are correct. Minor duplication of isEditableElement/isEditableTarget with button.tsx. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ToAppButton renders] --> B{signedInCount}
    B -->|0| C[Button href='/cloud'\nshortcutKey fires navigation]
    B -->|1| D[Button href=region.url\nshortcutKey fires navigation]
    B -->|2+| E[MultiRegionButton]
    E --> F[window keydown listener\nsetOpen toggle]
    E --> G[DropdownMenu controlled\nopen / onOpenChange]
    F --> G
    G --> H{open}
    H -->|true| I[DropdownMenuContent\nregion links + Add region]
    H -->|false| J[Button shown\nshortcutKey badge visible]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: components/ToAppButton.tsx
Line: 21-37

Comment:
**Duplicated utility functions**

`isEditableElement` and `isEditableTarget` are defined identically here and in `components/ui/button.tsx` (lines 52–72). Consider extracting them to a shared utility (e.g. `lib/keyboard-utils.ts`) and importing from both files to avoid divergence risk.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: components/ToAppButton.tsx
Line: 123-131

Comment:
**Redundant keyboard listener from `shortcutKey` prop**

Passing `shortcutKey` to this non-`asChild` `Button` causes `button.tsx` to register its own global keydown handler that calls `innerRef.current?.click()` — alongside `MultiRegionButton`'s `handleKeyDown` that calls `setOpen`. Because Radix ignores programmatic `.click()` on a `DropdownMenuTrigger` (as the PR notes), the button's built-in handler is a no-op and there is no double-toggle issue. The prop is still needed for the visual shortcut badge, but a short inline comment would help future readers understand why a separate `handleKeyDown` is also required.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/fix-laun..."](https://github.com/langfuse/langfuse-docs/commit/f899f31165358c414238ab5c2d37027061fdf2bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29132598)</sub>

<!-- /greptile_comment -->