### PR TITLE
chore: add CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Currently inactive
 # * @langfuse/maintainers
+
+# Require maintainer review for GitHub configuration changes
+.github/ @langfuse/maintainers


### PR DESCRIPTION
## Summary
- add/update `.github/CODEOWNERS` to require `@langfuse/maintainers` review for `.github/` changes

Linear: https://linear.app/langfuse/issue/LFE-9760/repo-owners-for-github-actions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR activates a CODEOWNERS rule requiring `@langfuse/maintainers` review for any changes under the `.github/` directory (workflows, actions config, and CODEOWNERS itself).

- Adds `.github/ @langfuse/maintainers` to `.github/CODEOWNERS`, replacing the previously commented-out catch-all rule.
- The previous global `* @langfuse/maintainers` rule remains commented out, so only `.github/` changes are gated for now.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a one-line config change that adds a CODEOWNERS rule requiring maintainer sign-off on future .github/ modifications.

The change is minimal and self-contained: it adds a single CODEOWNERS entry that gates future .github/ changes behind @langfuse/maintainers. The only note is that using /.github/ instead of .github/ would anchor the pattern to the repo root more precisely, but this is cosmetic for a repo that is unlikely to have nested .github/ directories.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / updated] --> B{Files changed under .github/?}
    B -- Yes --> C[GitHub requests review from @langfuse/maintainers]
    C --> D{Maintainer approves?}
    D -- Yes --> E[PR can be merged]
    D -- No --> F[PR blocked until approval]
    B -- No --> G[Normal review flow — no CODEOWNERS gate]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/CODEOWNERS:5
Using a leading `/` anchors the pattern to the repository root, making the match explicit and predictable. Without it, CODEOWNERS (which follows `.gitignore` rules) could theoretically match a `.github/` directory nested anywhere inside the repository tree.

```suggestion
/.github/ @langfuse/maintainers
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add codeowners for github config"](https://github.com/langfuse/langfuse-docs/commit/f745277160e175765c3aa23d3981469732960274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31952284)</sub>

<!-- /greptile_comment -->