### PR TITLE
docs(api): refresh Observations API v2 data availability callout

### DIFF
--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -18,7 +18,7 @@ For general information about API authentication, base URLs, and SDK access, see
 
 **Cloud-only:** The v2 Observations API is only available on Langfuse Cloud. We are working on a robust migration path for self-hosted deployments.
 
-**Data availability note:** When using current SDK versions, data may take approximately 5 minutes to appear on v2 endpoints. We will be releasing updated SDK versions soon that will make data available immediately.
+**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
 
 </Callout>
 


### PR DESCRIPTION
## Summary
- The Observations API v2 callout still warned that "current SDK versions" delay v2 ingestion by ~5 minutes. With Python SDK v4 and JS/TS SDK v5 (and OTEL exporters sending `x-langfuse-ingestion-version: 4`), data appears in real time.
- Rewrote the callout to mirror the framing on the [v4 docs page](/docs/v4): older SDKs/OTEL without the ingestion header may lag up to 10 minutes; upgrading resolves it.
- Linked the [Python v3→v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS v4→v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) migration guides directly from the callout.

## Test plan
- [ ] Visual check on the docs page — callout renders, links resolve.
- [ ] Confirm whether the same fix should land on the Metrics API v2 callout (`content/docs/metrics/features/metrics-api.mdx`), which still carries the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refreshes the data availability callout on the v2 Observations API docs page, replacing the stale "~5 minutes with current SDK versions" language with accurate guidance: older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or bare OTEL exporters missing the `x-langfuse-ingestion-version: 4` header may lag up to 10 minutes, while upgrading resolves the delay. Migration guide links are added for both Python and JS/TS SDKs.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a P2 noting that the parallel Metrics API docs page carries the same stale wording and could be updated in the same pass.

Single documentation file change with accurate, well-sourced content. No logic or security concerns. One P2 style observation about an equivalent stale callout in metrics-api.mdx that the author already flagged in the test plan but did not fix.

content/docs/metrics/features/metrics-api.mdx — same outdated data-availability callout not addressed in this PR

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/docs/api-and-data-platform/features/observations-api.mdx | Data availability callout updated to reflect current SDK versions (Python ≥4.0.0, JS ≥5.0.0) and the `x-langfuse-ingestion-version: 4` header requirement; delay updated from 5 to 10 minutes for older SDKs with migration guide links added. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SDK / OTEL Exporter sends span] --> B{Sends x-langfuse-ingestion-version: 4?}
    B -- Yes\n langfuse-python ≥4.0.0\n langfuse-js ≥5.0.0 --> C[Ingested via v4 pipeline]
    B -- No\n older SDK / bare OTEL --> D[Ingested via legacy pipeline]
    C --> E[Data available on v2 endpoints\nin real time]
    D --> F[Data delayed up to\n10 minutes on v2 endpoints]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/docs/api-and-data-platform/features/observations-api.mdx
Line: 21

Comment:
**Metrics API v2 callout still has stale wording**

The PR description flags this in the test plan, but `content/docs/metrics/features/metrics-api.mdx` (line 22) still reads:

> *"When using current SDK versions, data may take approximately 5 minutes to appear on v2 endpoints. We will be releasing updated SDK versions soon that will make data available immediately."*

This is the same outdated text this PR fixes here. Since both APIs share the same underlying ingestion pipeline, the same SDK version thresholds and 10-minute lag caveat apply. Consider applying an equivalent update to the Metrics API callout in the same PR.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(api): update Observations API v2 da..."](https://github.com/langfuse/langfuse-docs/commit/d368e7fe15d48ee881201499a8aef9c16a26ce04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29803368)</sub>

<!-- /greptile_comment -->