### PR TITLE
docs(sentry-js): clarify Sentry integration guidance

### DIFF
--- a/content/faq/all/existing-sentry-setup.mdx
+++ b/content/faq/all/existing-sentry-setup.mdx
@@ -72,7 +72,14 @@ For Python `sentry_sdk` v3+, which uses OTEL under the hood, use [Option B](#sha
 
 ### Option B: Shared TracerProvider [#shared-tracer-provider]
 
-If you need both Sentry's performance tracing **and** Langfuse, disable Sentry's automatic OTEL setup and configure a shared TracerProvider that includes both processors. This gives you distributed tracing across both tools.
+If you need both Sentry's performance tracing **and** Langfuse in the same distributed trace, disable Sentry's automatic OTEL setup and configure a shared TracerProvider that includes both processors.
+
+<Callout type="warning" title="Use Option B only when you want a shared distributed trace">
+  With Option B, Langfuse inherits the active OpenTelemetry context from
+  Sentry. Incoming `sentry-trace` headers can therefore change Langfuse trace
+  IDs and sampling decisions. If you want reliable standalone Langfuse traces
+  for each AI operation, prefer [Option C](#isolated-tracer-provider).
+</Callout>
 
 ```bash
 npm install @sentry/opentelemetry
@@ -126,6 +133,33 @@ Sentry.init({
 
 If you set this to `0.1`, only 10% of your LLM calls will appear in Langfuse. To send all traces to Langfuse while sampling for Sentry, use the [isolated TracerProvider](#isolated-tracer-provider) approach instead (Option C).
 
+#### Incoming `sentry-trace` Headers Also Affect Langfuse
+
+When `SentryPropagator` is enabled, backend requests continue the incoming
+Sentry distributed trace. Langfuse spans created in that context inherit both
+the upstream trace ID and the upstream sampling decision.
+
+- If the incoming trace is unsampled, the backend span can become non-recording and nothing will appear in Langfuse.
+- If multiple backend operations continue the same upstream trace, they can appear merged into a single Langfuse trace.
+
+If you want Langfuse to always create a separate trace for an AI workflow,
+prefer [Option C](#isolated-tracer-provider). If you need Option B for the rest
+of your app, you can detach a specific Langfuse-traced block by starting it in
+a fresh root context:
+
+```typescript
+import { context, ROOT_CONTEXT } from "@opentelemetry/api";
+import { startActiveObservation } from "@langfuse/tracing";
+
+await context.with(ROOT_CONTEXT, async () => {
+  await startActiveObservation("generateText", async () => {
+    // your Langfuse-traced AI call
+  });
+});
+```
+
+This deliberately breaks parentage to the incoming Sentry trace for that block.
+
 #### Filtering Langfuse Spans
 
 Langfuse already applies a default LLM-focused filter. In most Sentry setups, this means no extra filtering code is required.
@@ -161,7 +195,7 @@ If you omit any of these, Sentry's tracing may not work correctly.
 
 ### Option C: Isolated TracerProvider [#isolated-tracer-provider]
 
-If you don't need distributed tracing across Sentry and Langfuse spans, you can use a completely [isolated TracerProvider](/docs/observability/sdk/advanced-features#isolated-tracer-provider) for Langfuse. This is simpler to configure and avoids sampling conflicts.
+If you don't need distributed tracing across Sentry and Langfuse spans, you can use a completely [isolated TracerProvider](/docs/observability/sdk/advanced-features#isolated-tracer-provider) for Langfuse. This is the recommended setup for most AI applications because it keeps Langfuse traces independent from Sentry's sampling and propagation behavior.
 
 <LangTabs items={["JS/TS", "Python"]}>
 <Tab>
@@ -237,9 +271,21 @@ langfuse = Langfuse(tracer_provider=TracerProvider())
 
 #### Only some traces appear in Langfuse
 
-**Cause:** Sentry's `tracesSampleRate` is less than 1.0 and you're using Option B (shared provider).
+**Cause:** In Option B, Langfuse inherits Sentry's sampling decisions. This can come from Sentry's local `tracesSampleRate` or from an incoming `sentry-trace` header that was already unsampled upstream.
 
-**Solution:** Set `tracesSampleRate: 1.0` if you want all traces, or use Option C (isolated provider) to avoid the sampling issue.
+**Solution:** Set `tracesSampleRate: 1.0` if you want all traces and ensure upstream requests are sampled, or use Option C (isolated provider) to avoid the shared sampling issue entirely.
+
+#### No traces in Langfuse for requests coming from a Sentry-instrumented frontend
+
+**Cause:** In Option B, `SentryPropagator` continues the incoming `sentry-trace` header. If the upstream trace was unsampled, the backend span can be non-recording and Langfuse receives nothing.
+
+**Solution:** Prefer Option C if you want Langfuse to create its own traces. If you need Option B elsewhere, wrap the Langfuse-traced block in `context.with(ROOT_CONTEXT, ...)` to detach it from the incoming Sentry trace.
+
+#### Separate Langfuse traces appear merged into one trace
+
+**Cause:** In Option B, multiple backend operations can continue the same incoming `sentry-trace` header and therefore share the same trace ID.
+
+**Solution:** Prefer Option C for standalone Langfuse traces, or start the relevant Langfuse-traced block in a fresh `ROOT_CONTEXT` if you need to detach it from the incoming Sentry trace.
 
 ## AWS Lambda Considerations
 


### PR DESCRIPTION
## Summary

- clarify that Option C is the recommended setup for most AI applications
- explain that Option B shares Sentry propagation and sampling with Langfuse, including incoming `sentry-trace` headers
- add troubleshooting entries and a `ROOT_CONTEXT` workaround for missing or merged Langfuse traces

## Why

Users were running into confusing behavior with the shared Sentry/OpenTelemetry setup. In practice, Option B can make Langfuse inherit upstream trace IDs and sampling decisions, which can cause backend Langfuse traces to disappear or multiple operations to merge into one trace. The docs did not make that tradeoff explicit enough.

## Impact

- users get a clearer recommendation about when to choose Option B vs Option C
- users have a concrete workaround when they need shared Sentry tracing elsewhere but want a standalone Langfuse trace for a specific AI block

## Root cause

With a shared TracerProvider, `SentryPropagator` continues incoming distributed tracing headers and `SentrySampler` applies the inherited sampling decision. That means Langfuse spans created in the same OpenTelemetry context can inherit the upstream trace ID and sampling result.

## Validation

- reviewed the FAQ diff for the Sentry integration page
- ran `pnpm run link-check`; it failed due to many pre-existing localhost link failures across the repository, unrelated to this doc change

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR clarifies the Sentry/Langfuse integration docs by adding a warning callout on Option B, explaining how incoming `sentry-trace` headers affect Langfuse trace IDs and sampling, promoting Option C as the recommended choice for most AI apps, and adding three new troubleshooting entries with a `ROOT_CONTEXT` workaround code snippet.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with technically accurate content and verified API usage.

All changes are documentation improvements. The startActiveObservation function is confirmed to be a real export of @langfuse/tracing, ROOT_CONTEXT from @opentelemetry/api is the correct API for detaching context, and context.with() returning the Promise from the async callback is correctly awaited. No P0 or P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/faq/all/existing-sentry-setup.mdx | Documentation-only changes: adds Option B warning callout, ROOT_CONTEXT workaround snippet, and three new troubleshooting entries; all code samples use verified APIs. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User calls Sentry.init] --> B{Need Sentry\nperformance tracing?}
    B -- No --> C[Option A: skipOpenTelemetrySetup\nSentry error-only, Langfuse owns global provider]
    B -- Yes --> D{Need shared\ndistributed trace?}
    D -- Yes --> E[Option B: Shared TracerProvider\nSentryPropagator + LangfuseSpanProcessor]
    D -- No\nRecommended --> F[Option C: Isolated TracerProvider\nsetLangfuseTracerProvider with separate provider]
    E --> G{Incoming sentry-trace\nheader unsampled?}
    G -- Yes --> H[Langfuse span non-recording\nnothing appears in Langfuse]
    G -- No --> I[Shared trace ID between\nSentry and Langfuse]
    H --> J[Workaround: context.with ROOT_CONTEXT\ndetaches Langfuse block from Sentry trace]
    I --> J
```

<sub>Reviews (1): Last reviewed commit: ["clarify sentry integration guidance"](https://github.com/langfuse/langfuse-docs/commit/11d1b8ba5ac8dd86e065167ccafd4702464eea44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29149965)</sub>

<!-- /greptile_comment -->