### PR TITLE
docs: add FAQ on managing agent skills with prompt management

### DIFF
--- a/content/faq/all/managing-skills-with-prompt-management.mdx
+++ b/content/faq/all/managing-skills-with-prompt-management.mdx
@@ -23,36 +23,37 @@ Treat each skill file as its own Langfuse prompt. Use the prompt name to identif
 Because an agent execution often pulls in several skill files, you want to be able to reconstruct exactly which combination of skill versions produced a given trace. The simplest way to do this:
 
 1. When you fetch a skill file via `get_prompt()`, capture the returned version number.
-2. Write the resolved versions into the [trace metadata](/docs/observability/features/trace-ids-and-distributed-tracing) as a map of skill name to version.
+2. Write the resolved versions into the [trace metadata](/docs/observability/features/metadata) as a map of skill name to version.
 3. When debugging or evaluating a run later, you can read the metadata to know which exact skill files were active.
 
 A minimal example in Python:
 
 ```python
-from langfuse import Langfuse, observe, get_client
+from langfuse import observe, get_client, propagate_attributes
 
-langfuse = Langfuse()
+langfuse = get_client()
 
 @observe()
 def run_agent(user_input: str):
     skills_to_load = ["skill/code-review", "skill/data-analysis"]
     skills = {name: langfuse.get_prompt(name) for name in skills_to_load}
 
-    # Record which skill versions were used in this run
-    get_client().update_current_trace(
-        metadata={
-            "skill_versions": {
-                name: prompt.version for name, prompt in skills.items()
-            }
-        }
-    )
+    # Record which skill versions were used in this run.
+    # Propagated metadata keys must be alphanumeric and values must be strings,
+    # so we flatten the prompt names into per-skill keys.
+    skill_version_metadata = {
+        f"skill_{name.replace('skill/', '').replace('-', '_')}_version": str(prompt.version)
+        for name, prompt in skills.items()
+    }
 
-    # ... use skills[name].prompt as the skill file contents in your agent ...
+    with propagate_attributes(metadata=skill_version_metadata):
+        # ... use skills[name].prompt as the skill file contents in your agent ...
+        pass
 ```
 
 ### Link skills to your traces
 
