### PR TITLE
feat: add .well-known/mcp.json discovery file

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -183,6 +183,14 @@ const nextConfig = {
           { key: "Cache-Control", value: "public, max-age=3600" },
         ],
       },
+      // MCP Discovery — CORS and caching
+      {
+        source: "/.well-known/mcp.json",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Cache-Control", value: "public, max-age=3600" },
+        ],
+      },
       // Mark markdown endpoints as noindex and ensure correct content type
       {
         source: "/:path*.md",

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "langfuse-docs": {
+      "url": "https://langfuse.com/api/mcp",
+      "transport": "streamable-http",
+      "description": "Search Langfuse documentation, fetch individual doc pages, and get a high-level overview of Langfuse.",
+      "tools": [
+        "searchLangfuseDocs",
+        "getLangfuseDocsPage",
+        "getLangfuseOverview"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `public/.well-known/mcp.json` so agent tooling can auto-discover the Langfuse docs MCP server (`/api/mcp`)
- Add CORS (`Access-Control-Allow-Origin: *`) and cache (`max-age=3600`) headers for the discovery endpoint in `next.config.mjs`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a `public/.well-known/mcp.json` discovery file so agent tooling can auto-discover the Langfuse docs MCP server, and wires up the corresponding CORS and cache headers in `next.config.mjs`. The `next.config.mjs` change is clean and correctly mirrors the existing `/.well-known/agent-skills` header pattern. The main open question is whether the `mcpServers` JSON structure (Claude Desktop config format) matches what the target agent tooling actually parses from a `.well-known` discovery endpoint.

<h3>Confidence Score: 4/5</h3>

Safe to merge with low risk; only concern is format compatibility with MCP discovery consumers

Only P2 findings present — the discovery JSON format may not match the SEP-1649 server card spec, but this is not a breaking runtime error and does not affect the rest of the site

public/.well-known/mcp.json — verify the JSON structure against the discovery format expected by target agent tooling

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/.well-known/mcp.json | New MCP discovery file using the Claude Desktop `mcpServers` config format, which may not match the SEP-1649 server card specification expected by other agent tooling |
| next.config.mjs | Adds CORS (`Access-Control-Allow-Origin: *`) and cache (`max-age=3600`) headers for `/.well-known/mcp.json`, following the identical pattern already in place for `/.well-known/agent-skills/:path*` |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AgentTool as Agent Tooling
    participant DocsServer as langfuse.com (Next.js)
    participant MCPServer as langfuse.com/api/mcp

    AgentTool->>DocsServer: GET /.well-known/mcp.json
    DocsServer-->>AgentTool: 200 OK (mcp.json, CORS *, Cache max-age=3600)
    Note over AgentTool: Parse mcpServers config
    AgentTool->>MCPServer: Connect via Streamable HTTP
    MCPServer-->>AgentTool: MCP tools (searchLangfuseDocs, getLangfuseDocsPage, getLangfuseOverview)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: public/.well-known/mcp.json
Line: 2-13

Comment:
**Format may not match emerging MCP discovery standard**

The `mcpServers` key/structure here mirrors the Claude Desktop local config format (`claude_desktop_config.json`), not the SEP-1649 "MCP Server Card" proposal that defines `.well-known/mcp.json` discovery. The server card spec (SEP-1649) requires top-level fields like `$schema`, `version`, `protocolVersion`, `serverInfo` (with `name`/`version`), and a `transport` object, rather than a `mcpServers` map. Agent tooling that follows the server card spec will silently ignore this file. Verify which format(s) your target consumers expect; you may need to support both or restructure to the server card layout.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add .well-known/mcp.json discovery..."](https://github.com/langfuse/langfuse-docs/commit/41f7d61dbb89572cfd2fbc08c83834023781be62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29966147)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->