### PR TITLE
fix: make docs footer prev/next buttons mobile-friendly with flex layout

### DIFF
--- a/components/DocBodyChrome.tsx
+++ b/components/DocBodyChrome.tsx
@@ -72,13 +72,16 @@ export function DocBodyChrome({
           <>
             <hr className="mt-12 mb-0 border-t border-line-structure" />
             <div
-              className="flex flex-col sm:flex-row flex-wrap gap-4 sm:gap-6 justify-between sm:items-center py-6"
+              className="flex flex-col gap-2 py-6"
               id="docs-feedback"
             >
-              <DocsFeedback key={pathname} />
-              <DocsSupport />
+              <span className="text-sm font-medium">Was this page helpful?</span>
+              <div className="flex items-center justify-between gap-2">
+                <DocsFeedback key={pathname} />
+                <DocsSupport />
+              </div>
             </div>
-            <hr className="mt-0 mb-12 border-t border-line-structure" />
+            <hr className="mt-0 mb-4 border-t border-line-structure" />
           </>
         )}
       </div>

--- a/components/DocBodyChrome.tsx
+++ b/components/DocBodyChrome.tsx
@@ -77,7 +77,7 @@ export function DocBodyChrome({
             >
               <span className="text-sm font-medium">Was this page helpful?</span>
               <div className="flex items-center justify-between gap-2">
-                <DocsFeedback key={pathname} />
+                <DocsFeedback key={pathname} showLabel={false} />
                 <DocsSupport />
               </div>
             </div>

--- a/components/DocBodyChrome.tsx
+++ b/components/DocBodyChrome.tsx
@@ -72,7 +72,7 @@ export function DocBodyChrome({
           <>
             <hr className="mt-12 mb-0 border-t border-line-structure" />
             <div
-              className="flex flex-wrap gap-6 justify-between items-center py-6"
+              className="flex flex-col sm:flex-row flex-wrap gap-4 sm:gap-6 justify-between sm:items-center py-6"
               id="docs-feedback"
             >
               <DocsFeedback key={pathname} />

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -61,7 +61,6 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
           href={previous.url}
           variant="secondary"
           size="small"
-          className="w-full sm:w-auto"
           wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
           icon={<ArrowLeft className="h-3.5 w-3.5" />}
         >
@@ -76,7 +75,7 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
           href={next.url}
           variant="secondary"
           size="small"
-          className="w-full sm:w-auto"
+          className="!justify-end"
           wrapperClassName="flex-1 min-w-0 sm:max-w-[50%] sm:ml-auto"
           icon={<ArrowRight className="h-3.5 w-3.5" />}
           iconPosition="end"

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useFooterItems } from "fumadocs-ui/utils/use-footer-items";
 import NextLink from "next/link";
 import { cn } from "@/lib/utils";
@@ -29,13 +29,10 @@ function normalizePath(path: string): string {
 }
 
 const linkClasses =
-  "inline-flex w-full min-w-0 max-w-full items-center no-underline gap-[6px] overflow-hidden py-0.75 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-[2px] border [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)] border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg text-text-secondary";
+  "inline-flex w-full min-w-0 max-w-full no-underline overflow-hidden shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-[2px] border [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)] border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg text-text-secondary";
 
 const labelClasses =
   "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] [font-variant-numeric:ordinal] p-0";
-
-const iconBoxClasses =
-  "button-icon-area flex shrink-0 items-center justify-center h-full aspect-square *:max-w-full rounded-[1.5px] border-[0.5px] border-[rgba(64,61,57,0.20)] dark:border-[rgba(184,182,160,0.25)] bg-[rgba(64,61,57,0.10)] dark:bg-transparent p-[2px] text-text-tertiary pointer-events-none";
 
 export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
   const footerItems = useFooterItems();
@@ -71,18 +68,14 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
           <HoverCorners />
           <NextLink
             href={previous.url}
-            className={cn(linkClasses, "pl-[3px] pr-[8px] h-auto py-1.5")}
+            className={cn(linkClasses, "flex-col gap-1 px-3 py-2")}
           >
-            <span className={iconBoxClasses} aria-hidden>
-              <ArrowLeft className="h-3.5 w-3.5" />
+            <span className={cn(labelClasses, "min-w-0 truncate text-text-primary")}>
+              {previous.name}
             </span>
-            <span className="flex flex-col min-w-0 gap-0.5">
-              <span className={cn(labelClasses, "min-w-0 truncate")}>
-                {previous.name}
-              </span>
-              <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
-                Previous
-              </span>
+            <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
+              <ChevronLeft className="h-3 w-3" />
+              Previous
             </span>
           </NextLink>
         </div>
@@ -95,21 +88,14 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
           <HoverCorners />
           <NextLink
             href={next.url}
-            className={cn(
-              linkClasses,
-              "pr-[3px] pl-[8px] h-auto py-1.5 flex-row-reverse"
-            )}
+            className={cn(linkClasses, "flex-col gap-1 px-3 py-2 items-end")}
           >
-            <span className={iconBoxClasses} aria-hidden>
-              <ArrowRight className="h-3.5 w-3.5" />
+            <span className={cn(labelClasses, "min-w-0 truncate max-w-full text-text-primary")}>
+              {next.name}
             </span>
-            <span className="flex flex-col min-w-0 gap-0.5 items-end">
-              <span className={cn(labelClasses, "min-w-0 truncate max-w-full")}>
-                {next.name}
-              </span>
-              <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
-                Next
-              </span>
+            <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
+              Next
+              <ChevronRight className="h-3 w-3" />
             </span>
           </NextLink>
         </div>

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -2,11 +2,10 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useFooterItems } from "fumadocs-ui/utils/use-footer-items";
-import NextLink from "next/link";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { HoverCorners } from "@/components/ui/corner-box";
 
 type FooterItem = {
   name: string;
@@ -27,12 +26,6 @@ function normalizePath(path: string): string {
     ? stripped.slice(0, -1)
     : stripped;
 }
-
-const linkClasses =
-  "inline-flex w-full min-w-0 max-w-full no-underline overflow-hidden shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-[2px] border [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)] border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg text-text-secondary";
-
-const labelClasses =
-  "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] [font-variant-numeric:ordinal] p-0";
 
 export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
   const footerItems = useFooterItems();
@@ -64,41 +57,32 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
       {...props}
     >
       {previous ? (
-        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0">
-          <HoverCorners />
-          <NextLink
-            href={previous.url}
-            className={cn(linkClasses, "flex-col gap-1 px-3 py-2")}
-          >
-            <span className={cn(labelClasses, "min-w-0 truncate text-text-primary")}>
-              {previous.name}
-            </span>
-            <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
-              <ChevronLeft className="h-3 w-3" />
-              Previous
-            </span>
-          </NextLink>
-        </div>
+        <Button
+          href={previous.url}
+          variant="secondary"
+          size="small"
+          className="w-full sm:w-auto"
+          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
+          icon={<ArrowLeft className="h-3.5 w-3.5" />}
+        >
+          {previous.name}
+        </Button>
       ) : (
         <div className="hidden sm:block flex-1" />
       )}
 
       {next ? (
-        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0 sm:justify-end">
-          <HoverCorners />
-          <NextLink
-            href={next.url}
-            className={cn(linkClasses, "flex-col gap-1 px-3 py-2 items-end")}
-          >
-            <span className={cn(labelClasses, "min-w-0 truncate max-w-full text-text-primary")}>
-              {next.name}
-            </span>
-            <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
-              Next
-              <ChevronRight className="h-3 w-3" />
-            </span>
-          </NextLink>
-        </div>
+        <Button
+          href={next.url}
+          variant="secondary"
+          size="small"
+          className="w-full sm:w-auto"
+          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%] sm:ml-auto"
+          icon={<ArrowRight className="h-3.5 w-3.5" />}
+          iconPosition="end"
+        >
+          {next.name}
+        </Button>
       ) : null}
     </div>
   );

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useFooterItems } from "fumadocs-ui/utils/use-footer-items";
 import NextLink from "next/link";
 import { cn } from "@/lib/utils";
