### PR TITLE
pricing: add JP and HIPAA data regions

### DIFF
--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -50,7 +50,7 @@ const faqs: FAQItem[] = [
   {
     question: "Where is the data stored?",
     answer:
-      "Langfuse Cloud is hosted on AWS and data is stored in the US or EU depending on your selection. See our [security and privacy documentation](/security) for more details.",
+      "Langfuse Cloud is hosted on AWS and data is stored in the US, EU, or Japan depending on your selection. Enterprise customers can also choose a HIPAA-compliant US region. See our [security and privacy documentation](/security) for more details.",
   },
   {
     question: "I have security questions, where to start?",

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -1013,10 +1013,10 @@ const sections: Section[] = [
         href: "/security/data-regions",
         tiers: {
           cloud: {
-            Hobby: "US or EU",
-            Core: "US or EU",
-            Pro: "US or EU",
-            Enterprise: "US or EU",
+            Hobby: "US, EU, or JP",
+            Core: "US, EU, or JP",
+            Pro: "US, EU, or JP",
+            Enterprise: "US, EU, JP, or HIPAA",
           },
         },
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Data Region row on the pricing page to include Japan (JP) and HIPAA alongside the existing US and EU options.

**Changes:**
- `PricingTable.tsx`: Updated "Data region" feature row — Hobby/Core/Pro now show "US, EU, or JP"; Enterprise now shows "US, EU, JP, or HIPAA"
- `PricingFAQ.tsx`: Updated the "Where is the data stored?" FAQ answer to mention US, EU, Japan, and the HIPAA-compliant region for Enterprise customers

The `md-override/pricing.md` already had the correct values; this brings the React component in sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-334f7947-35ed-4d32-91ad-c9a5d11953cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-334f7947-35ed-4d32-91ad-c9a5d11953cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR updates the pricing page to reflect the addition of Japan (JP) and a HIPAA-compliant US region as available data regions. Both `PricingTable.tsx` and `PricingFAQ.tsx` are updated to bring the React components in sync with the already-correct `md-override/pricing.md`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are purely copy/content updates with no logic or functional impact.

Only a P2 style suggestion present. The FAQ wording is clear and correct; the minor label inconsistency in the table (HIPAA alongside geographic region codes) is non-blocking.

No files require special attention beyond the P2 suggestion on PricingTable.tsx line 1019.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/home/pricing/PricingTable.tsx | Adds JP to Hobby/Core/Pro data region and JP + HIPAA to Enterprise; HIPAA label may be misleading alongside geographic region codes |
| components/home/pricing/PricingFAQ.tsx | FAQ answer correctly updated to mention US, EU, Japan, and HIPAA-compliant US region for Enterprise — clear and accurate |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Pricing Page] --> B[PricingTable.tsx]
    A --> C[PricingFAQ.tsx]
    B --> D["Data Region Row"]
    D --> E["Hobby / Core / Pro\nUS, EU, or JP"]
    D --> F["Enterprise\nUS, EU, JP, or HIPAA"]
    C --> G["'Where is data stored?' FAQ"]
    G --> H["All plans: US, EU, or Japan"]
    G --> I["Enterprise: + HIPAA-compliant US region"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/home/pricing/PricingTable.tsx:1019
**HIPAA listed alongside geographic regions**

`HIPAA` is a compliance standard rather than a geographic region, so mixing it with `US`, `EU`, and `JP` in the same comma-separated list could confuse users into thinking it is a fourth location. The FAQ handles this more clearly by calling it a "HIPAA-compliant US region." Consider aligning the table label to avoid ambiguity.

```suggestion
            Enterprise: "US, EU, JP, or HIPAA (US)",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pricing: add JP and HIPAA data regions t..."](https://github.com/langfuse/langfuse-docs/commit/dd8258ae74da4fac96e96f5561a737ce172ee5cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30675775)</sub>

<!-- /greptile_comment -->