### PR TITLE
feat: Use `beautiful-mermaid` for rendering Mermaid diagrams

### DIFF
--- a/components/Mermaid.tsx
+++ b/components/Mermaid.tsx
@@ -1,72 +1,63 @@
-"use client";
-
-import { useEffect, useRef } from "react";
-
-declare global {
-  interface Window {
-    mermaid?: {
-      initialize: (config: object) => void;
-      render: (id: string, text: string) => Promise<{ svg: string }>;
-    };
-  }
-}
+import { renderMermaidSVG } from "beautiful-mermaid";
+import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
 
 interface MermaidProps {
   chart: string;
 }
 
-let mermaidScriptPromise: Promise<void> | null = null;
+// beautiful-mermaid is stricter than mermaid.js, so normalize a couple of
+// legacy patterns that still exist in docs content before rendering.
+function normalizeMermaidInput(chart: string): string {
+  const lines = chart.split("\n");
 
-function loadMermaid(): Promise<void> {
-  if (window.mermaid) return Promise.resolve();
-  if (!mermaidScriptPromise) {
-    mermaidScriptPromise = new Promise<void>((resolve, reject) => {
-      const script = document.createElement("script");
-      script.src =
-        "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js";
-      script.onload = () => resolve();
-      script.onerror = reject;
-      document.head.appendChild(script);
-    });
+  let startIndex = 0;
+  if (lines[0]?.trim() === "---") {
+    const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+    if (closingIndex !== -1) {
+      startIndex = closingIndex + 1;
+    }
   }
-  return mermaidScriptPromise;
+
+  return lines
+    .slice(startIndex)
+    .map((line) => line.replace(/;\s*$/, ""))
+    .join("\n")
+    .trim();
 }
 
-let idCounter = 0;
+// The library inlines Google Fonts imports into the SVG. Strip those so
+// diagrams inherit the site's existing font setup instead of loading fonts.
+function normalizeMermaidSvgFonts(svg: string): string {
+  return svg.replace(/@import\s+url\('https:\/\/fonts\.googleapis\.com\/[^']+'\);\s*/g, "");
+}
 
 export function Mermaid({ chart }: MermaidProps) {
-  const ref = useRef<HTMLDivElement>(null);
+  try {
+    const svg = normalizeMermaidSvgFonts(renderMermaidSVG(normalizeMermaidInput(chart), {
+      bg: "var(--surface-1)",
+      fg: "var(--text-primary)",
+      line: "var(--line-cta)",
+      accent: "var(--line-cta)",
+      muted: "var(--text-tertiary)",
+      surface: "var(--surface-2)",
+      border: "var(--text-tertiary)",
+      interactive: false,
+      transparent: true,
+    }));
 
-  useEffect(() => {
-    if (!ref.current) return;
-    const el = ref.current;
-    const id = `mermaid-diagram-${++idCounter}`;
+    return (
+      <div
+        className="mermaid-diagram my-4 overflow-x-auto border p-4 not-prose rounded-none"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    );
+  } catch (error) {
+    console.warn("Failed to render Mermaid diagram", error);
 
-    loadMermaid()
-      .then(() => {
-        window.mermaid!.initialize({
-          startOnLoad: false,
-          theme: document.documentElement.classList.contains("dark")
-            ? "dark"
-            : "default",
-          securityLevel: "loose",
-        });
-        return window.mermaid!.render(id, chart);
-      })
-      .then(({ svg }) => {
-        if (el) el.innerHTML = svg;
-      })
-      .catch(() => {
-        if (el) {
-          el.innerHTML = `<pre class="text-xs text-left overflow-x-auto">${chart}</pre>`;
-        }
-      });
-  }, [chart]);
-
-  return (
-    <div
-      ref={ref}
-      className="my-4 flex justify-center overflow-x-auto rounded-lg border bg-card p-4"
-    />
-  );
+    return (
+      <CodeBlock title="Mermaid">
+        <Pre>{normalizeMermaidInput(chart)}</Pre>
+      </CodeBlock>
+    );
+  }
 }

--- a/content/blog/2025-05-21-customizable-dashboards.mdx
+++ b/content/blog/2025-05-21-customizable-dashboards.mdx
@@ -65,7 +65,7 @@ Dashboards are built on top of 3 major components:
 
 Let's dive into each of these and show how we can use them to build the dashboards.
 
-<div className="bg-card p-4 rounded w-full border max-w-lg mx-auto mt-10 mb-3">
+<div className="w-full max-w-lg mx-auto mt-10 mb-3">
 
 **Architecture diagram**
 

--- a/content/docs/evaluation/experiments/data-model.mdx
+++ b/content/docs/evaluation/experiments/data-model.mdx
@@ -21,8 +21,6 @@ Datasets are a collection of inputs and, optionally, expected outputs that can b
 
 `Dataset`s are a collection of `DatasetItem`s.
 
-<div className="border rounded p-2 my-4">
-
 ```mermaid
 classDiagram
 direction LR
@@ -45,8 +43,6 @@ direction LR
 
     Dataset "1" --> "n" DatasetItem
 ```
-
-</div>
 
 #### Dataset object [#dataset-object]
 
@@ -77,7 +73,6 @@ direction LR
 Dataset runs are used to run a dataset through your LLM application and optionally apply evaluation methods to the results. This is often referred to as Experiment run.
 
 <br />
-<div className="border rounded p-2">
 
 ```mermaid
 classDiagram
@@ -100,8 +95,6 @@ direction LR
         observationId
     }
 ```
-
-</div>
 
 #### DatasetRun object [#datasetrun-object]
 
@@ -135,8 +128,6 @@ An experiment can combine a few Langfuse objects:
 - Optionally `Score`s can be added to the `Trace`s to evaluate the output of the LLM application during the `DatasetRun`.
 
 <br />
-
-<div className="border rounded p-2">
 
 ```mermaid
 classDiagram
@@ -203,8 +194,6 @@ direction LR
     Observation "1" --> "n" Score
     Trace "1" --> "n" Score
 ```
-
-</div>
 
 See the [Concepts page](/docs/evaluation/core-concepts) for more information on how these objects work together conceptually.
 See the [observability core concepts page](/docs/observability/data-model) for more details on traces and observations.

--- a/content/docs/evaluation/scores/data-model.mdx
+++ b/content/docs/evaluation/scores/data-model.mdx
@@ -18,7 +18,6 @@ For detailed reference please refer to
 Scores are the data object to store evaluation results. They are used to assign evaluation scores to traces, observations, sessions, or dataset runs. Scores can be added manually via annotations, programmatically via the SDK/API, or automatically via LLM-as-a-Judge evaluators.
 
 <br />
-<div className="border rounded p-2">
 
 ```mermaid
 classDiagram
@@ -39,8 +38,6 @@ direction LR
     Score --> Session: sessionId
     Score --> DatasetRun: datasetRunId
 ```
-
-</div>
 
 Scores have the following properties:
 - Each Score references **exactly one** of `Trace`, `Observation`, `Session`, or `DatasetRun`
@@ -79,14 +76,10 @@ Score configs are used to ensure that your scores follow a specific schema. Usin
 
 You can define a `ScoreConfig` in the Langfuse UI or via our API. Configs are immutable but can be archived (and restored anytime).
 
-<div className="border rounded p-2 my-4">
-
 ```mermaid
 classDiagram
   Score --> ScoreConfig: configId
 ```
-
-</div>
 
 A score config includes:
 - **Score name**

--- a/content/docs/observability/data-model.mdx
+++ b/content/docs/observability/data-model.mdx
@@ -59,7 +59,7 @@ Observations can be nested. The example below shows a trace with a nested observ
 
 <div className="grid grid-cols-2 mt-6 gap-2 md:gap-4">
 
-<div className="border rounded py-4 px-4 flex flex-col items-center justify-center bg-card">
+<div className="embedded-mermaid border rounded py-4 px-4 flex flex-col items-center justify-center bg-card">
 
 Hierarchical structure of observations in Langfuse
 
@@ -96,7 +96,7 @@ Example trace in Langfuse UI
 ### Traces
 
 A `trace` typically represents a single request or operation.
-For example, when a user asks a question to a chatbot, that interaction, from the user's question to the bot's response, is captured as one trace. 
+For example, when a user asks a question to a chatbot, that interaction, from the user's question to the bot's response, is captured as one trace.
 
 It serves as container of observations. Trace attributes such as `user_id`, `session_id`, `tags`, `metadata`, etc. are propagated to all observations within the trace.
 
@@ -108,7 +108,7 @@ A common example is a thread in a chat interface.
 
 <div className="grid grid-cols-2 mt-6 gap-2 md:gap-4">
 
-<div className="border rounded py-4 text-center px-4 flex flex-col bg-card">
+<div className="embedded-mermaid border rounded py-4 text-center px-4 flex flex-col bg-card">
 
 Optionally, sessions aggregate traces
 
@@ -260,5 +260,3 @@ sequenceDiagram
         App-->>App: process exits
     end
 ```
-
-

--- a/content/self-hosting/security/deployment-strategies.mdx
+++ b/content/self-hosting/security/deployment-strategies.mdx
@@ -17,8 +17,6 @@ In most cases, a single Langfuse deployment is the best approach. It leverages R
 
 A single Langfuse deployment is the standard and recommended setup. It centralizes management, scales efficiently across projects and environments, and takes full advantage of Langfuse's built-in RBAC features.
 
-<div className="border rounded p-4 pt-0 bg-card mt-6">
-
 ```mermaid
 graph TB
     subgraph AppVPC1["App/Env VPC 1"]
@@ -41,8 +39,6 @@ graph TB
     User["User/API/SDK"]
     LF -- Public Hostname and SSO --> User
 ```
-
-</div>
 
 ### When to Use
 
@@ -67,8 +63,6 @@ In this approach, you run a separate Langfuse deployment for each service, proje
 
 Langfuse can be deployed via infrastructure as code (IaC) tools like Terraform or Helm, making this approach more manageable.
 
-<div className="border rounded p-4 pt-0 bg-card mt-6">
-
 ```mermaid
 graph TB
     subgraph AppVPC1["App/Env VPC 1"]
@@ -92,8 +86,6 @@ graph TB
     LF2 -- VPN --> User
     LFn -- VPN --> User
 ```
-
-</div>
 
 ### When to Use
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@vercel/og": "^0.6.8",
     "@vidstack/react": "^1.12.13",
     "ai": "^6.0.153",
+    "beautiful-mermaid": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       ai:
         specifier: ^6.0.153
         version: 6.0.153(zod@4.3.6)
+      beautiful-mermaid:
+        specifier: ^1.1.3
+        version: 1.1.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3410,6 +3413,9 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3817,6 +3823,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
     peerDependencies:
@@ -3860,6 +3869,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -9987,6 +10000,11 @@ snapshots:
 
   basic-ftp@5.0.5: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -10351,6 +10369,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  elkjs@0.11.1: {}
+
   embla-carousel-react@8.6.0(react@18.3.1):
     dependencies:
       embla-carousel: 8.6.0
@@ -10388,6 +10408,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 

--- a/style.css
+++ b/style.css
@@ -214,6 +214,31 @@
 
 /* Nav layout tokens (`--lf-nav-*`, `--fd-nav-height`) are defined in src/overrides.css */
 
+.mermaid-diagram {
+  border-color: var(--line-structure);
+  background-color: var(--surface-1);
+  color: var(--text-primary);
+}
+
+.embedded-mermaid .mermaid-diagram {
+  border: 0 !important;
+  background-color: transparent !important;
+}
+
+.mermaid-diagram svg {
+  display: block;
+  width: 100%;
+  max-width: none;
+}
+
+/* .mermaid-diagram svg text {
+  font-family: var(--font-sans);
+}
+
+.mermaid-diagram svg .mono {
+  font-family: var(--font-mono);
+} */
+
 /* CSS custom properties for shadcn/ui color system */
 @layer base {
   :root {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the CDN-loaded `mermaid.js` client-side rendering approach with [`beautiful-mermaid`](https://www.npmjs.com/package/beautiful-mermaid), a lightweight SSR-compatible library that generates SVGs synchronously without DOM dependencies. It also cleans up manual wrapper divs in the MDX docs and adds CSS class hooks for integrating mermaid diagrams inside the `LangTabs` shell.

- **`Mermaid.tsx`** drops `"use client"`, calls `renderMermaidSVG` at render time with CSS-variable theming, and falls back to a `CodeBlock` display on parse failure — eliminating the previous CDN script-injection pattern and enabling SSR.
- **`style.css`** adds `.mermaid-diagram` styles and `:has()` rules that strip `CornerBox` chrome (border, background, padding) when a diagram appears inside a `LangTabs` shell.
- **MDX files** remove redundant `<div className="border rounded p-2">` wrappers that are now handled by the component itself.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the core rendering change is well-structured and the new library is purpose-built for SSR use. The two style-level issues (conflicting Tailwind classes and a stray indentation) are cosmetic and don't affect functionality.

The migration from CDN-loaded mermaid to `beautiful-mermaid` is clean and the fallback path is handled correctly. The conflicting `rounded-lg`/`rounded-none` classes in `Mermaid.tsx` are inert in practice (Tailwind's CSS ordering ensures `rounded-none` wins) but are misleading. The indentation inconsistency in `LangTabs.tsx` is purely cosmetic. No logic or data-integrity concerns were found.

components/Mermaid.tsx — conflicting border-radius utilities; components/LangTabs.tsx — stray indentation on the return statement.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MDX Page renders mermaid code block] --> B[Mermaid component receives chart string]
    B --> C{renderMermaidSVG\nbeautiful-mermaid}
    C -- success --> D[Returns SVG string\nwith CSS-variable theming]
    C -- throws --> E[Fallback: CodeBlock\nwith raw chart text]
    D --> F[dangerouslySetInnerHTML\ninjects SVG into div.mermaid-diagram]
    F --> G{Inside LangTabs?}
    G -- yes --> H[CSS :has rule strips\nCornerBox chrome]
    G -- no --> I[Normal bordered\ndiagram container]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
components/Mermaid.tsx:25
The className contains both `rounded-lg` and `rounded-none`, which are conflicting Tailwind utilities targeting the same CSS property. While Tailwind's stylesheet ordering means `rounded-none` (alphabetically later) typically wins, the presence of `rounded-lg` is dead/misleading code and can produce unexpected behavior depending on the Tailwind version or configuration. Since the intent appears to be no border radius (matching the `.mermaid-diagram` style context), `rounded-lg` should be removed.

```suggestion
        className="mermaid-diagram my-4 overflow-x-auto border p-4 not-prose rounded-none"
```

### Issue 2 of 3
components/LangTabs.tsx:169-171
The `return` keyword on line 169 is indented with 4 spaces, while the rest of the function body consistently uses 2-space indentation. This is a minor formatting inconsistency likely introduced during the refactor.

```suggestion
  return (
    <div ref={containerRef}>
      <CornerBox className="lang-tabs-shell">
```

### Issue 3 of 3
components/Mermaid.tsx:19-26
`interactive: true` instructs `beautiful-mermaid` to embed event handlers (click/hover) directly in the SVG, which is then injected via `dangerouslySetInnerHTML`. The library is relatively new (~2 months old, v1.1.3) and its SVG sanitization behaviour is not yet widely vetted. Because the mermaid source comes from developer-authored MDX rather than user input the practical risk is low, but it's worth confirming the library strips or escapes any unexpected constructs in the SVG output — especially with the `interactive` flag enabled.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Use beautiful-mermaid for renderin..."](https://github.com/langfuse/langfuse-docs/commit/3c06f020be6b3c079154ebd2bbb37b49fc22dfb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31307305)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->