@@ -27,6 +27,15 @@ function normalizePath(path: string): string {
     ? stripped.slice(0, -1)
     : stripped;
 }
+
+const linkClasses =
+  "inline-flex w-full min-w-0 max-w-full items-center no-underline gap-[6px] overflow-hidden py-0.75 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-[2px] border [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)] border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg text-text-secondary";
+
+const labelClasses =
+  "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] [font-variant-numeric:ordinal] p-0";
+
+const iconBoxClasses =
+  "button-icon-area flex shrink-0 items-center justify-center h-full aspect-square *:max-w-full rounded-[1.5px] border-[0.5px] border-[rgba(64,61,57,0.20)] dark:border-[rgba(184,182,160,0.25)] bg-[rgba(64,61,57,0.10)] dark:bg-transparent p-[2px] text-text-tertiary pointer-events-none";
 
 export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
   const footerItems = useFooterItems();
@@ -62,14 +71,18 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
           <HoverCorners />
           <NextLink
             href={previous.url}
-            className="flex flex-col gap-1 w-full rounded-[2px] border border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg px-3 py-2 no-underline transition-colors"
+            className={cn(linkClasses, "pl-[3px] pr-[8px] h-auto py-1.5")}
           >
-            <span className="font-sans text-[13px] font-medium leading-[150%] text-text-primary truncate">
-              {previous.name}
+            <span className={iconBoxClasses} aria-hidden>
+              <ArrowLeft className="h-3.5 w-3.5" />
             </span>
