### PR TITLE
Fix OG image issues: CJK line breaking and generic title enrichment

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -21,6 +21,31 @@ function wrapWords(text: string, maxChars: number): string[] {
   return lines.length ? lines : [""];
 }
 
+/**
+ * Split a string into "tokens" that can be laid out independently.
+ * Latin/space-delimited text stays as whole words; CJK characters become
+ * individual tokens so they can wrap at any character boundary.
+ */
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+  let buf = "";
+  for (const ch of text) {
+    const cp = ch.codePointAt(0)!;
+    if (/\s/.test(ch)) {
+      if (buf) { tokens.push(buf); buf = ""; }
+      continue;
+    }
+    if (isCjkOrFullWidth(cp)) {
+      if (buf) { tokens.push(buf); buf = ""; }
+      tokens.push(ch);
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) tokens.push(buf);
+  return tokens;
+}
+
 /** ~average char width for F37 (panel / two-line checks). */
 const ANALOG_CHAR_EM = 0.48;
 /**
@@ -50,8 +75,49 @@ const TITLE_LONG_TITLE_FONT_SIZES = [120, 112, ...TITLE_FONT_SIZES];
 const DESC_FONT_SIZES = [26, 24, 22, 20, 18, 16, 14, 13, 12];
 const TITLE_MAX_REFINE_FS = 120;
 
+/**
+ * CJK and other full-width characters render at roughly 1em while Latin
+ * letters average around the given `em` fraction.  Count effective character
+ * units so width estimation works for mixed-script titles (e.g. Japanese).
+ */
+function effectiveCharCount(line: string, em: number): number {
+  let units = 0;
+  for (const ch of line) {
+    const cp = ch.codePointAt(0)!;
+    if (isCjkOrFullWidth(cp)) {
+      units += 1.0 / em;
+    } else {
+      units += 1;
+    }
+  }
+  return units;
+}
+
+function isCjkOrFullWidth(cp: number): boolean {
+  return (
+    (cp >= 0x2e80 && cp <= 0x9fff) ||  // CJK radicals, kangxi, ideographs
+    (cp >= 0xf900 && cp <= 0xfaff) ||  // CJK compatibility ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) ||  // CJK compatibility forms
+    (cp >= 0xff01 && cp <= 0xff60) ||  // fullwidth Latin + halfwidth forms start
+    (cp >= 0xffe0 && cp <= 0xffe6) ||  // fullwidth signs
+    (cp >= 0x20000 && cp <= 0x2fa1f) || // CJK unified ext B–F, compat supplement
+    (cp >= 0x3000 && cp <= 0x303f) ||  // CJK symbols and punctuation
+    (cp >= 0x3040 && cp <= 0x309f) ||  // Hiragana
+    (cp >= 0x30a0 && cp <= 0x30ff) ||  // Katakana
+    (cp >= 0x31f0 && cp <= 0x31ff) ||  // Katakana phonetic extensions
+    (cp >= 0xac00 && cp <= 0xd7af)     // Hangul syllables
+  );
+}
+
+function hasCjk(text: string): boolean {
+  for (const ch of text) {
+    if (isCjkOrFullWidth(ch.codePointAt(0)!)) return true;
+  }
+  return false;
+}
+
 function approxLineWidthPx(line: string, fontSize: number, em: number): number {
-  return line.length * fontSize * em;
+  return effectiveCharCount(line, em) * fontSize * em;
 }
 
 /** Two lines using an approximate pixel budget (never wider than the panel). */
