### PR TITLE
feat: Improve visibility of logos with customer stories on homepage

### DIFF
--- a/components/shared/EnterpriseLogoGrid.tsx
+++ b/components/shared/EnterpriseLogoGrid.tsx
@@ -110,10 +110,12 @@ const companies: CompanyLogo[] = [
 const LogoImage = ({
   logo,
   name,
+  hoverable = true,
   compact = false,
 }: {
   logo: StaticImageData;
   name: string;
+  hoverable?: boolean;
   compact?: boolean;
 }) => {
   if (compact) {
@@ -122,7 +124,7 @@ const LogoImage = ({
         <Image
           src={logo}
           alt={`${name} logo`}
-          className="h-[56px] w-auto scale-125 transition-[filter] duration-200 hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] group-hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)]"
+          className={cn("h-[56px] w-auto scale-125", hoverable ? "hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] group-hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] transition-[filter] duration-200" : "")}
           sizes="(max-width: 768px) 30vw"
           priority={false}
         />
@@ -134,7 +136,7 @@ const LogoImage = ({
     <Image
       src={logo}
       alt={`${name} logo`}
-      className="h-[56px] object-cover max-w-full transition-[filter] duration-200 hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] group-hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)]"
+      className={cn("h-[56px] object-cover max-w-full", hoverable ? "hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] group-hover:filter-[grayscale(1)_brightness(0)_contrast(1.15)] transition-[filter] duration-200" : "")}
       sizes="(max-width: 768px) 50vw, (max-width: 1200px) 25vw, 20vw"
       priority={false}
     />
@@ -149,22 +151,18 @@ function LogoMarqueeItems({ duplicate = false }: { duplicate?: boolean }) {
       {visibleCompanies.map((company) => {
         const hasStory = Boolean(company.customerStoryPath);
         return (
-          <LinkBox
+          <div
             key={company.name}
-            href={company.customerStoryPath}
-            tooltip={hasStory ? "Read story" : undefined}
-            tooltipPlacement="bottom-center"
             className="shrink-0 flex items-center justify-center !p-0"
             aria-hidden={duplicate || undefined}
-            tabIndex={duplicate ? -1 : undefined}
             aria-label={
               hasStory
                 ? `Read ${company.name} user story`
                 : `${company.name} uses Langfuse`
             }
           >
-            <LogoImage logo={company.logo} name={company.name} compact />
-          </LinkBox>
+            <LogoImage hoverable={false} logo={company.logo} name={company.name} compact />
+          </div>
         );
       })}
     </>
@@ -226,20 +224,30 @@ export const EnterpriseLogoGrid = ({
       >
         {visibleCompanies.map((company) => {
           const hasStory = Boolean(company.customerStoryPath);
+
           return (
             <LinkBox
               key={company.name}
               href={company.customerStoryPath}
-              tooltip={hasStory ? "Read story" : undefined}
-              tooltipPlacement="bottom-center"
               className="-mr-px -mb-px flex items-center justify-center !p-0"
-              role="gridcell"
               aria-label={
                 hasStory
                   ? `Read ${company.name} user story`
                   : `${company.name} uses Langfuse`
               }
+              role="gridcell"
             >
+              {hasStory && (
+                <div className="absolute w-full h-full flex items-end justify-center -mt-1 pointer-events-none">
+                  <div
+                    className={cn(
+                      "tooltip-label z-50 inline-flex h-[12px] items-center justify-center gap-[3px] overflow-hidden rounded-none border-0 bg-primary/10 px-1 py-0.5 font-mono text-[10px] leading-none text-primary-foreground shadow-none outline-hidden group-hover:bg-primary transition",
+                    )}
+                  >
+                    Read story
+                  </div>
+                </div>
+              )}
               <LogoImage logo={company.logo} name={company.name} />
             </LinkBox>
           );


### PR DESCRIPTION
<img width="1495" height="825" alt="Screenshot 2026-05-07 at 14 45 53" src="https://github.com/user-attachments/assets/ff106dc2-f80e-4ff6-b589-1ebb4ea811d1" />

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR improves the visual affordance for customer-story logos on the homepage by replacing a hover tooltip with a persistent inline "Read story" badge (visible at rest as `bg-primary/10`, highlighted on hover) and by adding a `hoverable` prop to `LogoImage` so the mobile marquee's logos no longer apply grayscale on hover.

- **Desktop grid**: tooltip props removed; a custom absolutely-positioned badge now appears at the bottom of each story-linked logo cell using `group-hover` from `LinkBox`'s built-in `group` class and `link-box`'s `position: relative`.
- **Mobile marquee**: `LinkBox` wrappers replaced with plain `<div>` elements — logo hover effects and navigation links to customer stories are intentionally removed from the scrolling marquee.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are visual only and well-scoped to a single component.

The functional and visual changes are straightforward. Two minor accessibility issues were found: role="gridcell" was dropped from the desktop grid cells while the parent retains role="grid", and aria-label is now placed on non-interactive div elements in the marquee where it has no semantic effect. Neither blocks rendering or navigation for sighted users.

components/shared/EnterpriseLogoGrid.tsx — specifically the desktop grid's ARIA role alignment and the marquee item markup.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/shared/EnterpriseLogoGrid.tsx | Replaces the tooltip-based "Read story" affordance with an always-present (but faint) inline badge; removes link wrapping from marquee items; adds `hoverable` prop to LogoImage. Minor accessibility regressions: `role="gridcell"` dropped from grid children and `aria-label` left on a non-interactive `div` in the marquee. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EnterpriseLogoGrid] --> B{Viewport}
    B -->|Mobile| C{Reduced Motion?}
    C -->|Yes| D[Static scroll div]
    C -->|No| E[Framer Motion marquee]
    D --> F[LogoMarqueeItems]
    E --> F
    F --> G["div per company - no link, hoverable=false"]
    G --> H[LogoImage compact]
    B -->|Desktop| I["div role=grid"]
    I --> J["LinkBox per company - href if hasStory"]
    J --> K{hasStory?}
    K -->|Yes| L["Read story badge - absolute, group-hover"]
    K -->|No| M[Logo only]
    J --> N[LogoImage hoverable=true]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/shared/EnterpriseLogoGrid.tsx`, line 217-224 ([link](https://github.com/langfuse/langfuse-docs/blob/605da72156d8faa068d17a316e7da50aca8ca0e8/components/shared/EnterpriseLogoGrid.tsx#L217-L224)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`role="gridcell"` removed from grid children**

   The parent container retains `role="grid"`, but the `role="gridcell"` that was previously on each `LinkBox` was dropped in this PR. The ARIA spec requires that interactive children of a `grid` carry `role="gridcell"` (or `row` > `gridcell`); without it, assistive technologies may not expose the cells correctly, and some screen readers will ignore `aria-label` on the `LinkBox` entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: components/shared/EnterpriseLogoGrid.tsx
   Line: 217-224

   Comment:
   **`role="gridcell"` removed from grid children**

   The parent container retains `role="grid"`, but the `role="gridcell"` that was previously on each `LinkBox` was dropped in this PR. The ARIA spec requires that interactive children of a `grid` carry `role="gridcell"` (or `row` > `gridcell`); without it, assistive technologies may not expose the cells correctly, and some screen readers will ignore `aria-label` on the `LinkBox` entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/shared/EnterpriseLogoGrid.tsx:217-224
**`role="gridcell"` removed from grid children**

The parent container retains `role="grid"`, but the `role="gridcell"` that was previously on each `LinkBox` was dropped in this PR. The ARIA spec requires that interactive children of a `grid` carry `role="gridcell"` (or `row` > `gridcell`); without it, assistive technologies may not expose the cells correctly, and some screen readers will ignore `aria-label` on the `LinkBox` entirely.

### Issue 2 of 2
components/shared/EnterpriseLogoGrid.tsx:154-167
**`aria-label` on a non-interactive `<div>` in the marquee**

The marquee items were changed from `LinkBox` (which rendered as `<a>`) to a plain `<div>`. `aria-label` is only meaningful on elements with an implicit or explicit role (interactive or landmark elements); on a generic `<div>` it is silently ignored by most screen readers. Companies with a `customerStoryPath` that were previously reachable via the marquee link on mobile are also no longer navigable — the customer story link is now desktop-only.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Improve visibility of logos with c..."](https://github.com/langfuse/langfuse-docs/commit/605da72156d8faa068d17a316e7da50aca8ca0e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31164590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->