-            <span className="flex items-center gap-0.5 font-sans text-[12px] text-text-tertiary">
-              <ChevronLeft className="h-3 w-3" />
-              Previous
+            <span className="flex flex-col min-w-0 gap-0.5">
+              <span className={cn(labelClasses, "min-w-0 truncate")}>
+                {previous.name}
+              </span>
+              <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
+                Previous
+              </span>
             </span>
           </NextLink>
         </div>
@@ -78,18 +91,25 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
       )}
 
       {next ? (
-        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0">
+        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0 sm:justify-end">
           <HoverCorners />
           <NextLink
             href={next.url}
-            className="flex flex-col gap-1 w-full rounded-[2px] border border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg px-3 py-2 no-underline transition-colors items-end text-right"
+            className={cn(
+              linkClasses,
+              "pr-[3px] pl-[8px] h-auto py-1.5 flex-row-reverse"
+            )}
           >
-            <span className="font-sans text-[13px] font-medium leading-[150%] text-text-primary truncate max-w-full">
-              {next.name}
+            <span className={iconBoxClasses} aria-hidden>
+              <ArrowRight className="h-3.5 w-3.5" />
             </span>
-            <span className="flex items-center gap-0.5 font-sans text-[12px] text-text-tertiary">
-              Next
-              <ChevronRight className="h-3 w-3" />
+            <span className="flex flex-col min-w-0 gap-0.5 items-end">
+              <span className={cn(labelClasses, "min-w-0 truncate max-w-full")}>
+                {next.name}
+              </span>
+              <span className="font-sans text-[11px] leading-[150%] text-text-tertiary flex items-center gap-0.5">
+                Next
+              </span>
             </span>
           </NextLink>
         </div>

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -2,10 +2,11 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useFooterItems } from "fumadocs-ui/utils/use-footer-items";
-import { Button } from "@/components/ui/button";
+import NextLink from "next/link";
 import { cn } from "@/lib/utils";
+import { HoverCorners } from "@/components/ui/corner-box";
 
 type FooterItem = {
   name: string;
@@ -52,32 +53,46 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
   if (!previous && !next) return null;
 
   return (
-    <div className={cn("grid grid-cols-2 gap-2", className)} {...props}>
+    <div
+      className={cn("flex flex-col sm:flex-row gap-2", className)}
+      {...props}
+    >
       {previous ? (
-        <Button
-          href={previous.url}
-          variant="secondary"
-          size="small"
-          className="w-auto"
-          wrapperClassName="justify-self-start"
-          icon={<ArrowLeft className="h-3.5 w-3.5" />}
-        >
-          {previous.name}
-        </Button>
-      ) : null}
+        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0">
+          <HoverCorners />
+          <NextLink
+            href={previous.url}
+            className="flex flex-col gap-1 w-full rounded-[2px] border border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg px-3 py-2 no-underline transition-colors"
+          >
+            <span className="font-sans text-[13px] font-medium leading-[150%] text-text-primary truncate">
+              {previous.name}
+            </span>
+            <span className="flex items-center gap-0.5 font-sans text-[12px] text-text-tertiary">
+              <ChevronLeft className="h-3 w-3" />
+              Previous
+            </span>
+          </NextLink>
+        </div>
+      ) : (
+        <div className="hidden sm:block flex-1" />
+      )}
 
       {next ? (
-        <Button
-          href={next.url}
-          variant="secondary"
-          size="small"
-          className="w-auto"
-          wrapperClassName="col-start-2 justify-self-end"
-          icon={<ArrowRight className="h-3.5 w-3.5" />}
-          iconPosition="end"
-        >
-          {next.name}
-        </Button>
+        <div className="relative flex items-center p-1 group button-wrapper flex-1 min-w-0">
+          <HoverCorners />
+          <NextLink
+            href={next.url}
+            className="flex flex-col gap-1 w-full rounded-[2px] border border-line-structure dark:border-line-cta group-hover:border-line-cta bg-surface-bg px-3 py-2 no-underline transition-colors items-end text-right"
+          >
+            <span className="font-sans text-[13px] font-medium leading-[150%] text-text-primary truncate max-w-full">
+              {next.name}
+            </span>
+            <span className="flex items-center gap-0.5 font-sans text-[12px] text-text-tertiary">
+              Next
+              <ChevronRight className="h-3 w-3" />
+            </span>
+          </NextLink>
+        </div>
       ) : null}
     </div>
   );

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -359,11 +359,14 @@ export const MainContentWrapper = (props) => {
           pathname === path || (pathname ?? "").startsWith(path + "/")
       ) ? (
         <div
-          className="flex flex-col sm:flex-row flex-wrap gap-4 sm:gap-6 justify-between sm:items-center px-4 py-4 md:px-6 xl:px-8"
+          className="flex flex-col gap-2 px-4 py-4 md:px-6 xl:px-8"
           id="docs-feedback"
         >
-          <DocsFeedback key={pathname} />
-          <DocsSupport />
+          <span className="text-sm font-medium">Was this page helpful?</span>
+          <div className="flex items-center justify-between gap-2">
+            <DocsFeedback key={pathname} />
+            <DocsSupport />
+          </div>
         </div>
       ) : null}
     </>