@@ -61,18 +127,25 @@ function splitTwoLinesByWidth(
   innerW: number
 ): string[] | null {
   const budget = innerW;
-  const words = title.trim().split(/\s+/).filter(Boolean);
+  const cjk = hasCjk(title);
+  const words = cjk
+    ? tokenize(title)
+    : title.trim().split(/\s+/).filter(Boolean);
   if (words.length <= 1) return null;
+  const join = cjk ? joinTokens : (t: string[]) => t.join(" ");
   let best: string[] | null = null;
   let bestImbalance = Infinity;
   for (let cut = 1; cut < words.length; cut++) {
-    const l1 = words.slice(0, cut).join(" ");
-    const l2 = words.slice(cut).join(" ");
+    const l1 = join(words.slice(0, cut));
+    const l2 = join(words.slice(cut));
     if (
       approxLineWidthPx(l1, fontSize, ANALOG_CHAR_EM) <= budget &&
       approxLineWidthPx(l2, fontSize, ANALOG_CHAR_EM) <= budget
     ) {
-      const imbalance = Math.abs(l1.length - l2.length);
+      const imbalance = Math.abs(
+        approxLineWidthPx(l1, fontSize, ANALOG_CHAR_EM) -
+        approxLineWidthPx(l2, fontSize, ANALOG_CHAR_EM)
+      );
       if (imbalance < bestImbalance) {
         bestImbalance = imbalance;
         best = [l1, l2];
@@ -83,13 +156,17 @@ function splitTwoLinesByWidth(
 }
 
 function splitTwoLines(title: string, maxCharsPerLine: number): string[] | null {
-  const words = title.trim().split(/\s+/).filter(Boolean);
+  const cjk = hasCjk(title);
+  const words = cjk
+    ? tokenize(title)
+    : title.trim().split(/\s+/).filter(Boolean);
   if (words.length <= 1) return null;
+  const join = cjk ? joinTokens : (t: string[]) => t.join(" ");
   let best: string[] | null = null;
   let bestImbalance = Infinity;
   for (let cut = 1; cut < words.length; cut++) {
-    const l1 = words.slice(0, cut).join(" ");
-    const l2 = words.slice(cut).join(" ");
+    const l1 = join(words.slice(0, cut));
+    const l2 = join(words.slice(cut));
     if (l1.length <= maxCharsPerLine && l2.length <= maxCharsPerLine) {
       const imbalance = Math.abs(l1.length - l2.length);
       if (imbalance < bestImbalance) {
@@ -125,25 +202,48 @@ function titleTextBudgetWidthPx(innerW: number): number {
 }
 
 /**
+ * Join tokens back into display text: CJK tokens are adjacent without spaces;
+ * Latin tokens are separated by spaces.
+ */
+function joinTokens(tokens: string[]): string {
+  if (tokens.length === 0) return "";
+  let result = tokens[0];
+  for (let i = 1; i < tokens.length; i++) {
+    const prevCjk = hasCjk(tokens[i - 1]);
+    const curCjk = hasCjk(tokens[i]);
+    if (prevCjk && curCjk) {
+      result += tokens[i];
+    } else {
+      result += " " + tokens[i];
+    }
+  }
+  return result;
+}
+
+/**
  * Pack words into rows: each row is the longest prefix that still fits the text budget.
  * This matches one yellow row = one visual line (no `wrapWords` char cap that then soft-wraps in Satori).
+ * Uses tokenize() for CJK-aware splitting so characters can wrap mid-"word".
  */
 function greedyWordsToTitleRows(
   title: string,
   fontSize: number,
   innerW: number
 ): string[] {
-  const words = title.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) {
+  const tokens = hasCjk(title)
+    ? tokenize(title)
+    : title.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
     return [""];
   }
+  const join = hasCjk(title) ? joinTokens : (t: string[]) => t.join(" ");
   const budget = titleTextBudgetWidthPx(innerW);
   const rows: string[] = [];
   let start = 0;
-  while (start < words.length) {
+  while (start < tokens.length) {
     let end = start;
-    for (let j = start + 1; j <= words.length; j++) {
-      const candidate = words.slice(start, j).join(" ");
+    for (let j = start + 1; j <= tokens.length; j++) {
+      const candidate = join(tokens.slice(start, j));
       if (
         approxLineWidthPx(candidate, fontSize, TITLE_LONG_LINE_EM) *
           TITLE_RENDER_SAFETY <=
@@ -155,10 +255,10 @@ function greedyWordsToTitleRows(
       }
     }
     if (end === start) {
-      rows.push(words[start]);
+      rows.push(tokens[start]);
       start += 1;
     } else {
-      rows.push(words.slice(start, end).join(" "));
+      rows.push(join(tokens.slice(start, end)));
       start = end;
     }
   }
@@ -237,7 +337,11 @@ function splitTitleIntoBalancedLines(
   innerW: number,
   targetLines: number
 ): string[] | null {
-  const words = title.trim().split(/\s+/).filter(Boolean);
+  const cjk = hasCjk(title);
+  const words = cjk
+    ? tokenize(title)
+    : title.trim().split(/\s+/).filter(Boolean);
+  const join = cjk ? joinTokens : (t: string[]) => t.join(" ");
   const n = words.length;
   if (targetLines < 1 || targetLines > n) return null;
   const budget = titleTextBudgetWidthPx(innerW);
@@ -248,7 +352,7 @@ function splitTitleIntoBalancedLines(
   for (let i = 0; i < n; i++) {
     let line = "";
     for (let j = i; j < n; j++) {
-      line = line ? `${line} ${words[j]}` : words[j];
+      line = join(words.slice(i, j + 1));
       const w =
         approxLineWidthPx(line, fontSize, TITLE_LONG_LINE_EM) *
         TITLE_RENDER_SAFETY;
@@ -302,7 +406,7 @@ function splitTitleIntoBalancedLines(
   for (let k = targetLines; k >= 1; k--) {
     const start = prev[k][end];
     if (start < 0) return null;
-    out.push(words.slice(start, end).join(" "));
+    out.push(join(words.slice(start, end)));
     end = start;
   }
   out.reverse();
@@ -385,6 +489,7 @@ function fitTitleLayoutLongAtLineCount(
 function isLongTitle(title: string): boolean {
   const t = title.trim();
   if (t.length > 105) return true;
+  if (hasCjk(t) && effectiveCharCount(t, ANALOG_CHAR_EM) > 105 / ANALOG_CHAR_EM) return true;
   const words = t.split(/\s+/).filter(Boolean);
   return words.length > 14;
 }
@@ -393,6 +498,7 @@ function isLongTitle(title: string): boolean {
 function isShortTitle(title: string): boolean {
   const t = title.trim();
   if (!t) return false;
+  if (hasCjk(t)) return false;
   const words = t.split(/\s+/).filter(Boolean);
   return words.length <= 3 && t.length <= 36;
 }

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -489,7 +489,7 @@ function fitTitleLayoutLongAtLineCount(
 function isLongTitle(title: string): boolean {
   const t = title.trim();
   if (t.length > 105) return true;
-  if (hasCjk(t) && effectiveCharCount(t, ANALOG_CHAR_EM) > 105 / ANALOG_CHAR_EM) return true;
+  if (hasCjk(t) && effectiveCharCount(t, ANALOG_CHAR_EM) > 105) return true;
   const words = t.split(/\s+/).filter(Boolean);
   return words.length > 14;
 }

--- a/lib/mdx-page.ts
+++ b/lib/mdx-page.ts
@@ -41,6 +41,55 @@ export async function loadPage(
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
+ * Titles that are too generic to stand alone in an OG image (no parent context).
+ * When one of these is the page title and there is a slug parent segment or
+ * section title available, we enrich it automatically for the OG card.
+ */
+const GENERIC_TITLES = new Set([
+  "overview",
+  "get started",
+  "concepts",
+  "core concepts",
+  "data model",
+  "troubleshooting and faq",
+  "troubleshooting & faq",
+  "mcp server",
+]);
+
+const SLUG_WORD_OVERRIDES: Record<string, string> = {
+  api: "API",
+  sdk: "SDK",
+  faq: "FAQ",
+  llm: "LLM",
+  mcp: "MCP",
+  ui: "UI",
+};
+
+function slugSegmentToTitle(segment: string): string {
+  return segment
+    .split("-")
+    .map((w) => SLUG_WORD_OVERRIDES[w.toLowerCase()] ?? w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function enrichOgTitle(title: string, slug: string[], sectionTitle: string): string {
+  const lower = title.toLowerCase().trim();
+  if (!GENERIC_TITLES.has(lower)) return title;
+
+  let context: string;
+  if (slug.length >= 2) {
+    context = slugSegmentToTitle(slug[slug.length - 2]);
+  } else if (slug.length === 0) {
+    context = "Langfuse";
+  } else {
+    context = sectionTitle;
+  }
+
+  if (lower === "get started") return `Get Started with ${context}`;
+  return `${context} ${title}`;
+}
+
+/**
  * Builds Next.js Metadata for a section page.
  *
  * `opts.canonicalFallback` is consulted *after* `pageData.canonical` but *before*
@@ -61,8 +110,9 @@ export function buildSectionMetadata(
   const canonicalUrl =
     pageData.canonical ?? opts?.canonicalFallback ?? buildPageUrl(pagePath);
   const seoTitle = pageData.seoTitle || page.data.title;
+  const ogTitle = pageData.seoTitle ? seoTitle : enrichOgTitle(seoTitle, slug, sectionTitle);
   const ogImage = buildOgImageUrl({
-    title: seoTitle,
+    title: ogTitle,
     description: page.data.description,
     section: sectionTitle,
     staticOgImage: pageData.ogImage,

--- a/lib/mdx-page.ts
+++ b/lib/mdx-page.ts
@@ -109,10 +109,10 @@ export function buildSectionMetadata(
   const pagePath = `/${section}${slug.length > 0 ? `/${slug.join("/")}` : ""}`;
   const canonicalUrl =
     pageData.canonical ?? opts?.canonicalFallback ?? buildPageUrl(pagePath);
-  const seoTitle = pageData.seoTitle || page.data.title;
-  const ogTitle = pageData.seoTitle ? seoTitle : enrichOgTitle(seoTitle, slug, sectionTitle);
+  const rawTitle = pageData.seoTitle || page.data.title;
+  const seoTitle = pageData.seoTitle ? rawTitle : enrichOgTitle(rawTitle, slug, sectionTitle);
   const ogImage = buildOgImageUrl({
-    title: ogTitle,
+    title: seoTitle,
     description: page.data.description,
     section: sectionTitle,
     staticOgImage: pageData.ogImage,

--- a/lib/mdx-page.ts
+++ b/lib/mdx-page.ts
@@ -109,10 +109,10 @@ export function buildSectionMetadata(
   const pagePath = `/${section}${slug.length > 0 ? `/${slug.join("/")}` : ""}`;
   const canonicalUrl =
     pageData.canonical ?? opts?.canonicalFallback ?? buildPageUrl(pagePath);
-  const rawTitle = pageData.seoTitle || page.data.title;
-  const seoTitle = pageData.seoTitle ? rawTitle : enrichOgTitle(rawTitle, slug, sectionTitle);
+  const seoTitle = pageData.seoTitle || page.data.title;
+  const ogTitle = pageData.seoTitle ? seoTitle : enrichOgTitle(seoTitle, slug, sectionTitle);
   const ogImage = buildOgImageUrl({
-    title: seoTitle,
+    title: ogTitle,
     description: page.data.description,
     section: sectionTitle,
     staticOgImage: pageData.ogImage,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes LFE-9532 — two OG image issues.

## Issue 1: CJK line break broken

**Before:** Japanese titles like "Langfuse Cloud 日本リージョンを開始しました" were crammed onto a single line that overflowed, because the width estimator treated CJK characters (~1em wide) identically to Latin characters (~0.48em).

**After:** The title correctly wraps into two lines.

**Changes in `app/api/og/route.tsx`:**
- Added `isCjkOrFullWidth()` to detect CJK/full-width Unicode codepoints (Hiragana, Katakana, CJK ideographs, Hangul, etc.)
- Added `effectiveCharCount()` that weighs CJK characters at `1.0 / em` units instead of 1, making `approxLineWidthPx()` accurate for mixed-script text
- Added `tokenize()` to split CJK text at individual character boundaries (since CJK text often has no whitespace between words)
- Added `joinTokens()` to reconstruct display text with proper spacing between token types
- Updated `splitTwoLinesByWidth`, `splitTwoLines`, `greedyWordsToTitleRows`, and `splitTitleIntoBalancedLines` to use CJK-aware tokenization
- CJK titles are no longer classified as "short" (which forced single-line layout)

[Japanese OG image - properly line-wrapped](https://cursor.com/agents/bc-954c22ec-41b3-4ebd-b489-8d39e65f0b52/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fog-japan.png)

## Issue 2: Generic OG titles not descriptive enough

**Before:** Pages like `/docs/prompt-management/get-started` showed just "Get Started" in the OG image, and `/docs` showed just "Overview" — not meaningful in social shares.

**After:** Generic titles are automatically enriched with parent folder context:
- "Get Started" → "Get Started with Prompt Management"
- "Overview" (at `/docs`) → "Langfuse Overview"  
- "Overview" (at `/docs/metrics/overview`) → "Metrics Overview"
- "Troubleshooting and FAQ" → "Prompt Management Troubleshooting and FAQ"

Pages with explicit `seoTitle` frontmatter are not affected.

**Changes in `lib/mdx-page.ts`:**
- Added `GENERIC_TITLES` set of titles that need enrichment
- Added `slugSegmentToTitle()` to convert slug segments to title case (with known abbreviation overrides for API, SDK, FAQ, LLM, MCP, UI)
- Added `enrichOgTitle()` that prepends parent context for generic titles
- `buildSectionMetadata()` now uses enriched titles for OG images only (the page `<title>` tag is unchanged)

[Get Started OG image - enriched title](https://cursor.com/agents/bc-954c22ec-41b3-4ebd-b489-8d39e65f0b52/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fog-get-started.png)

[Langfuse Overview OG image](https://cursor.com/agents/bc-954c22ec-41b3-4ebd-b489-8d39e65f0b52/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fog-langfuse-overview.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9532](https://linear.app/langfuse/issue/LFE-9532/og-issues-round-2)

<div><a href="https://cursor.com/agents/bc-954c22ec-41b3-4ebd-b489-8d39e65f0b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-954c22ec-41b3-4ebd-b489-8d39e65f0b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes two OG image issues: CJK text (Japanese/Korean/Chinese) now wraps correctly via a new `isCjkOrFullWidth` detector, `effectiveCharCount` width estimator, and `tokenize`/`joinTokens` helpers; and generic page titles like "Overview" or "Get Started" are automatically enriched with parent-slug context via `enrichOgTitle` in `lib/mdx-page.ts`, leaving the page `<title>` tag unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found; only minor style inconsistencies flagged.

All P2 findings. The raw-length check in splitTwoLines is harmless because the pixel-budget check in tryTwoLineLayout catches any oversized candidates, and the primary splitTwoLinesByWidth path handles CJK correctly. The enrichOgTitle changes are isolated to OG metadata only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/og/route.tsx | Adds CJK-aware tokenization, width estimation, and line-splitting helpers; correctly excludes CJK titles from the short single-line fast path. Minor inconsistency in splitTwoLines (raw .length check, not effectiveCharCount) and redundant hasCjk call in greedyWordsToTitleRows; both are functionally harmless but worth cleaning up. |
| lib/mdx-page.ts | Adds enrichOgTitle to prepend parent-slug context to generic page titles (Overview, Get Started, etc.) in OG images only; page title tag is unchanged. Logic is straightforward and the seoTitle guard correctly bypasses enrichment when an explicit override exists. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fitTitleLayout] -->|isLongTitle?| B[fitTitleLayoutLong]
    A -->|isShortTitle?| C[fitTitleLayoutSingleLine]
    A --> D[splitTwoLinesByWidth\nCJK-aware pixel budget]
    A --> E[splitTwoLines\nchar budget fallback]
    A --> F[wrapWords\nchar-cap fallback]
    D --> G{tryTwoLineLayout\ntitleLinesFitRenderConstraints}
    E --> G
    F --> G
    subgraph CJK helpers
        H[hasCjk]
        I[tokenize\nper-char for CJK]
        J[joinTokens\nno space CJK-CJK]
        K[effectiveCharCount\n1/em units for CJK]
        L[approxLineWidthPx\nuses effectiveCharCount]
    end
    D --> I
    E --> I
    I --> J
    L --> K
    subgraph OG title enrichment
        M[buildSectionMetadata] --> N{pageData.seoTitle?}
        N -->|yes| O[use seoTitle as-is]
        N -->|no| P[enrichOgTitle]
        P --> Q{GENERIC_TITLES match?}
        Q -->|no| R[return title unchanged]
        Q -->|yes| S{slug.length}
        S -->|>=2| T[slugSegmentToTitle slug at -2]
        S -->|0| U[Langfuse prefix]
        S -->|1| V[sectionTitle prefix]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: app/api/og/route.tsx
Line: 158-178

Comment:
**`splitTwoLines` budget check ignores CJK width for mixed-script text**

The PR updated `splitTwoLines` to tokenize CJK text correctly, but the `l1.length <= maxCharsPerLine` guard still uses raw character count rather than `effectiveCharCount`. Since `maxCharsPerLine` is derived from pixel budget ÷ `ANALOG_CHAR_EM` (0.48), a CJK line of 18 raw characters would pass the guard while consuming roughly 2× the intended pixel budget (each CJK character is `1/0.48 ≈ 2.08×` the nominal char width). The downstream `tryTwoLineLayout` → `titleLinesFitRenderConstraints` will correctly reject these candidates, so correctness is preserved, but every CJK-tokenized split this function produces will be a false positive when font sizes are explored.

```suggestion
    if (
      effectiveCharCount(l1, ANALOG_CHAR_EM) <= maxCharsPerLine &&
      effectiveCharCount(l2, ANALOG_CHAR_EM) <= maxCharsPerLine
    ) {
      const imbalance = Math.abs(
        effectiveCharCount(l1, ANALOG_CHAR_EM) -
        effectiveCharCount(l2, ANALOG_CHAR_EM)
      );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: app/api/og/route.tsx
Line: 233-239

Comment:
**`hasCjk(title)` called twice**

`hasCjk(title)` is invoked on lines 233 and 239 — the result could be cached once into a local variable to avoid iterating over the string twice.

```suggestion
  const cjk = hasCjk(title);
  const tokens = cjk
    ? tokenize(title)
    : title.trim().split(/\s+/).filter(Boolean);
  if (tokens.length === 0) {
    return [""];
  }
  const join = cjk ? joinTokens : (t: string[]) => t.join(" ");
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix isLongTitle CJK threshold: use 105 n..."](https://github.com/langfuse/langfuse-docs/commit/93b33484cff138b2d4d175d5a4107e2c9157cc2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29981512)</sub>

<!-- /greptile_comment -->