### PR TITLE
Add "by ClickHouse" affiliation link next to logo in top nav

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -56,7 +56,7 @@ export function Logo({
       href="https://clickhouse.com"
       target="_blank"
       rel="noopener noreferrer"
-      className="hidden text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap sm:inline"
+      className="text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap"
     >
       by ClickHouse
     </a>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -17,7 +17,7 @@ export function Logo({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const images = (
-    <div className="flex gap-2 items-center -mr-4 cursor-pointer md:mr-0">
+    <div className="flex gap-2 items-center -mr-4 cursor-pointer md:mr-0 shrink-0">
       <Image
         src="/langfuse-wordart-white.svg"
         alt="Langfuse Logo"
@@ -56,7 +56,7 @@ export function Logo({
       href="https://clickhouse.com"
       target="_blank"
       rel="noopener noreferrer"
-      className="text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap"
+      className="text-[10px] sm:text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap shrink-0"
     >
       by ClickHouse
     </a>
@@ -64,10 +64,11 @@ export function Logo({
 
   return (
     <>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5 sm:gap-2 overflow-hidden">
         {wrapInLink ? (
           <Link
             href="/"
+            className="shrink-0"
             onContextMenu={(e) => {
               e.preventDefault();
               setMenuOpen(true);
@@ -77,6 +78,7 @@ export function Logo({
           </Link>
         ) : (
           <div
+            className="shrink-0"
             onContextMenu={(e) => {
               e.preventDefault();
               setMenuOpen(true);

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -17,7 +17,7 @@ export function Logo({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const images = (
-    <div className="flex gap-2 items-center -mr-4 cursor-pointer md:mr-0 shrink-0">
+    <div className="flex gap-2 items-center cursor-pointer shrink-0">
       <Image
         src="/langfuse-wordart-white.svg"
         alt="Langfuse Logo"

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -56,7 +56,7 @@ export function Logo({
       href="https://clickhouse.com"
       target="_blank"
       rel="noopener noreferrer"
-      className="text-[10px] sm:text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap shrink-0"
+      className="text-[10px] sm:text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap"
     >
       by ClickHouse
     </a>
@@ -64,7 +64,7 @@ export function Logo({
 
   return (
     <>
-      <div className="flex items-center gap-1.5 sm:gap-2 overflow-hidden">
+      <div className="flex items-center gap-1.5 sm:gap-2">
         {wrapInLink ? (
           <Link
             href="/"
@@ -87,7 +87,7 @@ export function Logo({
             {images}
           </div>
         )}
-        {byClickHouse}
+        {wrapInLink && byClickHouse}
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}
     </>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -51,9 +51,20 @@ export function Logo({
     </div>
   );
 
+  const byClickHouse = (
+    <a
+      href="https://clickhouse.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hidden text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap sm:inline"
+    >
+      by ClickHouse
+    </a>
+  );
+
   return (
     <>
-      <div className="flex items-center">
+      <div className="flex items-center gap-2">
         {wrapInLink ? (
           <Link
             href="/"
@@ -74,6 +85,7 @@ export function Logo({
             {images}
           </div>
         )}
+        {byClickHouse}
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}
     </>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -11,13 +11,16 @@ const ContextMenu = dynamic(() => import("./LogoContextMenu"), {
 
 export function Logo({
   wrapInLink = true,
+  showAffiliation = false,
 }: {
   /** When false, render only the image block (use when already inside a link, e.g. NavbarLogo). */
   wrapInLink?: boolean;
+  /** When true, show the "by ClickHouse" affiliation link next to the logo. */
+  showAffiliation?: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const images = (
-    <div className="flex gap-2 items-center cursor-pointer shrink-0">
+    <div className="logo-images flex gap-2 items-center cursor-pointer shrink-0">
       <Image
         src="/langfuse-wordart-white.svg"
         alt="Langfuse Logo"
@@ -33,7 +36,7 @@ export function Logo({
         className="block h-auto dark:hidden max-w-28 sm:max-w-none"
       />
       <style jsx>{`
-      div {
+      .logo-images {
         mask-image: linear-gradient(
           60deg,
           #bba0ff 25%,
@@ -43,7 +46,7 @@ export function Logo({
         mask-size: 400%;
         mask-position: 0%;
       }
-      div:hover {
+      .logo-images:hover {
         mask-position: 100%;
         transition: mask-position 1s ease, -webkit-mask-position 1s ease;
       }
@@ -87,7 +90,7 @@ export function Logo({
             {images}
           </div>
         )}
-        {wrapInLink && byClickHouse}
+        {showAffiliation && byClickHouse}
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}
     </>

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -30,7 +30,7 @@ export function Navbar() {
       <nav className="flex mx-auto h-full border-b max-w-360 border-line-structure">
         <div className={cn(cornersStyle, 'pr-0 lg:max-w-[240px] lg:pr-px')}>
           <div className={cn(contentStyle, 'rounded-r-none lg:rounded-r-sm')}>
-            <Logo />
+            <Logo showAffiliation />
           </div>
         </div>
         <div className={cn(cornersStyle, 'hidden relative px-0 lg:flex')}>

--- a/components/layout/NavbarDocs.tsx
+++ b/components/layout/NavbarDocs.tsx
@@ -17,22 +17,12 @@ export function NavbarDocs() {
       <nav className="flex mx-auto h-full border-b max-w-360 border-line-structure">
         <div className={cn(cornersStyle, 'pr-0 lg:max-w-[240px] lg:pr-px')}>
           <div className={cn(contentStyle, 'rounded-r-none lg:rounded-r-sm')}>
-            <div className="flex gap-1.5 sm:gap-2 items-center">
-              <Link href="/" className="flex gap-2 items-center shrink-0">
-                <Logo wrapInLink={false} />
-                <span className="hidden text-sm font-medium text-text-tertiary md:inline">
-                  Docs
-                </span>
-              </Link>
-              <a
-                href="https://clickhouse.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[10px] sm:text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap"
-              >
-                by ClickHouse
-              </a>
-            </div>
+            <Link href="/" className="flex gap-2 items-center shrink-0">
+              <Logo wrapInLink={false} />
+              <span className="hidden text-sm font-medium text-text-tertiary md:inline">
+                Docs
+              </span>
+            </Link>
           </div>
         </div>
         <div className={cn(cornersStyle, 'hidden relative px-0 lg:flex')}>

--- a/components/layout/NavbarDocs.tsx
+++ b/components/layout/NavbarDocs.tsx
@@ -17,12 +17,22 @@ export function NavbarDocs() {
       <nav className="flex mx-auto h-full border-b max-w-360 border-line-structure">
         <div className={cn(cornersStyle, 'pr-0 lg:max-w-[240px] lg:pr-px')}>
           <div className={cn(contentStyle, 'rounded-r-none lg:rounded-r-sm')}>
-            <Link href="/" className="flex gap-2 items-center shrink-0">
-              <Logo wrapInLink={false} />
-              <span className="hidden text-sm font-medium text-text-tertiary md:inline">
-                Docs
-              </span>
-            </Link>
+            <div className="flex gap-1.5 sm:gap-2 items-center">
+              <Link href="/" className="flex gap-2 items-center shrink-0">
+                <Logo wrapInLink={false} />
+                <span className="hidden text-sm font-medium text-text-tertiary md:inline">
+                  Docs
+                </span>
+              </Link>
+              <a
+                href="https://clickhouse.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] sm:text-[11px] leading-none text-text-tertiary/60 hover:text-text-tertiary transition-colors whitespace-nowrap"
+              >
+                by ClickHouse
+              </a>
+            </div>
           </div>
         </div>
         <div className={cn(cornersStyle, 'hidden relative px-0 lg:flex')}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a subtle "by ClickHouse" text link next to the Langfuse logo in the main website top navigation bar.

**Changes:**
- `components/Logo.tsx`: adds a `showAffiliation` prop (default `false`) that renders a "by ClickHouse" label beside the wordmark
- `components/layout/Navbar.tsx`: passes `showAffiliation` to `Logo`
- Links to `https://clickhouse.com` (opens in new tab, `rel="noopener noreferrer"`)
- Styled subtly: 10px on mobile / 11px on sm+, tertiary text color at 60% opacity, brightens on hover
- Visible on all screen sizes including mobile
- Scoped styled-jsx selector from bare `div` to `.logo-images` to prevent mask animation leaking to sibling elements
- **Not shown** on docs navbar or cloud sign-in page

Resolves MKT-2068
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [MKT-2068](https://linear.app/langfuse/issue/MKT-2068/clickhouse-affiliation-not-visible-on-new-website)

<div><a href="https://cursor.com/agents/bc-31381b87-d5cc-4893-a925-b744aab443ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31381b87-d5cc-4893-a925-b744aab443ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a "by ClickHouse" affiliation label next to the Langfuse logo in the shared `Logo` component, so it surfaces in both the marketing navbar and the docs layout. The implementation is clean: the external link is properly attributed with `rel="noopener noreferrer"`, uses a color token (`text-text-tertiary`) consistent with the rest of the codebase, and a native `<a>` tag (correct for external URLs rather than Next.js `<Link>`). Note that the PR description mentions the label is hidden on mobile via `sm:inline`, but the final code (updated by the second commit) intentionally shows it on all screen sizes — the description is slightly stale but the code intent is clear.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, self-contained change with no logic or security issues.

Only one file changed, all remaining findings are at most P2, security best practices are followed, and the color token is consistent with the rest of the codebase.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/Logo.tsx | Adds a "by ClickHouse" anchor element beside the Langfuse wordmark; uses `rel="noopener noreferrer"`, a valid custom color token, and correct Next.js vs native `<a>` usage for external links. No issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Logo Component] --> B{wrapInLink?}
    B -- true --> C[Next.js Link to /]
    B -- false --> D[div with onContextMenu]
    C --> E[images block\nLangfuse wordmark SVGs]
    D --> E
    A --> F["byClickHouse (new)\na href=clickhouse.com\ntarget=_blank\nrel=noopener noreferrer"]
    E & F --> G[Rendered inside flex items-center gap-2 div]
    A --> H{menuOpen?}
    H -- true --> I[ContextMenu portal]
```

<sub>Reviews (1): Last reviewed commit: ["Show &#39;by ClickHouse&#39; on mobile as well"](https://github.com/langfuse/langfuse-docs/commit/495ad61a9dcda0ad3c9f1472a645c3356da89f85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29154313)</sub>

<!-- /greptile_comment -->