@@ -445,8 +448,7 @@ export const DocsFeedback = () => {
   };
 
   return (
-    <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 sm:items-center">
-      <span className="text-sm font-medium">Was this page helpful?</span>
+    <div className="flex gap-2 items-center">
       <div className="flex gap-2">
         <Button
           variant="secondary"

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -364,7 +364,7 @@ export const MainContentWrapper = (props) => {
         >
           <span className="text-sm font-medium">Was this page helpful?</span>
           <div className="flex items-center justify-between gap-2">
-            <DocsFeedback key={pathname} />
+            <DocsFeedback key={pathname} showLabel={false} />
             <DocsSupport />
           </div>
         </div>
@@ -388,7 +388,7 @@ export const DocsSupport = () => {
   );
 };
 
-export const DocsFeedback = () => {
+export const DocsFeedback = ({ showLabel = true }: { showLabel?: boolean }) => {
   const pathname = usePathname();
   const [selected, setSelected] = useState<
     "positive" | "negative" | "submitted" | null
@@ -449,6 +449,9 @@ export const DocsFeedback = () => {
 
   return (
     <div className="flex gap-2 items-center">
+      {showLabel && (
+        <span className="text-sm font-medium">Was this page helpful?</span>
+      )}
       <div className="flex gap-2">
         <Button
           variant="secondary"

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -359,7 +359,7 @@ export const MainContentWrapper = (props) => {
           pathname === path || (pathname ?? "").startsWith(path + "/")
       ) ? (
         <div
-          className="flex flex-wrap gap-6 justify-between items-center px-4 py-4 md:px-6 xl:px-8"
+          className="flex flex-col sm:flex-row flex-wrap gap-4 sm:gap-6 justify-between sm:items-center px-4 py-4 md:px-6 xl:px-8"
           id="docs-feedback"
         >
           <DocsFeedback key={pathname} />
@@ -445,7 +445,7 @@ export const DocsFeedback = () => {
   };
 
   return (
-    <div className="flex gap-3 items-center">
+    <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 sm:items-center">
       <span className="text-sm font-medium">Was this page helpful?</span>
       <div className="flex gap-2">
         <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Previous/Next navigation buttons at the bottom of docs pages use a `grid-cols-2` layout. On mobile, when page titles are long, the buttons overflow and break the layout (MKT-2063). Additionally, the feedback section had awkward spacing and layout on mobile.

## Solution

### 1. Previous/Next navigation (`DocsFooter.tsx`)

Replaced `grid grid-cols-2` with `flex flex-col sm:flex-row`:

- Uses the existing `Button` component (secondary variant, small size) with arrow icon boxes
- **Mobile**: Buttons are full-width and stacked vertically
- **Desktop**: Each button fills its half (`flex-1`, capped at `max-w-[50%]`), with border and hover corners matching
- Previous button: left-aligned text (default)
- Next button: right-aligned text and arrow icon (`!justify-end`)
- Long page titles are truncated via the Button's built-in truncation
- When only "Next" exists, a hidden spacer keeps it right-aligned on desktop

### 2. Feedback section layout (`DocBodyChrome.tsx`, `MainContentWrapper.tsx`)

- Reduced bottom separator margin (`mb-12` → `mb-4`) so prev/next buttons sit closer to content
- Restructured feedback section into two rows:
  - Row 1: "Was this page helpful?" label
  - Row 2: Good/Bad buttons (left-aligned) + Support button (right-aligned via `justify-between`)
- Added `showLabel` prop to `DocsFeedback` (defaults to `true`) so standalone usages (e.g. changelog MDX demo) still render the label, while parent containers pass `showLabel={false}`

## Changes

- `components/DocsFooter.tsx` — flex layout, full-width buttons, right-aligned next
- `components/MainContentWrapper.tsx` — `DocsFeedback` now accepts `showLabel` prop; restructured feedback layout
- `components/DocBodyChrome.tsx` — reduced spacing, restructured feedback/support row
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MKT-2063](https://linear.app/langfuse/issue/MKT-2063/previousnext-buttons-on-mobile-often-break-when-their-text-is-to-long)

<div><a href="https://cursor.com/agents/bc-895c7ddc-ae18-400d-9587-753a6a87c4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-895c7ddc-ae18-400d-9587-753a6a87c4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a mobile layout bug (MKT-2063) where long page titles caused the Previous/Next navigation buttons to overflow. The fix replaces `grid-cols-2` with a `flex flex-col sm:flex-row` layout in `DocsFooter.tsx`, and restructures the feedback section in `DocBodyChrome.tsx` and `MainContentWrapper.tsx` into a two-row layout with a tighter separator margin.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are isolated to CSS/layout with no logic regressions.

All findings are P2 style suggestions. The layout logic is correct and the mobile/desktop responsive behavior is well-handled.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/DocsFooter.tsx | Replaced grid-cols-2 with flex flex-col sm:flex-row; buttons are full-width on mobile and half-width on desktop. Minor redundant sm:ml-auto when spacer is present. |
| components/DocBodyChrome.tsx | Feedback section restructured into two rows (label + buttons/support); bottom separator margin reduced from mb-12 to mb-4 to tighten spacing. |
| components/MainContentWrapper.tsx | Feedback section restructured to match DocBodyChrome — two-row layout with label on top and Good/Bad + Support buttons on the second row. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DocsFooter rendered] --> B{previous exists?}
    B -- yes --> C[Button: ArrowLeft + name\nflex-1 min-w-0 sm:max-w-50%]
    B -- no --> D[hidden sm:block flex-1 spacer]
    A --> E{next exists?}
    E -- yes --> F[Button: name + ArrowRight\nflex-1 min-w-0 sm:max-w-50% sm:ml-auto\n!justify-end]
    E -- no --> G[null]

    subgraph Mobile [Mobile — flex-col]
        C --> H[Full-width stacked]
        F --> H
    end

    subgraph Desktop [Desktop sm — flex-row]
        C --> I[Left half]
        D --> I
        F --> J[Right half]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: components/DocsFooter.tsx
Line: 79

Comment:
**Redundant `sm:ml-auto` alongside spacer `flex-1`**

When the spacer `<div className="hidden sm:block flex-1" />` is rendered, it and the Next button both carry `flex-1`, so the available width is split evenly between them and no free space remains for `ml-auto` to act on. The `sm:ml-auto` on `wrapperClassName` is therefore a no-op in that scenario. It's harmless, but removing it keeps the intent clearer.

```suggestion
          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/fix-docs..."](https://github.com/langfuse/langfuse-docs/commit/c1bb14c57ae9dde52ec7b55459e53b5ff311df60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29150351)</sub>

<!-- /greptile_comment -->