### PR TITLE
docs(integrations): add Asqav (signed agent audit trails) to frameworks

### DIFF
--- a/content/integrations/frameworks/asqav.mdx
+++ b/content/integrations/frameworks/asqav.mdx
@@ -1,0 +1,118 @@
+---
+title: Use Asqav with Langfuse for Signed Agent Audit Trails
+sidebarTitle: Asqav
+description: Asqav adds cryptographic, tamper-evident audit records to agent actions. Use it alongside Langfuse so the trace you debug with and the record you hand to an auditor stay linked by trace_id.
+category: Integrations
+---
+
+# Use Asqav with Langfuse
+
+This page shows how to combine [Asqav](https://asqav.com) with Langfuse so the trace you use to debug an agent and the audit record you hand to a regulator stay linked by a shared `trace_id`.
+
+> **What is Asqav?** [Asqav](https://github.com/asqav/asqav-sdk) is an AI agent governance layer that produces signed, tamper-evident audit records for agent actions. Each call to `agent.sign(...)` returns a verification URL backed by an ML-DSA (post-quantum) signature. By default the SDK runs in hash-only mode, so prompts and tool inputs are hashed locally and only the digest plus metadata is sent to Asqav. The default deployment is GDPR-aware data minimization and is designed to support EU AI Act reporting obligations.
+
+> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source LLM engineering platform. It captures traces, prompts, completions, evaluations, and scores so you can debug and improve your AI application.
+
+## When to use them together
+
+Langfuse and Asqav answer different questions about the same agent run:
+
+- **Langfuse** answers *"what did this run look like, and how good was it?"* It stores the prompt, completion, latency, cost, and any evals or scores you attach.
+- **Asqav** answers *"can I prove to an external auditor that this action happened, who initiated it, and that the record has not been altered?"* It stores a hash of the action, signed with the agent's key, plus a small set of metadata fields.
+
+They are not replacements for each other. A common pattern is to keep Langfuse as the day-to-day observability surface and use Asqav as the immutable audit log that an auditor or risk team can verify independently.
+
+## The pattern
+
+In your application code you call both tools in the same function and pass the same `trace_id` to each. Asqav exposes `asqav.generate_trace_id()` so you can mint a deterministic ID once and reuse it on the Langfuse span.
+
+<Steps>
+### Step 1: Install Dependencies
+
+```python
+%pip install langfuse asqav -q
+```
+
+### Step 2: Configure Credentials
+
+```python
+import os
+
+# Langfuse
+os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
+os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"
+
+# Asqav
+os.environ["ASQAV_API_KEY"] = "ak_..."
+```
+
+### Step 3: Initialize Both Clients
+
+```python
+import asqav
+from langfuse import get_client, observe
+
+asqav.init()  # picks up ASQAV_API_KEY from env
+agent = asqav.Agent.create(
+    "research-agent",
+    capabilities=["read:web", "summarize"],
+)
+
+langfuse = get_client()
+```
+
+### Step 4: Wrap a Function with Both
+
+```python
+@observe(name="answer-question")
+def answer_question(question: str) -> str:
+    trace_id = asqav.generate_trace_id()
+
+    # Tag the Langfuse trace so it can be cross-referenced.
+    langfuse.update_current_trace(metadata={"asqav_trace_id": trace_id})
+
+    # ... your LLM call here, e.g. via OpenAI, LangChain, etc. ...
+    answer = "42"
+
+    # Sign the action. By default only a hash of the context is sent.
+    receipt = agent.sign(
+        "answer:question",
+        context={"question": question, "answer": answer},
+        trace_id=trace_id,
+    )
+    return answer
+
+answer_question("What is the meaning of life?")
+langfuse.flush()
+```
+
+### Step 5: Verify Independently
+
+The `receipt` returned by `agent.sign(...)` includes a verification URL. An auditor or third party can hit that URL, recompute the hash from the canonical record, and check the signature against the agent's published public key without ever needing access to your Langfuse project.
+
+```python
+from asqav import verify_signature
+
+verify_signature(receipt)  # True if the record has not been altered
+```
+</Steps>
+
+## What gets stored where
+
+| Surface | Holds | Used by |
+| --- | --- | --- |
+| Langfuse | trace, prompt, completion, latency, cost, evals, scores | engineers debugging the agent |
+| Asqav | hash of the action, agent ID, action type, signature, timestamp, optional `trace_id` | auditors, risk and compliance teams |
+
+The `trace_id` you put on both sides is the join key. If a regulator asks for evidence of a specific signed action, you hand them the Asqav verification URL; if you need to look up the prompt and completion behind that action, you search Langfuse for the same `trace_id`.
+
+## Resources
+
+- [Asqav SDK on GitHub](https://github.com/asqav/asqav-sdk)
+- [Asqav on PyPI](https://pypi.org/project/asqav/)
+- [Asqav docs](https://asqav.com/docs)
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />

--- a/content/integrations/frameworks/asqav.mdx
+++ b/content/integrations/frameworks/asqav.mdx
@@ -9,7 +9,7 @@ category: Integrations
 
 This page shows how to combine [Asqav](https://asqav.com) with Langfuse so the trace you use to debug an agent and the audit record you hand to a regulator stay linked by a shared `trace_id`.
 
-> **What is Asqav?** [Asqav](https://github.com/asqav/asqav-sdk) is an AI agent governance layer that produces signed, tamper-evident audit records for agent actions. Each call to `agent.sign(...)` returns a verification URL backed by an ML-DSA (post-quantum) signature. By default the SDK runs in hash-only mode, so prompts and tool inputs are hashed locally and only the digest plus metadata is sent to Asqav. The default deployment is GDPR-aware data minimization and is designed to support EU AI Act reporting obligations.
+> **What is Asqav?** [Asqav](https://github.com/jagmarques/asqav-sdk) is an AI agent governance layer that produces signed, tamper-evident audit records for agent actions. Each call to `agent.sign(...)` returns a verification URL backed by an ML-DSA (post-quantum) signature. By default the SDK runs in hash-only mode, so prompts and tool inputs are hashed locally and only the digest plus metadata is sent to Asqav. The default deployment is GDPR-aware data minimization and is designed to support EU AI Act reporting obligations.
 
 > **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source LLM engineering platform. It captures traces, prompts, completions, evaluations, and scores so you can debug and improve your AI application.
 
@@ -109,7 +109,7 @@ The `trace_id` you put on both sides is the join key. If a regulator asks for ev
 
 ## Resources
 
-- [Asqav SDK on GitHub](https://github.com/asqav/asqav-sdk)
+- [Asqav SDK on GitHub](https://github.com/jagmarques/asqav-sdk)
 - [Asqav on PyPI](https://pypi.org/project/asqav/)
 - [Asqav docs](https://asqav.com/docs)
 

--- a/content/integrations/frameworks/meta.json
+++ b/content/integrations/frameworks/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "agno-agents",
     "amazon-agentcore",
+    "asqav",
     "autogen",
     "beeai",
     "claude-agent-sdk",


### PR DESCRIPTION
Adds Asqav as a frameworks integration page.

Asqav (https://asqav.com) is an AI agent governance layer that produces signed, tamper-evident audit records for agent actions. The page positions Asqav as a complement to Langfuse, not a replacement: Langfuse holds the trace, prompts, completions, and scores; Asqav holds a signed record that can be verified by an external auditor. The example shows both tools coexisting in one Python function with a shared `trace_id`.

The MDX matches the structure of recent framework pages (`crewai.mdx`, `pydantic-ai.mdx`, `openai-agents.mdx`). Sidebar registration done in `content/integrations/frameworks/meta.json` (alphabetical between `amazon-agentcore` and `autogen`). No new image asset was added; `logo` is optional in the schema.

## Test plan
- [ ] Fumadocs/Next.js build succeeds with the new file
- [ ] Sidebar order is correct in `Frameworks`
- [ ] Anchors and code blocks render correctly

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a new `asqav.mdx` framework integration page showing how Asqav's signed audit trails and Langfuse traces can be linked by a shared `trace_id`, and registers the page alphabetically in `meta.json`. The structure and writing style match existing framework pages well.

- Two links point to `https://github.com/asqav/asqav-sdk` (lines 12 and 112), but the actual repository is `https://github.com/jagmarques/asqav-sdk` — both will 404 for readers.
- The closing explanation says to \"search Langfuse for the same `trace_id`\", but the Asqav ID is stored as `metadata.asqav_trace_id` rather than as Langfuse's native trace ID; a small wording fix would prevent confusion.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two documentation links will 404 for all readers.

Two P1 findings (identical broken GitHub URL in two places) hold the score below 4. The remaining issues are P2 (import style, text clarity) and would not block on their own.

content/integrations/frameworks/asqav.mdx — fix the GitHub repository URLs on lines 12 and 112.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/integrations/frameworks/asqav.mdx | New integration page for Asqav; contains two broken GitHub links pointing to `asqav/asqav-sdk` instead of the correct `jagmarques/asqav-sdk`, and a mildly misleading cross-referencing description for the shared trace_id. |
| content/integrations/frameworks/meta.json | Adds "asqav" to the sidebar pages list in correct alphabetical position between "amazon-agentcore" and "autogen". |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant LF as Langfuse (@observe)
    participant Asqav as Asqav SDK

    App->>LF: @observe wraps answer_question()
    App->>Asqav: asqav.generate_trace_id()
    Asqav-->>App: trace_id (shared key)
    App->>LF: update_current_trace(metadata={asqav_trace_id: trace_id})
    App->>App: LLM call (OpenAI, LangChain, etc.)
    App->>Asqav: agent.sign(action, context, trace_id)
    Asqav-->>App: receipt (signature_id, verify_url)
    App->>LF: flush() — trace stored with asqav_trace_id in metadata
    Note over LF,Asqav: Linked by trace_id — debug in Langfuse, audit via Asqav verify_url
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: content/integrations/frameworks/asqav.mdx
Line: 12

Comment:
**Incorrect GitHub URL for Asqav SDK**

The link `https://github.com/asqav/asqav-sdk` will 404. Based on the PyPI package metadata, the `asqav.com` homepage, and the PR author's profile, the actual repository is at `https://github.com/jagmarques/asqav-sdk`.

```suggestion
> **What is Asqav?** [Asqav](https://github.com/jagmarques/asqav-sdk) is an AI agent governance layer that produces signed, tamper-evident audit records for agent actions. Each call to `agent.sign(...)` returns a verification URL backed by an ML-DSA (post-quantum) signature. By default the SDK runs in hash-only mode, so prompts and tool inputs are hashed locally and only the digest plus metadata is sent to Asqav. The default deployment is GDPR-aware data minimization and is designed to support EU AI Act reporting obligations.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/integrations/frameworks/asqav.mdx
Line: 112

Comment:
**Same incorrect GitHub URL in Resources**

Same broken link as in the blockquote above — the repository owner is `jagmarques`, not `asqav`.

```suggestion
- [Asqav SDK on GitHub](https://github.com/jagmarques/asqav-sdk)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/integrations/frameworks/asqav.mdx
Line: 94-98

Comment:
**Import placement and missing context**

Per the project's style guide, imports should be at the top of the module rather than scattered across separate steps. The `from asqav import verify_signature` here is also in a separate code block from the Step 3 imports, which means `receipt` (defined in Step 4) is undefined if a reader runs this cell standalone.

Consider consolidating the import into Step 3 and adding a note that `receipt` comes from the previous step, or add `verify_signature` to the Step 3 imports and just call it here without re-importing.

**Rule Used:** Move imports to the top of the module instead of p... ([source](https://app.greptile.com/review/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: content/integrations/frameworks/asqav.mdx
Line: 108

Comment:
**"Search Langfuse for the same `trace_id`" is misleading**

The Asqav-generated `trace_id` is stored in Langfuse as `metadata.asqav_trace_id`, not as Langfuse's native trace ID (which is auto-generated by `@observe`). Telling readers to "search Langfuse for the same `trace_id`" implies a direct ID lookup that won't work — they'd actually filter by metadata.

```suggestion
The `trace_id` you put on both sides is the join key. If a regulator asks for evidence of a specific signed action, you hand them the Asqav verification URL; if you need to look up the prompt and completion behind that action, you filter the Langfuse Trace Table by `metadata.asqav_trace_id` matching that value.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(integrations): add Asqav (signed ag..."](https://github.com/langfuse/langfuse-docs/commit/f751bfb4bdbfa656c8c0c9414f86446e915413a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30092049)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->