### PR TITLE
update claude code tracing to not block claude from finishing

### DIFF
--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -556,8 +556,6 @@ def main() -> int:
         return 0
 
     # Fork to run in background - parent exits immediately, child does the work
-    if BACKGROUND:
-    # Fork to run in background - parent exits immediately, child does the work
     if BACKGROUND and hasattr(os, "fork"):
         pid = os.fork()
         if pid > 0:

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -557,6 +557,8 @@ def main() -> int:
 
     # Fork to run in background - parent exits immediately, child does the work
     if BACKGROUND:
+    # Fork to run in background - parent exits immediately, child does the work
+    if BACKGROUND and hasattr(os, "fork"):
         pid = os.fork()
         if pid > 0:
             # Parent: exit immediately so Claude Code isn't blocked

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -92,6 +92,7 @@ STATE_FILE = STATE_DIR / "langfuse_state.json"
 LOCK_FILE = STATE_DIR / "langfuse_state.lock"
 
 DEBUG = os.environ.get("CC_LANGFUSE_DEBUG", "").lower() == "true"
+BACKGROUND = os.environ.get("CC_LANGFUSE_BACKGROUND", "true").lower() == "true"
 MAX_CHARS = int(os.environ.get("CC_LANGFUSE_MAX_CHARS", "20000"))
 
 # ----------------- Logging -----------------
@@ -554,6 +555,17 @@ def main() -> int:
         debug(f"Transcript path does not exist: {transcript_path}")
         return 0
 
+    # Fork to run in background - parent exits immediately, child does the work
+    if BACKGROUND:
+        pid = os.fork()
+        if pid > 0:
+            # Parent: exit immediately so Claude Code isn't blocked
+            debug(f"Forked child {pid}, parent exiting")
+            return 0
+        # Child: detach from parent session
+        os.setsid()
+        debug("Child process running in background")
+
     try:
         langfuse = Langfuse(public_key=public_key, secret_key=secret_key, host=host)
     except Exception:
@@ -668,6 +680,7 @@ Tracing is opt-in per project. The hook runs globally but immediately exits if `
 | `LANGFUSE_SECRET_KEY` | Your Langfuse secret key | Yes |
 | `LANGFUSE_BASE_URL` | Langfuse base URL (`https://cloud.langfuse.com` for EU, `https://us.cloud.langfuse.com` for US) | No (defaults to EU) |
 | `CC_LANGFUSE_DEBUG` | Set to `"true"` for verbose debug logging | No |
+| `CC_LANGFUSE_BACKGROUND` | Set to `"false"` to run synchronously (default: `"true"` for background execution) | No |
 
 ### Start Using Claude Code
 


### PR DESCRIPTION
When we run this stopping hook, claude does not finish until the hook is complete (and the traces are flushed). This will prevent claude from starting to process the next prompt.

This change updates the script to how we have been using it to spin off the flush into the background so claude can quickly process the stop hook and then keep churning to the next prompt.

There is an env variable to control this so the hook is debuggable by unbackgrounding it

Figured id submit this upstream because its been valuable to us but if its not of interest to include, no worries!

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates the Claude Code Langfuse Stop-hook script to fork a background child process (`os.fork()` + `os.setsid()`) before doing the heavy Langfuse flush work, so the parent exits immediately and no longer blocks Claude Code from processing the next prompt. A new `CC_LANGFUSE_BACKGROUND` env var (default `\"true\"`) lets users opt back into synchronous mode for debugging.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the os.fork() Windows/WSL portability gap, or after confirming the target audience is Unix-only.

The forking logic is correct on Unix — parent exits immediately, child detaches with setsid() and runs to completion. The only open concern is that os.fork() does not exist on Windows, and with BACKGROUND=true as the default, this will crash the hook rather than silently fall back to sync mode. A one-line hasattr guard resolves it. All other findings are P2 or below.

content/integrations/other/claude-code.mdx — the os.fork() call at line 560 needs a hasattr(os, 'fork') guard.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/integrations/other/claude-code.mdx | Adds os.fork() + os.setsid() to background the Stop-hook flush; defaults CC_LANGFUSE_BACKGROUND=true. os.fork() is Unix-only and will raise AttributeError on Windows, crashing the hook instead of falling back to sync mode. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CC as Claude Code
    participant Parent as Hook Process (parent)
    participant Child as Forked Child

    CC->>Parent: Run Stop hook
    Parent->>Parent: Validate keys, session, transcript
    alt BACKGROUND=true (default)
        Parent->>Child: os.fork()
        Parent-->>CC: return 0 (exits immediately)
        Child->>Child: os.setsid() (detach session)
        Child->>Child: Langfuse.init()
        Child->>Child: FileLock → read transcript → emit turns
        Child->>Child: langfuse.flush()
        Child->>Child: langfuse.shutdown()
        Child-->>Child: exit
    else BACKGROUND=false (debug)
        Parent->>Parent: Langfuse.init()
        Parent->>Parent: FileLock → read transcript → emit turns
        Parent->>Parent: langfuse.flush()
        Parent->>Parent: langfuse.shutdown()
        Parent-->>CC: return 0
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/integrations/other/claude-code.mdx
Line: 560-567

Comment:
**`os.fork()` unavailable on Windows/WSL**

`os.fork()` raises `AttributeError` on Windows (including some WSL configurations). With `BACKGROUND` defaulting to `"true"`, any user on such a platform will get an unhandled exception that crashes the hook instead of a graceful no-op. A guard like `if hasattr(os, 'fork'):` (falling back to synchronous execution) would protect against this:

```suggestion
    # Fork to run in background - parent exits immediately, child does the work
    if BACKGROUND and hasattr(os, "fork"):
        pid = os.fork()
        if pid > 0:
            # Parent: exit immediately so Claude Code isn't blocked
            debug(f"Forked child {pid}, parent exiting")
            return 0
        # Child: detach from parent session
        os.setsid()
        debug("Child process running in background")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["update claude code tracing to not block ..."](https://github.com/langfuse/langfuse-docs/commit/4b4298168bfc452af90024197c1d728e7eb3c03c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29217424)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->