### PR TITLE
Improve /careers page: heading, layout, CTA, carousel, and hiring badge

### DIFF
--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -13,6 +13,8 @@ import { WrappedDataProvider } from "@/components/wrapped/WrappedDataContext";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { usersSource, changelogSource } from "@/lib/source";
 import { sortCustomerStoriesByMetaOrder } from "@/lib/sortCustomerStoriesByMeta";
+import { cn } from "@/lib/utils";
+import { contentWidthClasses, type ContentWidthType } from "@/lib/content-width";
 
 type PageProps = {
   params: Promise<{ section: string; slug?: string[] }>;
@@ -32,7 +34,11 @@ export default async function SectionDocPage(props: PageProps) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result = await loadPage(config.source, effectiveSlug);
   if (!result) notFound();
-  const { MDX } = result;
+  const { MDX, page } = result;
+
+  const contentWidth: ContentWidthType =
+    (page.data as Record<string, unknown>).contentWidth as ContentWidthType | undefined
+    ?? "default";
 
   let bodyClient = <MDX components={getMDXComponents()} />;
 
@@ -62,7 +68,7 @@ export default async function SectionDocPage(props: PageProps) {
   }
 
   return (
-    <div className="mx-auto w-full px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px] py-10 md:py-16">
+    <div className={cn("mx-auto w-full py-10 md:py-16", contentWidthClasses[contentWidth])}>
       <DocBodyChrome withProse>{bodyClient}</DocBodyChrome>
     </div>
   );

--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -15,8 +15,9 @@ import { usersSource, changelogSource } from "@/lib/source";
 import { sortCustomerStoriesByMetaOrder } from "@/lib/sortCustomerStoriesByMeta";
 import { cn } from "@/lib/utils";
 import {
-  resolveContentWidthClasses,
+  contentWidthClasses,
   type ContentWidthType,
+  type ResolvedContentWidth,
 } from "@/lib/content-width";
 
 type PageProps = {
@@ -39,8 +40,9 @@ export default async function SectionDocPage(props: PageProps) {
   if (!result) notFound();
   const { MDX, page } = result;
 
-  const contentWidth = (page.data as Record<string, unknown>)
-    .contentWidth as ContentWidthType | undefined;
+  const contentWidth: ResolvedContentWidth =
+    (page.data as Record<string, unknown>).contentWidth as ContentWidthType | undefined
+    ?? "default";
 
   let bodyClient = <MDX components={getMDXComponents()} />;
 
@@ -73,7 +75,7 @@ export default async function SectionDocPage(props: PageProps) {
     <div
       className={cn(
         "mx-auto w-full py-10 md:py-16",
-        resolveContentWidthClasses(contentWidth)
+        contentWidthClasses[contentWidth]
       )}
       data-content-width={contentWidth}
     >

--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -68,7 +68,10 @@ export default async function SectionDocPage(props: PageProps) {
   }
 
   return (
-    <div className={cn("mx-auto w-full py-10 md:py-16", contentWidthClasses[contentWidth])}>
+    <div
+      className={cn("mx-auto w-full py-10 md:py-16", contentWidthClasses[contentWidth])}
+      data-content-width={contentWidth}
+    >
       <DocBodyChrome withProse>{bodyClient}</DocBodyChrome>
     </div>
   );

--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -14,7 +14,10 @@ import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { usersSource, changelogSource } from "@/lib/source";
 import { sortCustomerStoriesByMetaOrder } from "@/lib/sortCustomerStoriesByMeta";
 import { cn } from "@/lib/utils";
-import { contentWidthClasses, type ContentWidthType } from "@/lib/content-width";
+import {
+  resolveContentWidthClasses,
+  type ContentWidthType,
+} from "@/lib/content-width";
 
 type PageProps = {
   params: Promise<{ section: string; slug?: string[] }>;
@@ -36,9 +39,8 @@ export default async function SectionDocPage(props: PageProps) {
   if (!result) notFound();
   const { MDX, page } = result;
 
-  const contentWidth: ContentWidthType =
-    (page.data as Record<string, unknown>).contentWidth as ContentWidthType | undefined
-    ?? "default";
+  const contentWidth = (page.data as Record<string, unknown>)
+    .contentWidth as ContentWidthType | undefined;
 
   let bodyClient = <MDX components={getMDXComponents()} />;
 
@@ -69,7 +71,10 @@ export default async function SectionDocPage(props: PageProps) {
 
   return (
     <div
-      className={cn("mx-auto w-full py-10 md:py-16", contentWidthClasses[contentWidth])}
+      className={cn(
+        "mx-auto w-full py-10 md:py-16",
+        resolveContentWidthClasses(contentWidth)
+      )}
       data-content-width={contentWidth}
     >
       <DocBodyChrome withProse>{bodyClient}</DocBodyChrome>

--- a/components/CTACard.tsx
+++ b/components/CTACard.tsx
@@ -14,8 +14,8 @@ interface CTACardProps {
 
 export function CTACard({ title, description, children, className, showArrow = false }: CTACardProps) {
   return (
-    <Card className={cn("mt-8", className)} withStripes>
-      <CardContent className="py-6">
+    <Card className={cn("mt-8", className)} hoverStripes>
+      <CardContent className="p-4">
         <div className="flex flex-col gap-6 md:flex-row md:items-center">
           <div className="flex-1 space-y-2 md:flex-2">
             <h3 className="text-xl font-semibold text-text-primary">

--- a/components/CTACard.tsx
+++ b/components/CTACard.tsx
@@ -14,7 +14,7 @@ interface CTACardProps {
 
 export function CTACard({ title, description, children, className, showArrow = false }: CTACardProps) {
   return (
-    <Card className={cn("mt-8 border bg-card", className)}>
+    <Card className={cn("mt-8", className)} withStripes>
       <CardContent>
         <div className="flex flex-col gap-6 md:flex-row md:items-center">
           <div className="flex-1 space-y-2 md:flex-2">

--- a/components/CTACard.tsx
+++ b/components/CTACard.tsx
@@ -15,13 +15,13 @@ interface CTACardProps {
 export function CTACard({ title, description, children, className, showArrow = false }: CTACardProps) {
   return (
     <Card className={cn("mt-8", className)} hoverStripes>
-      <CardContent className="p-4">
+      <CardContent className="not-prose p-6">
         <div className="flex flex-col gap-6 md:flex-row md:items-center">
           <div className="flex-1 space-y-2 md:flex-2">
-            <h3 className="text-xl font-semibold text-text-primary">
+            <h3 className="m-0 text-xl font-medium leading-tight text-text-primary">
               {title}
             </h3>
-            <p className="text-text-tertiary">
+            <p className="m-0 text-text-tertiary">
               {description}
             </p>
           </div>

--- a/components/CTACard.tsx
+++ b/components/CTACard.tsx
@@ -15,13 +15,13 @@ interface CTACardProps {
 export function CTACard({ title, description, children, className, showArrow = false }: CTACardProps) {
   return (
     <Card className={cn("mt-8", className)} withStripes>
-      <CardContent>
+      <CardContent className="py-6">
         <div className="flex flex-col gap-6 md:flex-row md:items-center">
           <div className="flex-1 space-y-2 md:flex-2">
-            <h3 className="text-xl font-semibold text-foreground">
+            <h3 className="text-xl font-semibold text-text-primary">
               {title}
             </h3>
-            <p className="text-muted-foreground">
+            <p className="text-text-tertiary">
               {description}
             </p>
           </div>

--- a/components/CarouselSlide.tsx
+++ b/components/CarouselSlide.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+/**
+ * Fixed-aspect-ratio carousel slide that handles mixed image sizes gracefully.
+ * Uses a 16:9 container with object-cover so the carousel height stays
+ * consistent regardless of the source image's native aspect ratio.
+ */
+export function CarouselSlide({
+  src,
+  alt,
+  className,
+  aspectRatio = "aspect-[16/9]",
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+  aspectRatio?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded border border-line-structure bg-surface-1",
+        aspectRatio,
+        className
+      )}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className="object-cover"
+        sizes="(max-width: 680px) 100vw, 680px"
+      />
+    </div>
+  );
+}

--- a/components/CarouselSlide.tsx
+++ b/components/CarouselSlide.tsx
@@ -29,7 +29,7 @@ export function CarouselSlide({
         src={src}
         alt={alt}
         fill
-        className="object-cover"
+        className="object-cover md:cursor-pointer"
         sizes="(max-width: 680px) 100vw, 680px"
       />
     </div>

--- a/components/Frame.tsx
+++ b/components/Frame.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 // Image Zoom Modal Component
 const ImageZoomModal = ({
@@ -13,7 +14,11 @@ const ImageZoomModal = ({
   alt: string;
   onClose: () => void;
 }) => {
+  const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
+    setMounted(true);
+
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         onClose();
@@ -29,9 +34,11 @@ const ImageZoomModal = ({
     };
   }, [onClose]);
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-1000 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
     >
       <div className="relative max-h-[90vh] max-w-[90vw] bg-white rounded-lg shadow-2xl">
@@ -61,7 +68,8 @@ const ImageZoomModal = ({
           </svg>
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/components/Frame.tsx
+++ b/components/Frame.tsx
@@ -31,7 +31,7 @@ const ImageZoomModal = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
     >
       <div className="relative max-h-[90vh] max-w-[90vw] bg-white rounded-lg shadow-2xl">

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useRef } from "react";
+import NextLink from "next/link";
+import { cn } from "@/lib/utils";
+
+export function HiringBadge() {
+  const [isHovered, setIsHovered] = useState(false);
+  const [goats, setGoats] = useState<
+    Array<{ id: number; x: number; y: number; duration: number }>
+  >([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const goatIdRef = useRef(0);
+  const lastSpawnTimeRef = useRef(0);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!containerRef.current || !isHovered) return;
+    const now = Date.now();
+    if (now - lastSpawnTimeRef.current < 100) return;
+    lastSpawnTimeRef.current = now;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const newGoat = {
+      id: goatIdRef.current++,
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+      duration: 1.5 + Math.random() * 0.6,
+    };
+    setGoats((prev) => [...prev, newGoat]);
+    setTimeout(() => {
+      setGoats((prev) => prev.filter((g) => g.id !== newGoat.id));
+    }, (newGoat.duration + 0.5) * 1000);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="hidden relative lg:block"
+      onMouseMove={handleMouseMove}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        setGoats([]);
+      }}
+    >
+      <NextLink
+        href="/careers"
+        className={cn(
+          "inline-flex items-center gap-1.5 h-6 px-2.5",
+          "rounded-[2px] border border-line-structure",
+          "bg-surface-bg text-text-tertiary",
+          "font-sans text-[11px] font-[450] leading-[150%] tracking-[-0.06px]",
+          "no-underline transition-colors",
+          "hover:border-line-cta hover:text-text-secondary"
+        )}
+        style={{ width: "max-content" }}
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-[#FBFF7A] shrink-0" />
+        <span className="relative">
+          <span className={cn("block", isHovered && "invisible")}>
+            Hiring in Europe and SF
+          </span>
+          <span
+            className={cn(
+              "absolute left-0 top-0 whitespace-nowrap",
+              !isHovered && "invisible"
+            )}
+          >
+            Looking for GOATS!
+          </span>
+        </span>
+      </NextLink>
+
+      {isHovered && (
+        <div
+          className="overflow-visible fixed z-50 pointer-events-none"
+          style={{ top: 0, left: 0, width: "100vw", height: "100vh" }}
+        >
+          {goats.map((goat) => {
+            if (!containerRef.current) return null;
+            const rect = containerRef.current.getBoundingClientRect();
+            return (
+              <span
+                key={goat.id}
+                className="absolute text-lg animate-fall"
+                style={{
+                  left: `${rect.left + goat.x}px`,
+                  top: `${rect.top + goat.y}px`,
+                  animationDuration: `${goat.duration}s`,
+                }}
+              >
+                🐐
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import NextLink from "next/link";
 import { cn } from "@/lib/utils";
+import { HoverCorners } from "@/components/ui/corner-box";
 
 export function HiringBadge({ className }: { className?: string }) {
   const [isHovered, setIsHovered] = useState(false);
@@ -35,7 +36,7 @@ export function HiringBadge({ className }: { className?: string }) {
   return (
     <div
       ref={containerRef}
-      className={cn("relative", className)}
+      className={className}
       onMouseMove={handleMouseMove}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => {
@@ -43,36 +44,40 @@ export function HiringBadge({ className }: { className?: string }) {
         setGoats([]);
       }}
     >
-      <NextLink
-        href="/careers"
-        className={cn(
-          "inline-flex items-center gap-1.5 w-full h-6 px-2.5",
-          "rounded-[2px] border border-line-structure",
-          "bg-surface-bg text-text-tertiary",
-          "font-sans text-[11px] font-[450] leading-[150%] tracking-[-0.06px]",
-          "no-underline transition-colors",
-          "hover:border-line-cta hover:text-text-secondary"
-        )}
-      >
-        <span className="text-xs shrink-0" aria-hidden>🐐</span>
-        <span className="relative min-w-0">
-          <span className={cn("block truncate", isHovered && "invisible")}>
-            Hiring in Europe and SF
+      <div className="relative flex items-center p-1 group button-wrapper max-h-[34px]">
+        <HoverCorners />
+        <NextLink
+          href="/careers"
+          className={cn(
+            "inline-flex w-full min-w-0 max-w-full items-center gap-[6px] overflow-hidden",
+            "h-[26px] py-0.75 pl-[8px] pr-[8px] rounded-[2px]",
+            "border border-line-structure dark:border-line-cta group-hover:border-line-cta",
+            "bg-surface-bg text-text-secondary",
+            "shadow-sm [box-shadow:0_4px_8px_0_rgba(0,0,0,0.05),0_4px_4px_0_rgba(0,0,0,0.03)]",
+            "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px]",
+            "no-underline transition-colors"
+          )}
+        >
+          <span className="text-xs shrink-0" aria-hidden>🐐</span>
+          <span className="relative min-w-0 flex-1 text-left">
+            <span className={cn("block truncate", isHovered && "invisible")}>
+              Hiring in Europe and SF
+            </span>
+            <span
+              className={cn(
+                "absolute left-0 top-0 whitespace-nowrap",
+                !isHovered && "invisible"
+              )}
+            >
+              Looking for GOATS!
+            </span>
           </span>
-          <span
-            className={cn(
-              "absolute left-0 top-0 whitespace-nowrap",
-              !isHovered && "invisible"
-            )}
-          >
-            Looking for GOATS!
-          </span>
-        </span>
-      </NextLink>
+        </NextLink>
+      </div>
 
       {isHovered && (
         <div
-          className="overflow-visible fixed z-[100] pointer-events-none"
+          className="overflow-visible fixed z-100 pointer-events-none"
           style={{ top: 0, left: 0, width: "100vw", height: "100vh" }}
         >
           {goats.map((goat) => {

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -4,7 +4,7 @@ import { useState, useRef } from "react";
 import NextLink from "next/link";
 import { cn } from "@/lib/utils";
 
-export function HiringBadge() {
+export function HiringBadge({ className }: { className?: string }) {
   const [isHovered, setIsHovered] = useState(false);
   const [goats, setGoats] = useState<
     Array<{ id: number; x: number; y: number; duration: number }>
@@ -35,7 +35,7 @@ export function HiringBadge() {
   return (
     <div
       ref={containerRef}
-      className="hidden relative lg:block"
+      className={cn("relative", className)}
       onMouseMove={handleMouseMove}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => {
@@ -46,18 +46,17 @@ export function HiringBadge() {
       <NextLink
         href="/careers"
         className={cn(
-          "inline-flex items-center gap-1.5 h-6 px-2.5",
+          "inline-flex items-center gap-1.5 w-full h-6 px-2.5",
           "rounded-[2px] border border-line-structure",
           "bg-surface-bg text-text-tertiary",
           "font-sans text-[11px] font-[450] leading-[150%] tracking-[-0.06px]",
           "no-underline transition-colors",
           "hover:border-line-cta hover:text-text-secondary"
         )}
-        style={{ width: "max-content" }}
       >
-        <span className="w-1.5 h-1.5 rounded-full bg-[#FBFF7A] shrink-0" />
-        <span className="relative">
-          <span className={cn("block", isHovered && "invisible")}>
+        <span className="text-xs shrink-0" aria-hidden>🐐</span>
+        <span className="relative min-w-0">
+          <span className={cn("block truncate", isHovered && "invisible")}>
             Hiring in Europe and SF
           </span>
           <span
@@ -73,7 +72,7 @@ export function HiringBadge() {
 
       {isHovered && (
         <div
-          className="overflow-visible fixed z-50 pointer-events-none"
+          className="overflow-visible fixed z-[100] pointer-events-none"
           style={{ top: 0, left: 0, width: "100vw", height: "100vh" }}
         >
           {goats.map((goat) => {

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -77,7 +77,8 @@ export function HiringBadge({ className }: { className?: string }) {
 
       {isHovered && (
         <div
-          className="overflow-visible fixed z-100 pointer-events-none"
+          className="overflow-visible fixed z-[100] pointer-events-none"
+          aria-hidden="true"
           style={{ top: 0, left: 0, width: "100vw", height: "100vh" }}
         >
           {goats.map((goat) => {

--- a/components/TocCommunity.tsx
+++ b/components/TocCommunity.tsx
@@ -3,7 +3,6 @@ import { cn } from "@/lib/utils";
 import IconGithub from "@/components/icons/github";
 import IconX from "@/components/icons/x";
 import { AskAIButton } from "@/components/inkeep/ask-ai-button";
-import { Text } from "@/components/ui/text";
 
 type TocCommunityProps = {
   className?: string;
@@ -11,31 +10,33 @@ type TocCommunityProps = {
 
 export default function TocCommunity({ className }: TocCommunityProps) {
   return (
-    <div className={cn("px-2 pb-4 pt-4", className)}>
-      <Text size="s" className="font-[580] text-left text-text-primary mb-3">Community</Text>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Link
-            href="https://github.com/langfuse/langfuse"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-text-disabled hover:text-text-primary transition-colors"
-            aria-label="GitHub"
-          >
-            <IconGithub className="size-5" />
-          </Link>
-          <Link
-            href="https://x.com/langfuse"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-text-disabled hover:text-text-primary transition-colors mt-0.5"
-            aria-label="X / Twitter"
-          >
-            <IconX className="size-5" />
-          </Link>
-        </div>
-        <AskAIButton />
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 px-2 py-3",
+        className
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Link
+          href="https://github.com/langfuse/langfuse"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-text-disabled hover:text-text-primary transition-colors"
+          aria-label="GitHub"
+        >
+          <IconGithub className="size-5" />
+        </Link>
+        <Link
+          href="https://x.com/langfuse"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-text-disabled hover:text-text-primary transition-colors mt-0.5"
+          aria-label="X / Twitter"
+        >
+          <IconX className="size-5" />
+        </Link>
       </div>
+      <AskAIButton />
     </div>
   );
 }

--- a/components/blog/BlogAside.tsx
+++ b/components/blog/BlogAside.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { AsideShell } from "@/components/home/layout/AsideShell";
-import TocCommunity from "@/components/TocCommunity";
+import { RightSidebarHiringAndCommunity } from "@/components/home/layout/RightSidebarHiringAndCommunity";
 
 export function BlogAside() {
   return (
     <AsideShell>
-      <div className="flex-1" />
-      <TocCommunity className="border-t border-line-structure mt-auto" />
+      <div className="min-h-0 flex-1 bg-surface-1" />
+      <div className="mt-auto w-full shrink-0">
+        <RightSidebarHiringAndCommunity withTopRule />
+      </div>
     </AsideShell>
   );
 }

--- a/components/docs/cards.tsx
+++ b/components/docs/cards.tsx
@@ -48,7 +48,12 @@ export function Card({ icon, title = "", description = "", arrow: _arrow, childr
             {icon}
           </div>
         ) : null}
-        <div className={cn("flex flex-col gap-1", contentWrapperClassName)}>
+        <div
+          className={cn(
+            "flex flex-1 min-w-0 flex-col gap-1",
+            contentWrapperClassName
+          )}
+        >
           <Text as="h3" size="s" className="not-prose mb-0 font-medium text-left text-text-secondary">
             {title}
           </Text>

--- a/components/home/layout/AsideShell.tsx
+++ b/components/home/layout/AsideShell.tsx
@@ -30,7 +30,7 @@ export function AsideShell({
         height: "calc(100vh - var(--fd-banner-height, 0px) - var(--lf-nav-primary-height))",
       }}
     >
-      <nav className="flex overflow-y-auto overflow-x-hidden flex-col flex-1 gap-4 rounded-sm bg-surface-1">
+      <nav className="flex overflow-y-auto overflow-x-hidden flex-col flex-1 rounded-sm bg-surface-1">
         {children}
       </nav>
     </aside>

--- a/components/home/layout/HomeAside.tsx
+++ b/components/home/layout/HomeAside.tsx
@@ -6,8 +6,8 @@ import { AnchorProvider, useActiveAnchors } from "fumadocs-core/toc";
 import { Link } from "@/components/ui/link";
 import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/utils";
-import TocCommunity from "@/components/TocCommunity";
 import { useAISearchContext } from "@/components/inkeep/search";
+import { RightSidebarHiringAndCommunity } from "@/components/home/layout/RightSidebarHiringAndCommunity";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -141,11 +141,15 @@ export function HomeAside() {
         height: "calc(100vh - var(--fd-banner-height, 0px) - var(--lf-nav-primary-height))",
       }}
     >
-      <nav className="flex overflow-y-auto overflow-x-hidden flex-col flex-1 gap-4 rounded-sm bg-surface-1">
-        <AnchorProvider toc={items} single key={pathname}>
-          <TocOnThisPage items={items} />
-        </AnchorProvider>
-        <TocCommunity className="border-t border-line-structure" />
+      <nav className="flex overflow-y-auto overflow-x-hidden flex-col flex-1 rounded-sm bg-surface-1">
+        <div className="flex flex-col flex-1 pb-px bg-line-structure">
+          <div className="flex flex-col flex-1 rounded-sm bg-surface-1">
+            <AnchorProvider toc={items} single key={pathname}>
+              <TocOnThisPage items={items} />
+            </AnchorProvider>
+          </div>
+        </div>
+        <RightSidebarHiringAndCommunity />
       </nav>
     </aside>
   );

--- a/components/home/layout/HomeSidebar.tsx
+++ b/components/home/layout/HomeSidebar.tsx
@@ -4,6 +4,7 @@ import { LinkBox } from "@/components/ui/link-box";
 import { Text } from "@/components/ui/text";
 import discussionsData from "../../../src/langfuse_github_discussions.json";
 import { Link } from "@/components/ui/link";
+import { HiringBadge } from "@/components/HiringBadge";
 
 function formatCount(n: number): string {
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
@@ -199,6 +200,14 @@ export function HomeSidebar() {
             </div>
           </div>
         </div>
+
+        {/* ── Hiring Badge ─────────────────────────────────────────────── */}
+        <div className="pb-px bg-line-structure">
+          <div className="px-4 py-4 rounded-sm bg-surface-1">
+            <HiringBadge />
+          </div>
+        </div>
+
         <span className="flex px-px w-full bg-line-structure h-[3px]">
           <span className="w-full h-full rounded-t-sm bg-surface-1" />
         </span>

--- a/components/home/layout/HomeSidebar.tsx
+++ b/components/home/layout/HomeSidebar.tsx
@@ -4,7 +4,6 @@ import { LinkBox } from "@/components/ui/link-box";
 import { Text } from "@/components/ui/text";
 import discussionsData from "../../../src/langfuse_github_discussions.json";
 import { Link } from "@/components/ui/link";
-import { HiringBadge } from "@/components/HiringBadge";
 
 function formatCount(n: number): string {
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
@@ -198,13 +197,6 @@ export function HomeSidebar() {
                 </LinkBox>
               ))}
             </div>
-          </div>
-        </div>
-
-        {/* ── Hiring Badge ─────────────────────────────────────────────── */}
-        <div className="pb-px bg-line-structure">
-          <div className="px-4 py-4 rounded-sm bg-surface-1">
-            <HiringBadge />
           </div>
         </div>
 

--- a/components/home/layout/RightSidebarHiringAndCommunity.tsx
+++ b/components/home/layout/RightSidebarHiringAndCommunity.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { HiringBadge } from "@/components/HiringBadge";
+import TocCommunity from "@/components/TocCommunity";
+
+type RightSidebarHiringAndCommunityProps = {
+  /**
+   * When the block is not under a previous section with `pb-px bg-line-structure`
+   * (e.g. blog right aside: spacer + footer), a full-width top rule is needed so
+   * the hiring row does not look flush/buggy next to the main nav surface. Home
+   * `HomeAside` already gets a 1px rule from the TOC block above, so keep false.
+   */
+  withTopRule?: boolean;
+};
+
+/**
+ * Hiring + community strip for marketing right sidebars (HomeLayout + PageChrome).
+ * The marketing `Navbar` has no hiring badge; `NavbarDocs` shows it in the top
+ * bar — so docs layouts should not render this block (they use fumadocs TOC only).
+ */
+export function RightSidebarHiringAndCommunity({
+  withTopRule = false,
+}: RightSidebarHiringAndCommunityProps) {
+  return (
+    <>
+      {withTopRule && (
+        <div
+          className="h-px w-full bg-line-structure shrink-0"
+          aria-hidden
+        />
+      )}
+      <div className="pb-px bg-line-structure">
+        <div className="px-3 py-3 rounded-sm bg-surface-1">
+          <HiringBadge />
+        </div>
+      </div>
+      <div className="bg-line-structure">
+        <div className="rounded-sm bg-surface-1">
+          <TocCommunity />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,6 +1,5 @@
 import { NavbarExtraContent } from "@/components/NavbarExtraContent";
 import { NavLinks } from "@/components/NavLinks";
-import { HiringBadge } from "@/components/HiringBadge";
 import { type SectionNavData } from "@/lib/nav-tree";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/Logo";
@@ -40,7 +39,6 @@ export function Navbar() {
           <div className='flex flex-row-reverse flex-1 gap-2 px-2.5 py-3 rounded-sm md:flex-row md:items-center md:justify-center md:gap-4 bg-surface-1'>
             <InkeepSearchBar className="hidden" />
             <NavLinks sectionNavData={sectionNavData} />
-            <HiringBadge />
           </div>
         </div>
         <div className={cn(cornersStyle, 'flex-1 justify-end pl-0 lg:justify-center lg:max-w-[240px] lg:pl-px')}>

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { NavbarExtraContent } from "@/components/NavbarExtraContent";
 import { NavLinks } from "@/components/NavLinks";
+import { HiringBadge } from "@/components/HiringBadge";
 import { type SectionNavData } from "@/lib/nav-tree";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/Logo";
@@ -39,6 +40,7 @@ export function Navbar() {
           <div className='flex flex-row-reverse flex-1 gap-2 px-2.5 py-3 rounded-sm md:flex-row md:items-center md:justify-center md:gap-4 bg-surface-1'>
             <InkeepSearchBar className="hidden" />
             <NavLinks sectionNavData={sectionNavData} />
+            <HiringBadge />
           </div>
         </div>
         <div className={cn(cornersStyle, 'flex-1 justify-end pl-0 lg:justify-center lg:max-w-[240px] lg:pl-px')}>

--- a/components/layout/NavbarDocs.tsx
+++ b/components/layout/NavbarDocs.tsx
@@ -1,5 +1,6 @@
 import { Logo } from "@/components/Logo";
 import { NavbarExtraContent } from "@/components/NavbarExtraContent";
+import { HiringBadge } from "@/components/HiringBadge";
 import InkeepSearchBar from "@/components/inkeep/InkeepSearchBar";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -38,7 +39,8 @@ export function NavbarDocs() {
               bottom: `calc(-10px - var(--lf-nav-docs-secondary-height))`,
             }}
           />
-          <div className='flex flex-row-reverse flex-1 gap-2 px-2.5 py-3 lg:rounded-sm md:flex-row md:items-center md:justify-center md:gap-4 bg-surface-1'>
+          <div className='flex flex-1 gap-2 px-2.5 py-3 lg:rounded-sm items-center justify-between bg-surface-1'>
+            <HiringBadge className="hidden lg:block" />
             <InkeepSearchBar className="hidden lg:block" />
           </div>
         </div>

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { createPortal } from "react-dom";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react";
@@ -80,10 +81,16 @@ const ImageZoomModal = ({
   }, [onClose, onNavigate, currentIndex, images.length]);
 
   const currentImage = images[currentIndex];
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-1000 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
     >
       <div className="relative max-h-[90vh] max-w-[90vw] bg-white rounded-lg shadow-2xl">
@@ -133,7 +140,8 @@ const ImageZoomModal = ({
           ))}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -83,7 +83,7 @@ const ImageZoomModal = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
     >
       <div className="relative max-h-[90vh] max-w-[90vw] bg-white rounded-lg shadow-2xl">

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -231,8 +231,6 @@ import PublicMetricsDashboard from "@/components-mdx/public-metrics-dashboard.md
 
 <PublicMetricsDashboard />
 
-## Work with us
-
 <CTACard
   title="Curious to build with us?"
   description="If you are excited about delivering exceptional open-source developer experiences alongside an insanely motivated team that ships, reach out!"

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -44,30 +44,32 @@ If complex technical problems & great developer experiences excite you, we'd lov
 
 ## Team
 
+import { CarouselSlide } from "@/components/CarouselSlide";
+
 <Carousel
   className="w-full"
   opts={{
     loop: true,
   }}
 >
-  <CarouselContent>
+  <CarouselContent className="items-stretch">
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Team](/images/people/team.jpg)</Frame>
+      <CarouselSlide src="/images/people/team.jpg" alt="Langfuse Team" />
     </CarouselItem>
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Office](/images/careers/office3.jpg)</Frame>
+      <CarouselSlide src="/images/careers/office3.jpg" alt="Langfuse Office" />
     </CarouselItem>
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Team](/images/careers/team3.jpg)</Frame>
+      <CarouselSlide src="/images/careers/team3.jpg" alt="Langfuse Team" />
     </CarouselItem>
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Team](/images/careers/team4.jpg)</Frame>
+      <CarouselSlide src="/images/careers/team4.jpg" alt="Langfuse Team" />
     </CarouselItem>
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Team](/images/careers/team5.jpg)</Frame>
+      <CarouselSlide src="/images/careers/team5.jpg" alt="Langfuse Team" />
     </CarouselItem>
     <CarouselItem>
-      <Frame fullWidth>![Langfuse Team](/images/careers/team6.jpg)</Frame>
+      <CarouselSlide src="/images/careers/team6.jpg" alt="Langfuse Team" />
     </CarouselItem>
   </CarouselContent>
   <CarouselPrevious />

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/carousel";
 import { CredibilitySentence } from "@/components/CredibilitySentence";
 
-<div className="flex flex-col gap-4 mb-16 items-center text-center">
+<div className="not-prose flex flex-col gap-4 mb-8 items-center text-center">
   <Heading as="h1" size="large">
     <TextHighlight>Building Langfuse</TextHighlight>
   </Heading>

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -5,8 +5,9 @@ description: "Join the Langfuse team to build the leading open-source LLM engine
 
 import { CTACard } from "@/components/CTACard";
 import { Button } from "@/components/ui/button";
-import { Header } from "@/components/Header";
-import { ImpactChart } from "@/components/customers/ImpactChart";
+import { Heading } from "@/components/ui/heading";
+import { TextHighlight } from "@/components/ui/text-highlight";
+import { Text } from "@/components/ui/text";
 import {
   Carousel,
   CarouselContent,
@@ -16,21 +17,14 @@ import {
 } from "@/components/ui/carousel";
 import { CredibilitySentence } from "@/components/CredibilitySentence";
 
-<div className="md:container">
-  <div className="flex flex-col items-center content-center text-center my-10 mb-20">
-    <Header
-      title="Building Langfuse"
-      description="Join the team building the leading open-source LLM engineering platform"
-      h="h1"
-    />
-    <Button asChild variant="default" size="lg">
-      <a
-        href="https://jobs.ashbyhq.com/langfuse"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        View Open Positions →
-      </a>
+<div className="flex flex-col gap-4 mb-16 items-center text-center">
+  <Heading as="h1" size="large">
+    <TextHighlight>Building Langfuse</TextHighlight>
+  </Heading>
+  <Text>Join the team building the leading open-source LLM engineering platform</Text>
+  <div className="mt-2 inline-flex">
+    <Button href="https://jobs.ashbyhq.com/langfuse" target="_blank" rel="noopener noreferrer">
+      View Open Positions →
     </Button>
   </div>
 </div>

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -1,6 +1,7 @@
 ---
 title: Careers at Langfuse
 description: "Join the Langfuse team to build the leading open-source LLM engineering platform"
+contentWidth: docs
 ---
 
 import { CTACard } from "@/components/CTACard";

--- a/lib/content-width.ts
+++ b/lib/content-width.ts
@@ -1,0 +1,14 @@
+/**
+ * Reusable content-width abstraction for page layouts.
+ *
+ * - "docs"    — matches the docs reading column width (680px, same as .docs-chrome #nd-page)
+ * - "default" — current marketing/section default (680/840 responsive)
+ * - "full"    — no max-width constraint (full container width)
+ */
+export type ContentWidthType = "docs" | "default" | "full";
+
+export const contentWidthClasses: Record<ContentWidthType, string> = {
+  docs: "px-4 sm:px-8 md:px-0 md:max-w-[680px]",
+  default: "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]",
+  full: "px-4 sm:px-6 md:px-8",
+};

--- a/lib/content-width.ts
+++ b/lib/content-width.ts
@@ -12,3 +12,10 @@ export const contentWidthClasses: Record<ContentWidthType, string> = {
   default: "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]",
   full: "px-4 sm:px-6 md:px-8",
 };
+
+/** Footer overrides so the footer width matches the content width. */
+export const footerWidthClasses: Record<ContentWidthType, string> = {
+  docs: "xl:max-w-[680px]",
+  default: "",
+  full: "md:max-w-none xl:max-w-none px-4 sm:px-6 md:px-8",
+};

--- a/lib/content-width.ts
+++ b/lib/content-width.ts
@@ -1,21 +1,31 @@
 /**
  * Reusable content-width abstraction for page layouts.
  *
- * - "docs"    — matches the docs reading column width (680px, same as .docs-chrome #nd-page)
- * - "default" — current marketing/section default (680/840 responsive)
- * - "full"    — no max-width constraint (full container width)
+ * Frontmatter `contentWidth` is optional. When omitted, the main column uses
+ * the standard marketing width (680px / 840px responsive).
+ *
+ * When set in MDX (see `source.config.ts`):
+ * - `"docs"` — same reading width as docs (680px), and footer aligns via CSS.
+ * - `"full"` — no max-width on the content column.
  */
-export type ContentWidthType = "docs" | "default" | "full";
+export type ContentWidthType = "docs" | "full";
 
-export const contentWidthClasses: Record<ContentWidthType, string> = {
+/** Classes when `contentWidth` is not set in frontmatter. */
+const marketingContentWidthClasses =
+  "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]";
+
+const contentWidthByFrontmatter: Record<ContentWidthType, string> = {
   docs: "px-4 sm:px-8 md:px-0 md:max-w-[680px]",
-  default: "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]",
   full: "px-4 sm:px-6 md:px-8",
 };
 
-/** Footer overrides so the footer width matches the content width. */
-export const footerWidthClasses: Record<ContentWidthType, string> = {
-  docs: "xl:max-w-[680px]",
-  default: "",
-  full: "md:max-w-none xl:max-w-none px-4 sm:px-6 md:px-8",
-};
+/**
+ * Tailwind classes for the section page main column. `undefined` / `null` means
+ * no frontmatter override — use the standard marketing width.
+ */
+export function resolveContentWidthClasses(
+  value: ContentWidthType | null | undefined
+): string {
+  if (value == null) return marketingContentWidthClasses;
+  return contentWidthByFrontmatter[value];
+}

--- a/lib/content-width.ts
+++ b/lib/content-width.ts
@@ -7,25 +7,17 @@
  * When set in MDX (see `source.config.ts`):
  * - `"docs"` — same reading width as docs (680px), and footer aligns via CSS.
  * - `"full"` — no max-width on the content column.
+ *
+ * "default" is an internal-only fallback for pages that don't set
+ * contentWidth in frontmatter — it is NOT a valid frontmatter value.
  */
 export type ContentWidthType = "docs" | "full";
 
-/** Classes when `contentWidth` is not set in frontmatter. */
-const marketingContentWidthClasses =
-  "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]";
+/** Internal type including the code-side fallback. */
+export type ResolvedContentWidth = ContentWidthType | "default";
 
-const contentWidthByFrontmatter: Record<ContentWidthType, string> = {
+export const contentWidthClasses: Record<ResolvedContentWidth, string> = {
   docs: "px-4 sm:px-8 md:px-0 md:max-w-[680px]",
+  default: "px-4 sm:px-8 md:px-0 md:max-w-[680px] xl:max-w-[840px]",
   full: "px-4 sm:px-6 md:px-8",
 };
-
-/**
- * Tailwind classes for the section page main column. `undefined` / `null` means
- * no frontmatter override — use the standard marketing width.
- */
-export function resolveContentWidthClasses(
-  value: ContentWidthType | null | undefined
-): string {
-  if (value == null) return marketingContentWidthClasses;
-  return contentWidthByFrontmatter[value];
-}

--- a/source.config.ts
+++ b/source.config.ts
@@ -166,9 +166,13 @@ export const handbook = defineDocs({
   docs: { schema: sidebarFrontmatterSchema },
 });
 
+const marketingFrontmatterSchema = baseFrontmatterSchema.extend({
+  contentWidth: z.enum(["docs", "full"]).nullish(),
+});
+
 export const marketing = defineDocs({
   dir: "content/marketing",
-  docs: { schema: baseFrontmatterSchema },
+  docs: { schema: marketingFrontmatterSchema },
 });
 
 export default defineConfig({

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -1132,6 +1132,14 @@ details > summary {
   }
 }
 
+/*
+ * content-width-type: docs — lock the sibling footer to 680px at xl,
+ * matching the narrower reading column so content and footer align.
+ */
+#home-main-area > div:has(> [data-content-width="docs"]) > footer {
+  max-width: 42.5rem; /* 680px */
+}
+
 /* Inkeep override */
 inkeep-portal .inkeep-widget-vars {
   --ikp-font-family-heading: var(--font-sans);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Coordinated cleanup of the `/careers` page addressing six sub-issues in separate commits:

## Changes

### 1. Pricing-style heading with yellow highlight
- Replaced the old `Header` component with `Heading` + `TextHighlight` + `Text`, matching the pricing page pattern (centered, yellow highlight).
- Removed the unused `ImpactChart` import.
- Added `not-prose` to the hero div so DocsBody prose margins don't inflate the gap between heading and subtitle; uses `gap-4 mb-8` matching the pricing page.

### 2. Reusable `content-width-type` layout abstraction
- Created `lib/content-width.ts` with a `ContentWidthType` enum (`"docs"` | `"default"` | `"full"`) and corresponding Tailwind class sets plus footer width overrides.
- Added `contentWidth` frontmatter field to the marketing schema in `source.config.ts`.
- Updated `app/[section]/[[...slug]]/page.tsx` to read the frontmatter, apply the appropriate width classes, and emit a `data-content-width` attribute.
- The careers page now uses `contentWidth: docs` to match the docs reading column width (680px).

### 3. Footer width alignment
- Added a `:has()`-based CSS rule in `overrides.css` that constrains the footer to 680px when the sibling content uses docs width, preventing the footer from being wider than the page content at xl breakpoints.

### 4. Hero CTA button sizing
- The hero CTA button is now wrapped in an `inline-flex` container, ensuring it uses intrinsic width rather than stretching to full container width.

### 5. CTA card background styling
- Switched from `withStripes` (always visible) to `hoverStripes` so the hatch pattern only appears on hover.
- Equalized padding to `p-4` so vertical spacing matches horizontal.
- Updated text colors to use design system tokens (`text-text-primary`, `text-text-tertiary`).

### 6. Hiring goat navigation badge
- Re-created `components/HiringBadge.tsx` with a 🐐 goat emoji instead of a yellow dot.
- **Homepage**: placed as a full-width item in the left sidebar, under the Self Hosting Guides section.
- **Docs pages**: placed left-aligned in the docs top nav (`NavbarDocs`), with the search bar pushed to the right.
- Removed from the main marketing navbar center section.
- Preserves the hover interaction: text swaps to "Looking for GOATS!" and falling goat emojis animate from the cursor.

### 7. Carousel for mixed aspect ratios
- Created `components/CarouselSlide.tsx` with a fixed 16:9 aspect ratio container and `object-cover`, ensuring consistent slide height regardless of source image dimensions.
- Updated the careers carousel to use `CarouselSlide` instead of `Frame`, eliminating layout jumps between slides.

### 8. Image zoom overlay fix
- Bumped z-index on fullscreen image zoom modals (carousel `ImageZoomModal` + Frame `ImageZoomModal`) from `z-50` to `z-[100]` so the overlay covers the navbar, sidebar, and all other fixed UI elements.

## Testing
- Dev server tested: `/careers`, `/`, `/docs`, `/pricing`, `/enterprise`, `/support` all return 200 with no compilation errors.
- Verified homepage sidebar shows hiring badge with goat emoji.
- Verified docs page top nav shows hiring badge left-aligned with search right-aligned.
- Verified CTA cards use hover-only stripes.
- Verified all image zoom modals use z-[100].
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9412](https://linear.app/langfuse/issue/LFE-9412/improve-httpslangfusecomcareers-page-and)

<div><a href="https://cursor.com/agents/bc-4ec3e92a-e683-43a8-8248-d6e41ed19b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ec3e92a-e683-43a8-8248-d6e41ed19b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refreshes the `/careers` page with a pricing-style heading, fixed-aspect-ratio carousel slides, a striped `CTACard` background, a `contentWidth` frontmatter abstraction for marketing pages, and a fun `HiringBadge` goat-emoji component in the navbar. All changes are well-scoped and the dev-server verification covers the main affected routes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions with no correctness or data-integrity impact.

Only finding is a P2 type/schema divergence where "default" appears in ContentWidthType but not in the Zod enum; runtime behaviour is correct because "default" is only ever the fallback value, never read from frontmatter. No logic, security, or build-breaking issues found.

lib/content-width.ts and source.config.ts for the minor ContentWidthType/Zod schema divergence.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/[section]/[[...slug]]/page.tsx | Reads `contentWidth` from page frontmatter and applies the corresponding Tailwind classes; double-cast is safe since `null` and `undefined` both fall back to `"default"` via `??`. |
| components/CTACard.tsx | Switches from `bg-card` to `withStripes`, adds `py-6` padding, and updates text color tokens to design-system values — straightforward styling update. |
| components/CarouselSlide.tsx | New component wrapping `next/image` in a 16:9 aspect-ratio container with `object-cover`; correctly sets `fill` and `sizes` for responsive images. |
| components/HiringBadge.tsx | New client component with goat-emoji hover animation; throttles spawns at 100 ms, cleans up with `setTimeout`, and uses `pointer-events-none` on the overlay so it does not block clicks. |
| components/layout/Navbar.tsx | Inserts `HiringBadge` into the center navbar section; `hidden lg:block` keeps it off mobile screens. |
| content/marketing/careers.mdx | Replaces old `Header` + `Frame` pattern with `Heading`/`TextHighlight`/`CarouselSlide`; adds `contentWidth: docs` frontmatter; pre-existing `variant="default"` on bottom CTA buttons is unchanged. |
| lib/content-width.ts | Introduces `ContentWidthType` with three values (`"docs" | "default" | "full"`), but only two are accepted by the Zod schema — `"default"` in the type has no frontmatter equivalent. |
| source.config.ts | Adds `marketingFrontmatterSchema` with `contentWidth: z.enum(["docs", "full"]).nullish()` — omits `"default"` while `ContentWidthType` exposes it, causing a type/schema divergence. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MDX Frontmatter\ncontentWidth: docs, full, or absent"] --> B["source.config.ts\nZod: enum docs or full, nullish"]
    B --> C["page.tsx\nread page.data.contentWidth"]
    C -->|"null or undefined"| D["fallback to 'default'"]
    C -->|"'docs'"| E["contentWidthClasses.docs\nmax-w-680px"]
    C -->|"'full'"| F["contentWidthClasses.full\nfull container width"]
    D --> G["contentWidthClasses.default\nmax-w-680px or max-w-840px xl"]
    E --> H["DocBodyChrome wrapper div"]
    F --> H
    G --> H
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: source.config.ts
Line: 169-171

Comment:
**`"default"` missing from Zod schema but present in `ContentWidthType`**

The marketing schema only validates `"docs"` and `"full"`, but the exported `ContentWidthType` includes `"default"`. If a future contributor tries setting `contentWidth: default` in any marketing MDX file, Zod will reject it at build time with a confusing error, since the type suggests the value is valid. Keeping the type and schema aligned prevents this.

```suggestion
const marketingFrontmatterSchema = baseFrontmatterSchema.extend({
  contentWidth: z.enum(["docs", "default", "full"]).nullish(),
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(CTACard): add vertical padding and..."](https://github.com/langfuse/langfuse-docs/commit/b204e2059ed2961a7465fd45eeb92c71f35b4879) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29453183)</sub>

<!-- /greptile_comment -->