### PR TITLE
fix: Load latest release date from GitHub API

### DIFF
--- a/components/home/layout/HomeSidebar.tsx
+++ b/components/home/layout/HomeSidebar.tsx
@@ -1,5 +1,6 @@
 import { changelogSource } from "@/lib/source";
 import { getGitHubStars } from "@/lib/github-stars";
+import { getLatestGitHubReleaseDate } from "@/lib/github-releases";
 import { LinkBox } from "@/components/ui/link-box";
 import { Text } from "@/components/ui/text";
 import discussionsData from "../../../src/langfuse_github_discussions.json";
@@ -78,7 +79,7 @@ const selfHostingLinks = [
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function HomeSidebar() {
+export async function HomeSidebar() {
   const changelogItems = changelogSource
     .getPages()
     .filter((p) => p.data.title && p.data.date)
@@ -94,7 +95,8 @@ export function HomeSidebar() {
       date: new Date(p.data.date as string).toISOString(),
     }));
 
-  const latestReleaseDate = changelogItems[0]?.date;
+  const latestReleaseDate =
+    (await getLatestGitHubReleaseDate()) ?? changelogItems[0]?.date;
 
   return (
     <aside

--- a/lib/github-releases.ts
+++ b/lib/github-releases.ts
@@ -1,0 +1,30 @@
+type GitHubLatestRelease = {
+  published_at?: string;
+};
+
+const GITHUB_LATEST_RELEASE_API_URL =
+  "https://api.github.com/repos/langfuse/langfuse/releases/latest";
+
+export async function getLatestGitHubReleaseDate(): Promise<string | null> {
+  try {
+    const response = await fetch(GITHUB_LATEST_RELEASE_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch latest GitHub release: ${response.status} ${response.statusText}`
+      );
+      return null;
+    }
+
+    const release = (await response.json()) as GitHubLatestRelease;
+    return release.published_at ?? null;
+  } catch (error) {
+    console.error("Failed to fetch latest GitHub release", error);
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the \"Latest OSS release\" date shown in the `HomeSidebar` by fetching it live from the GitHub Releases API instead of deriving it from the local changelog files. The fallback to the changelog date is preserved when the fetch fails.

- `lib/github-releases.ts` is a new utility that calls `GET /repos/langfuse/langfuse/releases/latest`, caches the response for one hour via Next.js ISR, and returns `null` on any error.
- `HomeSidebar` is converted to an `async` component to `await` the release date, but the `export` keyword was accidentally dropped in the same line change, which will break the named imports that consumers rely on.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge as-is — the missing `export` keyword on `HomeSidebar` breaks every import of the component and would cause a build failure or blank sidebar.

The `async` conversion inadvertently dropped the `export` keyword from `HomeSidebar`, which is a named export depended on by `HomeLayout.tsx` and `components/layout/index.ts`. This single change would make the component unavailable to all consumers.

`components/home/layout/HomeSidebar.tsx` needs the `export` keyword restored on line 82.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant HomeSidebar as HomeSidebar (async)
    participant GHReleasesLib as lib/github-releases.ts
    participant GitHubAPI as GitHub API
    participant NextCache as Next.js Data Cache

    Browser->>HomeSidebar: Page render
    HomeSidebar->>GHReleasesLib: getLatestGitHubReleaseDate()
    GHReleasesLib->>NextCache: Check cached response (revalidate: 3600)
    alt Cache miss
        NextCache-->>GHReleasesLib: miss
        GHReleasesLib->>GitHubAPI: GET /repos/langfuse/langfuse/releases/latest
        GitHubAPI-->>GHReleasesLib: "{ published_at: "..." }"
        GHReleasesLib->>NextCache: Store response (TTL 1h)
    else Cache hit
        NextCache-->>GHReleasesLib: cached response
    end
    GHReleasesLib-->>HomeSidebar: "published_at string | null"
    alt release date available
        HomeSidebar-->>Browser: Shows GitHub release date
    else null (API error / rate limit)
        HomeSidebar-->>Browser: Falls back to changelogItems[0].date
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/home/layout/HomeSidebar.tsx:82
The `export` keyword was dropped when adding `async`, making `HomeSidebar` a module-private function. Both `HomeLayout.tsx` (`import { HomeSidebar } from "./HomeSidebar"`) and `components/layout/index.ts` (`export { HomeSidebar } from "../home/layout/HomeSidebar"`) rely on this named export — they will receive `undefined` at runtime or fail the TypeScript build.

```suggestion
export async function HomeSidebar() {
```

### Issue 2 of 2
lib/github-releases.ts:10-15
**No GitHub auth token — unauthenticated rate limit applies**

Unauthenticated GitHub API requests are capped at 60 per hour per IP. The `revalidate: 3600` cache helps for steady-state traffic, but a cold-start after deployment or CI/CD builds from multiple nodes can exhaust this budget quickly, causing the fetch to fail and silently fall back to the changelog date. Adding a `GITHUB_TOKEN` via an environment variable (as an `Authorization: Bearer` header) raises the limit to 5,000/hour and prevents flaky sidebar data.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Load latest release date from GitHu..."](https://github.com/langfuse/langfuse-docs/commit/3b92e2a7d39b4f3b366aafa4dd9499fb1d9c3587) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31308129)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->