### PR TITLE
docs(api-and-data-platform): refresh overview diagram and metrics API references [MKT-2116]

### DIFF
--- a/content/docs/api-and-data-platform/overview.mdx
+++ b/content/docs/api-and-data-platform/overview.mdx
@@ -15,12 +15,15 @@ Example use cases:
 - Fine-tuning based on raw exports of traces
 - Correlation of LLM Evals with observed user behavior in Data Warehouse
 
-<Frame fullWidth>
-  <img
-    src="/images/docs/open-data-platform-light.png"
-    alt="Open Data Platform"
-  />
-</Frame>
+```mermaid
+graph LR
+    LF["Langfuse<br/><br/>• Traces<br/>• Prompts<br/>• Scores"]
+
+    LF --> API["Public API"]
+    LF --> Dash["In-app Dashboards"]
+    LF --> Metrics["Metrics API"]
+    LF --> Export["Exports to S3 / DWH"]
+```
 
 ## Features
 
@@ -32,6 +35,7 @@ import {
   Download,
   Cloud,
   Blocks,
+  BarChart3,
 } from "lucide-react";
 
 <Cards num={3}>
@@ -51,6 +55,12 @@ import {
     title="Query via SDKs"
     href="/docs/api-and-data-platform/features/query-via-sdk"
     icon={<Code />}
+    arrow
+  />
+  <Card
+    title="Metrics API"
+    href="/docs/metrics/features/metrics-api"
+    icon={<BarChart3 />}
     arrow
   />
   <Card

--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -328,8 +328,7 @@ Categorical scores have an additional dimension:
 
 <Callout type="warning">
 
-This API is a legacy API. For new use cases, please use the [Metrics API](/docs/analytics/metrics-api) instead.
-It has higher rate-limits and offers more flexibility.
+This endpoint is legacy and is no longer listed in the [public API reference](https://api.reference.langfuse.com/). It remains available for backwards compatibility, but for new use cases please use the [Metrics API v2](#v2) above — it has higher rate limits and offers more flexibility.
 
 </Callout>
 
@@ -338,8 +337,6 @@ GET /api/public/metrics/daily
 ```
 
 Via the **Daily Metrics API**, you can retrieve aggregated daily usage and cost metrics from Langfuse for downstream use, e.g., in analytics, billing, and rate-limiting. The API allows you to filter by application type, user, or tags for tailored data retrieval.
-
-See [API reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/metrics/daily) for more details.
 
 ### Overview
 


### PR DESCRIPTION
## Summary

- Replace the static `open-data-platform-light.png` on the API & Data Platform overview with an editable mermaid diagram so it can be styled centrally and stays easy to edit.
- Rename the outdated **Daily Metrics API** node to **Metrics API** — `/api/public/metrics/daily` is no longer in the public OpenAPI spec; the current Metrics API is `GET /api/public/metrics` (v1) and `GET /api/public/v2/metrics` (v2).
- Add a **Metrics API** card to the overview's Features section so it is reachable from the API section, not only from the metrics section.
- Clean up the **Daily Metrics API (Legacy)** section on `/docs/metrics/features/metrics-api`:
  - Note that the endpoint is no longer listed in the public API reference but remains available for backwards compatibility.
  - Point the "use the Metrics API instead" link to the on-page `#v2` anchor (was a self-redirecting link to `/docs/analytics/metrics-api`).
  - Drop the broken `api.reference.langfuse.com` deep link to the daily endpoint.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the API & Data Platform overview by replacing a static PNG with an editable Mermaid diagram, adds a Metrics API feature card to the overview, and cleans up the legacy Daily Metrics API section to accurately reflect its current status.

- **Overview diagram**: Static image swapped for a `graph LR` Mermaid diagram with nodes for Public API, In-app Dashboards, Metrics API, and Exports; `BarChart3` icon imported from `lucide-react` for the new Metrics API card.
- **Metrics API docs**: Legacy callout updated to note the endpoint is absent from the public API reference but kept for backwards compatibility; the self-redirecting link is corrected to the on-page `#v2` anchor, and the broken deep link to `api.reference.langfuse.com` is removed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change with no runtime code affected; safe to merge.

All changes are confined to two MDX documentation files. The new Mermaid diagram uses valid syntax, the `#v2` anchor target exists on the page, the `BarChart3` lucide-react import is straightforward, and the removed broken deep link is a clear improvement. No logic, API behaviour, or application code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    PR["PR Changes"]
    PR --> OV["overview.mdx\n(API & Data Platform)"]
    PR --> MA["metrics-api.mdx\n(Metrics API)"]

    OV --> D1["Replace static PNG\nwith Mermaid diagram"]
    OV --> D2["Add BarChart3 import\nfrom lucide-react"]
    OV --> D3["Add Metrics API\nfeature card"]

    MA --> M1["Update legacy callout\n(no longer in public spec)"]
    MA --> M2["Fix self-redirecting link\n→ #v2 anchor"]
    MA --> M3["Remove broken\napi.reference deep link"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(api-and-data-platform): refresh ove..."](https://github.com/langfuse/langfuse-docs/commit/2447c6ef4000d0b7cdb625088f8e693bd062b14e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31393082)</sub>

<!-- /greptile_comment -->