### PR TITLE
Replace Academy diagrams with HTML components

### DIFF
--- a/components/academy/DatasetFieldsDiagram.tsx
+++ b/components/academy/DatasetFieldsDiagram.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+
+const INNER_W = 980;
+const INNER_H = 386;
+
+function estimateInitialScale(): number {
+  if (typeof window === "undefined") return 0.69;
+  return Math.min(1, Math.max(0.25, (document.documentElement.clientWidth - 32) / INNER_W));
+}
+
+function StageLabel({
+  y,
+  num,
+  name,
+}: {
+  y: number;
+  num: string;
+  name: string;
+}) {
+  return (
+    <div className="dataset-fields__stage-label" style={{ top: y }}>
+      <span className="dataset-fields__stage-num">{num}</span>
+      <span className="dataset-fields__stage-name">{name}</span>
+    </div>
+  );
+}
+
+function Node({
+  x,
+  y,
+  width,
+  children,
+  variant,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  children: React.ReactNode;
+  variant?: "live" | "stripe" | "terminal";
+}) {
+  return (
+    <div
+      className={`dataset-fields__node ${variant ? `dataset-fields__node--${variant}` : ""}`}
+      style={{ left: x, top: y, width }}
+    >
+      <span>{children}</span>
+    </div>
+  );
+}
+
+export function DatasetFieldsDiagram() {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const estScale = estimateInitialScale();
+
+  useLayoutEffect(() => {
+    const wrap = wrapRef.current;
+    const inner = innerRef.current;
+    if (!wrap || !inner) return;
+
+    const fit = () => {
+      const scale = Math.min(1, wrap.clientWidth / INNER_W);
+      inner.style.transform = `scale(${scale})`;
+      wrap.style.height = `${INNER_H * scale}px`;
+    };
+
+    fit();
+    let rafId = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(fit);
+    });
+    ro.observe(wrap);
+
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <figure className="dataset-fields not-prose" aria-label="Dataset fields and when they are used">
+      <div
+        ref={wrapRef}
+        suppressHydrationWarning
+        className="dataset-fields__wrap"
+        style={{ height: INNER_H * estScale }}
+      >
+        <div
+          ref={innerRef}
+          suppressHydrationWarning
+          className="dataset-fields__canvas"
+          style={{ transform: `scale(${estScale})` }}
+        >
+          <div className="dataset-fields__frame" />
+          <div className="dataset-fields__label-divider" />
+          <div className="dataset-fields__row-divider" style={{ top: 128 }} />
+          <div className="dataset-fields__row-divider" style={{ top: 257 }} />
+
+          <StageLabel y={0} num="01" name="Run experiment" />
+          <StageLabel y={128} num="02" name="Add context" />
+          <StageLabel y={257} num="03" name="Score" />
+
+          <svg className="dataset-fields__arrows" viewBox={`0 0 ${INNER_W} ${INNER_H}`} aria-hidden="true">
+            <defs>
+              <marker id="dataset-fields-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                <path d="M0 0 L10 5 L0 10 Z" fill="var(--text-secondary)" />
+              </marker>
+              <marker id="dataset-fields-arrow-dashed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                <path d="M0 0 L10 5 L0 10 Z" fill="var(--text-tertiary)" />
+              </marker>
+            </defs>
+            <path className="dataset-fields__arrow" d="M 340 64 H 400" markerEnd="url(#dataset-fields-arrow)" />
+            <path className="dataset-fields__arrow" d="M 620 64 H 680" markerEnd="url(#dataset-fields-arrow)" />
+            <path className="dataset-fields__arrow" d="M 340 192 H 400" markerEnd="url(#dataset-fields-arrow)" />
+            <path className="dataset-fields__arrow" d="M 340 321 H 680" markerEnd="url(#dataset-fields-arrow)" />
+            <path className="dataset-fields__arrow dataset-fields__arrow--dashed" d="M 770 94 V 286" markerEnd="url(#dataset-fields-arrow-dashed)" />
+            <path className="dataset-fields__arrow dataset-fields__arrow--dashed" d="M 510 222 V 250 H 770 V 286" markerEnd="url(#dataset-fields-arrow-dashed)" />
+          </svg>
+
+          <Node x={160} y={36} width={180} variant="live">Input</Node>
+          <Node x={400} y={36} width={220} variant="live">Task execution</Node>
+          <Node x={680} y={36} width={180} variant="live">Actual output</Node>
+
+          <Node x={160} y={164} width={180} variant="stripe">Metadata</Node>
+          <Node x={400} y={164} width={220} variant="stripe">Extra context for review</Node>
+
+          <Node x={160} y={293} width={180}>Expected output</Node>
+          <Node x={680} y={293} width={180} variant="terminal">Score / compare</Node>
+        </div>
+      </div>
+
+      <style>{`
+        .dataset-fields {
+          margin: 32px 0;
+          width: 100%;
+        }
+
+        .dataset-fields__wrap {
+          position: relative;
+          width: 100%;
+          overflow: hidden;
+        }
+
+        .dataset-fields__canvas {
+          position: relative;
+          width: ${INNER_W}px;
+          height: ${INNER_H}px;
+          transform-origin: top left;
+        }
+
+        .dataset-fields__frame,
+        .dataset-fields__label-divider,
+        .dataset-fields__row-divider,
+        .dataset-fields__stage-label,
+        .dataset-fields__arrows,
+        .dataset-fields__node {
+          position: absolute;
+        }
+
+        .dataset-fields__frame {
+          inset: 0;
+          border: 1px solid var(--line-structure);
+          border-radius: 2px;
+          background: var(--surface-bg);
+        }
+
+        .dataset-fields__label-divider {
+          top: 0;
+          bottom: 0;
+          left: 120px;
+          border-left: 1px dashed var(--line-divider-dash);
+        }
+
+        .dataset-fields__row-divider {
+          right: 0;
+          left: 0;
+          border-top: 1px solid var(--line-structure);
+        }
+
+        .dataset-fields__stage-label {
+          left: 0;
+          width: 120px;
+          height: 128px;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          padding-left: 14px;
+          padding-right: 20px;
+        }
+
+        .dataset-fields__stage-num,
+        .dataset-fields__stage-name {
+          display: block;
+          color: var(--text-tertiary);
+          font-family: var(--font-mono);
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .dataset-fields__stage-num {
+          margin-bottom: 4px;
+          color: var(--text-disabled);
+          font-size: 10px;
+          letter-spacing: 0.06em;
+        }
+
+        .dataset-fields__stage-name {
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          line-height: 1.4;
+        }
+
+        .dataset-fields__arrows {
+          inset: 0;
+          width: ${INNER_W}px;
+          height: ${INNER_H}px;
+          overflow: visible;
+          pointer-events: none;
+          z-index: 1;
+        }
+
+        .dataset-fields__arrow {
+          fill: none;
+          stroke: var(--text-secondary);
+          stroke-width: 1.5;
+        }
+
+        .dataset-fields__arrow--dashed {
+          stroke: var(--text-tertiary);
+          stroke-width: 1.25;
+          stroke-dasharray: 4 4;
+        }
+
+        .dataset-fields__node {
+          z-index: 2;
+          height: 56px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 1px solid var(--line-structure);
+          border-radius: 2px;
+          background: var(--surface-bg);
+          padding: 0 18px;
+          text-align: center;
+          transition: border-color 0.18s ease;
+        }
+
+        .dataset-fields__node::before {
+          content: "";
+          position: absolute;
+          inset: -1px;
+          z-index: 2;
+          pointer-events: none;
+          background-color: var(--line-cta);
+          --tl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E");
+          --bl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E");
+          --br: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E");
+          --tr: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+          -webkit-mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          -webkit-mask-position: top left, bottom left, bottom right, top right;
+          mask-position: top left, bottom left, bottom right, top right;
+          -webkit-mask-size: 8px 8px;
+          mask-size: 8px 8px;
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+        }
+
+        .dataset-fields__node span {
+          color: var(--text-primary);
+          font-family: var(--font-analog);
+          font-size: 18px;
+          font-weight: 500;
+          line-height: 1.1;
+        }
+
+        .dataset-fields__node--live {
+          border-color: var(--line-structure);
+          background: color-mix(in oklab, var(--callout-info) 10%, var(--surface-bg));
+        }
+
+        .dataset-fields__node--stripe {
+          background: repeating-linear-gradient(
+            315deg,
+            var(--surface-bg),
+            var(--surface-bg) 2px,
+            color-mix(in oklab, var(--text-tertiary) 12%, transparent) 4px,
+            var(--surface-bg) 4px
+          );
+        }
+
+        .dataset-fields__node--terminal {
+          border-color: var(--line-structure);
+          background: var(--surface-cta-primary);
+        }
+
+        .dataset-fields__node:hover {
+          border-color: var(--line-cta);
+        }
+
+        .dark .dataset-fields__node--live,
+        [data-theme="dark"] .dataset-fields__node--live,
+        .dark .dataset-fields__node--terminal,
+        [data-theme="dark"] .dataset-fields__node--terminal {
+          background: transparent;
+        }
+      `}</style>
+    </figure>
+  );
+}

