### PR TITLE
fix(cloud): prevent client crash on /cloud from in-page translation

### DIFF
--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -127,7 +127,10 @@ export default function CloudRegionSelectorPage() {
   );
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-surface-bg px-4 py-10 sm:px-6 lg:px-8">
+    <main
+      translate="no"
+      className="flex min-h-screen flex-col items-center justify-center bg-surface-bg px-4 py-10 sm:px-6 lg:px-8 notranslate"
+    >
       <div className="flex w-full max-w-[480px] flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-5">
           <Logo />


### PR DESCRIPTION
## Summary

- Adds `translate="no"` + `notranslate` to `<main>` on the [cloud region selector](app/cloud/[[...path]]/page.tsx) so in-page browser translators (Chrome built-in translate, Grammarly, etc.) don't mutate the DOM that React still owns.
- Defends against the well-known [React + DOM-mutating extension crash](https://github.com/facebook/react/issues/11538): `useCloudRegionSignIn` fires async fetches and calls `setSignedInRegions` after mount, and re-rendering against a translator-wrapped DOM can throw `NotFoundError: Failed to execute 'removeChild' / 'insertBefore' on 'Node'`, which Next.js shows as the generic "client-side exception" error page.
- The selector's content (region names, hostnames, AWS regions, "Signed in" label) is functional and shouldn't be translated anyway.

## Context

A user reported a client-side crash on `langfuse.com/cloud` (screenshot showed Chrome's translate icon active in the URL bar and the Next.js fallback error rendered in Portuguese). I haven't 100% confirmed in-page translate is the root cause vs. another DOM-mutating extension or unrelated bug, but this is a low-risk hardening that addresses the most likely class of cause and is appropriate for this page regardless.

## Test plan

- [x] `<main>` renders with `translate="no"` and `notranslate` class in dev.
- [x] Simulated Google Translate's `<font>`-wrap mutation on all text nodes — page didn't crash.
- [x] All 4 region anchors render correct destination URLs after the fix.
- [ ] Monitor PostHog/Sentry for client-error events on `/cloud` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `translate="no"` HTML attribute and `notranslate` CSS class to the `<main>` element on the `/cloud` region selector page to prevent browser in-page translators (e.g., Chrome Translate, Grammarly) from wrapping text nodes with `<font>` elements that React's reconciler doesn't own, which causes the known `removeChild`/`insertBefore` `NotFoundError` crash.

- `translate=\"no\"` is the W3C standard attribute; `notranslate` is the complementary class recognized by Google Translate — using both together gives the broadest coverage across different browser implementations.
- The fix is scoped to a self-contained, functional navigation page where translation of region names, hostnames, and AWS identifiers is never desirable.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line attribute addition to a self-contained page with no logic changes.

The fix is a well-known, standard defence against browser translator DOM mutations. Both translate="no" (W3C standard) and the notranslate CSS class (Google Translate convention) are used together for maximum coverage. No existing functionality is altered, no logic paths change, and the TypeScript types for translate on HTML elements accept "yes" | "no", so there are no type issues.

No files require special attention — the single changed file receives a minimal, well-scoped addition.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Translator as Browser Translator
    participant ReactDOM
    participant Component as CloudRegionSelectorPage

    Note over Browser,Component: Before fix - crash path
    Browser->>Component: Page load, React hydrates DOM
    Browser->>Translator: User activates translate
    Translator->>ReactDOM: Wraps text nodes with font elements
    Component->>ReactDOM: useCloudRegionSignIn fetch completes, setState
    ReactDOM->>ReactDOM: Reconcile tries removeChild on mutated node
    ReactDOM-->>Browser: NotFoundError thrown, Next.js error page shown

    Note over Browser,Component: After fix - safe path
    Browser->>Component: Page load, React hydrates DOM
    Note over Component: main element has translate=no and notranslate class
    Browser->>Translator: User activates translate
    Translator-->>Browser: Skips DOM mutation inside main element
    Component->>ReactDOM: useCloudRegionSignIn fetch completes, setState
    ReactDOM->>ReactDOM: Reconcile succeeds, DOM matches virtual tree
    ReactDOM-->>Browser: Re-render succeeds, page stays interactive
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): mark region selector as non-..."](https://github.com/langfuse/langfuse-docs/commit/fe24a0840a4a73be3a4288833e34636f7b79495d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31192729)</sub>

<!-- /greptile_comment -->