### PR TITLE
docs(experiments): move CI/CD content to a dedicated page

### DIFF
--- a/content/changelog/2026-05-05-experiment-ci-cd-gates.mdx
+++ b/content/changelog/2026-05-05-experiment-ci-cd-gates.mdx
@@ -4,7 +4,7 @@ title: "Experiments CI/CD integration"
 description: Run langfuse experiments in GitHub Actions to catch quality regressions before releasing changes to production.
 author: Tobias Wochinger
 ogImage: /images/changelog/2026-05-05-experiment-ci-cd.png
-canonical: /guides/experiments-ci-cd
+canonical: /docs/evaluation/experiments/experiments-ci-cd
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
@@ -42,7 +42,7 @@ import { FileCode } from "lucide-react";
 <Cards num={2}>
   <Card
     title="Run Experiments in CI/CD"
-    href="/guides/experiments-ci-cd"
+    href="/docs/evaluation/experiments/experiments-ci-cd"
     icon={<FileCode />}
     arrow
   />

--- a/content/docs/evaluation/experiments/experiments-ci-cd.mdx
+++ b/content/docs/evaluation/experiments/experiments-ci-cd.mdx
@@ -1,9 +1,9 @@
 ---
-title: Run Experiments in CI/CD
+title: Experiments in CI/CD
 description: Run Langfuse experiments in CI and gate changes before production.
 ---
 
-# Run Experiments in CI/CD
+# Experiments in CI/CD
 
 Use Langfuse experiments in your CI/CD pipeline to catch quality regressions before they ship.
 
@@ -26,7 +26,7 @@ The action installs the latest SDK version by default; set `python_sdk_version` 
   The GitHub Action requires Langfuse Python SDK v4.6.0+ or JS SDK v5.3.0+.
 </Callout>
 
-```yaml
+```yaml title=".github/workflows/langfuse-experiment.yml"
 name: Langfuse experiment gate
 
 on:
