### PR TITLE
chore: Remove stale ESLint comments

### DIFF
--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -35,7 +35,6 @@ export default async function SectionDocPage(props: PageProps) {
   if (DEDICATED_APP_SECTIONS.has(section)) notFound();
 
   const config = SECTION_CONFIG[section as keyof typeof SECTION_CONFIG];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result = await loadPage(config.source, effectiveSlug);
   if (!result) notFound();
   const { MDX, page } = result;

--- a/components/DocsChromePage.tsx
+++ b/components/DocsChromePage.tsx
@@ -10,9 +10,7 @@ import { getMDXComponents } from "@/mdx-components";
 
 type BodyChromeProps = Omit<ComponentProps<typeof DocBodyChrome>, "children">;
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 type LoadedPage = { data: any };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * Shared `<DocsPage>` chrome for every sidebar-based section — resolves the

--- a/components/ForceLightMode.tsx
+++ b/components/ForceLightMode.tsx
@@ -66,7 +66,6 @@ export function ForceLightMode() {
         setTheme(previousTheme.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return null;

--- a/components/japan/JapanLanding.tsx
+++ b/components/japan/JapanLanding.tsx
@@ -14,7 +14,7 @@ function CodeBox({ value }: { value: string }) {
       await navigator.clipboard.writeText(value);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {}
+    } catch { }
   };
   return (
     <div className="rounded-[2px] font-mono text-[11px] leading-[1.65] bg-[#222220] border border-[#3a3a35] text-[#e2e2dc] overflow-hidden">
@@ -598,7 +598,6 @@ function Customers() {
             className="px-4 py-9 flex items-center justify-center"
           >
             {c.logo ? (
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={c.logo}
                 alt={c.name}

--- a/components/ui/image.tsx
+++ b/components/ui/image.tsx
@@ -30,7 +30,6 @@ export function Image(props: ImgHTMLAttributes<HTMLImageElement> & { fill?: bool
   // next/image remotePatterns errors (e.g. shields.io badges).
   if (!isOptimizable(src)) {
     return (
-      // eslint-disable-next-line @next/next/no-img-element
       <img src={src} alt={alt ?? ""} width={width} height={height} className={className} style={style} {...rest} />
     );
   }

--- a/components/wrapped/OSS.tsx
+++ b/components/wrapped/OSS.tsx
@@ -123,7 +123,6 @@ export function OSS() {
                   className="inline-flex items-center gap-1 rounded-full border px-1 sm:px-2 py-0.5 sm:py-1 text-[10px] sm:text-sm hover:bg-muted transition-colors"
                 >
                   {contributor.avatarUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={contributor.avatarUrl}
                       alt={contributor.login}

--- a/lib/mdx-page.ts
+++ b/lib/mdx-page.ts
@@ -4,7 +4,6 @@ import type { TOCItemType } from "fumadocs-core/toc";
 import { buildOgImageUrl, buildPageUrl } from "@/lib/og-url";
 import type { ComponentType } from "react";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 type AnySource = {
   getPage: (slug: string[]) => any;
   getPages: () => any[];
@@ -38,7 +37,6 @@ export async function loadPage(
 
   return { page, toc, MDX };
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * Titles that are too generic to stand alone in an OG image (no parent context).
@@ -97,7 +95,6 @@ function enrichOgTitle(title: string, slug: string[], sectionTitle: string): str
  * computed canonicals (e.g. guides → cookbook mapping) without trampling an
  * explicit `canonical` field in frontmatter.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildSectionMetadata(
   page: { data: any; url?: string },
   section: string,

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -33,12 +33,9 @@ function baseUrl(contentDir: string): string {
 shortTitle ?? sidebarTitle from frontmatter when either field is set.
 Registered via pageTree.transformers in each loader so layouts call
 .getPageTree() directly with no post-processing required. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shortTitleTransformer: any = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   file(node: any, filePath?: string): any {
     if (!filePath) return node;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const page = (this as any).storage.read(filePath) as
       | { data?: { shortTitle?: string; sidebarTitle?: string } }
       | undefined;
@@ -67,9 +64,7 @@ const shortTitleTransformer: any = {
  * Link shortcut nodes have no backing MDX file, so `filePath` is `undefined` in
  * the transformer — that is how they are distinguished from real content pages.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shortcutLinkTransformer: any = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   file(node: any, filePath?: string): any {
     // Only link shortcuts have no backing file
     if (filePath) return node;

--- a/source.config.ts
+++ b/source.config.ts
@@ -3,7 +3,6 @@ import monokaiProLightRaw from "./lib/themes/monokai-pro-light.json";
 
 // JSON imports widen fontStyle to `string` instead of the required literal union.
 // Cast through unknown to satisfy Shiki's ThemeRegistrationAny at runtime.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const monokaiProLight = monokaiProLightRaw as unknown as any;
 import remarkGfm from "remark-gfm";
 import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes stale ESLint disable comments (`@typescript-eslint/no-explicit-any`, `@next/next/no-img-element`, `react-hooks/exhaustive-deps`) that are no longer needed because the corresponding rules are not active in the project. The only functional code changes are an empty `catch { }` block reformatting and adding a trailing newline to `OSS.tsx`.

- Removes 13 inline and block ESLint suppression comments across 9 files — none of these rules are enforced by any discoverable ESLint config in the repo.
- Minor formatting: `catch {}` → `catch { }` in `JapanLanding.tsx` and a missing trailing newline added to `OSS.tsx`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only removes suppression comments that have no effect in the absence of an active ESLint config.

The changes are purely comment removal with no logic or behavior changes. No ESLint configuration file exists in the repository, confirming these disable comments were genuinely stale. The two minor formatting edits (empty catch block spacing, trailing newline) are harmless.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source Files] --> B{ESLint Rules Active?}
    B -- "Before PR" --> C["Inline disable comments\nsuppress any/img/exhaustive-deps rules"]
    B -- "After PR" --> D["No ESLint config found\n→ rules not enforced"]
    C --> E[Build passes]
    D --> E
    E --> F[Next.js build]
    F --> G[Production]

    style D fill:#90EE90
    style C fill:#FFD700
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Remove stale ESLint comments"](https://github.com/langfuse/langfuse-docs/commit/ea00eccf79cc1b4e0ac283745129918cd05be97b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31310419)</sub>

<!-- /greptile_comment -->