--- a/components/academy/EvaluationEvolutionDiagram.tsx
+++ b/components/academy/EvaluationEvolutionDiagram.tsx
@@ -1,0 +1,374 @@
+import type { ReactNode } from "react";
+
+function Connector() {
+  return (
+    <div className="evaluation-evolution__connector" aria-hidden="true">
+      <div className="evaluation-evolution__line" />
+      <div className="evaluation-evolution__arrow" />
+    </div>
+  );
+}
+
+function ManualReviewGlyph() {
+  return (
+    <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
+      <g stroke="#6b5e2b" strokeWidth="1.25">
+        <rect x="24" y="18" width="168" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="24" y="38" width="168" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="24" y="58" width="168" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="24" y="78" width="168" height="14" rx="2" fill="#f6f6f3" />
+      </g>
+      <g fill="#6b5e2b" opacity="0.55">
+        <rect x="32" y="23" width="54" height="4" rx="1" />
+        <rect x="32" y="43" width="86" height="4" rx="1" />
+        <rect x="32" y="63" width="40" height="4" rx="1" />
+        <rect x="32" y="83" width="72" height="4" rx="1" />
+      </g>
+      <g transform="translate(150 50)">
+        <circle cx="0" cy="0" r="22" fill="#f1ede1" stroke="#2c2c28" strokeWidth="2" />
+        <circle cx="0" cy="0" r="22" fill="none" stroke="#fbff81" strokeWidth="4" opacity="0.5" />
+        <line x1="16" y1="16" x2="30" y2="30" stroke="#2c2c28" strokeWidth="3" strokeLinecap="round" />
+        <circle cx="-4" cy="-4" r="5" fill="#fff" opacity="0.55" />
+      </g>
+    </svg>
+  );
+}
+
+function FailureModesGlyph() {
+  return (
+    <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
+      <g stroke="#2c2c28" strokeWidth="1.5">
+        <rect x="34" y="14" width="14" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="34" y="38" width="14" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="34" y="62" width="14" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="34" y="86" width="14" height="14" rx="2" fill="#f6f6f3" />
+      </g>
+      <g stroke="#2c2c28" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none">
+        <path d="M37.5 21.5 l3 3 l5 -6" />
+        <path d="M37.5 45.5 l3 3 l5 -6" />
+        <path d="M37.5 69.5 l3 3 l5 -6" />
+      </g>
+      <g fill="#2c2c28" opacity="0.65">
+        <rect x="58" y="19" width="118" height="4" rx="1" />
+        <rect x="58" y="43" width="96" height="4" rx="1" />
+        <rect x="58" y="67" width="134" height="4" rx="1" />
+        <rect x="58" y="91" width="82" height="4" rx="1" opacity="0.45" />
+      </g>
+      <g transform="translate(150 92) rotate(-30)">
+        <path d="M0 0 L20 -4 L26 0 L20 4 Z" fill="#2c2c28" />
+        <path d="M-2 0 L4 -2 L4 2 Z" fill="#fbff81" />
+      </g>
+    </svg>
+  );
+}
+
+function AutomateGlyph() {
+  return (
+    <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
+      <g>
+        <rect x="22" y="22" width="86" height="66" rx="2" fill="#222220" stroke="#222220" />
+        <circle cx="30" cy="30" r="2" fill="#cc3314" />
+        <circle cx="38" cy="30" r="2" fill="#e09d00" />
+        <circle cx="46" cy="30" r="2" fill="#538a2e" />
+        <rect x="30" y="42" width="38" height="3" rx="1" fill="#fbff81" />
+        <rect x="30" y="50" width="58" height="3" rx="1" fill="#f6f6f3" opacity="0.55" />
+        <rect x="38" y="58" width="42" height="3" rx="1" fill="#f6f6f3" opacity="0.55" />
+        <rect x="38" y="66" width="30" height="3" rx="1" fill="#fbff81" />
+        <rect x="30" y="74" width="22" height="3" rx="1" fill="#f6f6f3" opacity="0.55" />
+      </g>
+      <g stroke="#2c2c28" strokeWidth="1.25" fill="none" strokeLinecap="round">
+        <path d="M115 38 H132" />
+        <path d="M115 56 H132" />
+        <path d="M115 74 H132" />
+      </g>
+      <g fill="#2c2c28">
+        <path d="M134 38 l-4 -3 l0 6 z" />
+        <path d="M134 56 l-4 -3 l0 6 z" />
+        <path d="M134 74 l-4 -3 l0 6 z" />
+      </g>
+      <g>
+        <rect x="138" y="30" width="60" height="16" rx="2" fill="#f6f6f3" stroke="#2c2c28" strokeWidth="1.25" />
+        <circle cx="148" cy="38" r="3" fill="#538a2e" />
+        <rect x="156" y="36" width="34" height="4" rx="1" fill="#2c2c28" opacity="0.55" />
+        <rect x="138" y="48" width="60" height="16" rx="2" fill="#fbff81" stroke="#2c2c28" strokeWidth="1.25" />
+        <circle cx="148" cy="56" r="3" fill="#2c2c28" />
+        <rect x="156" y="54" width="28" height="4" rx="1" fill="#2c2c28" opacity="0.7" />
+        <rect x="138" y="66" width="60" height="16" rx="2" fill="#f6f6f3" stroke="#2c2c28" strokeWidth="1.25" />
+        <circle cx="148" cy="74" r="3" fill="#cc3314" />
+        <rect x="156" y="72" width="40" height="4" rx="1" fill="#2c2c28" opacity="0.55" />
+      </g>
+    </svg>
+  );
+}
+
+function Stage({
+  className,
+  step,
+  title,
+  children,
+}: {
+  className: string;
+  step: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`evaluation-evolution__stage ${className}`}>
+      <span className="evaluation-evolution__caption">{step}</span>
+      <div className="evaluation-evolution__title">{title}</div>
+      <div className="evaluation-evolution__glyph">{children}</div>
+    </section>
+  );
+}
+
+export function EvaluationEvolutionDiagram() {
+  return (
+    <figure className="evaluation-evolution not-prose" aria-label="How evaluation typically evolves from manual review to automated evaluators">
+      <div className="evaluation-evolution__wrap">
+        <div className="evaluation-evolution__flow">
+          <Stage className="evaluation-evolution__stage--one" step="Step 01" title="Manual review">
+            <ManualReviewGlyph />
+          </Stage>
+          <Connector />
+          <Stage className="evaluation-evolution__stage--two" step="Step 02" title={"Identify\nfailure\u00a0modes"}>
+            <FailureModesGlyph />
+          </Stage>
+          <Connector />
+          <Stage className="evaluation-evolution__stage--three" step="Step 03" title="Automate">
+            <AutomateGlyph />
+          </Stage>
+        </div>
+
+        <div className="evaluation-evolution__loop" aria-hidden="true">
+          <svg viewBox="0 0 1000 100" preserveAspectRatio="none">
+            <path d="M 852 0 V 47" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 852 47 H 148" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 148 47 V 0" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 148 0 l -5 7 l 10 0 z" fill="#404039" />
+          </svg>
+        </div>
+      </div>
+
+      <style>{`
+        .evaluation-evolution {
+          --eval-stage-one-tint: #f1ede1;
+          --eval-stage-one-stroke: #d6cfb6;
+          --eval-stage-one-ink: #6b5e2b;
+          --eval-stage-two-tint: var(--surface-bg);
+          --eval-stage-two-stroke: var(--line-structure);
+          --eval-stage-two-ink: #2c2c28;
+          --eval-stage-three-tint: #f1ede1;
+          --eval-stage-three-stroke: #d6cfb6;
+          --eval-stage-three-ink: #6b5e2b;
+          container-type: inline-size;
+          margin: 32px 0 80px;
+          width: 100%;
+        }
+
+        .dark .evaluation-evolution,
+        [data-theme="dark"] .evaluation-evolution {
+          --eval-stage-one-tint: var(--surface-bg);
+          --eval-stage-one-stroke: var(--line-structure);
+          --eval-stage-one-ink: var(--text-secondary);
+          --eval-stage-three-tint: var(--surface-bg);
+          --eval-stage-three-stroke: var(--line-structure);
+          --eval-stage-three-ink: var(--text-secondary);
+        }
+
+        .evaluation-evolution__wrap {
+          position: relative;
+          width: 100%;
+        }
+
+        .evaluation-evolution__flow {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) clamp(18px, 8cqw, 56px) minmax(0, 1fr) clamp(18px, 8cqw, 56px) minmax(0, 1fr);
+          align-items: center;
+          gap: 0;
+        }
+
+        .evaluation-evolution__stage {
+          position: relative;
+          display: flex;
+          aspect-ratio: 1 / 1;
+          min-height: 0;
+          width: 100%;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: clamp(4px, 1.8cqw, 18px);
+          border: 1px solid var(--line-structure);
+          border-radius: 2px;
+          background: var(--surface-bg);
+          padding: clamp(12px, 7cqw, 44px) clamp(7px, 4cqw, 28px) clamp(8px, 5cqw, 32px);
+          transition: border-color 0.18s ease;
+        }
+
+        .evaluation-evolution__stage::before {
+          content: "";
+          position: absolute;
+          inset: -1px;
+          z-index: 2;
+          pointer-events: none;
+          background-color: var(--line-cta);
+          --tl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E");
+          --bl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E");
+          --br: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E");
+          --tr: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+          -webkit-mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          -webkit-mask-position: 0% 0%, 0% 100%, 100% 100%, 100% 0%;
+          mask-position: 0% 0%, 0% 100%, 100% 100%, 100% 0%;
+          -webkit-mask-size: 8px 8px;
+          mask-size: 8px 8px;
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+          opacity: 0.72;
+          transition: background-color 0.18s ease, opacity 0.18s ease;
+        }
+
+        .evaluation-evolution__stage:hover {
+          border-color: var(--line-cta);
+        }
+
+        .evaluation-evolution__stage:hover::before {
+          background-color: var(--line-cta);
+          opacity: 1;
+        }
+
+        .evaluation-evolution__stage--one {
+          border-color: var(--eval-stage-one-stroke);
+          background: var(--eval-stage-one-tint);
+        }
+
+        .evaluation-evolution__stage--one::before {
+          background-color: var(--eval-stage-one-ink);
+        }
+
+        .evaluation-evolution__stage--two {
+          border-color: var(--eval-stage-two-stroke);
+          background: var(--eval-stage-two-tint);
+        }
+
+        .evaluation-evolution__stage--two::before {
+          background-color: var(--eval-stage-two-ink);
+        }
+
+        .evaluation-evolution__stage--three {
+          border-color: var(--eval-stage-three-stroke);
+          background: var(--eval-stage-three-tint);
+        }
+
+        .evaluation-evolution__stage--three::before {
+          background-color: var(--eval-stage-three-ink);
+        }
+
+        .evaluation-evolution__caption {
+          position: absolute;
+          top: -1px;
+          left: 24px;
+          z-index: 3;
+          transform: translateY(-50%);
+          background: var(--surface-bg);
+          padding: 0 10px;
+          color: var(--text-secondary);
+          font-family: var(--font-mono);
+          font-size: clamp(5px, 1.6cqw, 11px);
+          letter-spacing: 0.08em;
+          line-height: 1.4;
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .evaluation-evolution__stage--one > .evaluation-evolution__caption {
+          color: var(--eval-stage-one-ink);
+        }
+
+        .evaluation-evolution__stage--three > .evaluation-evolution__caption {
+          color: var(--eval-stage-three-ink);
+        }
+
+        .evaluation-evolution__title {
+          color: var(--text-primary);
+          font-family: var(--font-analog);
+          font-feature-settings: "dlig" on;
+          font-size: clamp(8px, 3.1cqw, 24px);
+          font-weight: 500;
+          letter-spacing: 0;
+          line-height: 1.1;
+          white-space: pre-line;
+        }
+
+        .evaluation-evolution__glyph {
+          display: flex;
+          flex: 1 1 auto;
+          width: 100%;
+          min-height: 0;
+          max-height: clamp(28px, 16cqw, 120px);
+          align-items: center;
+          justify-content: center;
+        }
+
+        .evaluation-evolution__glyph svg {
+          width: 100%;
+          height: 100%;
+          overflow: visible;
+        }
+
+        .evaluation-evolution__connector {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .evaluation-evolution__line {
+          width: 100%;
+          height: 1px;
+          background-image: linear-gradient(to right, var(--text-tertiary) 50%, transparent 0%);
+          background-repeat: repeat-x;
+          background-size: 6px 1px;
+        }
+
+        .evaluation-evolution__arrow {
+          position: absolute;
+          right: 6px;
+          width: 0;
+          height: 0;
+          border-top: clamp(3px, 1cqw, 5px) solid transparent;
+          border-bottom: clamp(3px, 1cqw, 5px) solid transparent;
+          border-left: clamp(4px, 1.2cqw, 7px) solid var(--text-secondary);
+        }
+
+        .evaluation-evolution__loop {
+          position: absolute;
+          top: 100%;
+          right: 0;
+          left: 0;
+          height: 56px;
+          overflow: visible;
+          pointer-events: none;
+        }
+
+        .evaluation-evolution__loop svg {
+          width: 100%;
+          height: 100%;
+          overflow: visible;
+        }
+
+        @container (max-width: 520px) {
+          .evaluation-evolution__caption {
+            left: clamp(6px, 5cqw, 24px);
+            padding: 0 clamp(3px, 1.6cqw, 10px);
+            letter-spacing: 0.04em;
+          }
+
+          .evaluation-evolution__stage::before {
+            -webkit-mask-size: 6px 6px;
+            mask-size: 6px 6px;
+          }
+        }
+      `}</style>
+    </figure>
+  );
+}

