### PR TITLE
Use anchor links for logo context menu downloads and add PNG/SVG brand assets

### DIFF
--- a/components/LogoContextMenu.tsx
+++ b/components/LogoContextMenu.tsx
@@ -12,51 +12,47 @@ const LogoContextMenu: React.FC<{
   open: boolean;
   setOpen: (open: boolean) => void;
 }> = ({ open, setOpen }) => {
-  const handleAction = (
-    e: React.MouseEvent,
-    url: string,
-    isDownload: boolean
-  ) => {
-    e.preventDefault();
-
-    if (isDownload) {
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = url.split("/").pop() || ""; // Get filename from URL
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } else {
-      window.open(url, "_blank", "noopener,noreferrer");
-    }
-  };
-
   return (
     <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
       <DropdownMenuTrigger />
       <DropdownMenuPortal>
         <DropdownMenuContent className="min-w-[180px]">
-          <DropdownMenuItem
-            onClick={(e) => handleAction(e, "/langfuse-icon.svg", true)}
-            className="cursor-pointer"
-          >
-            <Download size={14} className="shrink-0" />
-            Langfuse Icon
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <a href="/brand-assets/icon/color/langfuse-icon.png" download>
+              <Download size={14} className="shrink-0" />
+              Langfuse Icon (png)
+            </a>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={(e) => handleAction(e, "/langfuse-wordart.svg", true)}
-            className="cursor-pointer"
-          >
-            <Download size={14} className="shrink-0" />
-            Langfuse Wordmark
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <a href="/brand-assets/icon/color/langfuse-icon.svg" download>
+              <Download size={14} className="shrink-0" />
+              Langfuse Icon (svg)
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <a
+              href="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.png"
+              download
+            >
+              <Download size={14} className="shrink-0" />
+              Langfuse Logo (png)
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <a
+              href="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.svg"
+              download
+            >
+              <Download size={14} className="shrink-0" />
+              Langfuse Logo (svg)
+            </a>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={(e) => handleAction(e, "/brand", false)}
-            className="cursor-pointer"
-          >
-            <ExternalLink size={14} className="shrink-0" />
-            Brand Assets & Guide
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <a href="/brand" target="_blank" rel="noopener noreferrer">
+              <ExternalLink size={14} className="shrink-0" />
+              Brand Assets & Guide
+            </a>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenuPortal>


### PR DESCRIPTION
### Motivation
- Replace custom JS download/open logic with native anchor links for simpler, more accessible downloads and external navigation.
- Expose both PNG and SVG variants of the icon and wordmark so users can download the preferred format.

### Description
- Removed the programmatic `handleAction` click handler and replaced menu item actions with `DropdownMenuItem asChild` wrapping `<a>` tags using `download` or `target="_blank" rel="noopener noreferrer"` for external links.
- Added PNG and SVG entries for the Langfuse icon and wordmark pointing to the `/brand-assets/...` paths and updated visible labels to indicate format.
- Preserved the external "Brand Assets & Guide" item while switching it to an anchor link for safer navigation.

### Testing
- Ran project build and type-check (`npm run build` and `npm run typecheck`) and they completed successfully.
- No automated unit tests were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8b91f9b0c832f8f54c3b685845846)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces the programmatic `handleAction` click handler in `LogoContextMenu` with native `<a>` anchor tags using the `download` attribute and `target="_blank"`, and expands the menu to include separate PNG and SVG entries for both the icon and wordmark. All referenced asset paths (`/brand-assets/icon/color/langfuse-icon.{png,svg}` and `/brand-assets/wordmark/Langfuse/light/langfuse-wordart.{png,svg}`) exist in `public/`. The change is straightforward and the Radix `asChild` pattern used here is correct.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a clean simplification with all asset paths verified to exist.

No P0 or P1 issues found. One P2 suggestion about missing dark/monochrome wordmark entries. All paths resolve to existing files in public/.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/LogoContextMenu.tsx | Replaces programmatic download handler with native anchor links; adds PNG/SVG variants for icon and wordmark. All referenced asset paths exist in public/. Minor omission: only light-theme wordmarks are exposed, dark/monochrome variants are available but not linked. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Menu as DropdownMenu
    participant AnchorLink as anchor tag
    participant Browser

    User->>Menu: Right-click logo
    Menu-->>User: Show context menu

    alt Download asset PNG or SVG
        User->>Menu: Click Langfuse Icon png/svg or Logo png/svg
        Menu->>AnchorLink: asChild delegates click to anchor with download attr
        AnchorLink->>Browser: Native download request for brand asset
        Browser-->>User: File saved to disk
    else Open Brand Guide
        User->>Menu: Click Brand Assets and Guide
        Menu->>AnchorLink: asChild delegates click to anchor with target blank
        AnchorLink->>Browser: Open /brand in new tab
        Browser-->>User: Brand page loaded in new tab
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/LogoContextMenu.tsx:32-48
**Light-only wordmark variants exposed**

The menu links exclusively to the `light/` wordmark variants (`langfuse-wordart.png` / `langfuse-wordart.svg`), but the repository already contains dark and monochrome equivalents (e.g. `public/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.png`). Users needing a dark-background-safe logo will have to navigate to the full brand guide instead of downloading directly — consider whether dark or monochrome entries should be added here as well.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(brand): use direct links in log..."](https://github.com/langfuse/langfuse-docs/commit/f13ad898025d8c1c7b9330c8c5389e919cef6ba2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30728635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->