### PR TITLE
docs: SSO Self Service

### DIFF
--- a/content/changelog/2026-05-08-self-service-enterprise-sso-setup.mdx
+++ b/content/changelog/2026-05-08-self-service-enterprise-sso-setup.mdx
@@ -1,0 +1,18 @@
+---
+date: 2026-05-08
+title: Self-Service Enterprise SSO Setup
+description: Organization admins on Langfuse Cloud can now verify domains and configure Enterprise SSO directly in settings.
+author: Mark
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Organization admins can now set up Enterprise SSO on Langfuse Cloud directly from **Organization Settings > SSO**, without contacting support.
+
+This is useful when security teams need to roll out SSO quickly during onboarding and when IT needs separate SSO configs for multiple verified company domains.
+
+Setup now includes DNS-based domain verification and provider-specific SSO configuration in one flow. DNS verification helps prevent phishing attacks and protects organizations against SSO domain hijacking.
+
+See [Authentication & SSO](/docs/administration/authentication-and-sso#configure-enterprise-sso) for the updated setup guide.

--- a/content/docs/administration/authentication-and-sso.mdx
+++ b/content/docs/administration/authentication-and-sso.mdx
@@ -50,12 +50,12 @@ For security reasons, Langfuse does not support switching between social logins 
   }}
 />
 
-Langfuse supports **Enterprise SSO** (e.g. Okta, Authentik, OneLogin, Azure AD, Keycloak, WorkOS, JumpCloud etc.) via OIDC. Please reach out to [support](/support) to enable this feature.
+Langfuse supports **Enterprise SSO** (e.g. Okta, Authentik, OneLogin, Azure AD, Keycloak, WorkOS, JumpCloud etc.) via OIDC.
 
 <Callout type="info">
 
-  Langfuse supports multiple domains per customer organization, but each domain must be exclusively owned by your organization.
-  Shared domains (e.g., from subcontractors or consultancies) are not supported.
+Langfuse supports multiple domains per customer organization, but each domain must be exclusively owned by your organization.
+Shared domains (e.g., from subcontractors or consultancies) are not supported.
 
 </Callout>
 
@@ -71,7 +71,39 @@ Details:
 
 <Callout type="info">
 
-  Langfuse supports authentication via **OIDC only**. SAML is not supported.
+Langfuse supports authentication via **OIDC only**. SAML is not supported.
+
+</Callout>
+
+### Configure Enterprise SSO on Langfuse Cloud [#configure-enterprise-sso]
+
+Organization admins can configure Enterprise SSO directly in **Organization Settings > SSO**.
+
+#### 1) Verify Domain
+
+1. Navigate to **Organization Settings > SSO**.
+2. In the **Verify Domain** section, click **Add Domain** and enter the domain you want to verify.
+3. Copy the DNS TXT record provided by Langfuse into your DNS provider.
+4. Wait for DNS propagation, then click **Verify** to verify the domain.
+
+<Callout type="info">
+
+Domain verification is required before SSO can be configured. This ensures only organizations that control a domain can configure SSO for it.
+
+If verification fails, confirm the record name/value match exactly, remove surrounding quotes, and re-check after propagation. Many DNS providers take a few minutes, but it can take up to 24 hours.
+
+</Callout>
+
+#### 2) Configure SSO
+
+1. In the **SSO Configuration** section, click **Configure SSO** next to the verified domain you want to set up.
+2. Copy the callback URL provided by Langfuse and whitelist it in your IdP application's redirect/callback URL allowlist.
+3. Enter the issuer URL, client ID, and client secret from your IdP, then save the configuration.
+4. Test sign-in with a user from the verified domain.
+
+<Callout type="warning">
+
+GitHub and GitHub Enterprise do not expose a standard OIDC discovery endpoint. Langfuse cannot pre-validate these issuer URLs during setup. Double-check the issuer and callback URL allowlist in your IdP, then run a test login immediately after saving to catch mistakes before rollout.
 
 </Callout>
 
@@ -104,19 +136,23 @@ Details:
 1. On the application's **General** tab, copy the **Client ID** and **Client Secret**
 2. Note your Okta **Issuer URL** (e.g., `https://example.okta.com`)
 
-##### Step 4: Share Credentials with Langfuse
+##### Step 4: Verify Your Domain in Langfuse
 
-Share the following with Langfuse via [support](/support):
+1. In Langfuse, open **Organization Settings > SSO**
+2. In the **Verify Domain** section, click **Add Domain** and enter the domain that should use Okta
+3. Copy the DNS TXT record provided by Langfuse into your DNS provider
+4. Wait for DNS propagation, then click **Verify** in Langfuse
 
