### PR TITLE
Add Cloud/BYOC guidance for ClickHouse scaling and disk growth

### DIFF
--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -88,6 +88,12 @@ If you notice that your disk space is increasing significantly on S3/Blob Storag
 In general, the most effective way to free disk space is to configure a [data retention](/docs/data-retention) policy.
 If this is not available in your plan, consider the options below.
 
+<Callout type="info">
+
+For larger deployments where ClickHouse disk growth becomes an operational bottleneck, consider [ClickHouse Cloud or BYOC](/self-hosting/deployment/infrastructure/clickhouse#cloudbyoc). These deployments separate storage from compute, so storage can grow independently of the compute that serves Langfuse queries. This does not replace retention policies because retained tracing data still consumes storage, but it removes much of the manual disk planning, volume expansion, and single-shard capacity management required in self-managed OSS ClickHouse setups.
+
+</Callout>
+
 ### S3 / Blob Storage Disk Usage
 
 You can implement lifecycle rules to automatically remove old files from your blob storage.

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -80,7 +80,7 @@ Replace `'user'` with your actual ClickHouse username and adjust the database na
 
 This section covers different deployment options and provides example environment variables.
 
-### ClickHouse Cloud
+### Cloud/BYOC (recommended) [#cloudbyoc]
 
 ClickHouse Cloud is a scalable and fully managed deployment option for ClickHouse.
 You can provision it directly from [ClickHouse](https://clickhouse.cloud/) or through one of the cloud provider marketplaces:
@@ -89,7 +89,11 @@ You can provision it directly from [ClickHouse](https://clickhouse.cloud/) or th
 - [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/clickhouse-public/clickhouse-cloud)
 - [Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/clickhouse.clickhouse_cloud?tab=Overview)
 
-ClickHouse Cloud clusters will be provisioned outside your cloud environment and your VPC, but Clickhouse offers [private links](https://clickhouse.com/docs/en/cloud/security/private-link-overview) for AWS, GCP, and Azure.
+ClickHouse Cloud clusters will be provisioned outside your cloud environment and your VPC, but ClickHouse offers [private links](https://clickhouse.com/docs/en/cloud/security/private-link-overview) for AWS, GCP, and Azure.
+
+If you need the operational model of ClickHouse Cloud while keeping the ClickHouse data plane in your own cloud account, consider [ClickHouse BYOC](https://clickhouse.com/cloud/bring-your-own-cloud). BYOC is a fully managed ClickHouse Cloud deployment on infrastructure in your cloud account and is designed for large-scale deployments with strict data residency, compliance, or VPC-boundary requirements.
+
+We recommend ClickHouse Cloud or BYOC for larger Langfuse deployments because they provide cloud-native scaling primitives that are not available in the self-managed OSS ClickHouse setup used by Langfuse. ClickHouse Cloud and BYOC separate storage from compute through [SharedMergeTree](https://clickhouse.com/docs/cloud/reference/shared-merge-tree), which helps scale compute independently of stored data, reduces replica storage overhead, and avoids manual shard planning for growth. They also support compute-compute separation through [warehouses](https://clickhouse.com/docs/cloud/reference/warehouses), so you can isolate ingestion writes, UI reads, analytical queries, or ad-hoc workloads on separate compute groups that share the same data but do not compete for the same CPU and memory. Langfuse can use this pattern via `CLICKHOUSE_READ_ONLY_URL` for read-heavy UI and public-API traffic.
 
 If you need assistance or want to talk to the ClickHouse team, you can reach out to them [here](https://clickhouse.com/company/contact).
 
@@ -118,7 +122,7 @@ See [Langfuse on Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) fo
 
 #### Example Configuration
 
-For a minimum production setup, we recommend to use the following values.yaml overwrites when deploying the Clickhouse Helm chart:
+For a minimum production setup, we recommend using the following values.yaml overrides when deploying the ClickHouse Helm chart:
 
 ```yaml
 clickhouse:
@@ -127,13 +131,13 @@ clickhouse:
   replicaCount: 3
   resourcesPreset: large # or more
   persistence:
-    size: 100Gi # Start with a large volume to prevent early resizing. Alternatively, consider a blob storage backed disked.
+    size: 100Gi # Start with a large volume to prevent early resizing. Alternatively, consider a blob storage-backed disk.
   auth:
     username: default
     password: changeme
 ```
 
-- **shards**: Shards are used for horizontally scaling ClickHouse. A single ClickHouse shard can handle multiple Terabytes of data. Today, Langfuse does not support a multi-shard cluster, i.e. this value _must_ be set to 1. Please get in touch with us if you hit scaling limits of a single shard cluster.
+- **shards**: Shards are used for horizontally scaling ClickHouse. A single ClickHouse shard can handle multiple Terabytes of data. Today, Langfuse does not support a multi-shard cluster, i.e. this value _must_ be set to 1. Please get in touch with us if you hit scaling limits of a single shard cluster or consider ClickHouse Cloud/BYOC.
 - **replicaCount**: The number of replicas for each shard. ClickHouse counts the all instances towards the number of replicas, i.e. a replica count of 1 means no redundancy at all. We recommend a minimum of 3 replicas for production setups. The number of replicas cannot be increased at runtime without manual intervention or downtime.
 - **resourcesPreset**: ClickHouse is CPU and memory intensive for analytical and highly concurrent requests. We recommend at least the `large` resourcesPreset and more for larger deployments.
 - **auth**: The username and password for the ClickHouse database. Overwrite those values according to your preferences, or mount them from a secret.


### PR DESCRIPTION
## Summary
- Renamed the ClickHouse deployment section to emphasize `Cloud/BYOC` as the recommended path.
- Added a BYOC paragraph explaining the managed-in-your-cloud option and why it fits larger deployments.
- Documented the main scaling benefits of ClickHouse Cloud/BYOC: separated storage and compute, and compute-compute separation via warehouses.
- Added a note in the scaling guide that Cloud/BYOC can help when ClickHouse disk growth becomes an operational bottleneck.
- Updated the single-shard guidance to point users toward ClickHouse Cloud/BYOC if they hit capacity limits.
- Cleaned up a few nearby wording issues in the ClickHouse deployment docs.

## Testing
- `git diff --check` passed.
- Performed targeted doc review of the updated scaling and ClickHouse deployment sections.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the self-hosting ClickHouse documentation by renaming the "ClickHouse Cloud" deployment section to "Cloud/BYOC (recommended)" with an explicit anchor, and adds guidance explaining BYOC and the scaling advantages (SharedMergeTree storage/compute separation and compute-compute separation via warehouses). A companion callout is added to the disk-usage scaling guide pointing users toward Cloud/BYOC when self-managed disk growth becomes a bottleneck.

- **`clickhouse.mdx`**: Renamed section heading, added BYOC explanation paragraph and a recommendation paragraph covering `SharedMergeTree`, `warehouses`, and `CLICKHOUSE_READ_ONLY_URL`; fixed capitalization ("Clickhouse" → "ClickHouse"), fixed "overwrites" → "overrides", and fixed "backed disked" → "backed disk".
- **`scaling.mdx`**: Added an info `<Callout>` in the "Increasing Disk Usage" section that links to the new `#cloudbyoc` anchor and clarifies the scope of storage/compute separation relative to retention policies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only changes with no runtime code; safe to merge.

Both files are pure documentation. Anchor syntax ([#cloudbyoc]) matches the pattern used throughout the repo. The cross-file link correctly targets the newly defined anchor. Typo fixes are accurate. The CLICKHOUSE_READ_ONLY_URL reference in clickhouse.mdx is consistent with its dedicated section already in scaling.mdx. No logic, schema, or configuration changes are present.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Self-hosting Langfuse] --> B{ClickHouse deployment size}
    B -->|Small / medium| C[Self-managed OSS ClickHouse\nHelm chart, single shard]
    B -->|Large / operational\nbottleneck| D{Data residency\nrequirement?}
    D -->|No strict requirement| E[ClickHouse Cloud\nProvisioned outside your VPC\nPrivate links available]
    D -->|Must stay in\nyour cloud account| F[ClickHouse BYOC\nManaged by ClickHouse\nin your cloud account]
    E --> G[SharedMergeTree: separate\nstorage from compute]
    F --> G
    G --> H[Warehouses: compute-compute\nseparation]
    H --> I[CLICKHOUSE_READ_ONLY_URL\nroutes UI reads to dedicated\ncompute group]
    C -->|Hit single-shard\ncapacity limits| D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add ClickHouse Cloud and BYOC scaling gu..."](https://github.com/langfuse/langfuse-docs/commit/88e0fd6ae993ec4093808eb0bd858eaf65ef70e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31939758)</sub>

<!-- /greptile_comment -->