### PR TITLE
Fix hover interactions of integrations fold

### DIFF
--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import { useState, type ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { HomeSection } from "./HomeSection";
@@ -220,7 +220,7 @@ function IntegrationGroupCard({
   showMoreLabel,
 }: {
   title: string;
-  items: { label: string; href: string; icon?: React.ReactNode }[];
+  items: { label: string; href: string; icon?: ReactNode }[];
   className?: string;
   showMoreLabel?: boolean;
 }) {
@@ -265,7 +265,7 @@ function MarqueeRow({
   direction?: "left" | "right";
   duration?: number;
 }) {
-  const [paused, setPaused] = React.useState(false);
+  const [paused, setPaused] = useState(false);
   const doubled = [...items, ...items];
   return (
     <div className="overflow-hidden w-full mask-[linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">

--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -347,7 +347,7 @@ export function Integrations() {
           <span className="text-[13px] text-text-secondary">
             Don&apos;t find your integration?{" "}
             <Link
-              href="/integrations"
+              href="/integrations#request-integration"
               className="text-text-secondary hover:text-text-primary underline underline-offset-2 decoration-line-structure hover:decoration-text-tertiary transition-colors"
             >
               Request it →

--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { HomeSection } from "./HomeSection";
-import { Heading, TextHighlight, ChipCard } from "@/components/ui";
+import { Heading, TextHighlight } from "@/components/ui";
+import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { IntegrationLabel } from "@/components/ui/integration-label";
 import IconPython from "@/components/icons/python";
@@ -224,8 +225,9 @@ function IntegrationGroupCard({
   showMoreLabel?: boolean;
 }) {
   return (
-    <ChipCard
+    <div
       className={cn(
+        "relative inline-flex items-center border border-line-structure bg-surface-bg rounded-[2px]",
         "integration-group flex flex-col gap-3.5 items-start p-3 sm:p-4.5",
         className
       )}
@@ -250,7 +252,7 @@ function IntegrationGroupCard({
           </span>
         )}
       </div>
-    </ChipCard>
+    </div>
   );
 }
 
@@ -326,7 +328,7 @@ export function Integrations() {
           showMoreLabel
         />
 
-        <ChipCard className="integration-group sm:col-span-2 flex flex-col gap-4 items-start p-3 sm:p-4.5">
+        <div className="integration-group sm:col-span-2 flex flex-col gap-4 items-start p-3 sm:p-4.5 border border-line-structure bg-surface-bg rounded-[2px]">
           <div className="flex flex-row flex-wrap gap-y-1 gap-x-3 justify-between items-baseline w-full">
             <Text size="m" className="font-medium text-left text-text-secondary">
               80+ more integrations
@@ -336,16 +338,22 @@ export function Integrations() {
             <MarqueeRow items={marqueeRow1} direction="left" duration={40} />
             <MarqueeRow items={marqueeRow2} direction="right" duration={48} />
           </div>
-        </ChipCard>
-      </div>
-      <div className="mt-4">
-        <Link
-          href="/integrations"
-          className="text-[13px] text-text-secondary hover:text-text-primary transition-colors"
-          onClick={(e) => e.stopPropagation()}
-        >
-          Don&apos;t find your integration? Request it →
-        </Link>
+        </div>
+
+        <div className="sm:col-span-2 flex flex-row flex-wrap gap-y-2 gap-x-3 justify-between items-center p-3 sm:px-4.5 sm:py-3 border border-line-structure bg-surface-bg rounded-[2px]">
+          <Button variant="secondary" size="small" href="/integrations">
+            See all integrations
+          </Button>
+          <span className="text-[13px] text-text-secondary">
+            Don&apos;t find your integration?{" "}
+            <Link
+              href="/integrations"
+              className="text-text-secondary hover:text-text-primary underline underline-offset-2 decoration-line-structure hover:decoration-text-tertiary transition-colors"
+            >
+              Request it →
+            </Link>
+          </span>
+        </div>
       </div>
     </HomeSection>
   );

--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -227,7 +227,7 @@ function IntegrationGroupCard({
   return (
     <div
       className={cn(
-        "relative inline-flex items-center border border-line-structure bg-surface-bg rounded-[2px]",
+        "relative border border-line-structure bg-surface-bg rounded-[2px]",
         "integration-group flex flex-col gap-3.5 items-start p-3 sm:p-4.5",
         className
       )}

--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import React from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion } from "framer-motion";
 import { HomeSection } from "./HomeSection";
 import { Heading, TextHighlight, ChipCard } from "@/components/ui";
 import { Text } from "@/components/ui/text";
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 // ─── Data (paths per homepage integration spec) ─────────────────────────────
 
 const languagesGroup = {
-  title: "Languages",
+  title: "Languages (via OTel)",
   items: [
     {
       label: "Python (Native SDK)",
@@ -216,10 +216,12 @@ function IntegrationGroupCard({
   title,
   items,
   className,
+  showMoreLabel,
 }: {
   title: string;
   items: { label: string; href: string; icon?: React.ReactNode }[];
   className?: string;
+  showMoreLabel?: boolean;
 }) {
   return (
     <ChipCard
@@ -233,7 +235,7 @@ function IntegrationGroupCard({
           {title}
         </Text>
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2 items-center">
         {items.map((item) => (
           <IntegrationLabel
             key={item.label}
@@ -242,6 +244,11 @@ function IntegrationGroupCard({
             label={item.label}
           />
         ))}
+        {showMoreLabel && (
+          <span className="text-[13px] text-text-tertiary ml-1">
+            and many more…
+          </span>
+        )}
       </div>
     </ChipCard>
   );
@@ -256,15 +263,19 @@ function MarqueeRow({
   direction?: "left" | "right";
   duration?: number;
 }) {
+  const [paused, setPaused] = React.useState(false);
   const doubled = [...items, ...items];
   return (
     <div className="overflow-hidden w-full mask-[linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
-      <motion.div
-        className="flex gap-2 w-max"
-        animate={{
-          x: direction === "left" ? ["0%", "-50%"] : ["-50%", "0%"],
+      <div
+        className={cn(
+          "flex gap-2 w-max",
+          direction === "left" ? "animate-marquee-left" : "animate-marquee-right"
+        )}
+        style={{
+          animationDuration: `${duration}s`,
+          animationPlayState: paused ? "paused" : "running",
         }}
-        transition={{ duration, repeat: Infinity, ease: "linear" }}
       >
         {doubled.map((item, i) => (
           <IntegrationLabel
@@ -272,9 +283,11 @@ function MarqueeRow({
             href={item.href}
             icon={<Image src={item.icon} alt="" width={18} height={18} />}
             label={item.label}
+            onMouseEnter={() => setPaused(true)}
+            onMouseLeave={() => setPaused(false)}
           />
         ))}
-      </motion.div>
+      </div>
     </div>
   );
 }
@@ -305,10 +318,12 @@ export function Integrations() {
         <IntegrationGroupCard
           title={agentFrameworksGroup.title}
           items={agentFrameworksGroup.items}
+          showMoreLabel
         />
         <IntegrationGroupCard
           title={modelProvidersGroup.title}
           items={modelProvidersGroup.items}
+          showMoreLabel
         />
 
         <ChipCard className="integration-group sm:col-span-2 flex flex-col gap-4 items-start p-3 sm:p-4.5">

--- a/components/inkeep/AskAiLink.tsx
+++ b/components/inkeep/AskAiLink.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useAISearchContext } from "./search-context";
+
+export function AskAiLink({ children }: { children?: React.ReactNode }) {
+  const { setOpen } = useAISearchContext();
+
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="inline text-text-secondary hover:text-text-primary underline underline-offset-2 decoration-line-structure hover:decoration-text-tertiary transition-colors cursor-pointer bg-transparent border-none p-0 font-inherit text-inherit"
+    >
+      {children ?? "Ask AI"}
+    </button>
+  );
+}

--- a/components/inkeep/AskAiLink.tsx
+++ b/components/inkeep/AskAiLink.tsx
@@ -9,7 +9,7 @@ export function AskAiLink({ children }: { children?: React.ReactNode }) {
     <button
       type="button"
       onClick={() => setOpen(true)}
-      className="inline text-text-links hover:text-text-links underline underline-offset-2 decoration-text-links/40 hover:decoration-text-links transition-colors cursor-pointer bg-transparent border-none p-0 font-[inherit] text-[length:inherit]"
+      className="inline text-text-links underline underline-offset-2 decoration-text-links/40 hover:decoration-text-links transition-colors cursor-pointer bg-transparent border-none p-0 font-[inherit] text-[length:inherit]"
     >
       {children ?? "Ask AI"}
     </button>

--- a/components/inkeep/AskAiLink.tsx
+++ b/components/inkeep/AskAiLink.tsx
@@ -9,7 +9,7 @@ export function AskAiLink({ children }: { children?: React.ReactNode }) {
     <button
       type="button"
       onClick={() => setOpen(true)}
-      className="inline text-text-secondary hover:text-text-primary underline underline-offset-2 decoration-line-structure hover:decoration-text-tertiary transition-colors cursor-pointer bg-transparent border-none p-0 font-inherit text-inherit"
+      className="inline text-text-links hover:text-text-links underline underline-offset-2 decoration-text-links/40 hover:decoration-text-links transition-colors cursor-pointer bg-transparent border-none p-0 font-[inherit] text-[length:inherit]"
     >
       {children ?? "Ask AI"}
     </button>

--- a/components/integrations/IntegrationIndex.tsx
+++ b/components/integrations/IntegrationIndex.tsx
@@ -1,23 +1,10 @@
 import { integrationsSource } from "@/lib/source";
 import { Cards } from "@/components/docs";
 import {
-  Puzzle,
-  Globe,
-  Server,
-  Wrench,
-  RectangleEllipsis,
-  ChartBar,
-  Code,
-  Database,
-} from "lucide-react";
-import {
   nativeIntegrationsMeta,
   dataPlatformIntegrationsMeta,
 } from "@/lib/integrations-meta";
 
-/**
- * Transforms meta config entries into integration page objects
- */
 function additionalLinksFromMeta(metaConfig: Record<string, any>) {
   return Object.entries(metaConfig)
     .filter(([_, config]) => config.href)
@@ -27,7 +14,15 @@ function additionalLinksFromMeta(metaConfig: Record<string, any>) {
     }));
 }
 
-const categoryConfig = {
+const categoryConfig: Record<
+  string,
+  {
+    title: string;
+    description: string;
+    additionalLinks?: { route: string; frontMatter: any }[];
+    featuredLinks?: ProcessedIntegrationPage[];
+  }
+> = {
   native: {
     title: "Native",
     description: "Native integrations with Langfuse",
@@ -36,7 +31,6 @@ const categoryConfig = {
   frameworks: {
     title: "Frameworks",
     description: "Integrate with popular AI frameworks",
-    // Featured links shown first, separated by a divider from the rest
     featuredLinks: [
       {
         route: "/integrations/frameworks/langchain",
@@ -117,12 +111,11 @@ const categoryConfig = {
   },
 };
 
+export const categoryOrder = Object.keys(categoryConfig);
+
 type IntegrationPage = { route: string; name?: string; frontMatter: any };
 type ProcessedIntegrationPage = IntegrationPage & { title: string };
 
-/**
- * Loads pages from the fumadocs integration source for a given category
- */
 function loadFilesystemPages(category: string): IntegrationPage[] {
   try {
     const allParams = integrationsSource.generateParams();
@@ -138,15 +131,11 @@ function loadFilesystemPages(category: string): IntegrationPage[] {
         } as IntegrationPage;
       })
       .filter(Boolean) as IntegrationPage[];
-  } catch (error) {
-    // Category directory doesn't exist or has no pages
+  } catch {
     return [];
   }
 }
 
-/**
- * Processes pages by adding title and sorting alphabetically
- */
 function processPages(pages: IntegrationPage[]): ProcessedIntegrationPage[] {
   return pages
     .map((page) => ({
@@ -157,117 +146,128 @@ function processPages(pages: IntegrationPage[]): ProcessedIntegrationPage[] {
     .sort((a, b) => a.title.localeCompare(b.title));
 }
 
+function getCategory(category: string) {
+  const config = categoryConfig[category];
+  if (!config) return null;
+
+  const filesystemPages = loadFilesystemPages(category);
+  const mergedPages = [
+    ...(config.additionalLinks ?? []),
+    ...(filesystemPages ?? []),
+  ];
+
+  if (mergedPages.length === 0) return null;
+
+  return {
+    config,
+    pages: processPages(mergedPages),
+    featured: config.featuredLinks,
+  };
+}
+
+function IntegrationCards({
+  pages,
+  featured,
+}: {
+  pages: ProcessedIntegrationPage[];
+  featured?: ProcessedIntegrationPage[];
+}) {
+  return (
+    <>
+      {featured && featured.length > 0 && (
+        <Cards num={3}>
+          {featured.slice(0, 6).map((page) => (
+            <Cards.Card
+              href={page.route}
+              key={page.route}
+              title={page.title}
+              className=""
+              icon={
+                page.frontMatter?.logo ? (
+                  <img
+                    src={page.frontMatter.logo}
+                    alt=""
+                    className="w-5 h-5 object-contain"
+                  />
+                ) : undefined
+              }
+              arrow
+            >
+              {""}
+            </Cards.Card>
+          ))}
+        </Cards>
+      )}
+      <div className={featured && featured.length > 0 ? "mt-8" : ""}>
+        <Cards num={3}>
+          {pages
+            .filter(
+              (p) => !(featured || []).some((f) => f.route === p.route)
+            )
+            .map((page) => (
+              <Cards.Card
+                href={page.route}
+                key={page.route}
+                title={page.title}
+                className=""
+                icon={
+                  page.frontMatter?.logo ? (
+                    <img
+                      src={page.frontMatter.logo}
+                      alt=""
+                      className="w-5 h-5 object-contain"
+                    />
+                  ) : undefined
+                }
+                arrow
+              >
+                {""}
+              </Cards.Card>
+            ))}
+        </Cards>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Renders a single integration category's description and cards.
+ * Headings are expected to be provided in the MDX so they appear in the TOC.
+ */
+export function IntegrationCategory({ category }: { category: string }) {
+  const data = getCategory(category);
+  if (!data) return null;
+
+  return (
+    <div className="mb-6">
+      <p className="text-sm text-text-tertiary -mt-4 mb-4">
+        {data.config.description}
+      </p>
+      <IntegrationCards pages={data.pages} featured={data.featured} />
+    </div>
+  );
+}
+
+/**
+ * Legacy wrapper that renders all categories with headings inline.
+ * Prefer using IntegrationCategory per-section in MDX for TOC support.
+ */
 export const IntegrationIndex = () => {
-  // Infer category order from the keys of categoryConfig, preserving their order of appearance
-  const categoryOrder = Object.keys(categoryConfig);
-
-  // Get pages from each category by merging filesystem and additional links
-  const categorizedPages = {} as Record<string, ProcessedIntegrationPage[]>;
-
-  categoryOrder.forEach((category) => {
-    const config = categoryConfig[category];
-
-    // Always load from filesystem
-    const filesystemPages = loadFilesystemPages(category);
-
-    // Merge with additional links if they exist
-    const mergedPages = [
-      ...(config.additionalLinks ?? []),
-      ...(filesystemPages ?? []),
-    ];
-
-    // Only include categories that have pages
-    if (mergedPages.length > 0) {
-      categorizedPages[category] = processPages(mergedPages);
-    }
-  });
-
   return (
     <>
       {categoryOrder
-        .filter(
-          (category) =>
-            categorizedPages[category] && categorizedPages[category].length > 0
-        )
+        .filter((category) => getCategory(category) !== null)
         .map((category) => {
-          const config = categoryConfig[category];
-          const pages = categorizedPages[category];
-          const featured = (categoryConfig as any)[category]?.featuredLinks as
-            | ProcessedIntegrationPage[]
-            | undefined;
-
+          const data = getCategory(category)!;
           return (
             <div key={category} className="my-10">
-              <div className="flex items-center gap-3 mb-4">
-                {config.icon}
-                <div>
-                  <h3 className="font-semibold tracking-tight text-slate-900 dark:text-slate-100 text-2xl">
-                    {config.title}
-                  </h3>
-                  <p className="text-sm text-slate-600 dark:text-slate-400">
-                    {config.description}
-                  </p>
-                </div>
-              </div>
-              {/* Featured (non-duplicated) */}
-              {featured && featured.length > 0 && (
-                <Cards num={3}>
-                  {featured
-                    .slice(0, 6)
-                    .map((page) => (
-                      <Cards.Card
-                        href={page.route}
-                        key={page.route}
-                        title={page.title}
-                        className=""
-                        icon={
-                          (page as any).frontMatter?.logo ? (
-                            <img
-                              src={(page as any).frontMatter.logo}
-                              alt=""
-                              className="w-5 h-5 object-contain"
-                            />
-                          ) : (
-                            config.icon
-                          )
-                        }
-                        arrow
-                      >
-                        {""}
-                      </Cards.Card>
-                    ))}
-                </Cards>
-              )}
-              <div className={featured && featured.length > 0 ? "mt-8" : ""}>
-                <Cards num={3}>
-                  {pages
-                    .filter(
-                      (p) => !(featured || []).some((f) => f.route === p.route)
-                    )
-                    .map((page) => (
-                  <Cards.Card
-                    href={page.route}
-                    key={page.route}
-                    title={page.title}
-                    className=""
-                    icon={
-                      page.frontMatter?.logo ? (
-                        <img
-                          src={page.frontMatter.logo}
-                          alt=""
-                          className="w-5 h-5 object-contain"
-                        />
-                      ) : (
-                        config.icon
-                      )
-                    }
-                    arrow
-                  >
-                    {""}
-                  </Cards.Card>
-                ))}
-                </Cards>
-              </div>
+              <h3 className="font-semibold tracking-tight text-text-primary text-2xl mb-1">
+                {data.config.title}
+              </h3>
+              <p className="text-sm text-text-tertiary mb-4">
+                {data.config.description}
+              </p>
+              <IntegrationCards pages={data.pages} featured={data.featured} />
             </div>
           );
         })}

--- a/components/ui/integration-label.tsx
+++ b/components/ui/integration-label.tsx
@@ -9,11 +9,15 @@ export function IntegrationLabel({
   label,
   href,
   className,
+  onMouseEnter,
+  onMouseLeave,
 }: {
   icon?: React.ReactNode;
   label: string;
   href?: string;
   className?: string;
+  onMouseEnter?: React.MouseEventHandler;
+  onMouseLeave?: React.MouseEventHandler;
 }) {
   const inner = (
     <>
@@ -28,11 +32,24 @@ export function IntegrationLabel({
 
   if (href) {
     return (
-      <Link href={href} className={cn(chipClassName, className)}>
+      <Link
+        href={href}
+        className={cn(chipClassName, className)}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
         {inner}
       </Link>
     );
   }
 
-  return <span className={cn(chipClassName, className)}>{inner}</span>;
+  return (
+    <span
+      className={cn(chipClassName, className)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {inner}
+    </span>
+  );
 }

--- a/components/ui/integration-label.tsx
+++ b/components/ui/integration-label.tsx
@@ -13,14 +13,14 @@ interface IntegrationLabelProps {
   onMouseLeave?: React.MouseEventHandler;
 }
 
-export function IntegrationLabel({
+export const IntegrationLabel: React.FC<IntegrationLabelProps> = ({
   icon,
   label,
   href,
   className,
   onMouseEnter,
   onMouseLeave,
-}: IntegrationLabelProps) {
+}) => {
   const inner = (
     <>
       {icon ? (
@@ -54,4 +54,4 @@ export function IntegrationLabel({
       {inner}
     </span>
   );
-}
+};

--- a/components/ui/integration-label.tsx
+++ b/components/ui/integration-label.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode, MouseEventHandler } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
@@ -5,22 +6,22 @@ const chipClassName =
   "integration-chip inline-flex items-center gap-2 px-1.5 py-1 border border-line-structure text-[13px] font-normal text-text-secondary leading-none whitespace-nowrap";
 
 interface IntegrationLabelProps {
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   label: string;
   href?: string;
   className?: string;
-  onMouseEnter?: React.MouseEventHandler;
-  onMouseLeave?: React.MouseEventHandler;
+  onMouseEnter?: MouseEventHandler;
+  onMouseLeave?: MouseEventHandler;
 }
 
-export const IntegrationLabel: React.FC<IntegrationLabelProps> = ({
+export function IntegrationLabel({
   icon,
   label,
   href,
   className,
   onMouseEnter,
   onMouseLeave,
-}) => {
+}: IntegrationLabelProps) {
   const inner = (
     <>
       {icon ? (
@@ -54,4 +55,4 @@ export const IntegrationLabel: React.FC<IntegrationLabelProps> = ({
       {inner}
     </span>
   );
-};
+}

--- a/components/ui/integration-label.tsx
+++ b/components/ui/integration-label.tsx
@@ -4,6 +4,15 @@ import { cn } from "@/lib/utils";
 const chipClassName =
   "integration-chip inline-flex items-center gap-2 px-1.5 py-1 border border-line-structure text-[13px] font-normal text-text-secondary leading-none whitespace-nowrap";
 
+interface IntegrationLabelProps {
+  icon?: React.ReactNode;
+  label: string;
+  href?: string;
+  className?: string;
+  onMouseEnter?: React.MouseEventHandler;
+  onMouseLeave?: React.MouseEventHandler;
+}
+
 export function IntegrationLabel({
   icon,
   label,
@@ -11,14 +20,7 @@ export function IntegrationLabel({
   className,
   onMouseEnter,
   onMouseLeave,
-}: {
-  icon?: React.ReactNode;
-  label: string;
-  href?: string;
-  className?: string;
-  onMouseEnter?: React.MouseEventHandler;
-  onMouseLeave?: React.MouseEventHandler;
-}) {
+}: IntegrationLabelProps) {
   const inner = (
     <>
       {icon ? (

--- a/content/integrations/index.mdx
+++ b/content/integrations/index.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 sidebarTitle: Overview
 ---
 
-import { IntegrationIndex } from "@/components/integrations/IntegrationIndex";
+import { IntegrationCategory } from "@/components/integrations/IntegrationIndex";
 import { AskAiLink } from "@/components/inkeep/AskAiLink";
 
 # Overview
@@ -13,9 +13,41 @@ See a full list of integrations below.
 
 Langfuse is based on OpenTelemetry. Use the Python SDK or JS/TS SDK to log traces to Langfuse. Alternatively, you can also directly use our [OpenTelemetry Endpoint](/integrations/native/opentelemetry) from any language.
 
-Not sure which integration to use? Use <AskAiLink /> to discuss your options. Cannot find the integration you are interested in? Let us know via [GitHub discussions below](#request-integration).
+Not sure which integration to use? Use <AskAiLink /> to discuss your options.
 
-<IntegrationIndex />
+Cannot find the integration you are interested in? [Request an integration via GitHub discussions below.](#request-integration)
+
+## Native [#native]
+
+<IntegrationCategory category="native" />
+
+## Frameworks [#frameworks]
+
+<IntegrationCategory category="frameworks" />
+
+## Model Providers [#model-providers]
+
+<IntegrationCategory category="model-providers" />
+
+## Gateways [#gateways]
+
+<IntegrationCategory category="gateways" />
+
+## No-Code [#no-code]
+
+<IntegrationCategory category="no-code" />
+
+## Analytics [#analytics]
+
+<IntegrationCategory category="analytics" />
+
+## Data Platform [#data]
+
+<IntegrationCategory category="data" />
+
+## Other [#other]
+
+<IntegrationCategory category="other" />
 
 ## Request a new integration [#request-integration]
 

--- a/content/integrations/index.mdx
+++ b/content/integrations/index.mdx
@@ -41,10 +41,6 @@ Cannot find the integration you are interested in? [Request an integration via G
 
 <IntegrationCategory category="analytics" />
 
-## Data Platform [#data]
-
-<IntegrationCategory category="data" />
-
 ## Other [#other]
 
 <IntegrationCategory category="other" />

--- a/content/integrations/index.mdx
+++ b/content/integrations/index.mdx
@@ -4,6 +4,7 @@ sidebarTitle: Overview
 ---
 
 import { IntegrationIndex } from "@/components/integrations/IntegrationIndex";
+import { AskAiLink } from "@/components/inkeep/AskAiLink";
 
 # Overview
 
@@ -12,11 +13,7 @@ See a full list of integrations below.
 
 Langfuse is based on OpenTelemetry. Use the Python SDK or JS/TS SDK to log traces to Langfuse. Alternatively, you can also directly use our [OpenTelemetry Endpoint](/integrations/native/opentelemetry) from any language.
 
-Not sure which integration to use? Use [Ask AI](/ask-ai) to discuss your options.
-
-## Overview
-
-<Callout type="info">Cannot find the integration you are interested in? Please let us know via GitHub discussions [below](#request-integration).</Callout>
+Not sure which integration to use? Use <AskAiLink /> to discuss your options. Cannot find the integration you are interested in? Let us know via [GitHub discussions below](#request-integration).
 
 <IntegrationIndex />
 

--- a/style.css
+++ b/style.css
@@ -556,11 +556,6 @@
   border-color: var(--color-line-cta);
 }
 
-.dark .integration-chip:hover {
-  background-color: var(--surface-1);
-  border-color: var(--color-line-cta);
-}
-
 /* Marquee animations for integrations carousel */
 @keyframes marquee-left {
   from { transform: translateX(0); }

--- a/style.css
+++ b/style.css
@@ -542,33 +542,39 @@
 }
 
 /**
- * Home / Integrations: chips use surface bg; hovering the whole group lifts all chips.
- * (Figma: 40% white overlay on surface-bg, 2px radius.)
+ * Home / Integrations: chips use surface bg with individual hover darkening.
+ * (Figma: 2px radius, darken on hover — no corner details.)
  */
 .integration-chip {
   border-radius: 2px;
   background-color: var(--surface-bg);
-  transition: background 0.15s ease;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
-.integration-group:hover .integration-chip {
-  background:
-    linear-gradient(
-      0deg,
-      rgba(255, 255, 255, 0.4) 0%,
-      rgba(255, 255, 255, 0.4) 100%
-    ),
-    var(--surface-bg);
+.integration-chip:hover {
+  background-color: var(--surface-1);
+  border-color: var(--color-line-cta);
 }
 
-.dark .integration-group:hover .integration-chip {
-  background:
-    linear-gradient(
-      0deg,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0.1) 100%
-    ),
-    var(--surface-bg);
+.dark .integration-chip:hover {
+  background-color: var(--surface-1);
+  border-color: var(--color-line-cta);
+}
+
+/* Marquee animations for integrations carousel */
+@keyframes marquee-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@keyframes marquee-right {
+  from { transform: translateX(-50%); }
+  to { transform: translateX(0); }
+}
+.animate-marquee-left {
+  animation: marquee-left linear infinite;
+}
+.animate-marquee-right {
+  animation: marquee-right linear infinite;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves LFE-9289

## Changes

### Homepage integrations fold
1. **Individual chip hover style** — each integration badge darkens on hover (`surface-1` bg + `line-cta` border), no corner details
2. **Marquee pause on hover** — carousel stops when hovering a specific integration chip (CSS animations with `animation-play-state: paused`)
3. **Languages card title** — now reads "Languages (via OTel)"
4. **"and many more…"** — subtle text after last integration in Agent Frameworks and Model Providers cards
5. **Group cards no longer indicate clickability** — replaced `ChipCard` with plain `div`, removing hover stripe animation and cursor-pointer
6. **New narrow CTA card** — "See all integrations" button (left) + "Don't find your integration? Request it →" link (right, links to `/integrations#request-integration`)

### /integrations page
7. **Category headings in TOC** — moved category headings (Native, Frameworks, Model Providers, etc.) from the `IntegrationIndex` component into the MDX as proper `##` headings with explicit anchors, so they appear in the table of contents
8. **Removed duplicate heading** — removed the second `## Overview`
9. **Fixed subtitle styles** — replaced hardcoded `text-slate-*` colors with semantic tokens (`text-text-tertiary` for descriptions, `text-text-primary` for headings)
10. **Ask AI triggers widget** — `<AskAiLink />` component opens the Inkeep AI search panel inline; styled with `text-text-links` (blue) for visibility in both light and dark mode
11. **Separate "request" paragraph** — "Cannot find the integration you are interested in?" is now its own paragraph with link text "Request an integration via GitHub discussions below."
12. **Merged callout into text** — removed the `<Callout>` wrapper

### Build fix
13. **Fixed TypeScript build error** — replaced `import React from "react"` with named imports. The default React import in React 19 types + `jsx: "react-jsx"` breaks `JSX.IntrinsicAttributes` resolution, causing `key` prop errors on custom components.

## Files changed
- `components/home/Integrations.tsx` — homepage integrations fold
- `components/ui/integration-label.tsx` — hover props + named type imports
- `components/integrations/IntegrationIndex.tsx` — refactored to export `IntegrationCategory` for per-section MDX rendering; fixed semantic token usage
- `components/inkeep/AskAiLink.tsx` — new inline link that triggers AI search widget (blue color)
- `content/integrations/index.mdx` — restructured with per-category `##` headings for TOC support
- `style.css` — chip hover styles + marquee keyframes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9289](https://linear.app/langfuse/issue/LFE-9289/fix-hover-interactions-of-integrations-fold)

<div><a href="https://cursor.com/agents/bc-1c3d3680-25ef-4d59-a13a-a6fc8d97f102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c3d3680-25ef-4d59-a13a-a6fc8d97f102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refactors the homepage integrations fold (per-chip hover styles, CSS marquee replacing framer-motion, new CTA card) and restructures `/integrations` with per-category `##` headings for TOC support, alongside a new `AskAiLink` inline component.

- **P1 – Missing `data` category in MDX:** `categoryConfig` defines a `data` (Data Platform) category with its own `additionalLinks`, but `content/integrations/index.mdx` has no `<IntegrationCategory category="data" />` section — those integrations are silently dropped from the page.
- **P1 – TypeScript error in `AskAiLink.tsx`:** `React.ReactNode` is used in the prop type without importing `React` or `ReactNode`; the PR's own build-fix rationale explicitly flags this pattern as the root cause of the TS error being resolved elsewhere.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without fixes — Data Platform integrations are silently omitted from /integrations, and the new AskAiLink component has a TypeScript error the PR set out to prevent.

Two P1 findings: a missing MDX category causes a visible content regression (Data Platform integrations disappear), and `React.ReactNode` without an import in the new file likely causes a TS build failure — the exact anti-pattern the PR description warns about.

`content/integrations/index.mdx` (missing data category) and `components/inkeep/AskAiLink.tsx` (unimported React type).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/home/Integrations.tsx | Replaces `framer-motion` marquee + `ChipCard` with CSS-animated marquee and plain `div` cards; adds per-chip hover/pause logic; adds new CTA card — minor conflicting Tailwind classes in `IntegrationGroupCard`. |
| components/inkeep/AskAiLink.tsx | New client component that opens the AI search panel; uses `React.ReactNode` type without importing `React`, likely causing a TypeScript build error — the same issue the PR's build-fix section describes. |
| components/integrations/IntegrationIndex.tsx | Refactored to export `IntegrationCategory` for per-section MDX use and `IntegrationCards` sub-component; legacy `IntegrationIndex` preserved; `getCategory` is called twice per entry in the legacy wrapper (filter + map). |
| components/ui/integration-label.tsx | Adds `onMouseEnter`/`onMouseLeave` props for marquee pause-on-hover; switches to named type imports — clean, no issues. |
| content/integrations/index.mdx | Restructured with per-category `##` headings for TOC support; missing the `data` (Data Platform) category section, so those integrations won't appear on the page. |
| style.css | Replaces group-hover chip lift with individual chip hover (bg + border); adds `marquee-left`/`marquee-right` keyframe animations — straightforward, no issues. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    MDX["content/integrations/index.mdx"] --> |"per-category ## headings"| IC1["IntegrationCategory native"]
    MDX --> IC2["IntegrationCategory frameworks"]
    MDX --> IC3["IntegrationCategory model-providers"]
    MDX --> IC4["IntegrationCategory gateways"]
    MDX --> IC5["IntegrationCategory no-code"]
    MDX --> IC6["IntegrationCategory analytics"]
    MDX --> IC7["IntegrationCategory other"]
    MDX -.->|"❌ MISSING"| IC8["IntegrationCategory data"]

    IC1 & IC2 & IC3 & IC4 & IC5 & IC6 & IC7 --> GC["getCategory(category)"]
    GC --> LFP["loadFilesystemPages()"]
    GC --> AL["config.additionalLinks"]
    LFP & AL --> PP["processPages() — sort + title"]
    PP --> Cards["IntegrationCards"]

    IC8 -.->|"data has additionalLinks\nfrom dataPlatformIntegrationsMeta"| GC
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: components/inkeep/AskAiLink.tsx
Line: 5

Comment:
**`React.ReactNode` referenced without importing React**

`React` is not imported in this file, so `React.ReactNode` in the prop type is an unresolved reference. The PR description explicitly calls out this exact pattern as the TypeScript build error being fixed elsewhere — yet the newly created `AskAiLink.tsx` repeats it. Use a named import instead.

```suggestion
export function AskAiLink({ children }: { children?: import("react").ReactNode }) {
```

Or add a named import at the top:
```ts
import type { ReactNode } from "react";
```
then use `children?: ReactNode`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/integrations/index.mdx
Line: 20-46

Comment:
**`data` (Data Platform) category missing from MDX**

`categoryConfig` in `IntegrationIndex.tsx` defines a `data` category (Data Platform, line 102–107) with its own `additionalLinks` from `dataPlatformIntegrationsMeta`. The new per-section MDX lists every other category (`native`, `frameworks`, `model-providers`, `gateways`, `no-code`, `analytics`, `other`) but omits `data`. Visitors to `/integrations` using the TOC-driven view will never see the Data Platform integrations.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: components/home/Integrations.tsx
Line: 228-233

Comment:
**Conflicting Tailwind utility classes in same `cn()` call**

The first class string sets `inline-flex items-center`, and the second immediately overrides both with `flex flex-col items-start`. `tailwind-merge` will discard `inline-flex` and `items-center`, leaving only the second set — but the stale classes add confusion and make the intent unclear. The first string should only contain classes that aren't duplicated in the second.

```suggestion
      className={cn(
        "relative border border-line-structure bg-surface-bg rounded-[2px]",
        "integration-group flex flex-col gap-3.5 items-start p-3 sm:p-4.5",
        className
      )}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/fix-inte..."](https://github.com/langfuse/langfuse-docs/commit/1a08d2caa5382e1a45bbb6d4202e2e707f202c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29452884)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->