@@ -76,7 +76,7 @@ jobs:
           github_token: ${{ github.token }}
 ```
 
-### Experiment Definition
+### Experiment definition
 
 The action runs your experiment code from the `experiment_path` configured in the workflow.
 
@@ -94,7 +94,7 @@ Use `context.runExperiment` (JS/TS) or `context.run_experiment` (Python) to run 
 <Tab>
 {/* Python SDK */}
 
-```python
+```python title="experiments/support-agent-gate.py"
 from langfuse import RunnerContext
 from langfuse.api import DatasetItem
 
@@ -115,7 +115,7 @@ def experiment(context: RunnerContext):
 <Tab>
 {/* JS/TS SDK */}
 
-```ts
+```ts title="experiments/support-agent-gate.ts"
 import type { ExperimentTaskParams, RunnerContext } from "@langfuse/client";
 
 // Define a task that calls your agent with each dataset item.
@@ -170,7 +170,7 @@ Raise `RegressionError` when a result should block the workflow. The example bel
 <Tab>
 {/* Python SDK */}
 
-```python
+```python title="experiments/support-agent-gate.py"
 from langfuse import Evaluation, RegressionError, RunnerContext
 
 
@@ -234,7 +234,7 @@ def avg_accuracy(*, item_results, **kwargs):
 <Tab>
 {/* JS/TS SDK */}
 
-```ts
+```ts title="experiments/support-agent-gate.ts"
 import {
   RegressionError,
   type Evaluation,
@@ -326,7 +326,7 @@ When `github_token` is provided and the workflow has `pull-requests: write`, the
 
 The same normalized data is available as the `result_json` action output. Use this when a later workflow step needs to upload the result as an artifact, send a Slack notification, or feed another reporting system. The output schema is available in the [`langfuse/experiment-action` repository](https://github.com/langfuse/experiment-action/blob/main/schemas/result-json.v1.schema.json).
 
-```yaml
+```yaml title=".github/workflows/langfuse-experiment.yml"
 - uses: langfuse/experiment-action@<release tag>
   id: experiment
   with:
@@ -343,7 +343,7 @@ The same normalized data is available as the `result_json` action output. Use th
 
 If your experiment needs provider keys or other secrets, set them as environment variables on the action step. The experiment subprocess inherits the step environment.
 
-```yaml
+```yaml title=".github/workflows/langfuse-experiment.yml"
 - uses: langfuse/experiment-action@<release tag>
   env:
     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -365,8 +365,7 @@ Integrate the experiment runner with testing frameworks like Pytest and Vitest t
 <Tab>
 {/* PYTHON SDK */}
 
-```python
-# test_geography_experiment.py
+```python title="test_geography_experiment.py"
 import pytest
 from langfuse import get_client, Evaluation
 from langfuse.openai import OpenAI
@@ -474,8 +473,7 @@ def test_geography_accuracy_fails(langfuse_client):
 <Tab>
 {/* JS/TS SDK */}
 
-```typescript
-// test/geography-experiment.test.ts
+```typescript title="test/geography-experiment.test.ts"
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { OpenAI } from "openai";
 import { NodeSDK } from "@opentelemetry/sdk-node";

--- a/content/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/content/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -15,6 +15,7 @@ See also the [JS/TS SDK reference](https://js.reference.langfuse.com/classes/_la
 - Use custom scoring functions to evaluate the outputs of a single item and the full run
 - Run multiple experiments on the same dataset in parallel
 - Easy to integrate with your existing evaluation infrastructure
+- [Run your experiments in CI/CD](/docs/evaluation/experiments/experiments-ci-cd) to catch regressions before they ship
 
 ## Experiment runner SDK
 
@@ -550,56 +551,6 @@ console.log(await result.format());
 
 </Tab>
 </LangTabs>
-
-## Testing in CI Environments [#testing-in-ci-environments]
-
-Use Langfuse experiments in your CI/CD pipeline to catch quality regressions before they ship. A typical workflow creates a dataset with regression test cases, runs your application against the dataset with the SDK, scores the outputs with evaluators, and fails the workflow when a score violates your threshold.
-
-<Callout type="info">
-  Follow the [CI/CD guide](/guides/experiments-ci-cd) to add experiment checks
-  to your release process and block changes that reduce quality before they
-  reach production.
-</Callout>
-
-For GitHub Actions, use [`langfuse/experiment-action`](https://github.com/langfuse/experiment-action) to run an experiment script and report the result on the pull request.
-
-```yaml
-name: Langfuse experiment gate
-
-on:
-  pull_request:
-
-permissions:
-  # Required to check out the repository.
-  contents: read
-  # Required to post or update the experiment result comment on pull requests.
-  pull-requests: write
-
-jobs:
-  experiment:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      # Add this only if your experiments use the Python SDK.
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      # Add this only if your experiments use the JS/TS SDK.
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - uses: langfuse/experiment-action@<release tag>
-        with:
-          langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
-          langfuse_base_url: https://cloud.langfuse.com
-          experiment_path: experiments/support-agent-gate
-          dataset_name: support-agent-regression-set
-          github_token: ${{ github.token }}
-```
 
 ## Low-level SDK methods
 

--- a/content/docs/evaluation/experiments/meta.json
+++ b/content/docs/evaluation/experiments/meta.json
@@ -4,6 +4,7 @@
     "data-model",
     "datasets",
     "experiments-via-sdk",
-    "experiments-via-ui"
+    "experiments-via-ui",
+    "experiments-ci-cd"
   ]
 }

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -55,7 +55,7 @@ import {
   <TutorialCard
     title="CI/CD for Experiments"
     description="Run Langfuse experiments in CI/CD pipelines to catch quality regressions before they reach production."
-    href="/guides/experiments-ci-cd"
+    href="/docs/evaluation/experiments/experiments-ci-cd"
     icon={<FileCode />}
   />
   <TutorialCard

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -946,6 +946,13 @@ const experimentsRedirects202509 = [
   ],
 ];
 
+const experimentsCiCdRedirects202605 = [
+  [
+    "/guides/experiments-ci-cd",
+    "/docs/evaluation/experiments/experiments-ci-cd",
+  ],
+];
+
 const handbookRedirects202509 = [
   ["/why", "/handbook/chapters/why"],
   ["/open-source", "/handbook/chapters/open-source"],
@@ -1439,6 +1446,7 @@ const permanentRedirects = [
   ...selfHostedTelemetryMove202603,
   ...blogRedirects202604,
   ...v4DashboardChangesMove202605,
+  ...experimentsCiCdRedirects202605,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };


### PR DESCRIPTION
## Summary

- Splits the CI/CD experiments content out of `experiments-via-sdk` into a new docs page at `/docs/evaluation/experiments/experiments-ci-cd`, sitting alongside the SDK and UI pages in the sidebar.
- Adds a permanent redirect from `/guides/experiments-ci-cd` to the new docs URL, and updates internal references on the guides index and the related changelog (incl. its `canonical`).
- Adds file-name titles to the code blocks on the new page (workflow file, experiment script, test files) using the Fumadocs `title="..."` meta.
- Adds a bullet on `experiments-via-sdk` linking to the new CI/CD page.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the CI/CD experiments content from `experiments-via-sdk.mdx` into a standalone docs page at `/docs/evaluation/experiments/experiments-ci-cd`, adds a permanent redirect from the old guide URL, and updates all internal cross-references accordingly.

- The guide file is renamed/moved to the docs tree, added to the sidebar `meta.json`, and Fumadocs `title=\"...\"` attributes are added to all code blocks for better readability.
- A permanent redirect (`/guides/experiments-ci-cd` → `/docs/evaluation/experiments/experiments-ci-cd`) is appended to `lib/redirects.js`, and the changelog canonical URL plus the guides index card are both updated to the new path.
- `experiments-via-sdk.mdx` loses its CI/CD section and gains a single bullet pointing readers to the new page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changed files are documentation and configuration; no application logic is touched.

The change is a clean docs restructure: a file rename, a redirect addition, and reference updates. No stale links to the old path remain outside the redirect source definition, the redirect array follows the established pattern in lib/redirects.js, and the new sidebar entry is correctly placed.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/guides/experiments-ci-cd (old URL)"] -->|permanent redirect| B["/docs/evaluation/experiments/experiments-ci-cd"]
    C["changelog: 2026-05-05-experiment-ci-cd-gates.mdx\ncanonical + card href"] --> B
    D["content/guides/index.mdx\nTutorialCard href"] --> B
    E["experiments-via-sdk.mdx\nbullet link"] --> B
    B --> F["Sidebar entry via meta.json"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): move CI/CD content to..."](https://github.com/langfuse/langfuse-docs/commit/d0fb551ad07fe8f618feff0ce7f5985f99274de8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31810883)</sub>

<!-- /greptile_comment -->