### PR TITLE
docs(self-hosting): document AUTH_EMAIL_VERIFICATION_REQUIRED

### DIFF
--- a/content/self-hosting/security/authentication-and-sso.mdx
+++ b/content/self-hosting/security/authentication-and-sso.mdx
@@ -40,6 +40,22 @@ To disable email/password authentication, set `AUTH_DISABLE_USERNAME_PASSWORD=tr
 
 If you decide to switch from email/password to SSO on a running instance, you can enable `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING=true` on the SSO provider. This will automatically merge accounts with the same email address.
 
+### Email verification on signup [#email-verification-on-signup]
+
+Set `AUTH_EMAIL_VERIFICATION_REQUIRED=true` to require new users to verify their email address via a one-time password (OTP) before they can set their password during email/password signup. This requires [transactional emails](/self-hosting/configuration/transactional-emails) to be configured.
+
+When enabled, the signup flow becomes:
+
+1.  User enters their email and name on the sign-up page.
+2.  User receives an OTP via email and enters it to verify the address.
+3.  User sets a password on `/auth/setup-password` and is signed in.
+
+Notes:
+
+- SSO sign-in is unaffected by this setting.
+- When this flag is on, direct calls to `POST /api/auth/signup` return `403`; signups must go through the OTP flow.
+- If a user abandons the flow after verification, signing up again re-sends the OTP, and they can also complete the flow via the password reset page.
+
 ### Creation of default user
 
 If you want to programmatically create a default user, check out the [Headless Initialization](/self-hosting/administration/headless-initialization) documentation. This is useful if you want to initialize the instance without using the UI, e.g. when running Langfuse in a CI/CD pipeline or programmatically deploying Langfuse into many environments.
@@ -290,6 +306,7 @@ These are additional configuration variables. Replace `<PROVIDER>` with the prov
 | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AUTH_DOMAINS_WITH_SSO_ENFORCEMENT`     | Comma-separated list of domains that are only allowed to sign in using SSO. Email/password sign in is disabled for these domains. E.g. `domain1.com,domain2.com`                                                                                                                              |
 | `AUTH_DISABLE_SIGNUP`                   | Set to `true` to disable sign up for new users. Only existing users can sign in. This affects all new users that try to sign up, also those who received an invite to a project and have no account yet.                                                                                      |
+| `AUTH_EMAIL_VERIFICATION_REQUIRED`      | Set to `true` to require new users to verify their email address via a one-time password (OTP) before setting a password during email/password signup. Requires [transactional emails](/self-hosting/configuration/transactional-emails) to be configured. SSO sign-in is unaffected. See [Email verification on signup](#email-verification-on-signup). |
 | `AUTH_SESSION_MAX_AGE`                  | Set the maximum age of the session (JWT) in minutes. The default is 30 days (`43200`). The value must be greater than 5 minutes, as the front-end application refreshes its session every 5 minutes.                                                                                          |
 | `AUTH_IGNORE_ACCOUNT_FIELDS`            | Comma-separated list of fields to ignore from the SSO IDP account when creating an account. Use this to correct errors with custom IDP providers.                                                                                                                                             |
 | `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING` | Set to `true` to allow merging accounts with the same email address. This is useful when users sign in with different providers or email/password but have the same email address. You need to be careful with this setting as it can lead to security issues if the emails are not verified. |


### PR DESCRIPTION
## Summary

- Documents the new `AUTH_EMAIL_VERIFICATION_REQUIRED` env var (optional OTP email verification on email/password signup) introduced in [langfuse/langfuse#12427](https://github.com/langfuse/langfuse/pull/12427).
- Adds a new \"Email verification on signup\" subsection under Email/Password covering the 3-phase flow, SMTP requirement, and behavior of the direct signup endpoint.
- Adds a row for the variable to the Additional configuration table.

Scope is intentionally narrow per discussion: only `content/self-hosting/security/authentication-and-sso.mdx` is touched. v2 deployment guide and transactional-emails page are deliberately not updated.

## Test plan

- [ ] `pnpm dev` and visit `/self-hosting/security/authentication-and-sso` — new subsection renders, anchor `#email-verification-on-signup` works, table row links to it
- [ ] Cross-link to `/self-hosting/configuration/transactional-emails` resolves
- [ ] No heading-level skips, single H1 preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only addition that introduces a new "Email verification on signup" subsection and a corresponding table row for the `AUTH_EMAIL_VERIFICATION_REQUIRED` environment variable, covering its OTP-based 3-phase signup flow, SMTP prerequisite, and `403` behavior on direct API calls.

- Adds a new H3 subsection under Email/Password with a named anchor (`#email-verification-on-signup`), a numbered flow description, and behavioral notes (SSO unaffected, `POST /api/auth/signup` returns `403`, abandoned-flow recovery).
- Adds a table row in the Additional configuration section that summarises the variable and cross-links to the new subsection.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

The new subsection is accurate, well-structured, and the anchor, table entry, 3-step flow, and cross-links all look correct. One documentation gap exists: how this flag interacts with the signup-disable flag is not addressed, which could confuse operators running invite-only deployments who enable email verification later.

content/self-hosting/security/authentication-and-sso.mdx — the Notes block in the new subsection would benefit from a clarifying sentence about combined flag behavior.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant SignUpPage as Sign-Up Page
    participant Email as Email (OTP)
    participant SetupPage as /auth/setup-password
    participant API as Direct API Signup

    Note over User,API: Email verification enabled

    User->>SignUpPage: Enter email + name
    SignUpPage->>Email: Send OTP
    Email-->>User: Deliver OTP
    User->>SignUpPage: Enter OTP to verify
    SignUpPage-->>User: Redirect to setup-password
    User->>SetupPage: Set password
    SetupPage-->>User: Signed in

    Note over API: Direct signup blocked
    User->>API: POST request
    API-->>User: 403 Forbidden

    Note over User,SignUpPage: Abandoned-flow recovery
    User->>SignUpPage: Sign up again (same email)
    SignUpPage->>Email: Re-send OTP
    User->>SetupPage: Complete via password reset
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/self-hosting/security/authentication-and-sso.mdx:53-57
**Undocumented interaction with the signup-disable flag**

The notes cover the `403` behavior for direct API calls and the SSO exemption, but say nothing about what happens when both this flag and the signup-disable flag are active simultaneously. Operators running invite-only deployments who later enable email verification may not realize the OTP-based UI flow is (or isn't) also blocked. A brief note clarifying the combined behavior — e.g. whether the OTP flow is still accessible for invited users — would prevent confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document AUTH\_EMAIL\_..."](https://github.com/langfuse/langfuse-docs/commit/3b3f22117cee0465c090cc9753ec376b54bc45ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31341531)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->