-You can also pass each skill prompt object to the corresponding generation or span so it shows up linked in the Langfuse UI. See [Link prompts with traces](/docs/prompts/get-started#link-with-langfuse-tracing-optional). This is useful when a single skill file maps directly to a model call. For agents that load many skills upfront, the metadata approach above tends to be more practical.
+You can also pass each skill prompt object to the corresponding generation or span so it shows up linked in the Langfuse UI. See [Link prompts with traces](/docs/prompt-management/features/link-to-traces). This is useful when a single skill file maps directly to a model call. For agents that load many skills upfront, the metadata approach above tends to be more practical.
 
 ## Limitations to be aware of
 

--- a/content/faq/all/managing-skills-with-prompt-management.mdx
+++ b/content/faq/all/managing-skills-with-prompt-management.mdx
@@ -54,9 +54,9 @@ def run_agent(user_input: str):
 
 You can also pass each skill prompt object to the corresponding generation or span so it shows up linked in the Langfuse UI. See [Link prompts with traces](/docs/prompts/get-started#link-with-langfuse-tracing-optional). This is useful when a single skill file maps directly to a model call. For agents that load many skills upfront, the metadata approach above tends to be more practical.
 
-## Things to be aware of
+## Limitations to be aware of
 
-- **No native "skill set" grouping yet.** Each skill is an independent prompt. If you want to manage a bundle of skills as a single unit, you currently need to handle that in your application code.
+- **No native folder-level grouping yet.** Each file is stored as an independent prompt. If you want to manage a skill folder (a `SKILL.md` plus reference files) or a bundle of skills as a single unit, you currently need to handle that in your application code.
 - **Playground and prompt experiments** are designed around a single prompt. They work for iterating on one skill file at a time, but not on a multi-skill agent setup as a whole.
 - **Variable detection** still uses Langfuse's `{{variable}}` syntax. If your skill files use a different templating style, see [Using external templating libraries](/faq/all/using-external-templating-libraries).
 

--- a/content/faq/all/managing-skills-with-prompt-management.mdx
+++ b/content/faq/all/managing-skills-with-prompt-management.mdx
@@ -1,0 +1,65 @@
+---
+title: Can I manage agent skills with Langfuse Prompt Management?
+description: Learn how to version and iterate on agent skill files using Langfuse Prompt Management today, and what we are working on for native skills support.
+tags: [prompt-management]
+---
+
+# Can I manage agent skills with Langfuse Prompt Management?
+
+Prompt Management was originally designed for single prompt files. The core primitives (versioning, labels, retrieval, linking to traces) map well to skills, but there are gaps around grouping multiple skill files together, navigating them as a set, and reasoning about which combination of skills was active for a given agent run. We are exploring more native support for these workflows.
+
+___If you are using (or want to use) Langfuse for skills management, please upvote, share your setup, pain points, and ideas on [this GitHub Discussion](https://github.com/orgs/langfuse/discussions/12290). We read these to shape what skills support should look like in Langfuse.___
+
+In the meantime, the recommendations below are what we have seen work best in practice.
+
+## Recommended pattern today
+
+### One prompt per skill file
+
+Treat each skill file as its own Langfuse prompt. Use the prompt name to identify the skill (for example, `skill/code-review`, `skill/data-analysis`) and store the full skill file contents as the prompt body. This gives you Langfuse's full versioning, labels (e.g. `production`, `staging`), and rollback capabilities per skill.
+
+### Track which skill versions were used in each trace
+
+Because an agent execution often pulls in several skill files, you want to be able to reconstruct exactly which combination of skill versions produced a given trace. The simplest way to do this:
+
+1. When you fetch a skill file via `get_prompt()`, capture the returned version number.
+2. Write the resolved versions into the [trace metadata](/docs/observability/features/trace-ids-and-distributed-tracing) as a map of skill name to version.
+3. When debugging or evaluating a run later, you can read the metadata to know which exact skill files were active.
+
+A minimal example in Python:
+
+```python
+from langfuse import Langfuse, observe, get_client
+
+langfuse = Langfuse()
+
+@observe()
+def run_agent(user_input: str):
+    skills_to_load = ["skill/code-review", "skill/data-analysis"]
+    skills = {name: langfuse.get_prompt(name) for name in skills_to_load}
+
+    # Record which skill versions were used in this run
+    get_client().update_current_trace(
+        metadata={
+            "skill_versions": {
+                name: prompt.version for name, prompt in skills.items()
+            }
+        }
+    )
+
+    # ... use skills[name].prompt as the skill file contents in your agent ...
+```
+
+### Link skills to your traces
+
+You can also pass each skill prompt object to the corresponding generation or span so it shows up linked in the Langfuse UI. See [Link prompts with traces](/docs/prompts/get-started#link-with-langfuse-tracing-optional). This is useful when a single skill file maps directly to a model call. For agents that load many skills upfront, the metadata approach above tends to be more practical.
+
+## Things to be aware of
+
+- **No native "skill set" grouping yet.** Each skill is an independent prompt. If you want to manage a bundle of skills as a single unit, you currently need to handle that in your application code.
+- **Playground and prompt experiments** are designed around a single prompt. They work for iterating on one skill file at a time, but not on a multi-skill agent setup as a whole.
+- **Variable detection** still uses Langfuse's `{{variable}}` syntax. If your skill files use a different templating style, see [Using external templating libraries](/faq/all/using-external-templating-libraries).
+
+## Share your feedback
+
+If you are using Langfuse Prompt Management for skills, or considering it, please comment on [this GitHub Discussion](https://github.com/orgs/langfuse/discussions/12290) with what is working, what isn't, and what you would want from native skills support.


### PR DESCRIPTION
## Summary

- Adds a new FAQ page (`content/faq/all/managing-skills-with-prompt-management.mdx`) acknowledging that Langfuse Prompt Management can be used for agent skill files today, while native skills support is still being explored.
- Documents the recommended pattern: one prompt per skill file, with resolved versions written into trace metadata so each agent run is reproducible.
- Surfaces a known limitation list (no skill-set grouping, Playground/experiments are per-prompt, variable syntax) and links to GitHub Discussion #12290 in two places to gather user feedback to shape native skills support.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a new FAQ page explaining how to use Langfuse Prompt Management for agent skill files today, while native skills support is being explored. It documents a recommended one-prompt-per-skill pattern with version tracking in trace metadata and lists current limitations.

- The page introduces a `get_prompt()` + trace metadata pattern for recording which skill versions were active in a given agent run, along with links to relevant SDK and prompt-management docs.
- Two internal links need correction: the \"trace metadata\" anchor points to the distributed-tracing page instead of `/docs/observability/features/metadata`, and the prompt-linking reference uses a stale anchor that no longer resolves on the current target page.

<h3>Confidence Score: 3/5</h3>

Two internal links send readers to wrong or empty-anchor destinations and should be corrected before publishing.

The prose and recommended patterns are accurate, but the 'trace metadata' link targets a distributed-tracing page that contains no metadata content, and the prompt-linking anchor no longer exists at the redirect target, silently dropping users at the top of an unrelated page.

content/faq/all/managing-skills-with-prompt-management.mdx — the two internal links at lines 28 and 53 need to be updated before this is published.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/faq/all/managing-skills-with-prompt-management.mdx | New FAQ page documenting how to use Langfuse Prompt Management for agent skill files; contains two broken/wrong internal links and an inconsistent code example pattern. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Agent App
    participant LF as Langfuse SDK
    participant PM as Prompt Management
    participant Trace as Langfuse Tracing

    App->>LF: get_prompt("skill/code-review")
    LF->>PM: Fetch prompt + version
    PM-->>LF: prompt object (version=N)
    LF-->>App: LangfusePrompt

    App->>LF: get_prompt("skill/data-analysis")
    LF->>PM: Fetch prompt + version
    PM-->>LF: prompt object (version=M)
    LF-->>App: LangfusePrompt

    App->>Trace: update_current_trace(metadata={skill_versions: {...}})
    Note over Trace: skill/code-review to N, skill/data-analysis to M

    App->>App: Run agent using skill file contents
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/faq/all/managing-skills-with-prompt-management.mdx:28
**Wrong documentation link for trace metadata**

The anchor text "trace metadata" links to `/docs/observability/features/trace-ids-and-distributed-tracing`, but that page covers custom trace IDs and distributed tracing — it contains no mention of metadata whatsoever. The dedicated metadata page is at `/docs/observability/features/metadata` and is the correct target here.

### Issue 2 of 3
content/faq/all/managing-skills-with-prompt-management.mdx:53
**Stale anchor in prompt-linking reference**

The link `/docs/prompts/get-started#link-with-langfuse-tracing-optional` uses an old redirect path and the anchor `#link-with-langfuse-tracing-optional` no longer exists in the current `/docs/prompt-management/get-started` target page, so users land at the top of that page with no in-page navigation to the right section. The dedicated page for this topic is `/docs/prompt-management/features/link-to-traces`.

### Issue 3 of 3
content/faq/all/managing-skills-with-prompt-management.mdx:32-42
The example imports and instantiates both `Langfuse` (via the constructor) and `get_client()` in the same code block, making the snippet inconsistent with the idiomatic v3/v4 pattern shown throughout the official SDK docs — where `langfuse = get_client()` is the recommended singleton accessor. The `Langfuse()` class instance and `get_client()` are the same singleton, but mixing them in a single example may confuse readers about which pattern to follow.

```suggestion
from langfuse import observe, get_client

langfuse = get_client()

@observe()
def run_agent(user_input: str):
    skills_to_load = ["skill/code-review", "skill/data-analysis"]
    skills = {name: langfuse.get_prompt(name) for name in skills_to_load}

    # Record which skill versions were used in this run
    langfuse.update_current_trace(
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add FAQ on managing agent skills w..."](https://github.com/langfuse/langfuse-docs/commit/b420c1b1d5c7ef5c15864bee943c729e79ce3562) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31057290)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->