### PR TITLE
docs(faq): v3 SDK observation lookup 404s

### DIFF
--- a/content/faq/all/v3-sdk-observation-lookup-404.mdx
+++ b/content/faq/all/v3-sdk-observation-lookup-404.mdx
@@ -1,0 +1,33 @@
+---
+title: Why do observation lookups with the v3 SDK return 404?
+sidebarTitle: v3 SDK observation lookup 404s
+description: When mixing the v3 SDK with the Fast (v4) UI, some observation ids — in particular `t-<traceId>` ids stored in `source_observation_id` — can't be resolved by the v3 SDK. Explanation and workaround.
+tags: [observability, tracing, evaluation]
+---
+
+# Why do observation lookups with the v3 SDK return 404?
+
+## What's happening
+
+The v4 data model only has observations — traces don't exist as a separate entity, so a trace's metadata needs to be represented *as* an observation. Langfuse does this by dual-writing a synthetic observation with id `t-<traceId>` whenever a trace comes in through the v3 ingestion path. That synthetic row lives in the events table (v4), not in the classic observations table (v3).
+
+When you add the trace to a dataset from the Fast (v4) UI, it stamps that synthetic id into `source_observation_id`. Looking the id up later with the v3 SDK defaults to the v3 table, which doesn't have the synthetic row — so it 404s.
+
+## Solution
+
+Two options, pick whichever fits your situation:
+
+**1. Stay on v3 SDK, add a query parameter**
+
+Pass `useEventsTable=true` on the call so the server reads from the events table where the synthetic row lives:
+
+```python
+langfuse.api.observations.get(
+    observation_id,
+    request_options={"additional_query_parameters": {"useEventsTable": "true"}},
+)
+```
+
+**2. Migrate to a v4 SDKs**
+
+[Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) use the v4 data model natively — the `useEventsTable` flag is implicit and no workaround is needed.

--- a/content/faq/all/v3-sdk-observation-lookup-404.mdx
+++ b/content/faq/all/v3-sdk-observation-lookup-404.mdx
@@ -28,6 +28,6 @@ langfuse.api.observations.get(
 )
 ```
 
-**2. Migrate to a v4 SDKs**
+**2. Migrate to v4 SDKs**
 
 [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) use the v4 data model natively — the `useEventsTable` flag is implicit and no workaround is needed.


### PR DESCRIPTION
Adds a FAQ entry explaining why observation lookups with the v3 SDK can return 404 when the Fast (v4) UI is used to add traces to datasets.

Relates to [LFE-9379](https://linear.app/langfuse/issue/LFE-9379/ui-bug-incorrect-source-observation-id-when-adding-trace-to-dataset).

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds a new FAQ page documenting why `t-<traceId>` synthetic observation ids stored by the Fast (v4) UI cause 404s when looked up via the v3 SDK, along with a `useEventsTable=true` workaround and a migration path to v4/v5 SDKs. The explanation is clear and technically accurate; the only issue is a minor grammar mistake on line 31 (`"a v4 SDKs"` → `"v4 SDKs"`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with one trivial grammar fix needed.

The PR adds a single new FAQ MDX file with no code changes. All findings are P2 (grammar), which do not block merge.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/faq/all/v3-sdk-observation-lookup-404.mdx | New FAQ entry explaining v3 SDK 404s when using the Fast (v4) UI; one minor grammar typo ("a v4 SDKs") on line 31 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application (v3 SDK)
    participant Langfuse as Langfuse Ingestion
    participant V3Table as observations table (v3)
    participant V4Table as events table (v4)
    participant UI as Fast UI (v4)
    participant SDK as v3 SDK lookup

    App->>Langfuse: ingest trace (v3 path)
    Langfuse->>V3Table: store trace data
    Langfuse->>V4Table: dual-write synthetic observation id=t-traceId

    UI->>V4Table: add trace to dataset → stamps source_observation_id = t-traceId

    SDK->>V3Table: GET observations/t-traceId
    V3Table-->>SDK: 404 (synthetic row not here)

    Note over SDK,V4Table: Workaround: pass useEventsTable=true
    SDK->>V4Table: GET observations/t-traceId?useEventsTable=true
    V4Table-->>SDK: 200 OK
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/faq/all/v3-sdk-observation-lookup-404.mdx
Line: 31

Comment:
**Grammar: "a v4 SDKs" should be "v4 SDKs"**

`"a"` is an indefinite article for a singular noun, but `SDKs` is plural. Remove `"a"`.

```suggestion
**2. Migrate to v4 SDKs**
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(faq): add FAQ for v3 SDK observatio..."](https://github.com/langfuse/langfuse-docs/commit/5a5f1a9873880e6f0ccc6c7b2cac10190d7f0c85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29473125)</sub>

<!-- /greptile_comment -->