-- **Instance URL** (e.g., `https://cloud.langfuse.com`, `https://us.cloud.langfuse.com`, `https://jp.cloud.langfuse.com`, or `https://hipaa.cloud.langfuse.com`)
-- **Issuer URL** (e.g., `https://example.okta.com`)
-- **Client ID**
-- **Client Secret**
+##### Step 5: Configure SSO in Langfuse
 
-You can share the credentials with any secure method.
-Usually, sharing via password managers works best.
+1. In **Organization Settings > SSO**, find your verified domain in the **SSO Configuration** section
+2. Click **Configure SSO**
+3. Select **Okta** as provider
+4. Copy the callback URL shown by Langfuse and add it to Okta's **Sign-in redirect URIs** allowlist
+5. Enter the **Issuer URL**, **Client ID**, and **Client Secret**
+6. Save the configuration
 
-##### Step 5: Assign Users
+##### Step 6: Assign Users
 
 1. In Okta, go to your Langfuse application's **Assignments** tab
 2. Assign users or groups who should have access to Langfuse


### PR DESCRIPTION
### Motivation

- Reorganize the Enterprise SSO documentation so the SSO sign-in flow illustration and the note that Langfuse supports OIDC (not SAML) appear in the broader Enterprise SSO & SSO Enforcement context instead of inside the step-by-step Cloud setup flow.

### Description

- Moved the `<Frame>` SSO sign-in image and the `OIDC only` `<Callout>` block from the end of the Cloud configuration steps into the Enterprise SSO overview area just after the details list. 
- Kept the Cloud `Verify Domain` and `Configure SSO` steps intact and removed the general context from the procedural flow to improve scan-ability.
- Modified `content/docs/administration/authentication-and-sso.mdx` to reflect the new ordering.

### Testing

- Ran `pnpm exec prettier --check content/docs/administration/authentication-and-sso.mdx` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdb1d23fc08333963e94d0460e5c98)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes the Enterprise SSO documentation to surface the sign-in flow illustration and the OIDC-only callout earlier in the overview, and replaces the legacy "contact support" setup path with a self-service Cloud configuration flow covering DNS domain verification and SSO configuration.

- The Okta vendor guide is updated from "share credentials with Langfuse support" to a self-service domain-verify + configure flow, with steps renumbered accordingly.
- A new changelog entry announces the self-service feature and links to the updated documentation anchor.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation reorganization is clean, but the Okta vendor guide now contains two conflicting redirect-URI instructions that could leave users with a misconfigured IdP allowlist.

The Okta guide's Step 2 still tells users to manually enter a hard-coded callback URL in Okta, while the new Step 5 tells them to copy a system-generated callback URL from Langfuse's UI and add it to the same allowlist. A user following the guide linearly will configure the redirect URI twice with possibly different values — the manually entered one from Step 2 may not match the UI-generated one, leaving SSO broken after setup.

content/docs/administration/authentication-and-sso.mdx — specifically the Okta vendor guide section where Step 2 (Configure the Application) and Step 5 (Configure SSO in Langfuse) both reference the Sign-in redirect URI.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User navigates to Org Settings > SSO] --> B[Add Domain]
    B --> C[Copy DNS TXT record to DNS provider]
    C --> D{DNS propagated?}
    D -- No --> E[Wait up to 24 hours]
    E --> D
    D -- Yes --> F[Click Verify in Langfuse]
    F --> G[Domain verified]
    G --> H[Click Configure SSO next to domain]
    H --> I[Copy callback URL from Langfuse UI]
    I --> J[Whitelist callback URL in IdP]
    J --> K[Enter Issuer URL, Client ID, Client Secret]
    K --> L[Save configuration]
    L --> M[Test sign-in with domain user]
    M --> N{Sign-in successful?}
    N -- Yes --> O[SSO configured ✓]
    N -- No --> P[Check issuer URL & callback allowlist]
    P --> K
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/administration/authentication-and-sso.mdx:126-132
**Redirect URI configured twice with potentially different values**

Step 2 instructs users to hard-code the redirect URI (`https://<langfuse-url>/api/auth/callback/<domain>.okta`) manually in Okta before they have done the domain-verification flow. Step 5 then tells them to copy the callback URL from Langfuse's UI and add it to the same Okta allowlist. A user following these steps linearly will attempt to set the redirect URI twice, and the Step 2 format (which uses a user-supplied `<domain>` slug) may not match what Langfuse generates in the UI — leaving the correct Langfuse-generated URL absent from Okta's allowlist or leaving a stale, manually-entered URL that never resolves correctly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: move SSO signin and OIDC note abov..."](https://github.com/langfuse/langfuse-docs/commit/82ca30b5204a4733a0f220ee17881267f0e17861) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31339050)</sub>

<!-- /greptile_comment -->