### PR TITLE
General Improvements

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -8,6 +8,8 @@ import { ContentColumns } from "@/components/layout";
 import { BlogPostSidebar } from "@/components/blog/BlogPostSidebar";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { PageFooterNav } from "@/components/PageFooterNav";
+import { getPageFooterItems } from "@/lib/page-footer-nav";
 
 type PageProps = {
   params: Promise<{ slug: string[] }>;
@@ -17,9 +19,23 @@ export default async function BlogPostPage(props: PageProps) {
   const { slug } = await props.params;
   const result = await loadPage(blogSource, slug);
   if (!result) notFound();
-  const { MDX } = result;
+  const { page, MDX } = result;
 
   const { tags, total } = getBlogTagCounts();
+
+  const footerItems = getPageFooterItems(
+    blogSource
+      .getPages()
+      .filter(
+        (page) => page.url !== "/blog" && page.data.showInBlogIndex !== false,
+      ),
+    page.url,
+    {
+      getDate: (page) => page.data.date as string | undefined,
+      getTitle: (page) => page.data.title,
+    },
+  );
+
 
   return (
     <ContentColumns
@@ -32,6 +48,7 @@ export default async function BlogPostPage(props: PageProps) {
             <MDX components={getMDXComponents()} />
           </DocBodyChrome>
         </MainContentWrapper>
+        <PageFooterNav items={footerItems} className="mt-10" />
       </div>
     </ContentColumns>
   );

--- a/app/changelog/[...slug]/page.tsx
+++ b/app/changelog/[...slug]/page.tsx
@@ -8,6 +8,7 @@ import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { ChangelogFrontMatterProvider } from "@/components/changelog/ChangelogFrontMatterContext";
 import type { ChangelogFrontMatter } from "@/components/changelog/ChangelogFrontMatterContext";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { PageFooterNav } from "@/components/PageFooterNav";
 
 type PageProps = {
   params: Promise<{ slug: string[] }>;
@@ -23,6 +24,31 @@ export default async function ChangelogPostPage(props: PageProps) {
     page.data as unknown as Record<string, unknown>
   ) as ChangelogFrontMatter;
 
+  const changelogPages = changelogSource
+    .getPages()
+    .filter((changelogPage) => changelogPage.url !== "/changelog")
+    .sort(
+      (a, b) =>
+        new Date((a.data.date as string) ?? 0).getTime() -
+        new Date((b.data.date as string) ?? 0).getTime(),
+    )
+    .map((changelogPage) => ({
+      name: changelogPage.data.title,
+      url: changelogPage.url,
+    }));
+
+  const currentIndex = changelogPages.findIndex(
+    (changelogPage) => changelogPage.url === page.url,
+  );
+
+  const footerItems =
+    currentIndex === -1
+      ? undefined
+      : {
+        previous: changelogPages[currentIndex - 1],
+        next: changelogPages[currentIndex + 1],
+      };
+
   return (
     <ContentColumns footerClassName="xl:max-w-[680px]">
       <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
@@ -32,6 +58,7 @@ export default async function ChangelogPostPage(props: PageProps) {
               <MDX components={getMDXComponents()} />
             </DocBodyChrome>
           </MainContentWrapper>
+          <PageFooterNav items={footerItems} className="mt-10" />
         </ChangelogFrontMatterProvider>
       </div>
     </ContentColumns>

--- a/app/changelog/[...slug]/page.tsx
+++ b/app/changelog/[...slug]/page.tsx
@@ -9,6 +9,7 @@ import { ChangelogFrontMatterProvider } from "@/components/changelog/ChangelogFr
 import type { ChangelogFrontMatter } from "@/components/changelog/ChangelogFrontMatterContext";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
 import { PageFooterNav } from "@/components/PageFooterNav";
+import { getPageFooterItems } from "@/lib/page-footer-nav";
 
 type PageProps = {
   params: Promise<{ slug: string[] }>;
@@ -23,31 +24,15 @@ export default async function ChangelogPostPage(props: PageProps) {
   const frontMatter = primitiveOnly(
     page.data as unknown as Record<string, unknown>
   ) as ChangelogFrontMatter;
-
-  const changelogPages = changelogSource
-    .getPages()
-    .filter((changelogPage) => changelogPage.url !== "/changelog")
-    .sort(
-      (a, b) =>
-        new Date((a.data.date as string) ?? 0).getTime() -
-        new Date((b.data.date as string) ?? 0).getTime(),
-    )
-    .map((changelogPage) => ({
-      name: changelogPage.data.title,
-      url: changelogPage.url,
-    }));
-
-  const currentIndex = changelogPages.findIndex(
-    (changelogPage) => changelogPage.url === page.url,
+  const footerItems = getPageFooterItems(
+    changelogSource.getPages().filter((page) => page.url !== "/changelog"),
+    page.url,
+    {
+      getDate: (page) => page.data.date as string | undefined,
+      getTitle: (page) => page.data.title,
+    },
   );
 
-  const footerItems =
-    currentIndex === -1
-      ? undefined
-      : {
-        previous: changelogPages[currentIndex - 1],
-        next: changelogPages[currentIndex + 1],
-      };
 
   return (
     <ContentColumns footerClassName="xl:max-w-[680px]">

--- a/components/Availability.tsx
+++ b/components/Availability.tsx
@@ -1,5 +1,3 @@
-import { Check, X } from "lucide-react";
-
 const plans = [
   { id: "hobby", label: "Hobby" },
   { id: "core", label: "Core" },
@@ -11,26 +9,20 @@ const plans = [
 const availabilities: {
   id: string;
   label?: string;
-  shortLabel?: string;
-  Icon: any;
 }[] = [
-  {
-    id: "ee",
-    label: "Enterprise Edition",
-    shortLabel: "Enterprise",
-    Icon: Check,
-  },
-  {
-    id: "team-add-on",
-    label: "Teams Add-on required",
-    shortLabel: "Team",
-    Icon: Check,
-  },
-  { id: "full", Icon: Check },
-  { id: "private-beta", label: "Private Beta", Icon: Check },
-  { id: "public-beta", label: "Public Beta", Icon: Check },
-  { id: "not-available", label: "Not Available", Icon: X },
-];
+    {
+      id: "ee",
+      label: "Enterprise Edition",
+    },
+    {
+      id: "team-add-on",
+      label: "Teams Add-on required",
+    },
+    { id: "full", label: "Available" },
+    { id: "private-beta", label: "Private Beta" },
+    { id: "public-beta", label: "Public Beta" },
+    { id: "not-available", label: "Not Available" },
+  ];
 
 export function AvailabilityBanner(props: {
   availability: Record<
@@ -48,30 +40,20 @@ export function AvailabilityBanner(props: {
     }));
 
   return (
-    <div className="border-t border-b py-3 my-4">
-      <div className="font-semibold text-primary/60 mb-2">
+    <div className="my-4 border relative border-line-structure bg-surface-bg">
+      <div className="flex list-none items-center justify-between px-4 py-2 text-text-primary with-stripes border-b border-line-structure">
         Where is this feature available?
       </div>
-      <ul className="flex flex-row gap-3 w-full justify-between flex-wrap">
+      <ul className="grid justify-between px-0! my-0! divide-y md:divide-x md:divide-y-0 md:grid-cols-5 grid-cols-1 not-prose">
         {availablePlans.map((plan) => (
           <li
             key={plan.id}
-            className="flex flex-row gap-2 md:flex-col md:items-center"
+            className="grid grid-cols-2 md:grid-cols-1 relative px-4 py-2 md:py-4 not-prose items-center gap-y-1"
           >
-            <div className="font-medium">{plan.label}</div>
-            <div className="md:flex md:items-center">
-              <plan.availability.Icon className="w-4 h-4 inline-block mr-1 lg:mr-2" />
-              {plan.availability.label && (
-                <span className="hidden md:inline-block text-xs">
-                  ({plan.availability.label})
-                </span>
-              )}
-              {plan.availability.shortLabel && (
-                <span className="inline-block md:hidden text-xs">
-                  ({plan.availability.shortLabel})
-                </span>
-              )}
-            </div>
+            <div className="text-xs font-medium">{plan.label}</div>
+            <span className="text-xs">
+              {plan.availability.label}
+            </span>
           </li>
         ))}
       </ul>

--- a/components/BrandAssets.tsx
+++ b/components/BrandAssets.tsx
@@ -29,7 +29,6 @@ export function BrandDownloadButton() {
 type BrandAssetVariant = "light" | "dark";
 
 interface BrandAssetCardProps {
-  href: string;
   src: string;
   alt: string;
   label: string;
@@ -38,7 +37,6 @@ interface BrandAssetCardProps {
 }
 
 export function BrandAssetCard({
-  href,
   src,
   alt,
   label,
@@ -48,7 +46,7 @@ export function BrandAssetCard({
   return (
     <a
       download
-      href={href}
+      href={src}
       className="block no-underline relative group border border-line-structure bg-surface-bg rounded-[2px] corner-box-corners--hover corner-box-hover-stripes transition-[background] duration-180 ease-out"
     >
       <div

--- a/components/Details.tsx
+++ b/components/Details.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type DetailsProps = React.DetailedHTMLProps<
+  React.DetailsHTMLAttributes<HTMLDetailsElement>,
+  HTMLDetailsElement
+>;
+
+type SummaryProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLElement>,
+  HTMLElement
+>;
+
+const DetailsContext = React.createContext<{ isOpen: boolean } | null>(null);
+
+export function Details({
+  children,
+  className,
+  open,
+  onToggle,
+  ...props
+}: DetailsProps) {
+  const [isOpen, setIsOpen] = React.useState(Boolean(open));
+
+  React.useEffect(() => {
+    setIsOpen(Boolean(open));
+  }, [open]);
+
+  return (
+    <DetailsContext.Provider value={{ isOpen }}>
+      <div
+        className={cn(
+          "relative my-4 border border-line-structure bg-surface-bg",
+          isOpen ? "corner-box-corners" : "corner-box-corners--hover"
+        )}
+      >
+        <details
+          className={cn(
+            "group relative overflow-hidden bg-surface-bg [&_summary~*]:px-4 [&_summary~*]:text-text-secondary [&_summary+*]:pt-4 [&_summary~*:last-child]:pb-4 [&_summary~p:first-of-type]:mt-0 [&_summary~p:last-of-type]:mb-0",
+            className
+          )}
+          open={open}
+          onToggle={(event) => {
+            setIsOpen(event.currentTarget.open);
+            onToggle?.(event);
+          }}
+          {...props}
+        >
+          {children}
+        </details>
+      </div>
+    </DetailsContext.Provider>
+  );
+}
+
+export function Summary({ children, className, ...props }: SummaryProps) {
+  const context = React.useContext(DetailsContext);
+
+  return (
+    <summary
+      className={cn(
+        "flex list-none items-center justify-between gap-4 px-4 py-2 text-text-primary cursor-pointer [&::-webkit-details-marker]:hidden",
+        context?.isOpen ? "with-stripes border-b border-line-structure" : "hover:bg-surface-1",
+        className
+      )}
+      {...props}
+    >
+      <span>{children}</span>
+      <div
+        aria-hidden
+        className={cn(
+          "shrink-0 text-base leading-none w-3 text-center select-none",
+          context?.isOpen ? "text-text-primary" : "text-text-tertiary"
+        )}
+      >
+        {context?.isOpen ? "-" : "+"}
+      </div>
+    </summary>
+  );
+}

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -2,21 +2,13 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useFooterItems } from "fumadocs-ui/utils/use-footer-items";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-
-type FooterItem = {
-  name: string;
-  description?: string;
-  url: string;
-};
+import { PageFooterNav, type PageFooterNavItem } from "./PageFooterNav";
 
 type DocsFooterProps = React.ComponentProps<"div"> & {
   items?: {
-    previous?: FooterItem;
-    next?: FooterItem;
+    previous?: PageFooterNavItem;
+    next?: PageFooterNavItem;
   };
 };
 
@@ -42,47 +34,16 @@ export function DocsFooter({ items, className, ...props }: DocsFooterProps) {
     if (currentIndex === -1) return {};
 
     return {
-      previous: footerItems[currentIndex - 1] as FooterItem | undefined,
-      next: footerItems[currentIndex + 1] as FooterItem | undefined,
+      previous: footerItems[currentIndex - 1] as PageFooterNavItem | undefined,
+      next: footerItems[currentIndex + 1] as PageFooterNavItem | undefined,
     };
   }, [footerItems, items, pathname]);
 
-  const { previous, next } = resolvedItems;
-
-  if (!previous && !next) return null;
-
   return (
-    <div
-      className={cn("flex flex-col sm:flex-row gap-2", className)}
+    <PageFooterNav
+      items={resolvedItems}
+      className={className}
       {...props}
-    >
-      {previous ? (
-        <Button
-          href={previous.url}
-          variant="secondary"
-          size="small"
-          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
-          icon={<ArrowLeft className="h-3.5 w-3.5" />}
-        >
-          {previous.name}
-        </Button>
-      ) : (
-        <div className="hidden sm:block flex-1" />
-      )}
-
-      {next ? (
-        <Button
-          href={next.url}
-          variant="secondary"
-          size="small"
-          className="!justify-end"
-          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%] sm:ml-auto"
-          icon={<ArrowRight className="h-3.5 w-3.5" />}
-          iconPosition="end"
-        >
-          {next.name}
-        </Button>
-      ) : null}
-    </div>
+    />
   );
 }

--- a/components/PageFooterNav.tsx
+++ b/components/PageFooterNav.tsx
@@ -1,0 +1,61 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PageFooterNavItem = {
+  name: string;
+  description?: string;
+  url: string;
+};
+
+type PageFooterNavProps = React.ComponentProps<"div"> & {
+  items?: {
+    previous?: PageFooterNavItem;
+    next?: PageFooterNavItem;
+  };
+};
+
+export function PageFooterNav({
+  items,
+  className,
+  ...props
+}: PageFooterNavProps) {
+  const { previous, next } = items ?? {};
+
+  if (!previous && !next) return null;
+
+  return (
+    <div
+      className={cn("flex flex-col gap-2 sm:flex-row", className)}
+      {...props}
+    >
+      {previous ? (
+        <Button
+          href={previous.url}
+          variant="secondary"
+          size="small"
+          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
+          icon={<ArrowLeft className="h-3.5 w-3.5" />}
+        >
+          {previous.name}
+        </Button>
+      ) : (
+        <div className="hidden flex-1 sm:block" />
+      )}
+
+      {next ? (
+        <Button
+          href={next.url}
+          variant="secondary"
+          size="small"
+          className="!justify-end"
+          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%] sm:ml-auto"
+          icon={<ArrowRight className="h-3.5 w-3.5" />}
+          iconPosition="end"
+        >
+          {next.name}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/docs/file-tree.tsx
+++ b/components/docs/file-tree.tsx
@@ -11,18 +11,55 @@ import {
   type FileProps,
   type FolderProps,
 } from "fumadocs-ui/components/files";
+import { cn } from "@/lib/utils";
 
 export type { FileProps, FolderProps };
 
+const fileTreeThemeVars = {
+  "--color-fd-card": "var(--surface-1)",
+  "--color-fd-card-foreground": "var(--text-secondary)",
+  "--color-fd-border": "var(--line-structure)",
+  "--color-fd-accent": "var(--surface-1)",
+  "--color-fd-accent-foreground": "var(--text-primary)",
+} as React.CSSProperties;
+
 export function FileTree({
   children,
+  className,
+  style,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
-  return <Files {...props}>{children}</Files>;
+  return (
+    <Files
+      className={cn(
+        "border-line-structure text-text-secondary rounded-none relative",
+        className,
+      )}
+      style={{ ...fileTreeThemeVars, ...style }}
+      {...props}
+    >
+      {children}
+    </Files>
+  );
 }
 
-export const FileTreeFile = File;
-export const FileTreeFolder = Folder;
+export function FileTreeFile(props: FileProps) {
+  return (
+    <File
+      className="text-text-secondary transition-colors hover:bg-surface-1 hover:text-text-primary rounded-none"
+      {...props}
+    />
+  );
+}
+
+export function FileTreeFolder(props: FolderProps) {
+  return (
+    <Folder
+      className="text-text-secondary transition-colors hover:bg-surface-1 hover:text-text-primary rounded-none"
+      {...props}
+    />
+  );
+}
 
 // Compound properties for RSC access via <FileTree.File> / <FileTree.Folder>
 FileTree.File = FileTreeFile;

--- a/components/home/GetStartedSection.tsx
+++ b/components/home/GetStartedSection.tsx
@@ -254,23 +254,26 @@ export function GetStartedSection() {
   return (
     <HomeSection id="get-started" className="pt-[120px]">
       <div className="flex flex-col gap-2.5">
-        <Text className="text-left">
+        <Text className="text-left hidden md:block">
           Get Started <span className="text-text-tertiary mx-1">—</span> <span className="text-text-tertiary">Free tier: <span className="text-primary">50k observations/month</span>. No credit card required.</span>
         </Text>
 
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-6">
           <Heading className="text-primary text-left" size="large">
-            <TextHighlight highlightClassName="mix-blend-multiply" className="max-sm:pr-1.5 xl:pr-3">Start improving</TextHighlight><TextHighlight highlightClassName="mix-blend-multiply">your agents</TextHighlight>
+            <TextHighlight highlightClassName="mix-blend-multiply" className="max-md:pr-1.5 xl:pr-3">Start improving</TextHighlight><TextHighlight highlightClassName="mix-blend-multiply">your agents</TextHighlight>
             <br />
             in under 5 minutes.
           </Heading>
-          <div className="flex sm:flex-col gap-0 items-start shrink-0 w-full sm:w-[150px]">
+          <Text className="text-left md:hidden">
+            Get Started <span className="text-text-tertiary mx-1">—</span> <span className="text-text-tertiary">Free tier: <span className="text-primary">50k observations/month</span>. No credit card required.</span>
+          </Text>
+          <div className="flex md:flex-col gap-0 items-start shrink-0 w-full sm:w-[150px] mt-2">
             <Button
               variant="primary"
               size="default"
               shortcutKey="s"
               href="/cloud"
-              wrapperClassName="sm:flex-none sm:w-full"
+              wrapperClassName="md:flex-none md:w-full"
             >
               Start free
             </Button>
@@ -279,7 +282,7 @@ export function GetStartedSection() {
               size="default"
               shortcutKey="d"
               href="/docs"
-              wrapperClassName="sm:flex-none sm:w-full"
+              wrapperClassName="md:flex-none md:w-full"
             >
               Documentation
             </Button>
@@ -290,7 +293,7 @@ export function GetStartedSection() {
         <div className="flex flex-col sm:flex-row items-start gap-3 mt-10">
           {/* Tab buttons — outside the content box, right-aligned, equal width */}
           <div className="flex sm:flex-col sm:items-end sm:justify-between shrink-0 gap-2 self-stretch">
-            <div className="flex sm:flex-col sm:items-end gap-2">
+            <div className="flex sm:flex-col sm:items-end gap-1 md:gap-2">
               {tabs.map((tab) => {
                 const isActive = activeTab === tab.id;
                 return (

--- a/components/home/layout/HomeLayout.tsx
+++ b/components/home/layout/HomeLayout.tsx
@@ -30,7 +30,7 @@ export function ContentColumns({
   footerClassName,
 }: ContentColumnsProps) {
   return (
-    <div id="home-layout" className={cn("flex flex-1 mx-auto w-full min-h-0 max-w-360 overflow-clip", className)}>
+    <div id="home-layout" className={cn("flex flex-1 mx-auto w-full min-h-0 max-w-380 overflow-clip", className)}>
       {leftSidebar ?? <HomeSidebar />}
       <HomeMainArea>
         {children}

--- a/components/inkeep/search-panel.tsx
+++ b/components/inkeep/search-panel.tsx
@@ -438,4 +438,3 @@ export function AISearchPanel() {
     </>
   );
 }
-

--- a/components/layout/DocsSecondaryNav.tsx
+++ b/components/layout/DocsSecondaryNav.tsx
@@ -64,7 +64,9 @@ export function DocsSecondaryNavMobile() {
   return (
     <div
       className="flex items-center px-3 gap-2 md:hidden sticky z-41 bg-surface-1 border-b border-line-structure [grid-area:header] h-[var(--lf-nav-docs-secondary-height)]"
-      style={{ top: "var(--lf-nav-primary-height)" }}
+      style={{
+        top: "calc(var(--fd-banner-height, 0px) + var(--lf-nav-primary-height))",
+      }}
     >
       <button
         aria-label={open ? "Close Sidebar" : "Open Sidebar"}
@@ -93,7 +95,9 @@ export function DocsSecondaryNav() {
   return (
     <div
       className="hidden overflow-x-auto overflow-y-hidden sticky z-50 md:block bg-surface-1"
-      style={{ top: "var(--lf-nav-primary-height)" }}
+      style={{
+        top: "calc(var(--fd-banner-height, 0px) + var(--lf-nav-primary-height))",
+      }}
     >
       <nav className="px-px mx-auto border-b max-w-360 bg-line-structure border-line-structure">
         <div className="flex gap-0 items-stretch rounded-sm bg-surface-1">

--- a/components/layout/DocsSecondaryNav.tsx
+++ b/components/layout/DocsSecondaryNav.tsx
@@ -99,7 +99,7 @@ export function DocsSecondaryNav() {
         top: "calc(var(--fd-banner-height, 0px) + var(--lf-nav-primary-height))",
       }}
     >
-      <nav className="px-px mx-auto border-b max-w-360 bg-line-structure border-line-structure">
+      <nav className="px-px mx-auto border-b max-w-380 bg-line-structure border-line-structure">
         <div className="flex gap-0 items-stretch rounded-sm bg-surface-1">
           {SECTIONS.map((item) => {
             const isActive = pathname?.startsWith(item.path);

--- a/components/layout/DocsSecondaryNav.tsx
+++ b/components/layout/DocsSecondaryNav.tsx
@@ -92,7 +92,7 @@ export function DocsSecondaryNav() {
   const pathname = usePathname();
   return (
     <div
-      className="hidden overflow-x-auto overflow-y-hidden sticky z-40 md:block bg-surface-1"
+      className="hidden overflow-x-auto overflow-y-hidden sticky z-50 md:block bg-surface-1"
       style={{ top: "var(--lf-nav-primary-height)" }}
     >
       <nav className="px-px mx-auto border-b max-w-360 bg-line-structure border-line-structure">

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -27,7 +27,7 @@ export function Navbar() {
       className="sticky z-50 h-(--lf-nav-primary-height) bg-surface-1 backdrop-blur-md"
       style={{ top: "var(--fd-banner-height, 0px)" }}
     >
-      <nav className="flex mx-auto h-full border-b max-w-360 border-line-structure">
+      <nav className="flex mx-auto h-full border-b max-w-380 border-line-structure">
         <div className={cn(cornersStyle, 'pr-0 lg:max-w-[240px] lg:pr-px')}>
           <div className={cn(contentStyle, 'rounded-r-none lg:rounded-r-sm')}>
             <Logo showAffiliation />

--- a/components/layout/NavbarDocs.tsx
+++ b/components/layout/NavbarDocs.tsx
@@ -15,7 +15,7 @@ export function NavbarDocs({ sectionLabel = "Docs" }: { sectionLabel?: string })
       className="sticky z-50 h-[var(--lf-nav-primary-height)] bg-surface-1 backdrop-blur-md"
       style={{ top: "var(--fd-banner-height, 0px)" }}
     >
-      <nav className="flex mx-auto h-full border-b max-w-360 border-line-structure">
+      <nav className="flex mx-auto h-full border-b max-w-380 border-line-structure">
         <div className={cn(cornersStyle, 'pr-0 lg:max-w-[240px] lg:pr-px')}>
           <div className={cn(contentStyle, 'rounded-r-none lg:rounded-r-sm')}>
             <Link href="/" className="flex gap-2 items-center shrink-0">

--- a/components/layout/SharedDocsLayout.tsx
+++ b/components/layout/SharedDocsLayout.tsx
@@ -9,6 +9,7 @@ import { AISearch, AISearchPanel, FloatingAskAI } from "@/components/inkeep/sear
 import { SidebarFolderItem } from "@/components/docs-sidebar/SidebarFolderItem";
 import { SidebarItem } from "@/components/docs-sidebar/SidebarItem";
 import { SidebarSeparatorItem } from "@/components/docs-sidebar/SidebarSeparatorItem";
+import { Banner } from "./Banner";
 
 /**
  * Shared wrapper used by all sidebar-based section layouts
@@ -51,6 +52,7 @@ export function SharedDocsLayout({
         }
       >
         <DocsPatternTracker />
+        <Banner />
         <NavbarDocs sectionLabel={sectionLabel} />
         {showSecondaryNav && <DocsSecondaryNav />}
         <DocsLayoutWrapper>

--- a/content/blog/2025-10-21-testing-llm-applications.mdx
+++ b/content/blog/2025-10-21-testing-llm-applications.mdx
@@ -7,6 +7,7 @@ tag: guide
 author: Abdallah
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
@@ -94,7 +95,7 @@ test_data = [
     {"input": "What is the capital of Spain?", "expected_output": "Madrid"},
 ]
 
-# The task function wraps your LLM application logic. It receives each test item and 
+# The task function wraps your LLM application logic. It receives each test item and
 # returns the LLM's response. This should be your full LLM application logic.
 def geography_task(*, item, **kwargs):
     """Task function that answers geography questions"""
@@ -105,14 +106,14 @@ def geography_task(*, item, **kwargs):
     )
     return response.choices[0].message.content
 
-# This evaluator checks if the expected answer appears anywhere in the output, accounting 
-# for LLM verbosity. You could also use more sophisticated evaluators, including LLM-as-a-judge 
+# This evaluator checks if the expected answer appears anywhere in the output, accounting
+# for LLM verbosity. You could also use more sophisticated evaluators, including LLM-as-a-judge
 # for semantic similarity.
 def accuracy_evaluator(*, input, output, expected_output, **kwargs):
     """Evaluator that checks if the expected answer is in the output"""
     if expected_output and expected_output.lower() in output.lower():
         return Evaluation(name="accuracy", value=1.0)
-    
+
     return Evaluation(name="accuracy", value=0.0)
 
 # Run-level evaluators aggregate scores across all test items, giving you a single
@@ -123,12 +124,12 @@ def average_accuracy_evaluator(*, item_results, **kwargs):
         eval.value for result in item_results
         for eval in result.evaluations if eval.name == "accuracy"
     ]
-    
+
     if not accuracies:
         return Evaluation(name="avg_accuracy", value=None)
-    
+
     avg = sum(accuracies) / len(accuracies)
-    
+
     return Evaluation(name="avg_accuracy", value=avg, comment=f"Average accuracy: {avg:.2%}")
 
 @pytest.fixture
@@ -145,13 +146,13 @@ def test_geography_accuracy_passes(langfuse_client: Langfuse):
         evaluators=[accuracy_evaluator],
         run_evaluators=[average_accuracy_evaluator]
     )
-    
+
     # Access the run evaluator result directly
     avg_accuracy = next(
         eval.value for eval in result.run_evaluations
         if eval.name == "avg_accuracy"
     )
-    
+
     # Assert minimum accuracy threshold
     assert avg_accuracy >= 0.8, f"Average accuracy {avg_accuracy:.2f} below threshold 0.8"
 ```
@@ -181,7 +182,7 @@ You can integrate these tests into your continuous integration pipeline.
 
 ### GitHub Actions Example
 
-First, setup the environment variables in your Github Actions secrets: 
+First, setup the environment variables in your Github Actions secrets:
 
 ![Github Actions secrets](/images/blog/2025-10-21-testing-llm-applications/github-actions-secrets.png)
 
@@ -198,19 +199,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    
+
     - name: Install dependencies
       run: |
         pip install pytest langfuse openai
-    
+
     - name: Run LLM unit tests
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -235,10 +236,10 @@ def langfuse_client() -> Langfuse:
 
 def test_with_remote_dataset(langfuse_client: Langfuse):
     """Test using a dataset stored in Langfuse with LLM-as-a-judge evaluation"""
-    
+
     # Fetch dataset from Langfuse
     dataset = langfuse_client.get_dataset("geography-questions")
-    
+
     def task(*, item, **kwargs):
         question = item.input
         response = OpenAI().chat.completions.create(
@@ -246,14 +247,14 @@ def test_with_remote_dataset(langfuse_client: Langfuse):
             messages=[{"role": "user", "content": question}]
         )
         return response.choices[0].message.content
-    
+
     # Run experiment - Langfuse automatically applies configured evaluators
     result = dataset.run_experiment(
         name="Geography Test with Remote Dataset",
         description="Testing geography QA with LLM-as-a-judge",
         task=task
     )
-    
+
     # The LLM-as-a-judge evaluator runs automatically in Langfuse
     # Results are visible in the Langfuse UI
     langfuse_client.flush()
@@ -299,23 +300,23 @@ import { FileCode, BookOpen, Video, Users, Joystick } from "lucide-react";
 
 ## FAQ
 
-<details>
-<summary>How do you test LLM applications?</summary>
+<Details>
+<Summary>How do you test LLM applications?</Summary>
 
 Testing LLM applications requires a different approach than traditional software testing. Instead of checking exact output matches, you use **evaluation functions** that score outputs on continuous scales. The typical approach combines three components: (1) **Datasets** — collections of input/output pairs representing test cases, (2) **Experiment runners** — tools that execute your LLM application against the dataset, and (3) **Evaluators** — scoring functions that assess output quality using LLM-as-a-Judge, semantic similarity, or custom logic. A test passes when evaluation scores meet your defined thresholds.
 
-</details>
+</Details>
 
-<details>
-<summary>What is the difference between LLM testing and LLM evaluation?</summary>
+<Details>
+<Summary>What is the difference between LLM testing and LLM evaluation?</Summary>
 
 **Testing** produces binary pass/fail results — your test suite tells you whether something broke. **Evaluation** measures quality on continuous scales — how accurate, helpful, or relevant are the responses. In practice, LLM testing and evaluation blend together: you "test" your application by "evaluating" its outputs with scoring functions, and a test passes if the evaluation score meets your threshold. Both are essential for building reliable LLM applications.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I automate LLM testing in CI/CD?</summary>
+<Details>
+<Summary>How do I automate LLM testing in CI/CD?</Summary>
 
 You can integrate LLM testing into your CI/CD pipeline using Langfuse's experiment runner SDK. Create a test script that: (1) loads your dataset (locally or from Langfuse), (2) runs your application against each test case, (3) scores the outputs with evaluator functions, and (4) asserts that scores meet minimum thresholds. Run this script as part of your CI pipeline using `pytest` or your preferred test runner. See the [experiments via SDK guide](/docs/evaluation/experiments/experiments-via-sdk) for implementation details.
 
-</details>
+</Details>

--- a/content/blog/2026-02-16-prompt-improvement-claude-skills.mdx
+++ b/content/blog/2026-02-16-prompt-improvement-claude-skills.mdx
@@ -7,6 +7,7 @@ author: Lotte
 ogImage: /images/blog/2026-02-16-prompt-improvement-claude-skills/og.jpg
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
@@ -25,7 +26,7 @@ We'll walk through the full loop using an example: a chatbot that searches past 
 
 ## Prerequisites
 
-**An LLM application with Langfuse tracing set up**. If your application is not instrumented yet, you can take a look at the [tracing get started page](/docs/observability/get-started) to set it up. 
+**An LLM application with Langfuse tracing set up**. If your application is not instrumented yet, you can take a look at the [tracing get started page](/docs/observability/get-started) to set it up.
 
 **An AI agent with the Langfuse skill installed**. You can use any AI agent, we'll use Claude with the [Langfuse skill](https://github.com/langfuse/skills/tree/main/skills/langfuse) in this guide (which uses the [Langfuse CLI](https://github.com/langfuse/langfuse-cli) under the hood).
 
@@ -46,7 +47,7 @@ The workflow is a loop with three steps: you look at traces, annotate the ones t
 
 ### The Example Application
 
-We're using a chatbot that searches GitHub discussions in the [Langfuse repository](https://github.com/langfuse/langfuse/discussions) to help users find whether their bug or feature request has already been  in the past. 
+We're using a chatbot that searches GitHub discussions in the [Langfuse repository](https://github.com/langfuse/langfuse/discussions) to help users find whether their bug or feature request has already been  in the past.
 
 <Frame>
   <img src="/images/docs/guides/prompt-improvement-terminal-example.png" alt="Terminal output of the GitHub issue search chatbot" />
@@ -54,8 +55,8 @@ We're using a chatbot that searches GitHub discussions in the [Langfuse reposito
 
 It fetches its system prompt from Langfuse, searches Github multiple times with different queries, evaluates the results and responds with the issues that are relevant. Every interaction produces a trace in Langfuse. You can find the full example repository [here](https://github.com/langfuse/langfuse-examples/tree/main/applications/github-issue-search).
 
-<details>
-<summary>Example application code snippet</summary>
+<Details>
+<Summary>Example application code snippet</Summary>
 
 ```python
 from langfuse import Langfuse, get_client, observe
@@ -93,7 +94,7 @@ def main():
     # ... conversation loop
 ```
 
-</details>
+</Details>
 
 {/* TODO: link to the full example repository */}
 
@@ -182,7 +183,7 @@ Here's what the diff looks like in Langfuse:
 
 ### 4. Keep iterating
 
-You can keep doing iterations of this loop until you don't see any obvious issues. In my case, I did about 3 iterations, after which I was consistently getting good results on my small set of traces. 
+You can keep doing iterations of this loop until you don't see any obvious issues. In my case, I did about 3 iterations, after which I was consistently getting good results on my small set of traces.
 
 ## Variations
 
@@ -190,11 +191,11 @@ In this guide we manually annotated traces, but the same approach works with dif
 
 - **User feedback from production**: If your app collects [user feedback (thumbs up/down, ratings, comments)](/docs/observability/features/user-feedback), you can fetch those via the CLI and use them in the same way. Be selective though: not all user feedback is actionable, so you may want to filter for feedback you actually agree with before handing it to the agent.
 - **Annotation queues**: If your team reviews traces through [Langfuse annotation queues](/docs/evaluation/evaluation-methods/annotation-queues), you can fetch scores from a specific queue to work with a curated set of annotations.
-- **Experiment results**: After running an [experiment](/docs/evaluation/experiments), you can fetch the scores and comments from that run. 
+- **Experiment results**: After running an [experiment](/docs/evaluation/experiments), you can fetch the scores and comments from that run.
 
 ## What's next
 
-At some point, it will make sense to do more structured evaluation, to make sure your prompt changes are not causing any regressions on earlier cases. 
+At some point, it will make sense to do more structured evaluation, to make sure your prompt changes are not causing any regressions on earlier cases.
 
 One natural next step is to [build a dataset](/docs/evaluation/experiments/datasets) out of the traces you annotated, so you can rerun your new prompts against this fixed set of cases. You can do this using the AI agent skill too, or you can use the Langfuse UI to create a dataset. Later, you can then:
 

--- a/content/blog/2026-03-13-weekly-digest-ai-skill.mdx
+++ b/content/blog/2026-03-13-weekly-digest-ai-skill.mdx
@@ -8,6 +8,7 @@ author: Lotte
 highlight: true
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 import { Frame } from "@/components/Frame";
 import { FileTree } from "@/components/docs";
@@ -42,7 +43,7 @@ Last week the skill processed 481 support tickets, 53 open and 14 recently close
 
 ### Grouping Tickets into Attention Points
 
-The skill groups issues into topics and identifies the most important ones. 
+The skill groups issues into topics and identifies the most important ones.
 
 A support ticket may say "prompt caching not traced," a GitHub issue says "cache tokens double-counted.", same underlying bug. The skill merges them into a single digest entry:
 
@@ -58,8 +59,8 @@ Every item links directly to its source, so we can read the original tickets to 
 
 The first version of the digest wasn't great. The loop to improve it works like this: run the skill, open the trace in Langfuse, and leave comments directly on the parts of the output that are off ("this item is too vague," "these two should be merged," "this link is wrong"). Then point another agent at those comments and have it update `SKILL.md` accordingly. Each cycle takes about ten minutes. Nine iterations later, the digest was in a completely different place. (For a deeper look at this pattern, see our [post on using agent skills for prompt improvement](/blog/2026-02-16-prompt-improvement-claude-skills).)
 
-<details>
-<summary>First iteration output (excerpt)</summary>
+<Details>
+<Summary>First iteration output (excerpt)</Summary>
 
 **Top Topics This Week:**
 
@@ -83,10 +84,10 @@ The first version of the digest wasn't great. The loop to improve it works like 
 
 The full output had 10 categories like this, plus recurring themes and a "What to Watch" section, all at this same level of vagueness, all grouped by product area.
 
-</details>
+</Details>
 
-<details>
-<summary>Last iteration output (excerpt)</summary>
+<Details>
+<Summary>Last iteration output (excerpt)</Summary>
 
 **Top Topics This Week:**
 
@@ -109,7 +110,7 @@ Users who add metadata filters to custom dashboards get empty results, even when
 
 The full output had 5 more sections (Roadmap Input, Integration Issues, What to Watch), each with this level of specificity, categorized by what kind of decision the item requires rather than by product area.
 
-</details>
+</Details>
 
 Compare the two: the first version groups by product area with vague descriptions ("users are experiencing tracing issues"). The last groups by decision type (is the path forward clear, or does this need discussion?) with descriptions specific enough that you can understand the problem without clicking through. Issues are properly deduplicated across sources, and every item links directly to the ticket, issue, or meeting it came from.
 

--- a/content/blog/2026-03-24-optimizing-ai-skill-with-autoresearch.mdx
+++ b/content/blog/2026-03-24-optimizing-ai-skill-with-autoresearch.mdx
@@ -8,6 +8,7 @@ author: Lotte
 highlight: true
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 import { Tweet } from "@/components/Tweet";
 import { Frame } from "@/components/Frame";
@@ -33,7 +34,7 @@ The result is hands-off iteration at machine speed. Karpathy reported ~12 experi
 
 ## The Setup for Autoresearching the Langfuse Skill
 
-The Langfuse skill is quite broad. It has instructions for general best practices, and detailed guidance for specific use cases. To contain the scope, we decided to focus specifically on the prompt migration use case. 
+The Langfuse skill is quite broad. It has instructions for general best practices, and detailed guidance for specific use cases. To contain the scope, we decided to focus specifically on the prompt migration use case.
 
 <div>
   <FileTree>
@@ -48,7 +49,7 @@ The Langfuse skill is quite broad. It has instructions for general best practice
   </FileTree>
 </div>
 
-The specific prompt migration instructions are in `references/prompt-migration.md`. 
+The specific prompt migration instructions are in `references/prompt-migration.md`.
 
 To make this approach work for an AI skill instead of code, we made a couple of adaptations to the autoresearch setup:
 
@@ -88,10 +89,10 @@ For each case we have an `expected.json` defining exactly what the evaluator che
 
 ## Before and After
 
-Here's what the skill looked like before and after 14 experiments. As you can see, the tone and degree of freedom for the agent is completely different. 
+Here's what the skill looked like before and after 14 experiments. As you can see, the tone and degree of freedom for the agent is completely different.
 
-<details>
-<summary>Original skill (before)</summary>
+<Details>
+<Summary>Original skill (before)</Summary>
 
 ```markdown
 # Langfuse Prompt Migration
@@ -218,10 +219,10 @@ Checklist:
 - Application behavior unchanged
 - Generations show linked prompt in UI (if tracing)
 ```
-</details>
+</Details>
 
-<details>
-<summary>Skill after autoresearch</summary>
+<Details>
+<Summary>Skill after autoresearch</Summary>
 
 ```markdown
 # Langfuse Prompt Migration
@@ -311,7 +312,7 @@ Key rules:
 2. All code uses get_prompt() with label="production" and .compile()
 3. Asset files are no longer read by the code
 ```
-</details>
+</Details>
 
 In summary, a couple of things changed:
 
@@ -345,15 +346,15 @@ The agent ran 14 experiments total. There were instances where autoresearch foun
 
 ### Where It Did Well
 
-**1. The double-brace CRITICAL warning** 
+**1. The double-brace CRITICAL warning**
 
-Across multiple experiments, the agent kept uploading prompts to Langfuse with `{var}` instead of `{{var}}`. Langfuse uses double curly braces for variable substitution — single braces get treated as literal text. 
+Across multiple experiments, the agent kept uploading prompts to Langfuse with `{var}` instead of `{{var}}`. Langfuse uses double curly braces for variable substitution — single braces get treated as literal text.
 
-The original skill mentioned this too, but it was tucked away in a table row. Autoresearch escalated it twice: first to inline instructions, then to a `**CRITICAL**` bold warning at the top of the prompt creation step. Each escalation improved the score. 
+The original skill mentioned this too, but it was tucked away in a table row. Autoresearch escalated it twice: first to inline instructions, then to a `**CRITICAL**` bold warning at the top of the prompt creation step. Each escalation improved the score.
 
-**2. The inventory step** 
+**2. The inventory step**
 
-On complex cases (12 prompts across 9 files), the agent would often start modifying code before it had a full picture of what needed to change, and then miss prompts or lose track. 
+On complex cases (12 prompts across 9 files), the agent would often start modifying code before it had a full picture of what needed to change, and then miss prompts or lose track.
 
 Autoresearch added an explicit step: "Before writing ANY code, make a complete list of every prompt you found" with 6 required fields (name, source file, code file to refactor, type, variables, prompt content). This forced the agent to plan before acting. Case `04` went from erratic results to consistently scoring above 0.88. Planning before acting is obvious advice for humans; turns out agents need it spelled out.
 
@@ -384,12 +385,12 @@ The original skill had full sections on identifying shared text across prompts (
 
 Autoresearch optimizes for exactly what you measure given the context you execute in. If your target function has gaps, it will find and exploit them. The [community around autoresearch](https://github.com/karpathy/autoresearch/pull/218) has been raising this same concern: it's Goodhart's Law at machine speed. Whatever metric you expose, the agent will exploit it relentlessly.
 
-Next to that, common criticism of autoresearch [in the broader community](https://news.ycombinator.com/item?id=47291123) is validation set overfitting. Run hundreds of experiments against a fixed set of test cases, and you end up optimizing for quirks of that specific data. 
+Next to that, common criticism of autoresearch [in the broader community](https://news.ycombinator.com/item?id=47291123) is validation set overfitting. Run hundreds of experiments against a fixed set of test cases, and you end up optimizing for quirks of that specific data.
 
 The problem is: **most people will not build a complete enough target function.** We didn't.
 
 **For a skill that does one narrow thing**, it's feasible to build a target function that covers the full surface area.
-And autoresearch will probably give you great results. For example, Shopify's Tobi Lutke [applied autoresearch to their Liquid templating engine](https://x.com/tobi/status/2032212531846971413) — a narrow, well-defined optimization target — and got 53% faster rendering and 61% fewer memory allocations from 93 automated commits. He still noted the overfitting though. 
+And autoresearch will probably give you great results. For example, Shopify's Tobi Lutke [applied autoresearch to their Liquid templating engine](https://x.com/tobi/status/2032212531846971413) — a narrow, well-defined optimization target — and got 53% faster rendering and 61% fewer memory allocations from 93 automated commits. He still noted the overfitting though.
 
 <Tweet id="2032212531846971413" />
 
@@ -411,4 +412,4 @@ It tested the skill far more than we ever would have manually: 14 experiments ac
 
 ## Using autoresearch for prompt optimization
 
-Beyond skills, the same pattern could apply to prompt optimization. We've [explored prompt improvement workflows before](/blog/2026-02-26-evaluate-ai-agent-skills), and automating that loop with autoresearch is a natural next step. Though the same caveats apply: if your evaluation dataset is too narrow or your target function too simple, you'll overfit just as efficiently. 
+Beyond skills, the same pattern could apply to prompt optimization. We've [explored prompt improvement workflows before](/blog/2026-02-26-evaluate-ai-agent-skills), and automating that loop with autoresearch is a natural next step. Though the same caveats apply: if your evaluation dataset is too narrow or your target function too simple, you'll overfit just as efficiently.

--- a/content/blog/2026-04-01-llm-as-a-judge-production-monitoring.mdx
+++ b/content/blog/2026-04-01-llm-as-a-judge-production-monitoring.mdx
@@ -8,6 +8,7 @@ ogImage: /images/blog/2026-03-25-llm-as-a-judge-production-monitoring/og.jpg
 highlight: true
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
@@ -73,8 +74,8 @@ We built template [evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judg
 
 You can see [our version of this evaluator](https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/evals?peek=e716ad75-cbf3-465e-afa5-804f3c504ba0) running in our sample project, or use the template prompt below as a starting point:
 
-<details>
-<summary>Example judge prompt: User Distress</summary>
+<Details>
+<Summary>Example judge prompt: User Distress</Summary>
 
 ```
 You are a User Distress Judge evaluating an LLM-based customer support assistant.
@@ -185,7 +186,7 @@ COMMENT: <concise justification>
 \`\`\`
 ```
 
-</details>
+</Details>
 
 ### 2. User Disagreement
 
@@ -201,8 +202,8 @@ COMMENT: <concise justification>
 
 You can see [our version of this evaluator](https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/evals?peek=bd0f9452-a64b-4cca-853c-f608bc6e104b) running in our sample project, or use the template prompt below as a starting point:
 
-<details>
-<summary>Example judge prompt: User Disagreement</summary>
+<Details>
+<Summary>Example judge prompt: User Disagreement</Summary>
 
 ```
 You are a User Disagreement Judge evaluating an LLM-based customer support assistant.
@@ -272,7 +273,7 @@ COMMENT: <concise justification>
 \`\`\`
 ```
 
-</details>
+</Details>
 
 ### 3. Out-of-Scope Request
 
@@ -288,8 +289,8 @@ COMMENT: <concise justification>
 
 You can see [our version of this evaluator](https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/evals?peek=38089bd6-e1f8-4559-8681-43b9bdaebde0) running in our sample project, or use the template prompt below as a starting point:
 
-<details>
-<summary>Example judge prompt: Out-of-Scope Request</summary>
+<Details>
+<Summary>Example judge prompt: Out-of-Scope Request</Summary>
 
 ```
 You are an Out-of-Scope Request Judge evaluating an LLM-based customer support assistant.
@@ -417,7 +418,7 @@ COMMENT: <concise justification>
 \`\`\`
 ```
 
-</details>
+</Details>
 
 ### 4. Insufficient Answer
 
@@ -433,8 +434,8 @@ COMMENT: <concise justification>
 
 You can see [our version of this evaluator](https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/evals?peek=639b636f-2ccb-4d86-8bec-48bce21cc880) running in our sample project, or use the template prompt below as a starting point:
 
-<details>
-<summary>Example judge prompt: Insufficient Answer</summary>
+<Details>
+<Summary>Example judge prompt: Insufficient Answer</Summary>
 
 ```
 You are an Insufficient Answer Judge evaluating an LLM-based customer support assistant.
@@ -560,7 +561,7 @@ COMMENT: <concise justification>
 \`\`\`
 ```
 
-</details>
+</Details>
 
 ## Setting This Up in Langfuse
 

--- a/content/blog/2026-04-14-categorical-llm-as-a-judge-user-intent.mdx
+++ b/content/blog/2026-04-14-categorical-llm-as-a-judge-user-intent.mdx
@@ -7,6 +7,7 @@ author: Lotte
 ogImage: /images/blog/2026-04-14-categorical-llm-as-a-judge-user-intent/og.jpg
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
@@ -41,8 +42,8 @@ We defined six intent categories that map to distinct user needs:
 | `ui-feedback` | The user gives feedback, reports a UI issue, or makes a product suggestion about the Langfuse application itself. |
 | `irrelevant-to-langfuse` | Greetings with no question, test messages, gibberish, or requests completely unrelated to Langfuse. |
 
-<details>
-<summary>Read the full evaluator prompt here.</summary>
+<Details>
+<Summary>Read the full evaluator prompt here.</Summary>
 
 You are a user intent classifier for a Langfuse support chatbot.
 You will be given the user's message. Classify it into exactly one of the following categories.
@@ -64,7 +65,7 @@ You will be given the user's message. Classify it into exactly one of the follow
 
 **Output:** Respond with only the category name, nothing else.
 
-</details>
+</Details>
 
 ---
 

--- a/content/changelog/2024-11-19-llm-as-a-judge-for-datasets.mdx
+++ b/content/changelog/2024-11-19-llm-as-a-judge-for-datasets.mdx
@@ -9,6 +9,7 @@ author: Marlies
 canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
 ---
 
+import { Details, Summary } from "@/components/Details";
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
 
 <ChangelogHeader />
@@ -28,8 +29,8 @@ import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
 
 Building reliable AI applications is challenging because it's hard to understand how changes impact performance. Without proper evaluation, teams end up playing whack-a-mole with bugs and regressions. [Datasets and experiments](/docs/datasets/overview) in Langfuse help transform this uncertainty into a structured engineering process.
 
-<details>
-<summary>Benefits of investing into datasets and development evaluations</summary>
+<Details>
+<Summary>Benefits of investing into datasets and development evaluations</Summary>
 
 - Measure the impact of changes before deployment
 - Identify regressions early
@@ -37,7 +38,7 @@ Building reliable AI applications is challenging because it's hard to understand
 - Build stronger conviction in your test datasets by identifying gaps between test and production evaluations
 - Create reliable feedback loops for development
 
-</details>
+</Details>
 
 Until now, datasets and experiments depended on custom evaluations that were added to the run via the SDKs/API. This is great if you need full flexibility or want to use your preferred evaluation library or scoring logic. There were LLM-as-a-judge evaluators, but they were _limited to production runs_ and _could not access the ground truth of your dataset_ (`expected_output`) which is necessary for a reliable offline evaluation.
 

--- a/content/docs/administration/llm-connection.mdx
+++ b/content/docs/administration/llm-connection.mdx
@@ -49,8 +49,8 @@ The Langfuse platform is currently supporting the following LLM providers:
 - Google Vertex AI
 - Amazon Bedrock
 
-<details>
-<summary>Supported models</summary>
+<Details>
+<Summary>Supported models</Summary>
 
 Currently the playground supports the following models by default. You may configure additional custom model names when adding your LLM API Key in the Langfuse project settings, e.g. when using a custom model or proxy.
 
@@ -157,7 +157,7 @@ export function ModelList() {
 
 <ModelList />
 
-</details>
+</Details>
 
 You may connect to third party LLM providers if their API schema implements the schema of one of our supported provider adapters. For example, you may connect to Mistral by using the OpenAI adapter in Langfuse to connect to Mistral's OpenAI compliant API.
 
@@ -196,6 +196,7 @@ This feature is currently available for the adapters for:
 
 Example for forcing reasoning effort `minimal` on an OpenAI gpt-5 invocation:
 
+import { Details, Summary } from "@/components/Details";
 import { Frame } from "@/components/Frame";
 import Image from "next/image";
 

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -40,6 +40,7 @@ LLM-as-a-Judge evaluators can run on three types of data: **Observations** (indi
 
 ### Decision Tree
 
+import { Details, Summary } from "@/components/Details";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 <div className="flex flex-col items-center gap-6 py-8 my-6">
@@ -360,15 +361,15 @@ You can show the LLM-as-a-Judge execution traces by filtering for the environmen
   environment](/images/docs/evaluation/llm-as-a-judge-debug-traces.png)
 </Frame>
 
-<details>
-<summary>LLM-as-a-Judge Execution Status</summary>
+<Details>
+<Summary>LLM-as-a-Judge Execution Status</Summary>
 
 - **Completed**: Evaluation finished successfully.
 - **Error**: Evaluation failed (click execution trace ID for details).
 - **Delayed**: Evaluation hit rate limits by the LLM provider and is being retried with exponential backoff.
 - **Pending**: Evaluation is queued and waiting to run.
 
-</details>
+</Details>
 
 ## Advanced Topics
 
@@ -402,40 +403,40 @@ This backfill flow runs from the traces table, but the resulting scores are atta
 
 ## FAQ
 
-<details>
-<summary>What is LLM-as-a-Judge evaluation?</summary>
+<Details>
+<Summary>What is LLM-as-a-Judge evaluation?</Summary>
 
 LLM-as-a-Judge is an evaluation methodology where a large language model (the "judge") assesses the quality of outputs from another LLM application. The judge model is given the input, the application's output, and a scoring rubric, then produces a score with reasoning. It's one of the most popular approaches for evaluating LLM applications because it combines human-like nuance with automated scalability.
 
-</details>
+</Details>
 
-<details>
-<summary>How accurate is LLM-as-a-Judge compared to human evaluation?</summary>
+<Details>
+<Summary>How accurate is LLM-as-a-Judge compared to human evaluation?</Summary>
 
 Research shows that strong LLM judges (such as GPT-5 class models) achieve 80-90% agreement with human evaluators on many quality dimensions, which is comparable to inter-annotator agreement between humans. Accuracy improves significantly with well-designed rubrics and clear evaluation criteria. For best results, calibrate your LLM-as-a-Judge setup against a small set of human-annotated examples.
 
-</details>
+</Details>
 
-<details>
-<summary>What models work best as LLM judges?</summary>
+<Details>
+<Summary>What models work best as LLM judges?</Summary>
 
 The most capable models generally produce the best evaluations. Models with strong instruction-following and reasoning capabilities (such as GPT-4o, Claude Sonnet, or Gemini Pro) are commonly used. The judge model should support structured output so scores can be reliably parsed. In Langfuse, you configure the judge model via [LLM Connections](/docs/administration/llm-connection).
 
-</details>
+</Details>
 
-<details>
-<summary>How much does LLM-as-a-Judge cost?</summary>
+<Details>
+<Summary>How much does LLM-as-a-Judge cost?</Summary>
 
 Cost depends on the judge model and the size of the inputs being evaluated. A typical evaluation costs $0.01-0.10 per assessment. You can manage costs by: (1) using sampling to evaluate a percentage of traces, (2) targeting specific observations instead of full traces, and (3) choosing cost-effective judge models for simpler evaluations.
 
-</details>
+</Details>
 
-<details>
-<summary>Can I use LLM-as-a-Judge for RAG evaluation?</summary>
+<Details>
+<Summary>Can I use LLM-as-a-Judge for RAG evaluation?</Summary>
 
 Yes. LLM-as-a-Judge is particularly effective for RAG pipelines. You can evaluate faithfulness (is the answer grounded in the retrieved context?), relevance (does the answer address the question?), and completeness (does the answer cover all relevant information?). Langfuse also integrates with [RAGAS](/guides/cookbook/evaluation_of_rag_with_ragas) for specialized RAG evaluation metrics.
 
-</details>
+</Details>
 
 ## GitHub Discussions
 

--- a/content/docs/evaluation/experiments/experiments-via-ui.mdx
+++ b/content/docs/evaluation/experiments/experiments-via-ui.mdx
@@ -39,8 +39,8 @@ Create a prompt that you want to test and evaluate. [How to create a prompt?](/d
   example below.
 </Callout>
 
-<details>
-<summary>Example: Prompt Variables & Dataset Item Keys Mapping</summary>
+<Details>
+<Summary>Example: Prompt Variables & Dataset Item Keys Mapping</Summary>
 <div className="grid md:grid-cols-1 gap-4">
 <div>
 
@@ -76,10 +76,10 @@ In this example:
 - The prompt variable `{{question}}` maps to the JSON key `"question"`
 - Both keys must exist in the dataset item's input JSON for the experiment to run successfully
 
-</details>
+</Details>
 
-<details>
-<summary>Example: Chat Message Placeholder Mapping</summary>
+<Details>
+<Summary>Example: Chat Message Placeholder Mapping</Summary>
 
 In addition to variables, you can also map placeholders in chat message prompts to dataset item keys.
 This is useful when the dataset item also contains for example a chat message history to use.
@@ -112,7 +112,7 @@ In this example:
 - The prompt variable `{{question}}` maps to the JSON key `"question"` in a variable not within a placeholder message.
 - Both keys must exist in the dataset item's input JSON for the experiment to run successfully
 
-</details>
+</Details>
 
 ### Create a usable dataset
 
@@ -124,8 +124,8 @@ Create a dataset with the inputs and expected outputs you want to use for your p
   prompt(s) you will use. See the example below.
 </Callout>
 
- <details>
-<summary>Example: Prompt Variables & Dataset Item Keys Mapping</summary>
+ <Details>
+<Summary>Example: Prompt Variables & Dataset Item Keys Mapping</Summary>
 <div className="grid md:grid-cols-1 gap-4">
 <div>
 
@@ -161,7 +161,7 @@ In this example:
 - The prompt variable `{{question}}` maps to the JSON key `"question"`
 - Both keys must exist in the dataset item's input JSON for the experiment to run successfully
 
-</details>
+</Details>
 
 ### Configure LLM connection
 
@@ -202,7 +202,7 @@ Experiments are currently started from the detail page of a dataset.
 
 1. **Set** an Experiment name
 2. **Select** the prompt you want to use
-   - If you only have one piece of dynamic content, we recommend a chat prompt with a static system prompt and a dynamic user message (e.g., full user message as a variable). This ensures you can map your dynamic content as the user message. 
+   - If you only have one piece of dynamic content, we recommend a chat prompt with a static system prompt and a dynamic user message (e.g., full user message as a variable). This ensures you can map your dynamic content as the user message.
    - If you have multiple pieces of dynamic content, we recommend creating a variable in the prompt for each piece of dynamic content. This ensures you can map your dynamic content to the corresponding variable.
 3. **Set up or select** the LLM connection you want to use
 4. **Select** the dataset you want to use
@@ -242,6 +242,7 @@ After each Experiment run, you can check the aggregated score in the Experiments
 
 ## GitHub Discussions
 
+import { Details, Summary } from "@/components/Details";
 import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
 
 <GhDiscussionsPreview labels={["feat-prompt-experiments"]} />

--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -7,6 +7,7 @@ description: Get started with LLM observability with Langfuse in minutes before 
 
 This guide walks you through ingesting your first trace into Langfuse. If you're looking to understand what tracing is and why it matters, check out the [Observability Overview](/docs/observability/overview) first. For details on how traces are structured in Langfuse and how it works in the background, see [Core Concepts](/docs/observability/data-model).
 
+import { Details, Summary } from "@/components/Details";
 import GetStartedPythonSdk from "@/components-mdx/get-started/python-sdk.mdx";
 import GetStartedJsSdk from "@/components-mdx/get-started/js-sdk.mdx";
 import GetStartedOpenaiSdk from "@/components-mdx/get-started/openai-sdk.mdx";
@@ -77,8 +78,8 @@ If you want to target a specific agent directly:
 npx skills add langfuse/skills --skill "langfuse" --agent "<agent-id>"
 ```
 
-<details>
-<summary>Alternatively you can manually clone the skill</summary>
+<Details>
+<Summary>Alternatively you can manually clone the skill</Summary>
 
 1. Clone repo somewhere stable
 ```bash
@@ -95,7 +96,7 @@ mkdir -p /path/to/<agent-skill-root>/skills
 ln -s /path/to/langfuse-skills/skills/langfuse /path/to/<agent-skill-root>/skills/langfuse
 ```
 
-</details>
+</Details>
 
 Then prompt your agent:
 

--- a/content/docs/observability/overview.mdx
+++ b/content/docs/observability/overview.mdx
@@ -4,6 +4,8 @@ seoTitle: "LLM Observability & Application Tracing (Open Source)"
 description: "Open source application tracing and observability for LLM apps. Capture traces, monitor latency, track costs, and debug issues across OpenAI, LangChain, LlamaIndex, and more."
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Observability & Application Tracing
 
 Because AI is inherently non-deterministic, debugging your application without any observability tool is more like guesswork.
@@ -40,31 +42,30 @@ Already know what you want? Take a look under _Features_ for guides on specific 
 
 ## FAQ
 
-<details>
-<summary>What is the difference between observability and tracing?</summary>
+<Details>
+<Summary>What is the difference between observability and tracing?</Summary>
 
 **Observability** is the broader capability of understanding the internal state of your system from its outputs. It encompasses tracing, metrics, and logging. **Tracing** is a specific observability technique that records the flow of a request through your system, preserving causal relationships between operations. In the context of LLM applications, tracing is the most important observability tool because it captures the full context of each request — prompts, responses, tool calls, and their relationships.
 
-</details>
+</Details>
 
-<details>
-<summary>What is application tracing?</summary>
+<Details>
+<Summary>What is application tracing?</Summary>
 
 Application tracing records the complete lifecycle of a request as it flows through your system. Each trace captures every operation — LLM calls, retrieval steps, tool executions, and custom logic — along with timing, inputs, outputs, and metadata. This gives you full visibility into what happened during each request, enabling debugging, performance optimization, and quality monitoring.
 
-</details>
+</Details>
 
-<details>
-<summary>How does Langfuse compare to other tracing solutions?</summary>
+<Details>
+<Summary>How does Langfuse compare to other tracing solutions?</Summary>
 
 Langfuse is purpose-built for LLM applications, which means it natively understands LLM-specific concepts like token usage, model parameters, prompt/completion pairs, and evaluation scores. Unlike general-purpose APM tools, Langfuse provides features specific to AI engineering: [LLM-as-a-Judge evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge), [prompt management](/docs/prompt-management/overview), [experiments and datasets](/docs/evaluation/experiments/datasets), and [custom dashboards](/docs/metrics/features/custom-dashboards). It's also [open source](/self-hosting) and can be self-hosted.
 
-</details>
+</Details>
 
-<details>
-<summary>Does Langfuse add latency to my application?</summary>
+<Details>
+<Summary>Does Langfuse add latency to my application?</Summary>
 
 No. Langfuse SDKs send tracing data asynchronously in the background. Trace events are queued locally and flushed in batches, so your application's response time is not affected. See [queuing and batching](/docs/observability/features/queuing-batching) for details.
 
-</details>
-
+</Details>

--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -4,6 +4,7 @@ description: Fully typed SDKs for Python and JavaScript/TypeScript with unified 
 category: SDKs
 ---
 
+import { Details, Summary } from "@/components/Details";
 import GetStartedPythonSdk from "@/components-mdx/get-started/python-sdk.mdx";
 import EnvJS from "@/components-mdx/env-js.mdx";
 import JSSDKPackages from "@/components-mdx/js-sdk-packages.mdx";
@@ -17,7 +18,7 @@ Langfuse offers two SDKs:
 - **JS/TS SDK v5** <a href="https://github.com/langfuse/langfuse-js"><img className="inline" alt="GitHub repository langfuse/langfuse-js" src="https://img.shields.io/badge/repo-langfuse--js-blue?style=flat-square&logo=GitHub" /></a> <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm+@langfuse/tracing" alt="NPM @langfuse/tracing" /></a>
 - [**Other Languages**](#other-languages) via OpenTelemetry
 
-The Langfuse SDKs are the recommended way to create [custom observations and traces](/docs/observability/sdk/instrumentation#custom-instrumentation) and use the Langfuse [prompt-management](/docs/prompt-management/overview) and [evaluation](/docs/evaluation/overview) features. 
+The Langfuse SDKs are the recommended way to create [custom observations and traces](/docs/observability/sdk/instrumentation#custom-instrumentation) and use the Langfuse [prompt-management](/docs/prompt-management/overview) and [evaluation](/docs/evaluation/overview) features.
 
 **Key benefits**
 
@@ -33,25 +34,25 @@ The Langfuse SDKs are the recommended way to create [custom observations and tra
 This section documents tracing related features of the Langfuse SDK. To use the Langfuse SDK for [prompt management](/docs/prompt-management/overview) and [evaluation](/docs/evaluation/overview), visit their respective documentation.
 </Callout>
 
-<details>
-<summary>Requirements for self-hosted Langfuse</summary>
+<Details>
+<Summary>Requirements for self-hosted Langfuse</Summary>
 
 <Callout type="info">
 If you are self-hosting Langfuse, the Python SDK v3 requires [**Langfuse platform version ≥ 3.125.0**](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) and the TypeScript SDK v4 requires [**Langfuse platform version ≥ 3.95.0**](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) for all features to work correctly.
 </Callout>
 
-</details>
+</Details>
 
 
-<details>
-<summary>Legacy documentation</summary>
+<Details>
+<Summary>Legacy documentation</Summary>
 
 This documentation is for the latest versions of the Langfuse SDKs.
 
 - Documentation for the legacy Python SDK v3 can be found [here](https://python-sdk-v3.docs-snapshot.langfuse.com/docs/observability/sdk/overview/).
 - Documentation for the legacy TypeScript SDK v4 can be found [here](https://js-sdk-v4-docs-snapshot.langfuse.com/docs/observability/sdk/overview/).
 
-</details>
+</Details>
 
 ## Quickstart
 
@@ -132,7 +133,7 @@ See the [trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz08
 
 ## Setup
 
-This section covers all detail of setting up the Langfuse SDKs. Follow the [Quickstart](#quickstart) guide to create your first trace. 
+This section covers all detail of setting up the Langfuse SDKs. Follow the [Quickstart](#quickstart) guide to create your first trace.
 
 <Steps>
 
@@ -235,8 +236,8 @@ else:
 
 The Langfuse client is a singleton. It can be accessed anywhere in your application using the [`get_client()`](https://python.reference.langfuse.com/langfuse#get_client) function.
 
-<details>
-<summary>Alternative: Configure via constructor</summary>
+<Details>
+<Summary>Alternative: Configure via constructor</Summary>
 
 Optionally, you can initialize the client via [`Langfuse()`](https://python.reference.langfuse.com/langfuse#Langfuse) to pass in configuration options (see below). Otherwise, it is created automatically when you call [`get_client()`](https://python.reference.langfuse.com/langfuse#get_client) based on environment variables.
 
@@ -257,7 +258,7 @@ langfuse = Langfuse(
 
 All key configuration options are listed in the [Python SDK reference](https://python.reference.langfuse.com/langfuse#Langfuse).
 
-</details>
+</Details>
 
 </Tab>
 <Tab title="JS/TS SDK">
@@ -270,8 +271,8 @@ import { LangfuseClient } from "@langfuse/client";
 const langfuse = new LangfuseClient();
 ```
 
-<details>
-<summary>Alternative: Configure via constructor</summary>
+<Details>
+<Summary>Alternative: Configure via constructor</Summary>
 
 You can also pass the Langfuse credentials directly to the constructor:
 
@@ -285,7 +286,7 @@ const langfuse = new LangfuseClient({
 });
 ```
 
-</details>
+</Details>
 
 
 </Tab>
@@ -293,7 +294,7 @@ const langfuse = new LangfuseClient({
 
 ### Use the SDK
 
-With the SDK set up, you can: 
+With the SDK set up, you can:
 
 - [Instrument your application](/docs/observability/sdk/instrumentation#custom-observations)
 - Use [Langfuse Prompt Management](/docs/prompt-management/get-started)

--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -8,6 +8,7 @@ description: Get started with Langfuse Prompt Management.
 
 This guide walks you through creating and using a prompt with Langfuse. If you're looking to understand what prompt management is and why it matters, check out the [Prompt Management Overview](/docs/prompt-management/overview) first. For details on how prompts are structured in Langfuse and how it works in the background, see [Core Concepts](/docs/prompt-management/data-model).
 
+import { Details, Summary } from "@/components/Details";
 import PromptCreate from "@/components-mdx/prompt-create.mdx";
 import PromptUse from "@/components-mdx/prompt-use.mdx";
 import { FaqPreview } from "@/components/faq/FaqPreview";
@@ -71,8 +72,8 @@ If you want to target a specific agent directly:
 npx skills add langfuse/skills --skill "langfuse" --agent "<agent-id>"
 ```
 
-<details>
-<summary>Alternatively you can manually clone the skill</summary>
+<Details>
+<Summary>Alternatively you can manually clone the skill</Summary>
 
 1. Clone repo somewhere stable
 ```bash
@@ -89,7 +90,7 @@ mkdir -p /path/to/<agent-skill-root>/skills
 ln -s /path/to/langfuse-skills/skills/langfuse /path/to/<agent-skill-root>/skills/langfuse
 ```
 
-</details>
+</Details>
 
 Then prompt your agent:
 

--- a/content/docs/security-and-guardrails.mdx
+++ b/content/docs/security-and-guardrails.mdx
@@ -173,6 +173,7 @@ In this trace ([public link](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 Find more examples of LLM security monitoring in our cookbook.
 
+import { Details, Summary } from "@/components/Details";
 import { FileCode, BookOpen } from "lucide-react";
 
 <Cards num={2}>
@@ -185,33 +186,33 @@ import { FileCode, BookOpen } from "lucide-react";
 
 ## FAQ
 
-<details>
-<summary>What is LLM Guard?</summary>
+<Details>
+<Summary>What is LLM Guard?</Summary>
 
 [LLM Guard](https://llm-guard.com) is an open-source library by Protect AI that provides security guardrails for LLM applications. It includes input scanners (prompt injection detection, PII anonymization, toxicity detection, topic banning) and output scanners (content moderation, bias detection, malicious URL detection, deanonymization). LLM Guard can be integrated with Langfuse to trace and monitor the effectiveness of each security check.
 
-</details>
+</Details>
 
-<details>
-<summary>What are security guardrails for LLMs?</summary>
+<Details>
+<Summary>What are security guardrails for LLMs?</Summary>
 
 Security guardrails are protective measures that intercept and filter inputs and outputs of LLM applications to prevent misuse and harm. They include input guardrails (blocking prompt injection and malicious inputs), output guardrails (filtering toxic or harmful responses), PII detection and redaction, content filtering, and topic restriction. Guardrails run at the application layer and are complementary to model-level safety training.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I prevent prompt injection in my LLM application?</summary>
+<Details>
+<Summary>How do I prevent prompt injection in my LLM application?</Summary>
 
 Prompt injection can be mitigated through multiple layers: (1) Use a guardrail library like LLM Guard or Lakera to detect and block injection attempts before they reach the model. (2) Implement clear separation between system instructions and user input. (3) Use Langfuse tracing to monitor for injection attempts in production. (4) Set up automated evaluations to flag suspicious patterns. No single approach is 100% effective, so a defense-in-depth strategy with monitoring is recommended.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I monitor LLM security in production?</summary>
+<Details>
+<Summary>How do I monitor LLM security in production?</Summary>
 
 Use Langfuse to monitor your LLM security posture: (1) Trace every request through your guardrail pipeline to see which checks triggered. (2) Use LLM-as-a-Judge evaluators to automatically score traces for toxicity, PII leakage, and prompt injection. (3) Set up custom dashboards to track security scores over time. (4) Use annotation queues for human review of flagged conversations. (5) Track the latency impact of security checks to balance protection with user experience.
 
-</details>
+</Details>
 
 ## GitHub Discussions
 

--- a/content/faq/all/chatbot-analytics.mdx
+++ b/content/faq/all/chatbot-analytics.mdx
@@ -4,6 +4,8 @@ description: "Learn how to use chatbot analytics tools to monitor performance, t
 tags: [article]
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Chatbot Analytics: How to Improve your AI Chatbot with Langfuse
 
 <Frame fullWidth>
@@ -222,30 +224,30 @@ When evaluating a chatbot analytics platform, consider these key capabilities:
 
 ## FAQ
 
-<details>
-<summary>What is chatbot analytics?</summary>
+<Details>
+<Summary>What is chatbot analytics?</Summary>
 
 Chatbot analytics is the practice of collecting, measuring, and analyzing data from your AI chatbot to understand its performance and improve user experience. This includes tracking metrics like response quality, conversation length, user satisfaction, cost per conversation, and error rates. With proper analytics, you can identify where your chatbot struggles, optimize prompts, and make data-driven improvements.
 
-</details>
+</Details>
 
-<details>
-<summary>What chatbot analytics tools should I use?</summary>
+<Details>
+<Summary>What chatbot analytics tools should I use?</Summary>
 
 The best toolset depends on your needs. For LLM-powered chatbots, start with an LLM observability platform like Langfuse for conversation tracing, cost tracking, and quality evaluation. Add product analytics tools like PostHog for user behavior analysis, and evaluation frameworks like Ragas for automated quality assessment. Most teams find that a combination of 2-3 tools covers their analytics needs.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I measure chatbot performance?</summary>
+<Details>
+<Summary>How do I measure chatbot performance?</Summary>
 
 Measure chatbot performance across multiple dimensions: (1) **Quality** — use LLM-as-a-Judge evaluation and user feedback scores, (2) **Efficiency** — track response latency, cost per conversation, and token usage, (3) **Effectiveness** — measure resolution rate, escalation rate, and user satisfaction, (4) **Safety** — monitor hallucination rate, compliance violations, and prompt injection attempts. Use custom dashboards to visualize trends over time.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I improve my chatbot's responses?</summary>
+<Details>
+<Summary>How do I improve my chatbot's responses?</Summary>
 
 Start by analyzing your chatbot analytics to identify problem areas. Use conversation tracing to inspect low-quality responses and understand why they failed. Set up automated evaluations to score responses on key dimensions (helpfulness, accuracy, tone). Build a dataset of problematic conversations and run experiments to test prompt improvements before deploying them to production. Continuously monitor production performance and feed edge cases back into your test dataset.
 
-</details>
+</Details>

--- a/content/faq/all/empty-trace-input-and-output.mdx
+++ b/content/faq/all/empty-trace-input-and-output.mdx
@@ -4,6 +4,8 @@ description: This article explains why the input and output of a trace might be 
 tags: [observability, observability-get-started]
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Why are the input and output of my trace empty?
 
 Having input and output on your traces affects several important features:
@@ -325,8 +327,8 @@ tracer.startActiveSpan("my-operation", (span) => {
 </Tab>
 </Tabs>
 
-<details>
-<summary>**Which attributes does my OTEL provider use?**</summary>
+<Details>
+<Summary>**Which attributes does my OTEL provider use?**</Summary>
 
 Different providers use different semantic conventions. Here's how to find out what your provider sends:
 
@@ -344,7 +346,7 @@ If your provider uses different attribute names, you have two options:
 1. Manually set the attributes Langfuse expects (as shown above)
 2. Open a [GitHub issue](https://github.com/langfuse/langfuse/issues) requesting support for your provider's conventions
 
-</details>
+</Details>
 
 Many OTEL-specific issues have been fixed in recent Langfuse versions. If you're self-hosting, make sure you're on the latest version.
 

--- a/content/faq/all/self-hosting-clickhouse-handling-failed-migrations.mdx
+++ b/content/faq/all/self-hosting-clickhouse-handling-failed-migrations.mdx
@@ -3,12 +3,14 @@ title: Clickhouse handling failed migrations in self-hosted Langfuse
 tags: [self-hosting]
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Clickhouse handling failed migrations in self-hosted Langfuse
 
 If you encounter a migration error, the migration tool will prevent you from running additional migrations on the same database. You'll see an error message like "Dirty database version 1. Fix and force version" even after fixing the erred migration. This means your database has been marked as 'dirty'. You need to investigate whether the migration was partially applied or not applied at all. After determining the actual state, force your database to the version that accurately reflects its current state. Once you've forced the correct version and fixed the migration, your database will be 'clean' again, allowing you to proceed with subsequent migrations.
 
-<details>
-<summary>Code Example to fix failed migrations</summary>
+<Details>
+<Summary>Code Example to fix failed migrations</Summary>
 
 Let's assume your migration 16 failed. You have corrected the failed migration. If you try to migrate again, migrate will STILL refuse:
 
@@ -29,4 +31,4 @@ If you migrate again, the output will now be:
 16/u migration_name (12.718637ms)
 ```
 
-</details>
+</Details>

--- a/content/faq/all/self-hosting-queue-management-bullmq-admin-api.mdx
+++ b/content/faq/all/self-hosting-queue-management-bullmq-admin-api.mdx
@@ -3,6 +3,8 @@ title: Queue management with BullMQ Admin API in self-hosted Langfuse
 tags: [self-hosting]
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Queue management with BullMQ Admin API in self-hosted Langfuse
 
 Langfuse uses BullMQ for managing background job queues. The BullMQ admin endpoint allows you to monitor queue lengths, replay failed events, and remove unwanted events from the queue. This is particularly useful for troubleshooting event processing issues and managing queue backlogs.
@@ -85,8 +87,8 @@ Available status options: `completed`, `failed`, `active`, `delayed`, `prioritiz
 
 ## API Specification
 
-<details>
-  <summary>Complete BullMQ Admin API Specification</summary>
+<Details>
+  <Summary>Complete BullMQ Admin API Specification</Summary>
 
 ```yaml
 openapi: 3.0.1
@@ -177,4 +179,4 @@ paths:
                     type: string
 ```
 
-</details>
+</Details>

--- a/content/handbook/chapters/open-source.mdx
+++ b/content/handbook/chapters/open-source.mdx
@@ -45,9 +45,10 @@ Enterprise Edition (EE) modules live in clearly marked `/ee` directories. These 
 
 The Langfuse deployment stack is exactly the same for OSS, Enterprise self-host, and Langfuse Cloud. See our [Self-Hosting Guide](/self-hosting) for instructions on running Langfuse locally and deployments at production scale.
 
-<details>
-<summary>Architecture</summary>
+<Details>
+<Summary>Architecture</Summary>
 
+import { Details, Summary } from "@/components/Details";
 import ArchitectureDiagram from "@/components-mdx/architecture-diagram-v3.mdx";
 
 <ArchitectureDiagram />
@@ -56,35 +57,35 @@ import ArchitectureDescription from "@/components-mdx/architecture-description-v
 
 <ArchitectureDescription />
 
-</details>
+</Details>
 
 ## Frequently Asked Questions [#enterprise-edition-ee-faq]
 
-<details>
-<summary>Is Langfuse really open source?</summary>
+<Details>
+<Summary>Is Langfuse really open source?</Summary>
 
 Yes. Everything outside the `/ee` folders is MIT-licensed — an OSI-approved license. You get the four freedoms: use, study, modify, distribute.
 
-</details>
+</Details>
 
-<details>
-<summary>Will I accidentally use EE features?</summary>
+<Details>
+<Summary>Will I accidentally use EE features?</Summary>
 
 No. EE packages are isolated and gated by the license key check. You can run the core image without a key without running EE code.
 
-</details>
+</Details>
 
-<details>
-<summary>Which self-host licensing options exist?</summary>
+<Details>
+<Summary>Which self-host licensing options exist?</Summary>
 
 All product features are freely available under the MIT license.
 
 A commercial Enterprise license is only required for advanced security capabilities such as SCIM, extended audit logging, and data retention policies (see [pricing page](/pricing-self-host)). You can add a [license key](/self-hosting/license-key) to your deployment to enable these features at any time.
 
-</details>
+</Details>
 
-<details>
-<summary>Does Langfuse rely only on open-source components?</summary>
+<Details>
+<Summary>Does Langfuse rely only on open-source components?</Summary>
 
 Yes. The entire stack is open source and can be self-hosted. Find a complete list in the configuration files across our repositories:
 
@@ -94,31 +95,31 @@ Yes. The entire stack is open source and can be self-hosted. Find a complete lis
 
 As the core Langfuse server is most actively developed, we run an [automated license check](https://github.com/langfuse/langfuse/actions/workflows/licensecheck.yml) on every change to avoid adding dependencies with non-permissive licenses. If you find any issues, please let us know.
 
-</details>
+</Details>
 
-<details>
-<summary>What's the release cadence and how do I stay up to date?</summary>
+<Details>
+<Summary>What's the release cadence and how do I stay up to date?</Summary>
 
 We cut a **GitHub Release multiple times a week** (tagged `vX.Y.Z`) and publish detailed notes in the [changelog](https://github.com/langfuse/langfuse/releases). Langfuse Cloud is always running the latest version; self-host users can pull the identical Docker image tag to stay up to date or upgrade on their own schedule ([docs](/self-hosting/upgrade)).
 
-</details>
+</Details>
 
-<details>
-<summary>Does the OSS build phone home? Can I disable telemetry?</summary>
+<Details>
+<Summary>Does the OSS build phone home? Can I disable telemetry?</Summary>
 
 By default, Langfuse OSS sends **aggregated usage telemetry** (no personal data) so we can improve the product. **No traces, prompts, or customer data leave your cluster.** You can disable it via `TELEMETRY_ENABLED=false` (details in the [telemetry docs](/self-hosting/security/telemetry)).
 
-</details>
+</Details>
 
-<details>
-<summary>Can I run Langfuse completely offline / air-gapped?</summary>
+<Details>
+<Summary>Can I run Langfuse completely offline / air-gapped?</Summary>
 
 Yes. After the initial image pull, Langfuse **does not require any outbound network calls** to work. Teams in regulated environments run it inside air-gapped Kubernetes clusters; just disable telemetry as above and mirror the Docker registry locally.
 
-</details>
+</Details>
 
-<details>
-<summary>How do I contribute?</summary>
+<Details>
+<Summary>How do I contribute?</Summary>
 
 Here are the best ways to contribute to Langfuse via GitHub:
 
@@ -126,10 +127,10 @@ Here are the best ways to contribute to Langfuse via GitHub:
 2. Create and comment on [Issues](/issues).
 3. Create a pull request. See [Contributing.md](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md) to get started.
 
-</details>
+</Details>
 
-<details>
-<summary>I want to see the code!</summary>
+<Details>
+<Summary>I want to see the code!</Summary>
 
 All our repositories are on [GitHub](https://github.com/langfuse):
 
@@ -138,10 +139,10 @@ All our repositories are on [GitHub](https://github.com/langfuse):
 - JS SDK and integrations: [`langfuse/langfuse-js`](https://github.com/langfuse/langfuse-js)
 - Docs: [`langfuse/langfuse-docs`](https://github.com/langfuse/langfuse-docs)
 
-</details>
+</Details>
 
-<details>
-<summary>Can you share some public metrics on how widely Langfuse is used?</summary>
+<Details>
+<Summary>Can you share some public metrics on how widely Langfuse is used?</Summary>
 
 Sure, we summarized some statistics in [this blog post](/blog/2024-11-most-used-oss-llmops) and in the dashboard below.
 
@@ -149,4 +150,4 @@ import PublicMetricsDashboard from "@/components-mdx/public-metrics-dashboard.md
 
 <PublicMetricsDashboard />
 
-</details>
+</Details>

--- a/content/integrations/gateways/truefoundry.mdx
+++ b/content/integrations/gateways/truefoundry.mdx
@@ -15,32 +15,32 @@ category: Integrations
 
 Truefoundry’s AI Gateway and Langfuse combine to give you enterprise-grade observability, governance, and cost control over every LLM request—set up in minutes.
 
-<details>
-<summary><strong>Unified OpenAI-Compatible Endpoint</strong></summary>
+<Details>
+<Summary><strong>Unified OpenAI-Compatible Endpoint</strong></Summary>
 
 Point the Langfuse OpenAI client at Truefoundry’s gateway URL. Truefoundry routes to any supported model (OpenAI, Anthropic, self-hosted, etc.), while Langfuse transparently captures each call—no code changes required.
-</details>
+</Details>
 
-<details>
-<summary><strong>End-to-End Tracing & Metrics</strong></summary>
+<Details>
+<Summary><strong>End-to-End Tracing & Metrics</strong></Summary>
 
 Langfuse delivers:
-- **Full request/response logs** (including system messages)  
-- **Token usage** (prompt, completion, total)  
-- **Latency breakdowns** per call  
-- **Cost analytics** by model and environment  
+- **Full request/response logs** (including system messages)
+- **Token usage** (prompt, completion, total)
+- **Latency breakdowns** per call
+- **Cost analytics** by model and environment
 Drill into any trace in seconds to optimize performance or debug regressions.
-</details>
+</Details>
 
-<details>
-<summary><strong>Production-Ready Controls</strong></summary>
+<Details>
+<Summary><strong>Production-Ready Controls</strong></Summary>
 
 Truefoundry augments your LLM stack with:
-- **Rate limiting & quotas** per team or user  
-- **Budget alerts & spend caps** to prevent overruns  
-- **Scoped API keys** with RBAC for dev, staging, prod  
-- **On-prem/VPC deployment** for full data sovereignty  
-</details>
+- **Rate limiting & quotas** per team or user
+- **Budget alerts & spend caps** to prevent overruns
+- **Scoped API keys** with RBAC for dev, staging, prod
+- **On-prem/VPC deployment** for full data sovereignty
+</Details>
 
 ## Prerequisites
 
@@ -168,7 +168,7 @@ def analyze_customer_query(query, customer_id):
         metadata={"gateway": "truefoundry"},
         version="1.0.0"
     ):
-    
+
         response = client.chat.completions.create(
             model="openai-main/gpt-4o",
             messages=[
@@ -177,7 +177,7 @@ def analyze_customer_query(query, customer_id):
             ],
             temperature=0.3
         )
-        
+
         result = response.choices[0].message.content
 
     # Set input and output on the current observation
@@ -185,7 +185,7 @@ def analyze_customer_query(query, customer_id):
         input={"query": query, "customer_id": customer_id},
         output={"response": result},
     )
-    
+
     return result
 
 # Usage
@@ -210,6 +210,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 
+import { Details, Summary } from "@/components/Details";
 import LearnMore from "@/components-mdx/integration-learn-more.mdx";
 
 <LearnMore />

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -5,6 +5,8 @@ sidebarTitle: OpenTelemetry
 logo: /images/integrations/opentelemetry_icon.svg
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # OpenTelemetry (OTEL) for LLM Observability
 
 [OpenTelemetry (OTEL)](https://opentelemetry.io/) is a [CNCF](https://www.cncf.io/) project that provides a set of specifications, APIs, and libraries that define a standard way to collect distributed traces and metrics from your application.
@@ -175,9 +177,9 @@ Any OpenTelemetry compatible instrumentation can be used to export traces to Lan
 - [Arize](/docs/opentelemetry/example-arize)
 - [MLflow](/docs/opentelemetry/example-mlflow)
 
-<details>
+<Details>
 
-<summary>Comparison of OpenTelemetry Instrumentation Libraries</summary>
+<Summary>Comparison of OpenTelemetry Instrumentation Libraries</Summary>
 
 | Category   | Item                          | OpenLLMetry | openlit | Arize |
 | ---------- | ----------------------------- | ----------- | ------- | ----- |
@@ -248,7 +250,7 @@ Any OpenTelemetry compatible instrumentation can be used to export traces to Lan
 |            | LangChain.js                  |             |         | ✅    |
 |            | Vercel AI SDK                 |             |         | ✅    |
 
-</details>
+</Details>
 
 **Framework integrations powered by OpenTelemetry**
 

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -6,6 +6,8 @@ description: "Trace Claude Code AI coding assistant conversations, user inputs, 
 category: Integrations
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Claude Code Tracing with Langfuse
 
 > **What is Claude Code?**: [Claude Code](https://claude.com/product/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, help you write and edit code, execute commands, create and run tests, and help you accomplish complex coding tasks with natural language. Claude Code brings the power of Claude's AI capabilities directly into your development workflow.
@@ -59,8 +61,8 @@ Create the hook script at `~/.claude/hooks/langfuse_hook.py`:
 mkdir -p ~/.claude/hooks
 ```
 
-<details>
-<summary>View full langfuse_hook.py script</summary>
+<Details>
+<Summary>View full langfuse_hook.py script</Summary>
 
 ```python
 #!/usr/bin/env python3
@@ -615,7 +617,7 @@ if __name__ == "__main__":
     sys.exit(main())
 ```
 
-</details>
+</Details>
 
 ### Register the Hook
 

--- a/content/marketing/brand.mdx
+++ b/content/marketing/brand.mdx
@@ -22,27 +22,87 @@ or confuses Langfuse with another brand.
 ### Icon
 
 <BrandAssetGrid>
-  <BrandAssetCard href="/brand-assets/icon/color/langfuse-icon.svg" src="/brand-assets/icon/color/langfuse-icon.svg" alt="Langfuse icon color SVG preview" label="Icon - Color (SVG)" tall />
-  <BrandAssetCard href="/brand-assets/icon/color/langfuse-icon.png" src="/brand-assets/icon/color/langfuse-icon.png" alt="Langfuse icon color PNG preview" label="Icon - Color (PNG)" tall />
-  <BrandAssetCard href="/brand-assets/icon/monochrome/langfuse-icon-monochrome.svg" src="/brand-assets/icon/monochrome/langfuse-icon-monochrome.svg" alt="Langfuse icon monochrome SVG preview" label="Icon - Monochrome (SVG)" tall />
+  <BrandAssetCard
+    src="/brand-assets/icon/color/langfuse-icon.svg"
+    alt="Langfuse icon color SVG preview"
+    label="Icon - Color (SVG)"
+    tall
+  />
+  <BrandAssetCard
+    src="/brand-assets/icon/color/langfuse-icon.png"
+    alt="Langfuse icon color PNG preview"
+    label="Icon - Color (PNG)"
+    tall
+  />
+  <BrandAssetCard
+    src="/brand-assets/icon/monochrome/langfuse-icon-monochrome.svg"
+    alt="Langfuse icon monochrome SVG preview"
+    label="Icon - Monochrome (SVG)"
+    tall
+  />
 </BrandAssetGrid>
+
 
 ### Wordmark - Langfuse
 
 <BrandAssetGrid>
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.svg" src="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.svg" alt="Langfuse wordmark light SVG preview" label="Wordmark Light (SVG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.png" src="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.png" alt="Langfuse wordmark light PNG preview" label="Wordmark Light (PNG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse/monochrome/langfuse-wordart-monochrome.svg" src="/brand-assets/wordmark/Langfuse/monochrome/langfuse-wordart-monochrome.svg" alt="Langfuse wordmark monochrome SVG preview" label="Wordmark Monochrome (SVG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.svg" src="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.svg" alt="Langfuse wordmark dark SVG preview" label="Wordmark Dark (SVG)" variant="dark" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.png" src="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.png" alt="Langfuse wordmark dark PNG preview" label="Wordmark Dark (PNG)" variant="dark" />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.svg"
+    alt="Langfuse wordmark light SVG preview"
+    label="Wordmark Light (SVG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse/light/langfuse-wordart.png"
+    alt="Langfuse wordmark light PNG preview"
+    label="Wordmark Light (PNG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse/monochrome/langfuse-wordart-monochrome.svg"
+    alt="Langfuse wordmark monochrome SVG preview"
+    label="Wordmark Monochrome (SVG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.svg"
+    alt="Langfuse wordmark dark SVG preview"
+    label="Wordmark Dark (SVG)"
+    variant="dark"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse/dark/langfuse-wordart-white.png"
+    alt="Langfuse wordmark dark PNG preview"
+    label="Wordmark Dark (PNG)"
+    variant="dark"
+  />
 </BrandAssetGrid>
 
 ### Wordmark - Langfuse by ClickHouse
 
 <BrandAssetGrid>
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.svg" src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.svg" alt="Langfuse by ClickHouse light SVG preview" label="By ClickHouse Light (SVG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.png" src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.png" alt="Langfuse by ClickHouse light PNG preview" label="By ClickHouse Light (PNG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/monochrome/langfuse-by-clickhouse-monochrome.svg" src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/monochrome/langfuse-by-clickhouse-monochrome.svg" alt="Langfuse by ClickHouse monochrome SVG preview" label="By ClickHouse Monochrome (SVG)" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.svg" src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.svg" alt="Langfuse by ClickHouse dark SVG preview" label="By ClickHouse Dark (SVG)" variant="dark" />
-  <BrandAssetCard href="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.png" src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.png" alt="Langfuse by ClickHouse dark PNG preview" label="By ClickHouse Dark (PNG)" variant="dark" />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.svg"
+    alt="Langfuse by ClickHouse light SVG preview"
+    label="By ClickHouse Light (SVG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.png"
+    alt="Langfuse by ClickHouse light PNG preview"
+    label="By ClickHouse Light (PNG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/monochrome/langfuse-by-clickhouse-monochrome.svg"
+    alt="Langfuse by ClickHouse monochrome SVG preview"
+    label="By ClickHouse Monochrome (SVG)"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.svg"
+    alt="Langfuse by ClickHouse dark SVG preview"
+    label="By ClickHouse Dark (SVG)"
+    variant="dark"
+  />
+  <BrandAssetCard
+    src="/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.png"
+    alt="Langfuse by ClickHouse dark PNG preview"
+    label="By ClickHouse Dark (PNG)"
+    variant="dark"
+  />
 </BrandAssetGrid>

--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -7,6 +7,7 @@ description: FAQ and deployment options for Langfuse in an enterprise environmen
 
 Langfuse is the leading LLM Engineering platform built for enterprise-grade security, scalability, and compliance. Trusted by **19 of the Fortune 50** and **63 of the Fortune 500**, Langfuse addresses key challenges when deploying LLM-based applications within an enterprise environment.
 
+import { Details, Summary } from "@/components/Details";
 import { CredibilitySentence } from "@/components/CredibilitySentence";
 
 <CredibilitySentence style="list" />
@@ -140,16 +141,16 @@ We're here to help you find the right solution for your use case.
   that are not answered, please reach out to us: enterprise@langfuse.com
 </Callout>
 
-<details>
-<summary>What deployment options are available for Langfuse?</summary>
+<Details>
+<Summary>What deployment options are available for Langfuse?</Summary>
 
 1. Managed Cloud (cloud.langfuse.com), see [Pricing](/pricing) and [Security](/security) page for details.
 2. [Self-hosted](/self-hosting) on your own infrastructure. Contact us if you are interested in additional support.
 
-</details>
+</Details>
 
-<details>
-<summary>Support SLO for our enterprise customers</summary>
+<Details>
+<Summary>Support SLO for our enterprise customers</Summary>
 
 Here are our general SLOs of our support for our Enterprise Cloud customers. These can be customized upon request.
 
@@ -176,10 +177,10 @@ Here are our general SLOs of our support for our Enterprise Cloud customers. The
 - Medium Priority: Addressed in the next maintenance release or hot-fix, with updates on progress.
 - Low Priority: Scheduled for the regular development cycle, with updates provided upon release.
 
-</details>
+</Details>
 
-<details>
-<summary>Uptime SLA for our enterprise customers</summary>
+<Details>
+<Summary>Uptime SLA for our enterprise customers</Summary>
 
 Our Enterprise Cloud customers get an uptime SLA:
 
@@ -189,19 +190,19 @@ Our Enterprise Cloud customers get an uptime SLA:
 
 If Langfuse fails to maintain an uptime percentage of greater than 99% for any 3 months in a 6 month period, Customer may terminate their agreement upon 10 days written notice to Langfuse. The calculations of uptime do not include: Delays to data ingestion or scheduled maintenance.
 
-</details>
+</Details>
 
-<details>
-<summary>What is the difference between Langfuse Cloud and the open-source version?</summary>
+<Details>
+<Summary>What is the difference between Langfuse Cloud and the open-source version?</Summary>
 
 The Langfuse team provides Langfuse Cloud as a managed solution to simplify the initial setup of Langfuse and to minimize the operational overhead of maintaining high availability in production. You can choose to self-host Langfuse on your own infrastructure.
 
 Some features are not available in the open-source version. Please refer to the overview [here](/pricing-self-host).
 
-</details>
+</Details>
 
-<details>
-<summary>How does Authentication and RBAC work in Langfuse?</summary>
+<Details>
+<Summary>How does Authentication and RBAC work in Langfuse?</Summary>
 
 Langfuse offers a list of prebuilt roles which apply on an organizational and project level to restrict access ([RBAC documentation](/docs/rbac)).
 
@@ -209,10 +210,10 @@ If needed, environments (production, staging, development) can be separated into
 
 SSO with Langfuse is simple. Currently Google, GitHub, Azure AD, Okta, Auth0, AWS Cognito, Keycloak, and JumpCloud are supported. We can easily add additional providers based on your requirements. As an enterprise customer, you can also enforce SSO for your organization.
 
-</details>
+</Details>
 
-<details>
-<summary>What is the easiest way to try Langfuse?</summary>
+<Details>
+<Summary>What is the easiest way to try Langfuse?</Summary>
 
 The Hobby Plan on [Langfuse Cloud](/cloud) includes enough resources to try Langfuse for free while in a non-production environment, no credit card required.
 
@@ -220,10 +221,10 @@ Alternatively, you can quickly spin up Langfuse on your own machine using `docke
 
 If you require security and compliance features to run a POC, please reach out to us at enterprise@langfuse.com.
 
-</details>
+</Details>
 
-<details>
-<summary>Common Enterprise LLM Platform Architecture</summary>
+<Details>
+<Summary>Common Enterprise LLM Platform Architecture</Summary>
 
 Langfuse aims to address the challenges of debugging, monitoring, and continuously improving LLM-based applications. It focuses on observability, evaluation, and prompt management.
 
@@ -243,4 +244,4 @@ graph LR
   Gateway -->|"optional: forward llm calls"| LF
 ```
 
-</details>
+</Details>

--- a/content/marketing/non-profit.mdx
+++ b/content/marketing/non-profit.mdx
@@ -26,6 +26,7 @@ Non-profits do vital work—your infrastructure budget should go as far as possi
 | Additional events | US $8 per 100k events beyond the included amount |
 | Duration | Ongoing, reviewed annually |
 
+import { Details, Summary } from "@/components/Details";
 import { FilePenLine } from "lucide-react";
 
 <Cards num={1}>
@@ -85,33 +86,33 @@ Your organization qualifies if **all** of the following are true:
 
 ## Frequently Asked
 
-<details>
-<summary>What happens when my credit renews?</summary>
+<Details>
+<Summary>What happens when my credit renews?</Summary>
 
 Credits reset on the first of each month. Unused credit does not roll over.
 
-</details>
+</Details>
 
-<details>
-<summary>Can I switch to the 75 % discount later?</summary>
+<Details>
+<Summary>Can I switch to the 75 % discount later?</Summary>
 
 Yes. If your usage grows beyond what the monthly credit covers, email [support@langfuse.com](mailto:support@langfuse.com) and we'll switch you to the percentage-based discount.
 
-</details>
+</Details>
 
-<details>
-<summary>Does the discount apply to self-hosted Langfuse?</summary>
+<Details>
+<Summary>Does the discount apply to self-hosted Langfuse?</Summary>
 
 The monthly credit applies to Langfuse Cloud only. Self-hosted Langfuse is open-source and free under the MIT license—no discount needed.
 
-</details>
+</Details>
 
-<details>
-<summary>We're a startup / research lab / student team — different program?</summary>
+<Details>
+<Summary>We're a startup / research lab / student team — different program?</Summary>
 
 Yes! Check out the [Startups Program](/startups) or the [Research & Education Program](/research) for offers tailored to your situation.
 
-</details>
+</Details>
 
 ---
 

--- a/content/marketing/startups.mdx
+++ b/content/marketing/startups.mdx
@@ -3,12 +3,14 @@ title: Langfuse for Startups
 description: 50 % off your entire Langfuse bill for early-stage teams
 ---
 
+import { Details, Summary } from "@/components/Details";
+
 # Langfuse for Startups 🚀
 
-Building with LLMs is chaotic enough. Observability pricing shouldn’t add to the stress.  
+Building with LLMs is chaotic enough. Observability pricing shouldn’t add to the stress.
 If your team is just getting started, **enjoy 50 % off your entire Langfuse bill for 12 months**.
 
-> **TL;DR**  
+> **TL;DR**
 > Early-stage startup? Bootstrapped or < $5 m raised? [Fill in the form](https://forms.gle/eJAYjRWeCZU1Mn6j8), get approved, and the discount
 > is automatically applied to every invoice for a full year. [Apply here](https://forms.gle/eJAYjRWeCZU1Mn6j8).
 
@@ -33,7 +35,7 @@ Your company qualifies if **all** of the following are true:
 | Status      | Privately held & independent                                 |
 | Usage       | New or existing Langfuse Cloud customer                      |
 
-> **Note**  
+> **Note**
 > If you exceed the funding cap after approval, the discount remains active
 > for the full 12-month term—no gotchas.
 
@@ -64,29 +66,29 @@ Langfuse is a YC W23 alum. If you’re a current YC company or an alum, head to 
 
 ## Frequently asked
 
-<details>
-<summary>What happens after 12 months?</summary>
+<Details>
+<Summary>What happens after 12 months?</Summary>
 
 You roll onto standard pricing.
 
-</details>
+</Details>
 
-<details>
-<summary>Does the discount stack with other coupons or credits?</summary>
+<Details>
+<Summary>Does the discount stack with other coupons or credits?</Summary>
 
 No. You'll need to choose one offer.
 
-</details>
+</Details>
 
-<details>
-<summary>Can existing paying customers join?</summary>
+<Details>
+<Summary>Can existing paying customers join?</Summary>
 
-Yes, so long as you still meet the funding cap. You can add the coupon code received via email after filling out the form in your billing settings. 
+Yes, so long as you still meet the funding cap. You can add the coupon code received via email after filling out the form in your billing settings.
 
-</details>
+</Details>
 
-<details>
-<summary>We’re open-source / non-profit / research / students — different program?</summary>
+<Details>
+<Summary>We’re open-source / non-profit / research / students — different program?</Summary>
 
 We have dedicated programs for other communities:
 
@@ -94,7 +96,7 @@ We have dedicated programs for other communities:
 - **Research & Education** → [Research Program](/research)
 - **Open-source projects** → Email **startups@langfuse.com**
 
-</details>
+</Details>
 
 ---
 

--- a/lib/page-footer-nav.ts
+++ b/lib/page-footer-nav.ts
@@ -1,0 +1,33 @@
+import type { PageFooterNavItem } from "@/components/PageFooterNav";
+
+export function getPageFooterItems<TPage extends { url: string }>(
+  pages: TPage[],
+  currentUrl: string,
+  options: {
+    getDate: (page: TPage) => string | undefined;
+    getTitle: (page: TPage) => string | undefined;
+  },
+): {
+  previous?: PageFooterNavItem;
+  next?: PageFooterNavItem;
+} | undefined {
+  const footerPages = [...pages]
+    .sort(
+      (a, b) =>
+        new Date(options.getDate(a) ?? 0).getTime() -
+        new Date(options.getDate(b) ?? 0).getTime(),
+    )
+    .map((page) => ({
+      name: options.getTitle(page) ?? "",
+      url: page.url,
+    }));
+
+  const currentIndex = footerPages.findIndex((page) => page.url === currentUrl);
+
+  if (currentIndex === -1) return undefined;
+
+  return {
+    previous: footerPages[currentIndex - 1],
+    next: footerPages[currentIndex + 1],
+  };
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -18,6 +18,7 @@ import { EvaluationEvolutionDiagram } from "@/components/academy/EvaluationEvolu
 import { TracingHierarchyDiagram } from "@/components/academy/TracingHierarchyDiagram";
 import { RagTraceViewDiagram } from "@/components/academy/RagTraceViewDiagram";
 import { DatasetFieldsDiagram } from "@/components/academy/DatasetFieldsDiagram";
+import { Details, Summary } from "@/components/Details";
 
 // Lazy-load Video so @vidstack/react (~800 KB) is NOT bundled on every MDX page.
 // It only downloads on pages that actually render a <Video> tag.
@@ -74,6 +75,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TracingHierarchyDiagram,
     RagTraceViewDiagram,
     DatasetFieldsDiagram,
+    details: Details,
+    summary: Summary,
     ...components,
   };
 }

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -18,7 +18,6 @@
   --fd-nav-height: calc(
     var(--lf-nav-primary-height) + var(--lf-nav-docs-secondary-height)
   );
-  --fd-banner-height: 0px;
 }
 
 /*

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -293,7 +293,7 @@
 }
 
 .layout-wrapper {
-  max-width: 1440px;
+  max-width: 1520px;
   margin: 0 auto;
   position: relative;
   border-right: 1px solid var(--line-structure);
@@ -702,9 +702,9 @@
   display: none;
 }
 
-@media (min-width: 1440px) {
+@media (min-width: 1520px) {
   #nd-docs-layout [data-sidebar-panel] {
-    left: calc((100vw - 1440px) / 2);
+    left: calc((100vw - 1520px) / 2);
   }
 }
 

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -945,11 +945,6 @@ svg .edgeLabel {
   row-gap: 0.2rem;
 }
 
-/* Subsequent details should have less of a gap */
-details + details {
-  margin-top: 0.5rem !important;
-}
-
 /* Docs footer pagination: style as secondary buttons */
 #nd-page > div:last-child > a {
   display: inline-flex !important;
@@ -979,16 +974,6 @@ details + details {
 }
 #nd-page > div:last-child > a > p:last-child {
   display: none !important;
-}
-
-/* Fix detail padding */
-details > div {
-  padding: 0.25rem;
-}
-
-/* Details header should be bold */
-details > summary {
-  font-weight: 700;
 }
 
 #nd-page > .prose {


### PR DESCRIPTION
Issues
- Resolves LFE-9401
- Resolves MKT-2059
- Resolves LFE-9396
- Resolves LFE-9459
- Resolves LFE-9302
- Resolves LFE-9397
- Resolves LFE-9555
- Resolves LFE-9556

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers a broad set of UI and content improvements: a new styled `Details`/`Summary` component pair replaces native HTML `<details>`/`<summary>` across docs, marketing, and handbook pages, and a reusable `PageFooterNav` component is extracted from `DocsFooter` and added to blog and changelog post pages.

- **New `Details`/`Summary` components** (`components/Details.tsx`): controlled component pair using `DetailsContext` for styling sync; replaces CSS hacks in `overrides.css`. All existing MDX content has been updated to use the capitalized React components.
- **`PageFooterNav` + `getPageFooterItems`** (`components/PageFooterNav.tsx`, `lib/page-footer-nav.ts`): footer navigation extracted into a shared component and utility, then wired into blog and changelog post pages so readers can step through posts in chronological order.
- **Layout & styling updates**: max-width raised from 1440 px to 1520 px across navbars, secondary nav, and the layout wrapper; `FileTree` gets inline CSS variable theming; `Availability` banner redesigned; `BrandAssetCard` simplified by dropping the redundant `href` prop in favour of reusing `src`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are additive UI work with no data-path risk.

The two flagged items are minor quality issues that don't affect any currently rendered page. `getPageFooterItems` mutates its input array but current callers pass `.filter()` results; the missing `summary` mapping in mdx-components could cause styling gaps only for future content written with lowercase tags.

`lib/page-footer-nav.ts` (sort mutation) and `mdx-components.tsx` (missing `summary` mapping) are worth a quick look; all other files look clean.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MDX Content"] -->|"details mapping"| B["Details component"]
    B --> C["Summary component"]
    B --> D["Content children"]
    E["Blog/Changelog page.tsx"] -->|"getPageFooterItems()"| F["lib/page-footer-nav.ts"]
    F --> G["PageFooterNav"]
    H["DocsFooter.tsx"] -->|"useFooterItems()"| I["resolvedItems"]
    I --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/page-footer-nav.ts:14-19
The `pages.sort()` call mutates the array that was passed in. The current callers always pass a fresh array from `.filter()`, so there's no observable breakage today, but any future caller that passes the raw `getPages()` result directly would silently corrupt the source order for the rest of the render. Spread the array before sorting to make the function safe regardless of caller.

```suggestion
  const footerPages = [...pages]
    .sort(
      (a, b) =>
        new Date(options.getDate(a) ?? 0).getTime() -
        new Date(options.getDate(b) ?? 0).getTime(),
    )
```

### Issue 2 of 2
mdx-components.tsx:70-71
The `details` element is remapped to the custom `Details` component, but `summary` is not remapped to `Summary`. If any MDX content uses lowercase `` without explicitly importing `Summary`, the outer `Details` wrapper will apply its corner-box styling and `DetailsContext`, but the `<summary>` will render as a plain HTML element — no striped header, no `+/-` toggle icon, and no hover styling. Adding `summary: Summary` keeps the pair consistent.

```suggestion
    details: Details,
    summary: Summary,
    ...components,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: \`Availability\` component styling"](https://github.com/langfuse/langfuse-docs/commit/4916804814c59879761070be4a34ddc4a0923c34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31308915)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->