### PR TITLE
style(demo): align example-project demos with site design tokens

### DIFF
--- a/components/ai-elements/actions.tsx
+++ b/components/ai-elements/actions.tsx
@@ -28,14 +28,14 @@ export const Action = ({
   children,
   label,
   className,
-  variant = "ghost",
-  size = "sm",
+  variant = "text",
+  size = "small",
   ...props
 }: ActionProps) => {
   const button = (
     <Button
       className={cn(
-        "size-9 p-1.5 text-muted-foreground hover:text-foreground",
+        "size-7 w-7 rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted/60",
         className
       )}
       size={size}

--- a/components/ai-elements/code-block.tsx
+++ b/components/ai-elements/code-block.tsx
@@ -152,10 +152,13 @@ export const CodeBlockCopyButton = ({
 
   return (
     <Button
-      className={cn('shrink-0', className)}
+      className={cn(
+        'shrink-0 size-7 w-7 rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted/60',
+        className,
+      )}
       onClick={copyToClipboard}
-      size="icon"
-      variant="ghost"
+      size="small"
+      variant="text"
       {...props}
     >
       {children ?? <Icon size={14} />}

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -44,19 +44,16 @@ export const ConversationScrollButton = ({
 
   return (
     !isAtBottom && (
-      <Button
+      <button
+        type="button"
+        onClick={handleScrollToBottom}
         className={cn(
-          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
+          "absolute bottom-4 left-[50%] translate-x-[-50%] inline-flex items-center justify-center size-8 rounded-[2px] border border-line-structure bg-[#403d391a] dark:bg-[#b8b6a01a] text-text-primary shadow-sm hover:bg-[#403d3926] dark:hover:bg-[#b8b6a026] hover:border-line-cta transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
           className,
         )}
-        onClick={handleScrollToBottom}
-        size="icon"
-        type="button"
-        variant="outline"
-        {...props}
       >
         <ArrowDownIcon className="size-4" />
-      </Button>
+      </button>
     )
   );
 };

--- a/components/ai-elements/response.tsx
+++ b/components/ai-elements/response.tsx
@@ -204,7 +204,10 @@ const components: Options["components"] = {
   ),
   a: ({ node, children, className, ...props }) => (
     <a
-      className={cn("font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 underline", className)}
+      className={cn(
+        "text-text-links decoration-text-links underline decoration-1 underline-offset-2 hover:text-primary hover:decoration-primary font-normal",
+        className
+      )}
       rel="noreferrer"
       target="_blank"
       {...props}
@@ -310,7 +313,7 @@ const components: Options["components"] = {
     return (
       <code
         className={cn(
-          "rounded bg-muted px-1.5 py-0.5 font-mono text-sm",
+          "rounded-[2px] bg-muted text-foreground px-1.5 py-0.5 font-mono text-[0.85em]",
           className
         )}
         {...props}
@@ -371,7 +374,7 @@ export const Response = memo(
     return (
       <div
         className={cn(
-          "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          "size-full text-sm text-text-secondary [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
           className
         )}
         {...props}

--- a/components/ai-elements/suggestion.tsx
+++ b/components/ai-elements/suggestion.tsx
@@ -32,8 +32,8 @@ export const Suggestion = ({
   suggestion,
   onClick,
   className,
-  variant = 'outline',
-  size = 'sm',
+  variant = 'secondary',
+  size = 'small',
   children,
   ...props
 }: SuggestionProps) => {
@@ -43,7 +43,7 @@ export const Suggestion = ({
 
   return (
     <Button
-      className={cn('cursor-pointer rounded-full px-4', className)}
+      className={cn('cursor-pointer rounded-[2px] px-3', className)}
       onClick={handleClick}
       size={size}
       type="button"

--- a/components/imageGenerator/index.tsx
+++ b/components/imageGenerator/index.tsx
@@ -134,7 +134,7 @@ export const ImageGenerator = ({
 
   return (
     <div className={cn("h-[62vh]", className)} {...props}>
-      <div className="flex flex-col h-full border border-border/40 rounded-2xl bg-gradient-to-br from-background via-background/95 to-muted/20 backdrop-blur-md shadow-xl shadow-black/10 dark:shadow-black/30 p-5 transition-all duration-300 hover:shadow-2xl hover:shadow-black/15 dark:hover:shadow-black/40 relative overflow-hidden before:absolute before:inset-0 before:bg-gradient-to-br before:from-primary/5 before:via-transparent before:to-transparent before:pointer-events-none">
+      <div className="flex flex-col h-full rounded-[2px] border border-line-structure bg-surface-bg corner-box-corners p-5 relative overflow-hidden">
         <div className="flex-1 overflow-y-auto relative z-10 space-y-4">
           {/* Prompt input */}
           <form onSubmit={handleFormSubmit} className="space-y-3">
@@ -144,12 +144,12 @@ export const ImageGenerator = ({
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Describe the image you want to generate..."
-                className="flex-1 px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                className="flex-1 px-3 py-2 rounded-[2px] border border-line-structure bg-surface-bg text-text-secondary text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-line-cta"
               />
               <button
                 type="submit"
                 disabled={!input.trim() || loading}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-[2px] border border-line-structure bg-text-primary text-surface-bg text-sm font-medium shadow-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
               >
                 {loading ? (
                   <Loader size={14} />
@@ -204,8 +204,8 @@ export const ImageGenerator = ({
           {/* Generated image */}
           {currentImage && !loading && (
             <div className="space-y-3">
-              <div className="p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">Prompt: </span>
+              <div className="p-3 rounded-[2px] border border-line-structure bg-[#403d391a] dark:bg-[#b8b6a01a] text-sm text-text-secondary">
+                <span className="font-medium text-text-primary">Prompt: </span>
                 {currentImage.prompt}
               </div>
 
@@ -215,7 +215,7 @@ export const ImageGenerator = ({
                   mediaType={currentImage.mediaType}
                   uint8Array={new Uint8Array()}
                   alt={currentImage.prompt}
-                  className="max-w-md rounded-lg shadow-lg"
+                  className="max-w-md rounded-[2px] border border-line-structure"
                 />
               </div>
 
@@ -223,22 +223,22 @@ export const ImageGenerator = ({
               <div className="flex items-center gap-2 justify-center">
                 <button
                   onClick={handleDownload}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  className="inline-flex items-center gap-1.5 px-2 py-1 rounded-[2px] text-xs text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
                 >
                   <DownloadIcon className="size-3.5" />
                   Download
                 </button>
-                <div className="w-px h-4 bg-border" />
+                <div className="w-px h-4 bg-line-structure" />
                 <span className="text-xs text-muted-foreground">
                   Rate this:
                 </span>
                 <button
                   onClick={() => handleFeedback(1)}
                   className={cn(
-                    "p-1.5 rounded-md transition-colors",
+                    "p-1.5 rounded-[2px] transition-colors",
                     feedback === 1
-                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                   )}
                 >
                   <ThumbsUpIcon className="size-3.5" />
@@ -246,10 +246,10 @@ export const ImageGenerator = ({
                 <button
                   onClick={() => handleFeedback(0)}
                   className={cn(
-                    "p-1.5 rounded-md transition-colors",
+                    "p-1.5 rounded-[2px] transition-colors",
                     feedback === 0
-                      ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      ? "text-red-700 dark:text-red-400"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                   )}
                 >
                   <ThumbsDownIcon className="size-3.5" />

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -139,7 +139,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
 
   return (
     <div className={cn("h-[62vh]", className)} {...props}>
-      <div className="flex flex-col h-full border border-border/40 rounded-2xl bg-gradient-to-br from-background via-background/95 to-muted/20 backdrop-blur-md shadow-xl shadow-black/10 dark:shadow-black/30 p-5 transition-all duration-300 hover:shadow-2xl hover:shadow-black/15 dark:hover:shadow-black/40 relative overflow-hidden before:absolute before:inset-0 before:bg-gradient-to-br before:from-primary/5 before:via-transparent before:to-transparent before:pointer-events-none">
+      <div className="flex flex-col h-full rounded-[2px] border border-line-structure bg-surface-bg corner-box-corners p-5 relative overflow-hidden">
         <Conversation className="flex-1 overflow-y-hidden relative z-10">
           {!hasUserMessages && (
             <div className="absolute inset-0 flex flex-col items-center justify-center z-20">
@@ -151,19 +151,19 @@ export const Chat = ({ className, ...props }: ChatProps) => {
               <div className="flex gap-3 items-center flex-wrap justify-center">
                 <button
                   onClick={() => handleExampleQuestion("What can I use Langfuse for?")}
-                  className="text-xs text-muted-foreground italic hover:text-foreground transition-colors cursor-pointer border border-border rounded-md px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words"
+                  className="text-xs text-text-tertiary italic hover:text-text-primary transition-colors cursor-pointer border border-line-structure hover:border-line-cta rounded-[2px] px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words bg-surface-bg"
                 >
                   What can I use Langfuse for?
                 </button>
                 <button
                   onClick={() => handleExampleQuestion("How do I link my prompts to my traces? My code is in python")}
-                  className="text-xs text-muted-foreground italic hover:text-foreground transition-colors cursor-pointer border border-border rounded-md px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words"
+                  className="text-xs text-text-tertiary italic hover:text-text-primary transition-colors cursor-pointer border border-line-structure hover:border-line-cta rounded-[2px] px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words bg-surface-bg"
                 >
                   How do I link my prompts to my traces? My code is in python
                 </button>
                 <button
                   onClick={() => handleExampleQuestion("How do I get started with tracing?")}
-                  className="text-xs text-muted-foreground italic hover:text-foreground transition-colors cursor-pointer border border-border rounded-md px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words"
+                  className="text-xs text-text-tertiary italic hover:text-text-primary transition-colors cursor-pointer border border-line-structure hover:border-line-cta rounded-[2px] px-3 py-1.5 w-52 h-12 text-center whitespace-normal break-words bg-surface-bg"
                 >
                   How do I get started with tracing?
                 </button>
@@ -206,7 +206,11 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                   className={message.role === "assistant" ? "[&>div]:max-w-full" : undefined}
                 >
                   <MessageContent
-                    className={message.role === "assistant" ? "!bg-transparent px-0 rounded-none" : undefined}
+                    className={
+                      message.role === "assistant"
+                        ? "!bg-transparent px-0 rounded-none"
+                        : "!bg-[#403d391a] dark:!bg-[#b8b6a01a] !text-text-primary border border-line-structure rounded-[2px] px-3 py-2"
+                    }
                   >
                     {message.parts.map((part, i) => {
                       if (part.type === "text") {
@@ -337,7 +341,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
 
         <PromptInput
           onSubmit={handleSubmit}
-          className="mt-4 border-border/40 shadow-lg transition-all duration-200 hover:shadow-xl hover:border-primary/20 relative z-10"
+          className="mt-4 rounded-[2px] border-line-structure bg-surface-bg shadow-sm relative z-10 focus-within:border-line-cta transition-colors"
         >
           <div className="flex items-end gap-2">
             <PromptInputTextarea
@@ -345,7 +349,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
               onChange={(e) => setInput(e.target.value)}
               value={input}
               placeholder="Ask a question about Langfuse..."
-              className="flex-1 pr-2 min-h-[40px] max-h-[300px] leading-5 pt-[10px] pb-[10px] overflow-y-auto"
+              className="flex-1 pr-2 min-h-[40px] max-h-[300px] leading-5 pt-[10px] pb-[10px] overflow-y-auto text-sm"
               style={{ height: "auto" }}
               minHeight={40}
               maxHeight={300}

--- a/components/sentimentClassifier/index.tsx
+++ b/components/sentimentClassifier/index.tsx
@@ -135,7 +135,7 @@ export const SentimentClassifier = ({
 
   return (
     <div className={cn("h-[62vh]", className)} {...props}>
-      <div className="flex flex-col h-full border border-border/40 rounded-2xl bg-gradient-to-br from-background via-background/95 to-muted/20 backdrop-blur-md shadow-xl shadow-black/10 dark:shadow-black/30 p-5 transition-all duration-300 hover:shadow-2xl hover:shadow-black/15 dark:hover:shadow-black/40 relative overflow-hidden before:absolute before:inset-0 before:bg-gradient-to-br before:from-primary/5 before:via-transparent before:to-transparent before:pointer-events-none">
+      <div className="flex flex-col h-full rounded-[2px] border border-line-structure bg-surface-bg corner-box-corners p-5 relative overflow-hidden">
         <div className="flex-1 overflow-y-auto relative z-10 space-y-4">
           {/* Input area */}
           <div className="space-y-3">
@@ -143,13 +143,13 @@ export const SentimentClassifier = ({
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="Enter text to analyze sentiment..."
-              className="w-full h-32 p-3 rounded-lg border border-border bg-background text-foreground text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+              className="w-full h-32 p-3 rounded-[2px] border border-line-structure bg-surface-bg text-text-secondary text-sm shadow-sm resize-none focus:outline-none focus:ring-1 focus:ring-line-cta"
             />
             <div className="flex items-center gap-3">
               <button
                 onClick={() => handleSubmit()}
                 disabled={!input.trim() || loading}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-[2px] border border-line-structure bg-text-primary text-surface-bg text-sm font-medium shadow-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
               >
                 {loading ? (
                   <Loader size={14} />
@@ -204,8 +204,8 @@ export const SentimentClassifier = ({
           {result && colors && (
             <div className="space-y-4">
               {/* Analyzed text */}
-              <div className="p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">Analyzed: </span>
+              <div className="p-3 rounded-[2px] border border-line-structure bg-[#403d391a] dark:bg-[#b8b6a01a] text-sm text-text-secondary">
+                <span className="font-medium text-text-primary">Analyzed: </span>
                 {result.inputText}
               </div>
 
@@ -213,7 +213,7 @@ export const SentimentClassifier = ({
               <div className="flex items-center gap-4">
                 <span
                   className={cn(
-                    "inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold capitalize",
+                    "inline-flex items-center px-3 py-1 rounded-[2px] text-sm font-semibold capitalize",
                     colors.bg,
                     colors.text
                   )}
@@ -249,7 +249,7 @@ export const SentimentClassifier = ({
                     {result.result.keyPhrases.map((phrase, i) => (
                       <span
                         key={i}
-                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-muted text-xs text-muted-foreground"
+                        className="inline-flex items-center px-2 py-0.5 rounded-[2px] border border-line-structure bg-[#403d391a] dark:bg-[#b8b6a01a] text-xs text-text-secondary"
                       >
                         {phrase}
                       </span>
@@ -266,10 +266,10 @@ export const SentimentClassifier = ({
                 <button
                   onClick={() => handleFeedback(1)}
                   className={cn(
-                    "p-1.5 rounded-md transition-colors",
+                    "p-1.5 rounded-[2px] transition-colors",
                     feedback === 1
-                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                   )}
                 >
                   <ThumbsUpIcon className="size-3.5" />
@@ -277,10 +277,10 @@ export const SentimentClassifier = ({
                 <button
                   onClick={() => handleFeedback(0)}
                   className={cn(
-                    "p-1.5 rounded-md transition-colors",
+                    "p-1.5 rounded-[2px] transition-colors",
                     feedback === 0
-                      ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                      ? "text-red-700 dark:text-red-400"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                   )}
                 >
                   <ThumbsDownIcon className="size-3.5" />

--- a/components/voiceAgent/index.tsx
+++ b/components/voiceAgent/index.tsx
@@ -174,7 +174,7 @@ export const VoiceAgent = ({ className, ...props }: VoiceAgentProps) => {
 
   return (
     <div className={cn("h-[62vh]", className)} {...props}>
-      <div className="flex flex-col h-full border border-border/40 rounded-2xl bg-gradient-to-br from-background via-background/95 to-muted/20 backdrop-blur-md shadow-xl shadow-black/10 dark:shadow-black/30 p-5 transition-all duration-300 hover:shadow-2xl hover:shadow-black/15 dark:hover:shadow-black/40 relative overflow-hidden before:absolute before:inset-0 before:bg-gradient-to-br before:from-primary/5 before:via-transparent before:to-transparent before:pointer-events-none">
+      <div className="flex flex-col h-full rounded-[2px] border border-line-structure bg-surface-bg corner-box-corners p-5 relative overflow-hidden">
         <div className="flex-1 flex flex-col items-center justify-center relative z-10">
           {/* Not configured fallback */}
           {agentState === "not-configured" && (
@@ -187,7 +187,7 @@ export const VoiceAgent = ({ className, ...props }: VoiceAgentProps) => {
                 The voice agent demo is powered by{" "}
                 <a
                   href="https://livekit.io"
-                  className="underline hover:text-foreground"
+                  className="text-text-links decoration-text-links underline decoration-1 underline-offset-2 hover:text-primary hover:decoration-primary"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -203,7 +203,7 @@ export const VoiceAgent = ({ className, ...props }: VoiceAgentProps) => {
                 See the{" "}
                 <a
                   href="/integrations/frameworks/livekit"
-                  className="underline hover:text-foreground"
+                  className="text-text-links decoration-text-links underline decoration-1 underline-offset-2 hover:text-primary hover:decoration-primary"
                 >
                   LiveKit integration docs
                 </a>{" "}
@@ -271,13 +271,11 @@ export const VoiceAgent = ({ className, ...props }: VoiceAgentProps) => {
                     <div
                       key={i}
                       className={cn(
-                        "text-sm px-3 py-2 rounded-lg",
-                        t.role === "user"
-                          ? "bg-primary/10 text-foreground ml-8"
-                          : "bg-muted text-foreground mr-8",
+                        "text-sm px-3 py-2 rounded-[2px] border border-line-structure bg-[#403d391a] dark:bg-[#b8b6a01a] text-text-primary",
+                        t.role === "user" ? "ml-8" : "mr-8",
                       )}
                     >
-                      <span className="text-xs text-muted-foreground font-medium">
+                      <span className="text-xs text-text-tertiary font-medium">
                         {t.role === "user" ? "You" : "Agent"}:{" "}
                       </span>
                       {t.text}
@@ -293,7 +291,7 @@ export const VoiceAgent = ({ className, ...props }: VoiceAgentProps) => {
                   LLM → TTS pipeline is traced in Langfuse via{" "}
                   <a
                     href="/integrations/frameworks/livekit"
-                    className="underline hover:text-foreground"
+                    className="text-text-links decoration-text-links underline decoration-1 underline-offset-2 hover:text-primary hover:decoration-primary"
                   >
                     LiveKit Agents
                   </a>


### PR DESCRIPTION
## Summary

Restyles the four interactive demos on the `/docs/demo` example-project page (Q&A Chatbot, Image Generator, Sentiment Classifier, Voice Agent) so they use the same design tokens and visual language as the rest of the docs site.

Before, the demo containers used a heavy gradient + backdrop-blur + `rounded-2xl` + `shadow-xl` look, several internal buttons rendered as black blocks because they passed `variant="ghost"` / `variant="outline"` to the project's `Button` (which only knows `primary | secondary | text` and falls through to dark `primary`), and prose links rendered as raw `text-blue-600` with a black underline instead of the site's `--text-links` color.

## Scope

Limited to the four demo components and the `components/ai-elements/*` building blocks they use. Confirmed via grep that `ai-elements/*` is only imported by these four demos — no impact on other docs, marketing, blog, or changelog pages.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces the gradient/blur/`rounded-2xl` styling on the four interactive demos (`/docs/demo`) with the site's angular design tokens (`rounded-[2px]`, `border-line-structure`, `bg-surface-bg`, `corner-box-corners`), and fixes action buttons that previously fell through to a black `primary` style by switching them to `variant="text"`.

- **Shared building blocks** (`ai-elements/actions`, `code-block`, `conversation`, `response`, `suggestion`) updated to site variants/sizes and CSS custom-property color tokens.
- **All four demo containers** (`qaChatbot`, `imageGenerator`, `sentimentClassifier`, `voiceAgent`) receive consistent outer card style, user-bubble fills, prompt-input borders, and link/inline-code typography.
- `ConversationScrollButton` was refactored from a `Button` wrapper to a native `<button>`, but its exported prop-type was not updated to match, and collected props are silently dropped.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are limited to visual styling on the four demo components and their shared building blocks, with no logic or data-flow modifications.

The refactor is well-scoped and all token names are confirmed defined in style.css. The stale ConversationScrollButton prop-type silently drops caller-supplied props, and the thumbs-up/down feedback buttons lost their background-fill active state, making it harder for users to confirm their rating.

components/ai-elements/conversation.tsx (stale prop-type) and components/imageGenerator/index.tsx / components/sentimentClassifier/index.tsx (thumbs feedback active state).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/ai-elements/actions.tsx | Switches default variant/size to `text`/`small` and tightens icon button dimensions; all changes are correct and self-contained. |
| components/ai-elements/code-block.tsx | Copy button switches to `variant="text" size="small"` with explicit icon sizing; change is clean and consistent with the actions.tsx update. |
| components/ai-elements/conversation.tsx | Scroll-to-bottom button switched from `Button` to native `<button>`, but `ConversationScrollButtonProps` is still typed as `ComponentProps<typeof Button>` and collected `...props` are never forwarded, silently dropping any caller-supplied props. |
| components/ai-elements/response.tsx | Link and inline-code styles updated to use site design tokens; changes are correct and narrowly scoped to markdown render components. |
| components/ai-elements/suggestion.tsx | Suggestion pill defaults changed to `secondary`/`small` with `rounded-[2px]`; aligns correctly with the project's Button API. |
| components/imageGenerator/index.tsx | Outer card and all interactive elements aligned to site tokens; thumbs-up/down active state lost its background fill, making the selected state less visually distinct. |
| components/qaChatbot/index.tsx | Outer card, example-question buttons, user message bubbles, and prompt input all updated to site tokens; changes are consistent and correct. |
| components/sentimentClassifier/index.tsx | Card, textarea, key-phrase chips, and sentiment badge updated to site tokens; same thumbs feedback active-state visibility regression as imageGenerator. |
| components/voiceAgent/index.tsx | Outer card, transcript bubbles, and inline links updated to site tokens; no issues found. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Demo Page /docs/demo] --> B[qaChatbot]
    A --> C[imageGenerator]
    A --> D[sentimentClassifier]
    A --> E[voiceAgent]

    B & C & D & E --> F[ai-elements/actions\nvariant=text, size=small]
    B & C --> G[ai-elements/suggestion\nvariant=secondary, size=small]
    B --> H[ai-elements/conversation\nConversationScrollButton → native button]
    B & C & D --> I[ai-elements/response\nlinks: text-text-links\ninline code: bg-muted text-foreground]
    C & D --> J[ai-elements/code-block\nCopyButton → variant=text]

    F & G & H & I & J --> K[Site Design Tokens\nrounded-2px · border-line-structure\nbg-surface-bg · corner-box-corners\ntext-text-links · text-text-secondary]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/ai-elements/conversation.tsx`, line 33-38 ([link](https://github.com/langfuse/langfuse-docs/blob/056e678e3f3a7346735671e62bc798e396a9eb50/components/ai-elements/conversation.tsx#L33-L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale type contract silently drops props**

   `ConversationScrollButtonProps` is still typed as `ComponentProps<typeof Button>`, which includes Button-specific props like `variant`, `size`, and `asChild`. However, the component now renders a native `<button>` and the collected `...props` are never spread onto it — any prop beyond `className` is silently swallowed. The type should be updated to `ComponentProps<"button">` to reflect the new implementation and prevent misleading callers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: components/ai-elements/conversation.tsx
   Line: 33-38

   Comment:
   **Stale type contract silently drops props**

   `ConversationScrollButtonProps` is still typed as `ComponentProps<typeof Button>`, which includes Button-specific props like `variant`, `size`, and `asChild`. However, the component now renders a native `<button>` and the collected `...props` are never spread onto it — any prop beyond `className` is silently swallowed. The type should be updated to `ComponentProps<"button">` to reflect the new implementation and prevent misleading callers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/ai-elements/conversation.tsx:33-38
**Stale type contract silently drops props**

`ConversationScrollButtonProps` is still typed as `ComponentProps<typeof Button>`, which includes Button-specific props like `variant`, `size`, and `asChild`. However, the component now renders a native `<button>` and the collected `...props` are never spread onto it — any prop beyond `className` is silently swallowed. The type should be updated to `ComponentProps<"button">` to reflect the new implementation and prevent misleading callers.

### Issue 2 of 2
components/imageGenerator/index.tsx:243-256
**Active feedback state lost background fill**

The selected state for thumbs-up/down buttons changed from a filled chip (`bg-green-100 text-green-700 dark:bg-green-900/30`) to a text-colour-only change (`text-green-700 dark:text-green-400`). Without a background fill, the pressed vs. unpressed states are visually very similar, making it harder for users to confirm their feedback was recorded. The same pattern is repeated in `sentimentClassifier/index.tsx`. Consider restoring a subtle background — or at minimum a `font-semibold` toggle — to keep the active state distinguishable.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(demo): align example-project demos..."](https://github.com/langfuse/langfuse-docs/commit/056e678e3f3a7346735671e62bc798e396a9eb50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31053997)</sub>

<!-- /greptile_comment -->