### PR TITLE
docs(security): recommend blob storage export for cross-region tracing backup [LFE-9406]

### DIFF
--- a/content/security/data-regions.mdx
+++ b/content/security/data-regions.mdx
@@ -85,6 +85,16 @@ S3 media buckets store uploaded media items referenced from traces. They are not
 
 All secondary regions are within the same legal jurisdiction as their primary region (EU ↔ EU, US ↔ US, Japan ↔ Japan), so cross-region replication does not change the data-residency or cross-border-transfer posture declared in the [DPA](/security/dpa) and [HIPAA BAA](/security/hipaa).
 
+<Callout type="info">
+  **Protecting tracing data against a regional outage:** Since ClickHouse
+  tracing data and S3 media buckets are not replicated cross-region, we
+  recommend using the [Blob Storage
+  integration](/docs/api-and-data-platform/features/export-to-blob-storage) to
+  continuously export traces and observations into your own bucket. If that
+  bucket resides outside of your Langfuse Cloud region, your tracing data is
+  protected against a regional failure.
+</Callout>
+
 ## Self-hosted Instances
 
 Alternatively, you can self-host Langfuse for full control over your data and infrastructure. For installation and configuration, see: [Self-hosting guide](/self-hosting)


### PR DESCRIPTION
## Summary

Adds an info callout at the end of the **Cross-Region Backup** section of the Data Regions & Availability page recommending the [Blob Storage integration](/docs/api-and-data-platform/features/export-to-blob-storage) as a way to protect tracing data against a regional outage.

Since ClickHouse tracing data and S3 media buckets are not replicated cross-region, exporting traces and observations to a customer-owned bucket outside the Langfuse Cloud region gives users an out-of-region copy of their tracing data.

Refs: LFE-9406

## Test plan

- [ ] Visit `/security/data-regions` and verify the callout renders at the end of the Cross-Region Backup section
- [ ] Confirm the link to `/docs/api-and-data-platform/features/export-to-blob-storage` resolves

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an informational callout to the Cross-Region Backup section of the Data Regions & Availability page, recommending the Blob Storage integration as a way for users to maintain their own out-of-region copy of tracing data. The linked documentation page (`/docs/api-and-data-platform/features/export-to-blob-storage`) resolves correctly.

- The callout describes exports as "continuous," but the integration's minimum schedule is hourly — not real-time — which could overstate the protection level against data loss in an outage.
- The opening clause groups ClickHouse tracing data and S3 media buckets together as unprotected, but the recommended Blob Storage integration only covers traces/observations/scores, not uploaded media, potentially leaving readers with a false sense of completeness.
- No mention of plan-level restrictions: the Blob Storage feature is unavailable on Hobby and Core plans, which may confuse users on those tiers who follow the recommendation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor documentation accuracy improvements recommended before publishing.

The change is a small documentation-only callout with no code or logic impact. The linked Blob Storage page exists and resolves correctly. The main concerns are three content accuracy gaps: the word continuously misrepresents the hourly-minimum export schedule; the recommendation only covers ClickHouse data while the framing implies it also addresses S3 media buckets; and there is no mention of the Pro/Enterprise plan requirement for the feature. None of these block merging, but they could mislead users and may warrant a quick wording pass before the page goes live.

content/security/data-regions.mdx — the wording of the new callout would benefit from a second pass for accuracy before publishing.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Application / SDK] -->|Traces & Observations| B[Langfuse Cloud\nPrimary Region]
    B --> C[(ClickHouse\nTracing Data\nNot replicated)]
    B --> D[(S3 Media Bucket\nNot replicated)]
    B --> E[(Postgres\nReplicated to\nSecondary Region)]
    E --> F[(Secondary Region\nPostgres Backup)]
    B -->|Scheduled export\nhourly / daily / weekly| G[(Customer-owned\nBlob Storage\nExternal Region)]
    G -.->|Partial recovery\nTraces & Observations only\nNot media| H[Recovery Point\non Regional Failure]
    D -.->|No cross-region copy\nPermanent loss on failure| I[Unrecoverable\nMedia Items]
    style C fill:#f9c74f
    style D fill:#f94144
    style G fill:#90be6d
    style F fill:#90be6d
    style I fill:#f94144
    style H fill:#90be6d
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/security/data-regions.mdx:89-95
**"continuously export" overstates the export frequency**

The Blob Storage integration runs on an `hourly`, `daily`, or `weekly` schedule — the minimum cadence is one hour. Describing it as "continuously" sets an incorrect expectation; in the worst case, up to an hour of tracing data could still be lost after a regional failure. Consider replacing "continuously" with something like "periodically" or "on a scheduled basis (hourly at minimum)".

### Issue 2 of 3
content/security/data-regions.mdx:88-96
**S3 media buckets are not covered by the Blob Storage export**

The callout's opening clause names both "ClickHouse tracing data and S3 media buckets" as unprotected, but the recommended Blob Storage integration only exports traces, observations, and scores — it does not back up uploaded media items. A reader could interpret the callout as a complete mitigation for both gaps when it only addresses one. Consider narrowing the opening clause to "ClickHouse tracing data" or explicitly noting that media items remain unprotected even after enabling the export.

### Issue 3 of 3
content/security/data-regions.mdx:88-96
**Blob Storage integration has plan-level availability restrictions**

The Blob Storage export is only available on the Pro (team add-on) and Enterprise plans — it is not available on Hobby or Core. The callout recommends it without any qualification, so Hobby and Core users who follow the link will discover they cannot use the feature. A brief note such as "available on Pro (team add-on) and Enterprise plans" would set correct expectations upfront.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(security): recommend blob storage e..."](https://github.com/langfuse/langfuse-docs/commit/55d82869f7fc3cdc35f76767f93d9f209ae2a3b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31338203)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->