### PR TITLE
fix: prevent author widget from jumping on hover

### DIFF
--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -13,16 +13,18 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align as any}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 border border-line-structure bg-surface-bg p-4 text-text-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
-      className
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align as any}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 border border-line-structure bg-surface-bg p-4 text-text-primary shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When there are multiple authors on a blog post, changelog post, or other pages, hovering from one author to another causes the author card to jump. The author icons also slightly shift on hover.

Fixes LFE-9460.

## Root Cause

The `HoverCardContent` component was rendered inline in the DOM tree, directly inside the flex containers that hold the author elements. When a hover card opens/closes, it inserts/removes DOM elements within the flex layout, triggering layout recalculations that shift the neighboring author avatars and trigger elements.

## Fix

Wrapped `HoverCardContent` in Radix's `HoverCardPrimitive.Portal`, which renders the hover card content in `document.body` instead of inline. This is the standard recommended pattern for Radix UI popover-type components and ensures the card content is completely outside the document flow — it cannot interfere with the layout of trigger elements.

This fix applies globally to all `HoverCard` usages (author widgets, pricing table info icons, docs contributor cards), which is the correct behavior since portaled popovers are the expected default.

## Testing

- Verified pages with 2 authors (blog posts), 3+ authors (overlapping avatars), and changelog posts all render correctly (HTTP 200).
- Dev server starts without errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9460](https://linear.app/langfuse/issue/LFE-9460/author-widget-moves-on-hover)

<div><a href="https://cursor.com/agents/bc-1953ad40-e47d-4b0f-a1d0-923464a7d80a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1953ad40-e47d-4b0f-a1d0-923464a7d80a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR wraps `HoverCardPrimitive.Content` in `HoverCardPrimitive.Portal` inside the shared `HoverCardContent` component, rendering the card into `document.body` instead of inline in the flex layout — the standard Radix UI pattern for floating elements. The fix is minimal, correct, and applies globally to all `HoverCard` usages across the app.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-file, standard Radix UI portal pattern, no logic changes.

The change is a one-file, two-line structural fix using the officially recommended Radix UI portal pattern. No logic, props, or API surface is altered; all findings are P2 or lower (none found), so 5/5 is appropriate.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/ui/hover-card.tsx | Wraps HoverCardPrimitive.Content in HoverCardPrimitive.Portal to render the hover card outside the document flow, preventing layout shifts on hover. Change is correct and follows Radix UI conventions. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HoverTrigger
    participant HoverCardContent
    participant DocumentBody

    User->>HoverTrigger: mouseenter
    HoverTrigger->>HoverCardContent: open state = true
    Note over HoverCardContent: Portal renders into document.body
    HoverCardContent->>DocumentBody: inject card DOM node
    Note over HoverTrigger: flex layout unaffected (no DOM siblings added)
    User->>HoverTrigger: mouseleave
    HoverCardContent->>DocumentBody: remove card DOM node
    Note over HoverTrigger: no layout shift on neighbours
```

<sub>Reviews (1): Last reviewed commit: ["fix: wrap HoverCardContent in Portal to ..."](https://github.com/langfuse/langfuse-docs/commit/964c42666d810492a1b344a36fe4c69328f1547d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29442354)</sub>

<!-- /greptile_comment -->