### PR TITLE
docs(open-source): add telemetry docs link to OSS telemetry FAQ

### DIFF
--- a/content/handbook/chapters/open-source.mdx
+++ b/content/handbook/chapters/open-source.mdx
@@ -106,7 +106,7 @@ We cut a **GitHub Release multiple times a week** (tagged `vX.Y.Z`) and publish 
 <details>
 <summary>Does the OSS build phone home? Can I disable telemetry?</summary>
 
-By default, Langfuse reports **aggregated usage analytics** (no personal data) so we know which features matter. **No traces, prompts, or customer data leave your cluster.** You can opt out of this.
+By default, Langfuse OSS sends **aggregated usage telemetry** (no personal data) so we can improve the product. **No traces, prompts, or customer data leave your cluster.** You can disable it via `TELEMETRY_ENABLED=false` (details in the [telemetry docs](/self-hosting/security/telemetry)).
 
 </details>
 


### PR DESCRIPTION
### Motivation
- Make the Open Source FAQ clearer about what telemetry the OSS build sends and provide an explicit link and instructions for disabling it.

### Description
- Update `content/handbook/chapters/open-source.mdx` to rephrase the OSS telemetry answer, mention the `TELEMETRY_ENABLED=false` opt-out, and add a link to the telemetry docs at `/self-hosting/security/telemetry`.

### Testing
- Ran `pnpm exec prettier --check content/handbook/chapters/open-source.mdx` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e751945618832f9993357f650200dd)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates the OSS FAQ answer about telemetry to be more precise: it replaces "aggregated usage analytics" with "aggregated usage telemetry", rephrases the purpose, adds the explicit opt-out env var `TELEMETRY_ENABLED=false`, and links to the telemetry docs page. The linked page exists in the repo, so the internal link is valid.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a documentation clarification with a valid internal link

Single-line prose change in a docs file; no code logic affected; linked telemetry page is confirmed to exist in the repo; no P0/P1 findings

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/handbook/chapters/open-source.mdx | One-line documentation update: clarifies telemetry wording, adds TELEMETRY_ENABLED=false opt-out, and links to /self-hosting/security/telemetry (which exists in the repo) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OSS Self-hosted Langfuse] -->|default| B[Sends aggregated usage telemetry - no personal or trace data]
    A -->|TELEMETRY_ENABLED=false| C[Telemetry disabled]
    B --> D[Telemetry docs page]
```

<sub>Reviews (1): Last reviewed commit: ["docs(open-source): add telemetry docs li..."](https://github.com/langfuse/langfuse-docs/commit/8f38ebf69567eadc20810972e6d6e607cd17bcf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29234659)</sub>

<!-- /greptile_comment -->