### PR TITLE
adjust wording

### DIFF
--- a/components/japan/JapanLanding.tsx
+++ b/components/japan/JapanLanding.tsx
@@ -106,7 +106,7 @@ function Hero() {
             すべてをAWSとClickHouseの
             <b className="text-text-primary font-medium">東京リージョン</b>
             でホスト。
-            世界中で使われているLangfuse Cloudを、データを日本に置いたまま動かせます。
+            世界中で使われているLangfuse Cloudを、データを国内に保管したまま動かせます。
           </p>
           <p className="font-analog italic text-[15px] text-text-tertiary m-0 -tracking-[0.005em]">
             Langfuse Cloud Japan — LLM observability, hosted in Tokyo.
@@ -139,7 +139,7 @@ function Hero() {
         className={`${cornerBoxBase} no-tl no-tr grid grid-cols-2 md:grid-cols-4 [border-top:none]`}
       >
         {[
-          ["機能はグローバル版と同じ", "機能差分なし"],
+          ["機能はグローバル版と同じ", "機能差なし"],
           ["AWS + ClickHouse", "東京でホスト"],
           ["エンタープライズ対応", "SOC 2 · ISO 27001"],
           ["オープンソース", "MIT · いつでもセルフホスト"],
@@ -243,8 +243,8 @@ function WhyJapan() {
     {
       kanji: "所在",
       eyebrow: "データ所在地",
-      title: "データは日本に置いたまま。",
-      body: "トレース、プロンプト、評価はすべてAWS ap-northeast-1（東京）のClickHouseに保管されます。主要なアプリケーションデータがリージョンの外に出ることはありません。",
+      title: "データは国内に保管。",
+      body: "トレース、プロンプト、評価はすべてAWS ap-northeast-1（東京）のClickHouseに保管されます。主要なアプリケーションデータがリージョン外に出ることはありません。",
       visual: "region" as const,
     },
     {
@@ -268,7 +268,7 @@ function WhyJapan() {
       <div className="flex flex-col items-start gap-3.5 mb-10">
         <div className="japan-eyebrow">なぜLangfuse Cloud Japan?</div>
         <h2 className="japan-h2 max-w-[26ch]">
-          日本でLLMを動かすチームのための
+          日本でAIエージェントを開発しているチームのための
           <br />
           <span className="japan-highlight">プラットフォーム。</span>
         </h2>
@@ -446,19 +446,19 @@ function GetStarted() {
     {
       n: "01",
       title: "サインアップ",
-      body: "jp.cloud.langfuse.com にアクセスして、組織・プロジェクトを作成、APIキーを発行します。1分もかかりません。",
+      body: "jp.cloud.langfuse.com にアクセスして、1分以内に組織・プロジェクトを作成し、APIキーを発行できます。",
       action: ["アカウントを作成", "https://jp.cloud.langfuse.com"],
     },
     {
       n: "02",
       title: "アプリを設定",
-      body: "SDKのBase URLを日本リージョンに向けます。APIキーはさっき発行したものをそのまま使います。",
+      body: "SDKのBase URLを日本リージョンに向けます。APIキーは先ほど発行したものをそのまま使います。",
       code: true,
     },
     {
       n: "03",
       title: "トレースを追加",
-      body: "AIコーディングエージェントとLangfuseスキルを組み合わせれば、スタックに合わせてトレースを自動で入れてくれます。",
+      body: "AIコーディングエージェントとLangfuseスキルを組み合わせれば、コードベースに合わせてトレースを自動で組み込んでくれます。",
       action: ["Langfuse skillsを開く", "https://github.com/langfuse/skills"],
     },
   ];
@@ -819,7 +819,7 @@ function Migration() {
             className="japan-h2 max-w-[20ch] mb-3.5"
             style={{ fontSize: "clamp(28px, 3vw, 40px)" }}
           >
-            すでにLangfuseを使っている? 4ステップで移行できます。
+            すでにLangfuseをご利用ですか？ 4ステップで移行できます。
           </h2>
           <p className="japan-body-sm m-0 max-w-[44ch]">
             別リージョンからでも、セルフホストからでもOK。エクスポート → インポート → base URL切り替え、それだけです。クックブックで手順を最初から最後までカバーしています。
@@ -880,7 +880,7 @@ function FAQ() {
       ),
     },
     {
-      q: "日本リージョンを使っているか、どう確認すればいい?",
+      q: "日本リージョンを使っているか確認するには？",
       a: (
         <>
           <p>チェックするのは2点です:</p>
@@ -898,7 +898,7 @@ function FAQ() {
       ),
     },
     {
-      q: "移行はどう進めるの?",
+      q: "移行の手順は？",
       a: (
         <p>
           日本リージョンにプロジェクトを作る → 元のプロジェクトからデータをエクスポート → インポート → アプリのbase URLを切り替える、の4ステップです。詳しい手順は{" "}


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR makes Japanese copy adjustments across the `JapanLanding.tsx` component — replacing informal phrasings with more polished alternatives (e.g., "日本に置いたまま" → "国内に保管", casual question marks with full-width `？`, and "LLMを動かす" → "AIエージェントを開発している"). All changes are text-only with no logic or structural modifications.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure Japanese copy adjustments with no logic changes.

All changes are text-only wording refinements in Japanese. No code logic, component structure, imports, or functionality was modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/japan/JapanLanding.tsx | Text-only wording adjustments across Hero, WhyJapan, GetStarted, Migration, and FAQ sections — no logic or structural changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[JapanLanding.tsx] --> B[Hero]
    A --> C[WhyJapan]
    A --> D[GetStarted]
    A --> E[Migration]
    A --> F[FAQ]

    B -->|"データを国内に保管したまま動かせます"| B1[Updated copy]
    C -->|"AIエージェントを開発しているチームのための"| C1[Updated copy]
    D -->|"1分以内に / 先ほど / コードベースに合わせて"| D1[Updated copy]
    E -->|"ご利用ですか？"| E1[Updated copy]
    F -->|"確認するには？ / 移行の手順は？"| F1[Updated copy]
```

<sub>Reviews (1): Last reviewed commit: ["wording"](https://github.com/langfuse/langfuse-docs/commit/9004f0a3315e6640292d71a7465279a6f957baa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29787791)</sub>

<!-- /greptile_comment -->