--- a/components/academy/EvaluationEvolutionDiagram.tsx
+++ b/components/academy/EvaluationEvolutionDiagram.tsx
@@ -90,7 +90,7 @@ function AutomateGlyph() {
         <rect x="138" y="30" width="60" height="16" rx="2" fill="var(--eval-glyph-light-surface)" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
         <circle cx="148" cy="38" r="3" fill="#538a2e" />
         <rect x="156" y="36" width="34" height="4" rx="1" fill="var(--eval-glyph-ink)" opacity="0.55" />
-        <rect x="138" y="48" width="60" height="16" rx="2" fill="#fbff81" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
+        <rect x="138" y="48" width="60" height="16" rx="2" fill="var(--eval-glyph-highlight-bg)" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
         <circle cx="148" cy="56" r="3" fill="var(--eval-glyph-ink)" />
         <rect x="156" y="54" width="28" height="4" rx="1" fill="var(--eval-glyph-ink)" opacity="0.7" />
         <rect x="138" y="66" width="60" height="16" rx="2" fill="var(--eval-glyph-light-surface)" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
@@ -167,6 +167,7 @@ export function EvaluationEvolutionDiagram() {
           --eval-manual-ink: #6b5e2b;
           --eval-loop-line: #6c6760;
           --eval-loop-arrow: #404039;
+          --eval-glyph-highlight-bg: #fbff81;
           container-type: inline-size;
           margin: 32px 0 80px;
           width: 100%;
@@ -188,6 +189,7 @@ export function EvaluationEvolutionDiagram() {
           --eval-manual-ink: var(--text-secondary);
           --eval-loop-line: var(--text-tertiary);
           --eval-loop-arrow: var(--text-secondary);
+          --eval-glyph-highlight-bg: #5a5a1f;
         }
 
         .evaluation-evolution__wrap {

--- a/components/academy/EvaluationEvolutionDiagram.tsx
+++ b/components/academy/EvaluationEvolutionDiagram.tsx
@@ -13,10 +13,10 @@ function ManualReviewGlyph() {
   return (
     <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
       <g stroke="#6b5e2b" strokeWidth="1.25">
-        <rect x="24" y="18" width="168" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="24" y="38" width="168" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="24" y="58" width="168" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="24" y="78" width="168" height="14" rx="2" fill="#f6f6f3" />
+        <rect x="24" y="18" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="24" y="38" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="24" y="58" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="24" y="78" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
       </g>
       <g fill="#6b5e2b" opacity="0.55">
         <rect x="32" y="23" width="54" height="4" rx="1" />
@@ -25,9 +25,9 @@ function ManualReviewGlyph() {
         <rect x="32" y="83" width="72" height="4" rx="1" />
       </g>
       <g transform="translate(150 50)">
-        <circle cx="0" cy="0" r="22" fill="#f1ede1" stroke="#2c2c28" strokeWidth="2" />
+        <circle cx="0" cy="0" r="22" fill="var(--eval-glyph-warm-surface)" stroke="var(--eval-glyph-ink)" strokeWidth="2" />
         <circle cx="0" cy="0" r="22" fill="none" stroke="#fbff81" strokeWidth="4" opacity="0.5" />
-        <line x1="16" y1="16" x2="30" y2="30" stroke="#2c2c28" strokeWidth="3" strokeLinecap="round" />
+        <line x1="16" y1="16" x2="30" y2="30" stroke="var(--eval-glyph-ink)" strokeWidth="3" strokeLinecap="round" />
         <circle cx="-4" cy="-4" r="5" fill="#fff" opacity="0.55" />
       </g>
     </svg>
@@ -37,25 +37,25 @@ function ManualReviewGlyph() {
 function FailureModesGlyph() {
   return (
     <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
-      <g stroke="#2c2c28" strokeWidth="1.5">
-        <rect x="34" y="14" width="14" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="34" y="38" width="14" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="34" y="62" width="14" height="14" rx="2" fill="#f6f6f3" />
-        <rect x="34" y="86" width="14" height="14" rx="2" fill="#f6f6f3" />
+      <g stroke="var(--eval-glyph-ink)" strokeWidth="1.5">
+        <rect x="34" y="14" width="14" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="34" y="38" width="14" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="34" y="62" width="14" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
+        <rect x="34" y="86" width="14" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
       </g>
-      <g stroke="#2c2c28" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none">
+      <g stroke="var(--eval-glyph-ink)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none">
         <path d="M37.5 21.5 l3 3 l5 -6" />
         <path d="M37.5 45.5 l3 3 l5 -6" />
         <path d="M37.5 69.5 l3 3 l5 -6" />
       </g>
-      <g fill="#2c2c28" opacity="0.65">
+      <g fill="var(--eval-glyph-ink)" opacity="0.65">
         <rect x="58" y="19" width="118" height="4" rx="1" />
         <rect x="58" y="43" width="96" height="4" rx="1" />
         <rect x="58" y="67" width="134" height="4" rx="1" />
         <rect x="58" y="91" width="82" height="4" rx="1" opacity="0.45" />
       </g>
       <g transform="translate(150 92) rotate(-30)">
-        <path d="M0 0 L20 -4 L26 0 L20 4 Z" fill="#2c2c28" />
+        <path d="M0 0 L20 -4 L26 0 L20 4 Z" fill="var(--eval-glyph-ink)" />
         <path d="M-2 0 L4 -2 L4 2 Z" fill="#fbff81" />
       </g>
     </svg>
@@ -66,7 +66,7 @@ function AutomateGlyph() {
   return (
     <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
       <g>
-        <rect x="22" y="22" width="86" height="66" rx="2" fill="#222220" stroke="#222220" />
+        <rect x="22" y="22" width="86" height="66" rx="2" fill="var(--eval-glyph-panel)" stroke="var(--eval-glyph-panel)" />
         <circle cx="30" cy="30" r="2" fill="#cc3314" />
         <circle cx="38" cy="30" r="2" fill="#e09d00" />
         <circle cx="46" cy="30" r="2" fill="#538a2e" />
@@ -76,26 +76,26 @@ function AutomateGlyph() {
         <rect x="38" y="66" width="30" height="3" rx="1" fill="#fbff81" />
         <rect x="30" y="74" width="22" height="3" rx="1" fill="#f6f6f3" opacity="0.55" />
       </g>
-      <g stroke="#2c2c28" strokeWidth="1.25" fill="none" strokeLinecap="round">
+      <g stroke="var(--eval-glyph-ink)" strokeWidth="1.25" fill="none" strokeLinecap="round">
         <path d="M115 38 H132" />
         <path d="M115 56 H132" />
         <path d="M115 74 H132" />
       </g>
-      <g fill="#2c2c28">
+      <g fill="var(--eval-glyph-ink)">
         <path d="M134 38 l-4 -3 l0 6 z" />
         <path d="M134 56 l-4 -3 l0 6 z" />
         <path d="M134 74 l-4 -3 l0 6 z" />
       </g>
       <g>
-        <rect x="138" y="30" width="60" height="16" rx="2" fill="#f6f6f3" stroke="#2c2c28" strokeWidth="1.25" />
+        <rect x="138" y="30" width="60" height="16" rx="2" fill="var(--eval-glyph-light-surface)" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
         <circle cx="148" cy="38" r="3" fill="#538a2e" />
-        <rect x="156" y="36" width="34" height="4" rx="1" fill="#2c2c28" opacity="0.55" />
-        <rect x="138" y="48" width="60" height="16" rx="2" fill="#fbff81" stroke="#2c2c28" strokeWidth="1.25" />
-        <circle cx="148" cy="56" r="3" fill="#2c2c28" />
-        <rect x="156" y="54" width="28" height="4" rx="1" fill="#2c2c28" opacity="0.7" />
-        <rect x="138" y="66" width="60" height="16" rx="2" fill="#f6f6f3" stroke="#2c2c28" strokeWidth="1.25" />
+        <rect x="156" y="36" width="34" height="4" rx="1" fill="var(--eval-glyph-ink)" opacity="0.55" />
+        <rect x="138" y="48" width="60" height="16" rx="2" fill="#fbff81" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
+        <circle cx="148" cy="56" r="3" fill="var(--eval-glyph-ink)" />
+        <rect x="156" y="54" width="28" height="4" rx="1" fill="var(--eval-glyph-ink)" opacity="0.7" />
+        <rect x="138" y="66" width="60" height="16" rx="2" fill="var(--eval-glyph-light-surface)" stroke="var(--eval-glyph-ink)" strokeWidth="1.25" />
         <circle cx="148" cy="74" r="3" fill="#cc3314" />
-        <rect x="156" y="72" width="40" height="4" rx="1" fill="#2c2c28" opacity="0.55" />
+        <rect x="156" y="72" width="40" height="4" rx="1" fill="var(--eval-glyph-ink)" opacity="0.55" />
       </g>
     </svg>
   );
@@ -160,6 +160,10 @@ export function EvaluationEvolutionDiagram() {
           --eval-stage-three-tint: #f1ede1;
           --eval-stage-three-stroke: #d6cfb6;
           --eval-stage-three-ink: #6b5e2b;
+          --eval-glyph-ink: #2c2c28;
+          --eval-glyph-panel: #222220;
+          --eval-glyph-light-surface: #f6f6f3;
+          --eval-glyph-warm-surface: #f1ede1;
           container-type: inline-size;
           margin: 32px 0 80px;
           width: 100%;
@@ -170,9 +174,14 @@ export function EvaluationEvolutionDiagram() {
           --eval-stage-one-tint: var(--surface-bg);
           --eval-stage-one-stroke: var(--line-structure);
           --eval-stage-one-ink: var(--text-secondary);
+          --eval-stage-two-ink: var(--text-secondary);
           --eval-stage-three-tint: var(--surface-bg);
           --eval-stage-three-stroke: var(--line-structure);
           --eval-stage-three-ink: var(--text-secondary);
+          --eval-glyph-ink: var(--text-secondary);
+          --eval-glyph-panel: var(--surface-2);
+          --eval-glyph-light-surface: var(--surface-2);
+          --eval-glyph-warm-surface: var(--surface-2);
         }
 
         .evaluation-evolution__wrap {

--- a/components/academy/EvaluationEvolutionDiagram.tsx
+++ b/components/academy/EvaluationEvolutionDiagram.tsx
@@ -12,13 +12,13 @@ function Connector() {
 function ManualReviewGlyph() {
   return (
     <svg viewBox="0 0 240 110" fill="none" aria-hidden="true">
-      <g stroke="#6b5e2b" strokeWidth="1.25">
+      <g stroke="var(--eval-manual-ink)" strokeWidth="1.25">
         <rect x="24" y="18" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
         <rect x="24" y="38" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
         <rect x="24" y="58" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
         <rect x="24" y="78" width="168" height="14" rx="2" fill="var(--eval-glyph-light-surface)" />
       </g>
-      <g fill="#6b5e2b" opacity="0.55">
+      <g fill="var(--eval-manual-ink)" opacity="0.55">
         <rect x="32" y="23" width="54" height="4" rx="1" />
         <rect x="32" y="43" width="86" height="4" rx="1" />
         <rect x="32" y="63" width="40" height="4" rx="1" />
@@ -141,10 +141,10 @@ export function EvaluationEvolutionDiagram() {
 
         <div className="evaluation-evolution__loop" aria-hidden="true">
           <svg viewBox="0 0 1000 100" preserveAspectRatio="none">
-            <path d="M 852 0 V 47" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
-            <path d="M 852 47 H 148" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
-            <path d="M 148 47 V 0" stroke="#6c6760" strokeWidth="1" strokeDasharray="3 3" fill="none" />
-            <path d="M 148 0 l -5 7 l 10 0 z" fill="#404039" />
+            <path d="M 852 0 V 47" stroke="var(--eval-loop-line)" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 852 47 H 148" stroke="var(--eval-loop-line)" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 148 47 V 0" stroke="var(--eval-loop-line)" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+            <path d="M 148 0 l -5 7 l 10 0 z" fill="var(--eval-loop-arrow)" />
           </svg>
         </div>
       </div>
@@ -164,6 +164,9 @@ export function EvaluationEvolutionDiagram() {
           --eval-glyph-panel: #222220;
           --eval-glyph-light-surface: #f6f6f3;
           --eval-glyph-warm-surface: #f1ede1;
+          --eval-manual-ink: #6b5e2b;
+          --eval-loop-line: #6c6760;
+          --eval-loop-arrow: #404039;
           container-type: inline-size;
           margin: 32px 0 80px;
           width: 100%;
@@ -182,6 +185,9 @@ export function EvaluationEvolutionDiagram() {
           --eval-glyph-panel: var(--surface-2);
           --eval-glyph-light-surface: var(--surface-2);
           --eval-glyph-warm-surface: var(--surface-2);
+          --eval-manual-ink: var(--text-secondary);
+          --eval-loop-line: var(--text-tertiary);
+          --eval-loop-arrow: var(--text-secondary);
         }
 
         .evaluation-evolution__wrap {

--- a/components/academy/RagTraceViewDiagram.tsx
+++ b/components/academy/RagTraceViewDiagram.tsx
@@ -164,7 +164,7 @@ export function RagTraceViewDiagram() {
             <span className="rag-trace-view__legend-item rag-trace-view__legend-item--gen"><span />generation</span>
             <span className="rag-trace-view__legend-item rag-trace-view__legend-item--event"><span />event</span>
           </div>
-          <span>9 observations - p95 1.82s</span>
+          <span>1 trace, 8 observations - p95 1.82s</span>
         </div>
       </div>
 

--- a/components/academy/RagTraceViewDiagram.tsx
+++ b/components/academy/RagTraceViewDiagram.tsx
@@ -1,0 +1,447 @@
+const GRID_LINES = [22.73, 45.45, 68.18, 90.91];
+
+const ROWS = [
+  {
+    type: "trace",
+    label: "Trace",
+    name: "rag-chat-pipeline",
+    duration: "4.23s",
+    depth: 0,
+    barLeft: 0,
+    barWidth: 96.14,
+  },
+  {
+    type: "span",
+    label: "Span",
+    name: "retrieve-documents",
+    duration: "1.07s",
+    depth: 1,
+    barLeft: 0,
+    barWidth: 24.32,
+  },
+  {
+    type: "gen",
+    label: "Gen",
+    name: "embed-query",
+    duration: "150ms",
+    depth: 2,
+    barLeft: 0,
+    barWidth: 3.41,
+  },
+  {
+    type: "span",
+    label: "Span",
+    name: "vector-db-search",
+    duration: "510ms",
+    depth: 2,
+    barLeft: 3.86,
+    barWidth: 11.59,
+  },
+  {
+    type: "event",
+    label: "Event",
+    name: "cache-miss",
+    duration: "@ 225ms",
+    depth: 3,
+    eventLeft: 5.11,
+  },
+  {
+    type: "gen",
+    label: "Gen",
+    name: "rerank-results",
+    duration: "180ms",
+    depth: 2,
+    barLeft: 17.5,
+    barWidth: 4.09,
+  },
+  {
+    type: "span",
+    label: "Span",
+    name: "generate-answer",
+    duration: "3.16s",
+    depth: 1,
+    barLeft: 24.32,
+    barWidth: 71.82,
+  },
+  {
+    type: "gen",
+    label: "Gen",
+    name: "generate-answer",
+    duration: "1.07s",
+    depth: 2,
+    barLeft: 24.77,
+    barWidth: 24.32,
+  },
+  {
+    type: "event",
+    label: "Event",
+    name: "stream-complete",
+    duration: "@ 1.93s",
+    depth: 2,
+    eventLeft: 43.86,
+  },
+] as const;
+
+function GridLines() {
+  return (
+    <div className="rag-trace-view__gridlines" aria-hidden="true">
+      {GRID_LINES.map((left) => (
+        <div
+          key={left}
+          className="rag-trace-view__gridline"
+          style={{ left: `${left}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Indents({ depth }: { depth: number }) {
+  return (
+    <>
+      {Array.from({ length: depth }, (_, index) => (
+        <span key={index} className="rag-trace-view__indent" aria-hidden="true" />
+      ))}
+    </>
+  );
+}
+
+export function RagTraceViewDiagram() {
+  return (
+    <figure className="rag-trace-view not-prose" aria-label="RAG chat pipeline trace timeline">
+      <div className="rag-trace-view__card corner-box-corners">
+        <div className="rag-trace-view__columns">
+          <div className="rag-trace-view__column-header rag-trace-view__column-header--left">
+            <span>Name</span>
+            <span>Duration</span>
+          </div>
+          <div className="rag-trace-view__column-header">
+            <div className="rag-trace-view__ruler">
+              <span style={{ left: "0%" }}>0</span>
+              <span style={{ left: "22.73%" }}>1s</span>
+              <span style={{ left: "45.45%" }}>2s</span>
+              <span style={{ left: "68.18%" }}>3s</span>
+              <span style={{ left: "90.91%" }}>4s</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rag-trace-view__body">
+          {ROWS.map((row) => (
+            <div className="rag-trace-view__row" key={`${row.type}-${row.name}-${row.duration}`}>
+              <div className="rag-trace-view__left">
+                <Indents depth={row.depth} />
+                <span className={`rag-trace-view__pill rag-trace-view__pill--${row.type}`}>
+                  {row.label}
+                </span>
+                <span className="rag-trace-view__name">{row.name}</span>
+                <span className="rag-trace-view__duration">{row.duration}</span>
+              </div>
+              <div className="rag-trace-view__right">
+                <GridLines />
+                {row.type === "event" ? (
+                  <span
+                    className="rag-trace-view__event-marker"
+                    style={{ left: `${row.eventLeft}%` }}
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <span
+                    className={`rag-trace-view__bar rag-trace-view__bar--${row.type}`}
+                    style={{ left: `${row.barLeft}%`, width: `${row.barWidth}%` }}
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="rag-trace-view__footer">
+          <div className="rag-trace-view__legend">
+            <span className="rag-trace-view__legend-item rag-trace-view__legend-item--trace"><span />trace</span>
+            <span className="rag-trace-view__legend-item rag-trace-view__legend-item--span"><span />span</span>
+            <span className="rag-trace-view__legend-item rag-trace-view__legend-item--gen"><span />generation</span>
+            <span className="rag-trace-view__legend-item rag-trace-view__legend-item--event"><span />event</span>
+          </div>
+          <span>9 observations - p95 1.82s</span>
+        </div>
+      </div>
+
+      <style>{`
+        .rag-trace-view {
+          container-type: inline-size;
+          margin: 32px 0;
+          width: 100%;
+          color: var(--text-primary);
+        }
+
+        .rag-trace-view__card {
+          position: relative;
+          overflow: hidden;
+          border: 1px solid var(--line-structure);
+          border-radius: 2px;
+          background: var(--surface-bg);
+        }
+
+        .rag-trace-view__card::before {
+          background-color: var(--line-cta);
+        }
+
+        .rag-trace-view__columns,
+        .rag-trace-view__row {
+          display: grid;
+          grid-template-columns: 50% 50%;
+        }
+
+        .rag-trace-view__column-header {
+          display: flex;
+          height: clamp(14px, 5.3cqw, 36px);
+          align-items: center;
+          border-bottom: 1px solid var(--line-structure);
+          background: var(--surface-1);
+          color: var(--text-tertiary);
+          font-family: var(--font-mono);
+          font-size: clamp(4px, 1.45cqw, 10px);
+          letter-spacing: 0.06em;
+          line-height: 1;
+          text-transform: uppercase;
+        }
+
+        .rag-trace-view__column-header--left {
+          justify-content: space-between;
+          padding: 0 clamp(5px, 2.1cqw, 14px);
+        }
+
+        .rag-trace-view__ruler {
+          position: relative;
+          width: 100%;
+          height: 100%;
+        }
+
+        .rag-trace-view__ruler span {
+          position: absolute;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          color: var(--text-tertiary);
+          font-family: var(--font-mono);
+          font-size: clamp(4px, 1.45cqw, 10px);
+          white-space: nowrap;
+        }
+
+        .rag-trace-view__ruler span:first-child {
+          transform: translate(0, -50%);
+        }
+
+        .rag-trace-view__row {
+          min-height: clamp(16px, 5.6cqw, 38px);
+          border-bottom: 1px dashed var(--line-divider-dash);
+        }
+
+        .rag-trace-view__row:last-child {
+          border-bottom: 0;
+        }
+
+        .rag-trace-view__left {
+          display: flex;
+          min-width: 0;
+          align-items: center;
+          gap: clamp(3px, 1.45cqw, 10px);
+          padding: clamp(3px, 1.2cqw, 8px) clamp(5px, 2.1cqw, 14px);
+        }
+
+        .rag-trace-view__right {
+          position: relative;
+          border-left: 1px solid var(--line-structure);
+        }
+
+        .rag-trace-view__gridlines {
+          position: absolute;
+          inset: 0;
+          pointer-events: none;
+        }
+
+        .rag-trace-view__gridline {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          width: 1px;
+          background: var(--line-divider-dash);
+          opacity: 0.5;
+        }
+
+        .rag-trace-view__indent {
+          position: relative;
+          width: clamp(4px, 2cqw, 14px);
+          height: 100%;
+          flex: 0 0 auto;
+        }
+
+        .rag-trace-view__indent::before {
+          content: "";
+          position: absolute;
+          top: -50%;
+          bottom: -50%;
+          left: 50%;
+          width: 1px;
+          background: var(--line-structure);
+        }
+
+        .rag-trace-view__pill {
+          display: inline-flex;
+          height: clamp(8px, 2.7cqw, 18px);
+          min-width: clamp(22px, 7.6cqw, 52px);
+          flex: 0 0 auto;
+          align-items: center;
+          justify-content: center;
+          border: 1px solid currentColor;
+          border-radius: 2px;
+          font-family: var(--font-mono);
+          font-size: clamp(3.8px, 1.35cqw, 9.5px);
+          font-weight: 500;
+          letter-spacing: 0.06em;
+          line-height: 1;
+          text-transform: uppercase;
+        }
+
+        .rag-trace-view__pill--trace {
+          color: var(--text-secondary);
+          background: var(--surface-1);
+        }
+
+        .rag-trace-view__pill--span {
+          color: var(--text-code-blue);
+          background: color-mix(in oklab, var(--text-code-blue) 12%, var(--surface-bg));
+        }
+
+        .rag-trace-view__pill--gen {
+          color: var(--text-code-pink);
+          background: color-mix(in oklab, var(--text-code-pink) 12%, var(--surface-bg));
+        }
+
+        .rag-trace-view__pill--event {
+          color: var(--text-code-orange);
+          background: color-mix(in oklab, var(--text-code-orange) 14%, var(--surface-bg));
+        }
+
+        .rag-trace-view__name,
+        .rag-trace-view__duration {
+          color: var(--text-primary);
+          font-family: var(--font-mono);
+          font-size: clamp(4.5px, 1.9cqw, 13px);
+          letter-spacing: 0;
+          line-height: 1.15;
+          white-space: nowrap;
+        }
+
+        .rag-trace-view__name {
+          min-width: 0;
+          flex: 1 1 auto;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .rag-trace-view__duration {
+          flex: 0 0 auto;
+          color: var(--text-secondary);
+          font-size: clamp(4px, 1.75cqw, 12px);
+        }
+
+        .rag-trace-view__bar {
+          position: absolute;
+          top: 50%;
+          height: clamp(6px, 2.35cqw, 16px);
+          transform: translateY(-50%);
+          border: 1px solid currentColor;
+          border-radius: 2px;
+        }
+
+        .rag-trace-view__bar--trace {
+          color: var(--text-tertiary);
+          background: color-mix(in oklab, var(--text-tertiary) 22%, var(--surface-bg));
+        }
+
+        .rag-trace-view__bar--span {
+          color: var(--text-code-blue);
+          background: color-mix(in oklab, var(--text-code-blue) 32%, var(--surface-bg));
+        }
+
+        .rag-trace-view__bar--gen {
+          color: var(--text-code-pink);
+          background: color-mix(in oklab, var(--text-code-pink) 28%, var(--surface-bg));
+        }
+
+        .rag-trace-view__event-marker {
+          position: absolute;
+          top: 50%;
+          width: 2px;
+          height: clamp(7px, 2.65cqw, 18px);
+          transform: translateY(-50%);
+          border-radius: 1px;
+          background: var(--text-code-orange);
+        }
+
+        .rag-trace-view__footer {
+          display: flex;
+          height: clamp(14px, 4.7cqw, 32px);
+          align-items: center;
+          justify-content: space-between;
+          gap: clamp(4px, 2cqw, 14px);
+          border-top: 1px solid var(--line-structure);
+          background: var(--surface-1);
+          color: var(--text-tertiary);
+          font-family: var(--font-mono);
+          font-size: clamp(4px, 1.45cqw, 10px);
+          letter-spacing: 0.06em;
+          line-height: 1;
+          padding: 0 clamp(5px, 2.1cqw, 14px);
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .rag-trace-view__legend {
+          display: flex;
+          min-width: 0;
+          align-items: center;
+          gap: clamp(4px, 2cqw, 14px);
+          overflow: hidden;
+        }
+
+        .rag-trace-view__legend-item {
+          display: inline-flex;
+          align-items: center;
+          gap: clamp(2px, 0.9cqw, 6px);
+        }
+
+        .rag-trace-view__legend-item span {
+          width: clamp(4px, 1.45cqw, 10px);
+          height: clamp(4px, 1.45cqw, 10px);
+          border: 1px solid currentColor;
+          border-radius: 2px;
+        }
+
+        .rag-trace-view__legend-item--trace {
+          color: var(--text-tertiary);
+        }
+
+        .rag-trace-view__legend-item--span {
+          color: var(--text-code-blue);
+        }
+
+        .rag-trace-view__legend-item--gen {
+          color: var(--text-code-pink);
+        }
+
+        .rag-trace-view__legend-item--event {
+          color: var(--text-code-orange);
+        }
+
+        .rag-trace-view__legend-item--event span {
+          width: 2px;
+          border-color: var(--text-code-orange);
+          background: var(--text-code-orange);
+        }
+      `}</style>
+    </figure>
+  );
+}

--- a/components/academy/RagTraceViewDiagram.tsx
+++ b/components/academy/RagTraceViewDiagram.tsx
@@ -109,7 +109,7 @@ function Indents({ depth }: { depth: number }) {
 export function RagTraceViewDiagram() {
   return (
     <figure className="rag-trace-view not-prose" aria-label="RAG chat pipeline trace timeline">
-      <div className="rag-trace-view__card corner-box-corners">
+      <div className="rag-trace-view__card">
         <div className="rag-trace-view__columns">
           <div className="rag-trace-view__column-header rag-trace-view__column-header--left">
             <span>Name</span>
@@ -185,7 +185,24 @@ export function RagTraceViewDiagram() {
         }
 
         .rag-trace-view__card::before {
+          content: "";
+          position: absolute;
+          inset: -1px;
+          z-index: 2;
+          pointer-events: none;
           background-color: var(--line-cta);
+          --tl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E");
+          --bl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E");
+          --br: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E");
+          --tr: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+          -webkit-mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          -webkit-mask-position: 0% 0%, 0% 100%, 100% 100%, 100% 0%;
+          mask-position: 0% 0%, 0% 100%, 100% 100%, 100% 0%;
+          -webkit-mask-size: 8px 8px;
+          mask-size: 8px 8px;
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
         }
 
         .rag-trace-view__columns,

--- a/components/academy/TracingHierarchyDiagram.tsx
+++ b/components/academy/TracingHierarchyDiagram.tsx
@@ -1,0 +1,219 @@
+import type { ReactNode } from "react";
+
+const TRACE_OBSERVATION_COUNTS = [3, 4, 2];
+
+function CornerRing({
+  className,
+  children,
+}: {
+  className: string;
+  children: ReactNode;
+}) {
+  return <div className={`tracing-hierarchy__ring ${className}`}>{children}</div>;
+}
+
+function Observation() {
+  return (
+    <CornerRing className="tracing-hierarchy__observation">
+      <span className="tracing-hierarchy__dot" />
+      <span className="tracing-hierarchy__observation-label">Observation</span>
+    </CornerRing>
+  );
+}
+
+function Trace({ observationCount }: { observationCount: number }) {
+  return (
+    <CornerRing className="tracing-hierarchy__trace">
+      <span className="tracing-hierarchy__caption">Trace</span>
+      <div className="tracing-hierarchy__observations">
+        {Array.from({ length: observationCount }, (_, index) => (
+          <Observation key={index} />
+        ))}
+      </div>
+    </CornerRing>
+  );
+}
+
+export function TracingHierarchyDiagram() {
+  return (
+    <figure className="tracing-hierarchy not-prose" aria-label="Sessions contain traces, and traces contain observations">
+      <CornerRing className="tracing-hierarchy__session">
+        <span className="tracing-hierarchy__caption">Session</span>
+        <div className="tracing-hierarchy__traces">
+          {TRACE_OBSERVATION_COUNTS.map((observationCount, index) => (
+            <Trace key={index} observationCount={observationCount} />
+          ))}
+        </div>
+      </CornerRing>
+
+      <style>{`
+        .tracing-hierarchy {
+          --trace-session-tint: #eceaf7;
+          --trace-session-stroke: #b3abef;
+          --trace-session-ink: #4a3fb3;
+          --trace-tint: #f1ede1;
+          --trace-stroke: #d6cfb6;
+          --trace-ink: #6b5e2b;
+          --trace-observation-stroke: var(--line-structure);
+          container-type: inline-size;
+          margin: 32px 0;
+          width: 100%;
+        }
+
+        .dark .tracing-hierarchy,
+        [data-theme="dark"] .tracing-hierarchy {
+          --trace-session-tint: transparent;
+          --trace-session-stroke: var(--line-structure);
+          --trace-session-ink: var(--text-secondary);
+          --trace-tint: transparent;
+          --trace-stroke: var(--line-structure);
+          --trace-ink: var(--text-secondary);
+        }
+
+        .tracing-hierarchy__ring {
+          position: relative;
+          border: 1px solid var(--line-structure);
+          border-radius: 2px;
+          background: var(--surface-bg);
+          transition: border-color 0.18s ease;
+        }
+
+        .tracing-hierarchy__ring::before {
+          content: "";
+          position: absolute;
+          inset: -1px;
+          z-index: 2;
+          pointer-events: none;
+          background-color: var(--line-cta);
+          --tl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E");
+          --bl: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E");
+          --br: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E");
+          --tr: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+          -webkit-mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          mask-image: var(--tl), var(--bl), var(--br), var(--tr);
+          -webkit-mask-position: top left, bottom left, bottom right, top right;
+          mask-position: top left, bottom left, bottom right, top right;
+          -webkit-mask-size: clamp(4px, 1.2cqw, 8px) clamp(4px, 1.2cqw, 8px);
+          mask-size: clamp(4px, 1.2cqw, 8px) clamp(4px, 1.2cqw, 8px);
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+          transition: background-color 0.18s ease;
+        }
+
+        .tracing-hierarchy__observation:hover,
+        .tracing-hierarchy__trace:hover:not(:has(.tracing-hierarchy__observation:hover)),
+        .tracing-hierarchy__session:hover:not(:has(.tracing-hierarchy__trace:hover)) {
+          border-color: var(--line-cta);
+        }
+
+        .tracing-hierarchy__observation:hover::before,
+        .tracing-hierarchy__trace:hover:not(:has(.tracing-hierarchy__observation:hover))::before,
+        .tracing-hierarchy__session:hover:not(:has(.tracing-hierarchy__trace:hover))::before {
+          background-color: var(--line-cta);
+        }
+
+        .tracing-hierarchy__caption {
+          position: absolute;
+          top: -1px;
+          left: clamp(6px, 3.5cqw, 24px);
+          z-index: 3;
+          transform: translateY(-50%);
+          padding: 0 clamp(3px, 1.5cqw, 10px);
+          font-family: var(--font-mono);
+          font-size: clamp(4.5px, 1.55cqw, 10.5px);
+          letter-spacing: 0.08em;
+          line-height: 1.4;
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .tracing-hierarchy__session {
+          padding: clamp(14px, 6cqw, 40px) clamp(10px, 4.8cqw, 32px) clamp(12px, 5.4cqw, 36px);
+          border-color: var(--trace-session-stroke);
+          background: var(--trace-session-tint);
+        }
+
+        .tracing-hierarchy__session::before {
+          background-color: var(--trace-session-ink);
+        }
+
+        .tracing-hierarchy__session > .tracing-hierarchy__caption {
+          background: var(--surface-bg);
+          color: var(--trace-session-ink);
+        }
+
+        .tracing-hierarchy__traces {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: clamp(4px, 3.2cqw, 22px);
+        }
+
+        .tracing-hierarchy__trace {
+          padding: clamp(12px, 4.4cqw, 30px) clamp(6px, 3.2cqw, 22px) clamp(8px, 3.5cqw, 24px);
+          border-color: var(--trace-stroke);
+          background: var(--trace-tint);
+        }
+
+        .tracing-hierarchy__trace::before {
+          background-color: var(--trace-ink);
+        }
+
+        .tracing-hierarchy__trace > .tracing-hierarchy__caption {
+          background: var(--trace-session-tint);
+          color: var(--trace-ink);
+        }
+
+        .dark .tracing-hierarchy__trace > .tracing-hierarchy__caption,
+        [data-theme="dark"] .tracing-hierarchy__trace > .tracing-hierarchy__caption {
+          background: var(--surface-bg);
+        }
+
+        .tracing-hierarchy__observations {
+          display: grid;
+          gap: clamp(2px, 1.2cqw, 8px);
+        }
+
+        .tracing-hierarchy__observation {
+          display: flex;
+          min-height: clamp(12px, 4.2cqw, 28px);
+          align-items: center;
+          gap: clamp(3px, 1.5cqw, 10px);
+          padding: clamp(3px, 1.5cqw, 10px) clamp(4px, 2.1cqw, 14px);
+          border-color: var(--trace-observation-stroke);
+          background: var(--surface-bg);
+        }
+
+        .dark .tracing-hierarchy__observation,
+        [data-theme="dark"] .tracing-hierarchy__observation {
+          background: transparent;
+        }
+
+        .tracing-hierarchy__observation::before {
+          background-color: var(--line-cta);
+        }
+
+        .tracing-hierarchy__dot {
+          width: clamp(3px, 1cqw, 7px);
+          height: clamp(3px, 1cqw, 7px);
+          flex: 0 0 auto;
+          border-radius: 9999px;
+          background: var(--text-secondary);
+        }
+
+        .tracing-hierarchy__observation-label {
+          min-width: 0;
+          color: var(--text-secondary);
+          font-family: var(--font-mono);
+          font-size: clamp(4px, 1.35cqw, 10.5px);
+          letter-spacing: 0.06em;
+          line-height: 1.2;
+          overflow: hidden;
+          text-overflow: clip;
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+      `}</style>
+    </figure>
+  );
+}

--- a/content/academy/datasets.mdx
+++ b/content/academy/datasets.mdx
@@ -26,7 +26,7 @@ A dataset is made up of items, each item represents one test case: a situation y
 
 ### The three fields of a dataset item
 
-![Dataset Fields — When They Are Used](/images/academy/dataset-fields-v2.png)
+<DatasetFieldsDiagram />
 
 A good mental model is:
 

--- a/content/academy/evaluate.mdx
+++ b/content/academy/evaluate.mdx
@@ -16,7 +16,7 @@ Offline evaluation is the step in the loop between running an experiment and shi
 
 Most of the time, you start by **manually reviewing outputs** to build intuition for what good and bad look like in your application. From there, you **identify specific failure modes** worth checking for. Once you can define them precisely, you **automate with dedicated evaluators**.
 
-![How evaluation typically evolves](/images/academy/evaluation-evolves-v2.png)
+<EvaluationEvolutionDiagram />
 
 The rest of this page covers the different kinds of evaluation in detail. In practice, you'll likely end up combining all of them. But the path to a well-functioning automated evaluation setup almost always starts from manual review.
 

--- a/content/academy/tracing.mdx
+++ b/content/academy/tracing.mdx
@@ -35,7 +35,7 @@ A trace can be as complex or as simple as your application requires, but all tra
 
 A trace has a hierarchical tree structure. Nested inside are observations that can contain other observations, forming a parent-child structure that mirrors the actual execution of your AI application.
 
-![Trace hierarchy example](/images/academy/trace-hierarchy-v2.png)
+<RagTraceViewDiagram />
 
 You can see what happened in what order, and which steps were part of which larger step.
 
@@ -62,7 +62,7 @@ Beyond input and output, there are a few attributes on observations that are tab
 
 Most of the time you would not see an entire agent's lifecycle execution in one trace. Traces can be grouped into [sessions](/docs/observability/features/sessions). But where do you draw the line between a trace and a session?
 
-![Traces vs sessions](/images/academy/traces-vs-sessions.png)
+<TracingHierarchyDiagram />
 
 A general rule of thumb is: **one trace corresponds to one invocation of your system**, typically one API call or one agent execution. A session then groups multiple traces together, for example all the turns in a multi-turn conversation.
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -14,6 +14,10 @@ import { Callout } from "@/components/ui/callout";
 import { Table } from "@/components/ui/table";
 import { LoopDiagram } from "@/components/academy/LoopDiagram";
 import { OnlineLoop, OfflineLoop } from "@/components/academy/LoopSubset";
+import { EvaluationEvolutionDiagram } from "@/components/academy/EvaluationEvolutionDiagram";
+import { TracingHierarchyDiagram } from "@/components/academy/TracingHierarchyDiagram";
+import { RagTraceViewDiagram } from "@/components/academy/RagTraceViewDiagram";
+import { DatasetFieldsDiagram } from "@/components/academy/DatasetFieldsDiagram";
 
 // Lazy-load Video so @vidstack/react (~800 KB) is NOT bundled on every MDX page.
 // It only downloads on pages that actually render a <Video> tag.
@@ -66,6 +70,10 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     LoopDiagram,
     OnlineLoop,
     OfflineLoop,
+    EvaluationEvolutionDiagram,
+    TracingHierarchyDiagram,
+    RagTraceViewDiagram,
+    DatasetFieldsDiagram,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary
- replace Academy evaluation, tracing, and dataset PNG diagrams with responsive HTML/React components
- add dark-mode and hover states for the new diagrams
- keep diagrams scaled as a single layout on narrow screens

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces four static PNG diagrams in the Academy docs (evaluation, tracing, datasets, tracing hierarchy) with responsive HTML/React components that support container-query scaling, hover states, and dark mode theming.

- `DatasetFieldsDiagram`, `TracingHierarchyDiagram`, and `RagTraceViewDiagram` are cleanly authored; all styles and color variables are self-contained, with proper ResizeObserver cleanup in the one client component.
- `EvaluationEvolutionDiagram` applies dark mode CSS to the outer stage cards but the three inline SVG glyphs use hardcoded light-palette hex values that will not change in dark mode, leaving the artwork visually mismatched on dark themes.
- `RagTraceViewDiagram` uses an externally-scoped utility class (`corner-box-corners`) for its card decoration, unlike the other three components which define the full corner-box CSS inline; the corner effect will silently not render if the class is not globally loaded on the page.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the two findings are cosmetic and do not break any page or component behavior.

The change is a well-scoped documentation improvement with three of the four components cleanly authored and self-contained. The SVG glyph colors in EvaluationEvolutionDiagram remain light-palette in dark mode, and RagTraceViewDiagram’s corner decoration implicitly depends on a globally-defined CSS class not verified to be in scope.

components/academy/EvaluationEvolutionDiagram.tsx (SVG dark mode colors) and components/academy/RagTraceViewDiagram.tsx (corner-box-corners class dependency)
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    MDX["mdx-components.tsx\n(getMDXComponents)"]

    MDX --> EED["EvaluationEvolutionDiagram\nServer Component\n⚠ SVG hardcoded colors"]
    MDX --> THD["TracingHierarchyDiagram\nServer Component"]
    MDX --> RTD["RagTraceViewDiagram\nServer Component\n⚠ corner-box-corners dependency"]
    MDX --> DFD["DatasetFieldsDiagram\nClient Component\nResizeObserver + scale"]

    EED --> Eval["evaluate.mdx"]
    THD --> Tracing1["tracing.mdx"]
    RTD --> Tracing2["tracing.mdx"]
    DFD --> Datasets["datasets.mdx"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/academy/EvaluationEvolutionDiagram.tsx:337-427
**Hardcoded SVG fill colors not adapted for dark mode**

All three glyph SVGs (`ManualReviewGlyph`, `FailureModesGlyph`, `AutomateGlyph`) use hardcoded light-mode colors — `#f6f6f3`, `#6b5e2b`, `#2c2c28`, `#222220` — as `fill` and `stroke` attributes. The component's `.dark .evaluation-evolution` overrides only restyle the outer stage card (borders and background), leaving the SVG glyph content unchanged in dark mode. In practice, values like `fill="#f6f6f3"` (near-white) against a dark transparent background will remain light-colored, creating contrast and visual inconsistency that defeats the dark mode theming applied to the container.

### Issue 2 of 2
components/academy/RagTraceViewDiagram.tsx:103
**Implicit dependency on externally-defined `corner-box-corners` class**

The card div mixes `rag-trace-view__card` (defined inline) with `corner-box-corners` (not defined anywhere in this file). The inline `::before` rule for `.rag-trace-view__card` only sets `background-color: var(--line-cta)` — the mask-image, mask-position, mask-size, and mask-repeat properties that produce the corner decoration are expected to come from `corner-box-corners`. The other three new diagram components define the full corner-box CSS pattern inline. If `corner-box-corners` is not loaded on every page that embeds this diagram, the corner visual effect will silently not render, with no error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: replace academy diagrams with html..."](https://github.com/langfuse/langfuse-docs/commit/132aaaa922cd15e2bf01e8eed751a0289592b6c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31246830)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->