### PR TITLE
docs(self-host): clarify container for ingestion masking env vars

### DIFF
--- a/content/self-hosting/security/data-masking.mdx
+++ b/content/self-hosting/security/data-masking.mdx
@@ -86,7 +86,12 @@ sequenceDiagram
 
 ### Configuration
 
-Configure the masking callback using the following environment variables on the Langfuse Worker container:
+Masking configuration is split across the Langfuse Web and Worker containers.
+The Web container extracts propagated headers from the incoming request; the
+Worker container makes the outbound callback request. Set each variable on the
+container listed below. Setting all variables on both containers is also safe.
+
+Configure the following environment variables on the **Langfuse Worker** container:
 
 | Variable                                          | Required / Default | Description                                                                                                                                                                                  |
 | ------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -94,7 +99,12 @@ Configure the masking callback using the following environment variables on the 
 | `LANGFUSE_INGESTION_MASKING_CALLBACK_TIMEOUT_MS`  | `500`              | Timeout in milliseconds for the callback request. If the callback does not respond within this time, the behavior is determined by the fail mode setting.                                    |
 | `LANGFUSE_INGESTION_MASKING_CALLBACK_FAIL_CLOSED` | `false`             | When set to `true`, events are dropped if the callback fails or times out, and a warning is logged. When `false` (default, fail open), events are processed without masking if the callback fails. |
 | `LANGFUSE_INGESTION_MASKING_MAX_RETRIES`          | `1`                | Maximum number of retries for failed callback requests. If the callback fails after this many attempts, the behavior is determined by the fail mode setting.                                 |
-| `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS`   | `''`               | Comma-separated list of headers to propagate from the original request to the masking callback. These headers will be forwarded from the Web container and added to the header in the callback request. |
+
+Configure the following environment variable on the **Langfuse Web** container:
+
+| Variable                                          | Required / Default | Description                                                                                                                                                                                              |
+| ------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS`   | `''`               | Comma-separated list of header names to extract from the incoming OpenTelemetry ingestion request on the Web container and forward to the masking callback on the Worker container. Header names are case-insensitive. |
 
 ### Callback Interface
 


### PR DESCRIPTION
## Summary

- `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` is read on the Langfuse **Web** container — that is where the incoming OTEL ingestion request lands and where the env var controls which headers are extracted off the request. The extracted values then travel to the Worker via the internal queue payload.
- The other masking env vars (`CALLBACK_URL`, `CALLBACK_TIMEOUT_MS`, `FAIL_CLOSED`, `MAX_RETRIES`) are read on the Langfuse **Worker** container, where the outbound callback request is actually made.
- Previously, the configuration table grouped all five vars under a single "on the Langfuse Worker container" heading. Operators following that literally would set `PROPAGATED_HEADERS` only on the Worker, which has no effect (headers aren't extracted, so nothing arrives at the callback). Split the configuration into two tables so each variable is placed on the right container, with a short intro explaining why.

## Test plan

- [ ] Skim the rendered page to confirm the two tables render cleanly and the intro paragraph reads naturally.
- [ ] Sanity-check that no other page links to or duplicates the old single-table wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR correctly splits the masking configuration section into two tables — one for the Worker container and one for the Web container — fixing misleading guidance that caused `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` to be silently ignored when set only on the Worker.

- The "Masking not being applied" troubleshooting block (lines 243–245) was not updated: it still instructs operators to check `LANGFUSE_INGESTION_MASKING_CALLBACK_URL` on the **Web** container, directly contradicting the new Worker-container table.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the stale troubleshooting reference to the wrong container.

The core change is correct and valuable, but one troubleshooting item contradicts the new container assignments and would mislead operators debugging a misconfiguration.

content/self-hosting/security/data-masking.mdx — troubleshooting section lines 243–245

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| content/self-hosting/security/data-masking.mdx | Splits env var config table into Web vs Worker containers — correct intent, but the troubleshooting section still points operators to the wrong (Web) container for CALLBACK_URL, directly contradicting the new tables. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Incoming OTEL Request"] --> B["Langfuse Web Container"]
    B -->|"Extracts headers\n(PROPAGATED_HEADERS)"| C["Internal Queue\n(Redis + S3 reference)"]
    C --> D["Langfuse Worker Container"]
    D -->|"CALLBACK_URL\nCALLBACK_TIMEOUT_MS\nFAIL_CLOSED\nMAX_RETRIES"| E["Masking Callback Service"]
    E --> D
    D --> F["Processed / Masked Event"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `content/self-hosting/security/data-masking.mdx`, line 243-245 ([link](https://github.com/langfuse/langfuse-docs/blob/602ea5e6d1aa6f59031add3cd9c64db21a3f2de7/content/self-hosting/security/data-masking.mdx#L243-L245)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Troubleshooting steps reference wrong container**

   The "Masking not being applied" troubleshooting block still says to verify `LANGFUSE_INGESTION_MASKING_CALLBACK_URL` on the "Langfuse Web container" and check reachability from the Web container — but this PR's own new table places that variable on the **Worker** container. An operator following these steps would look in the wrong place and remain stuck.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: content/self-hosting/security/data-masking.mdx
   Line: 243-245

   Comment:
   **Troubleshooting steps reference wrong container**

   The "Masking not being applied" troubleshooting block still says to verify `LANGFUSE_INGESTION_MASKING_CALLBACK_URL` on the "Langfuse Web container" and check reachability from the Web container — but this PR's own new table places that variable on the **Worker** container. An operator following these steps would look in the wrong place and remain stuck.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/self-hosting/security/data-masking.mdx
Line: 243-245

Comment:
**Troubleshooting steps reference wrong container**

The "Masking not being applied" troubleshooting block still says to verify `LANGFUSE_INGESTION_MASKING_CALLBACK_URL` on the "Langfuse Web container" and check reachability from the Web container — but this PR's own new table places that variable on the **Worker** container. An operator following these steps would look in the wrong place and remain stuck.

```suggestion
  1. Verify `LANGFUSE_INGESTION_MASKING_CALLBACK_URL` is correctly set on the Langfuse Worker container.
  2. Check that your masking service is reachable from the Langfuse Worker container.
  3. Ensure your masking logic is correctly modifying the data and returning it.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-host): clarify container for i..."](https://github.com/langfuse/langfuse-docs/commit/602ea5e6d1aa6f59031add3cd9c64db21a3f2de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29426473)</sub>

<!-- /greptile_comment -->