### PR TITLE
docs(scaling): document CLICKHOUSE deletion timeout and lightweight delete mode

### DIFF
--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -119,7 +119,7 @@ If data retention jobs or project/trace deletions fail with timeout errors, the 
 Increase `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` (default `600000`, i.e. 10 minutes) to give long-running deletes more headroom.
 This applies to both scheduled retention jobs and user-triggered deletes across traces, observations, scores, dataset run items, and events.
 
-On ClickHouse 25.5 and above, you can further reduce mutation pressure by opting into lightweight deletes and updates.
+On ClickHouse 25.7 and above, you can further reduce mutation pressure by opting into lightweight deletes and updates.
 Set `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` from its default `alter_update` to `lightweight_update` (or `lightweight_update_force`) to resolve `DELETE` statements via lightweight deletes instead of `ALTER TABLE ... DELETE` mutations.
 Additionally, set `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` to route tracing-table updates through native `UPDATE` statements instead of `ALTER TABLE ... UPDATE` mutations.
 Both reduce the amount of background merge work ClickHouse performs on deletion-heavy workloads.

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -113,6 +113,17 @@ SELECT table, formatReadableSize(size) as size, rows FROM (
 )
 ```
 
+#### Slow or timing-out deletions [#clickhouse-deletion-timeouts]
+
+If data retention jobs or project/trace deletions fail with timeout errors, the client-side ClickHouse HTTP timeout for delete operations is likely exhausted.
+Increase `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` (default `600000`, i.e. 10 minutes) to give long-running deletes more headroom.
+This applies to both scheduled retention jobs and user-triggered deletes across traces, observations, scores, dataset run items, and events.
+
+On ClickHouse 25.5 and above, you can further reduce mutation pressure by opting into lightweight deletes and updates.
+Set `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` from its default `alter_update` to `lightweight_update` (or `lightweight_update_force`) to resolve `DELETE` statements via lightweight deletes instead of `ALTER TABLE ... DELETE` mutations.
+Additionally, set `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` to route event-table updates through native `UPDATE` statements instead of `ALTER TABLE ... UPDATE` mutations.
+Both reduce the amount of background merge work ClickHouse performs on deletion-heavy workloads.
+
 #### ClickHouse system log tables [#clickhouse-system-log-tables]
 
 On default ClickHouse configurations, the system log tables (`trace_log`, `text_log`, `opentelemetry_span_log`, `asynchronous_metric_log`, `metric_log`, `latency_log`) can dominate disk usage.

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -121,7 +121,7 @@ This applies to both scheduled retention jobs and user-triggered deletes across 
 
 On ClickHouse 25.5 and above, you can further reduce mutation pressure by opting into lightweight deletes and updates.
 Set `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` from its default `alter_update` to `lightweight_update` (or `lightweight_update_force`) to resolve `DELETE` statements via lightweight deletes instead of `ALTER TABLE ... DELETE` mutations.
-Additionally, set `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` to route event-table updates through native `UPDATE` statements instead of `ALTER TABLE ... UPDATE` mutations.
+Additionally, set `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` to route tracing-table updates through native `UPDATE` statements instead of `ALTER TABLE ... UPDATE` mutations.
 Both reduce the amount of background merge work ClickHouse performs on deletion-heavy workloads.
 
 #### ClickHouse system log tables [#clickhouse-system-log-tables]


### PR DESCRIPTION
## Summary

- Adds a new subsection to the self-hosting scaling guide covering `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` (default 10 minutes) for users hitting timeouts on data-retention jobs or project/trace deletions.
- Documents the ClickHouse 25.5+ lightweight delete/update knobs (`CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE`, `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE`) as a way to reduce mutation pressure on deletion-heavy workloads.

Placed as a new H4 under `ClickHouse Disk Usage`, before the existing `ClickHouse system log tables` subsection — right where someone following the retention / TTL story will hit it.

## Test plan

- [ ] Review rendered page locally via `pnpm dev` at `/self-hosting/configuration/scaling#clickhouse-deletion-timeouts`
- [ ] Confirm anchor, heading level, and surrounding section flow look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a new H4 subsection under "ClickHouse Disk Usage" documenting the `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` variable and two lightweight-mutation knobs (`CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE`, `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE`) for users experiencing deletion timeouts.

Two factual issues need resolution before merge:
- The version gate "ClickHouse 25.5 and above" appears incorrect for `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE`; the lightweight `UPDATE` patch-part mechanism was introduced in ClickHouse **25.7**, not 25.5.
- The documented default for `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` is `alter_update`, which looks like a copy-paste error on a DELETE-mode variable — the correct default should be verified against the source code.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the version requirement and default value are verified — incorrect docs could cause user-facing failures.

Two P1 factual errors exist: the ClickHouse version gate for lightweight UPDATE (25.5 documented, 25.7 actual) and the likely wrong default value for CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE (`alter_update` on a DELETE-mode variable). Both could actively mislead operators.

content/self-hosting/configuration/scaling.mdx — lines 122-125 covering the version gate and default value for CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/self-hosting/configuration/scaling.mdx | Adds documentation for deletion timeout and lightweight delete/update knobs; contains a likely incorrect version gate (25.5 vs 25.7 for lightweight UPDATE) and a suspicious default value for CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deletion triggered
retention job / user delete] --> B{Timeout?}
    B -- No --> C[Success]
    B -- Yes --> D[Increase LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS
default: 600 000 ms]
    D --> E{ClickHouse version?}
    E -- "< 25.5" --> F[ALTER TABLE ... DELETE mutation
heavyweight path]
    E -- "25.5+" --> G[Set CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE
= lightweight_update / lightweight_update_force]
    E -- "25.7+" --> H[Also set CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true
patch-part UPDATE path]
    G --> I[Reduced mutation pressure]
    H --> I
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/self-hosting/configuration/scaling.mdx
Line: 122-125

Comment:
**Incorrect minimum ClickHouse version for lightweight UPDATE**

The section states "On ClickHouse 25.5 and above" as the gate for both lightweight delete mode and lightweight update. However, the lightweight `UPDATE` statement (the patch-part mechanism that `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` relies on) was introduced as a beta feature in **ClickHouse 25.7**, not 25.5. Users running 25.5 or 25.6 who set `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE=true` will not have the underlying server support and may encounter errors.

If the lightweight delete-mode knob genuinely works from 25.5, it's worth splitting the version gate: mention 25.5 only for `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE`, and 25.7+ (or "latest stable") for `CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/self-hosting/configuration/scaling.mdx
Line: 123

Comment:
**Suspicious default value for `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE`**

The docs state the default is `alter_update`, but this is an `_update` suffix on a `DELETE_MODE` variable. The expected default for a delete mode should be something like `alter_delete` (the heavy mutation path). If the real default is accidentally documented as `alter_update` here, users who don't change the setting will have an incorrect mental model of what Langfuse is doing by default.

Please verify the actual default against the source and correct if needed.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(scaling): document LANGFUSE\_CLICKHO..."](https://github.com/langfuse/langfuse-docs/commit/a5f067d795d4ff8f6c4bb82ca24c35a2a6547091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29421980)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->