### PR TITLE
fix(broken-link): point 404 issue creation to langfuse-docs

### DIFF
--- a/components/BrokenLinkIssue.tsx
+++ b/components/BrokenLinkIssue.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
-const REPO = "langfuse/langfuse.com";
+const REPO = "langfuse/langfuse-docs";
 
 export function BrokenLinkIssue() {
   const [href, setHref] = useState<string>(


### PR DESCRIPTION
### Motivation
- The 404 page's "Submit an issue about broken link" button was creating GitHub issues in `langfuse/langfuse.com` instead of the docs repository, producing broken links for reported issues.

### Description
- Change the `REPO` constant in `components/BrokenLinkIssue.tsx` from `"langfuse/langfuse.com"` to `"langfuse/langfuse-docs"` so the generated issue URL targets the correct repository.

### Testing
- Ran `pnpm run agents:check` which completed successfully.
- Ran `pnpm exec eslint components/BrokenLinkIssue.tsx` which failed due to the repo's ESLint configuration not being discoverable by a direct ESLint invocation.
- Attempted `pnpm run lint` which failed because there is no `lint` script defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e865088e2c832f860aceb4b02b2854)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a bug in the 404 page's "Submit an issue about broken link" button, which was incorrectly targeting `langfuse/langfuse.com` instead of `langfuse/langfuse-docs`. The one-line change to the `REPO` constant in `components/BrokenLinkIssue.tsx` is correct and sufficient to resolve the issue.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted one-line bug fix with no side effects.

The change is a single constant update that directly fixes the reported bug. No logic changes, no new dependencies, imports are correctly placed at the top of the module per the repo's rule, and the rest of the component is unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/BrokenLinkIssue.tsx | Single-line fix changing the `REPO` constant from `"langfuse/langfuse.com"` to `"langfuse/langfuse-docs"` so issue reports target the correct repository. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant 404Page as 404 Page (BrokenLinkIssue)
    participant GitHub as GitHub Issues

    User->>404Page: Visits broken URL
    404Page->>404Page: useEffect sets href with pathname + encoded title/body
    User->>404Page: Clicks "Submit an issue about broken link"
    404Page->>GitHub: Opens langfuse/langfuse-docs/issues/new?title=Broken link: /path&body=...
```

<sub>Reviews (1): Last reviewed commit: ["fix: point broken-link issue button to l..."](https://github.com/langfuse/langfuse-docs/commit/e9ab45e08983811f14ff513aed6f39b8d642528b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29235214)</sub>

<!-- /greptile_comment -->