### PR TITLE
docs(self-hosting): document FINAL-modifier skip for OTel projects

### DIFF
--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -79,6 +79,23 @@ Set `CLICKHOUSE_READ_ONLY_URL` and Langfuse will route UI and public-API read qu
 Credentials (`CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`) and the database name are reused from the primary configuration, so the read-only compute group must accept the same user.
 Both variables are optional and unset by default; on a single-node ClickHouse or a non-compute-separated cluster they provide no benefit because the endpoint would be the same as the primary.
 
+### Skipping the FINAL modifier for OTel projects [#skip-final-otel-projects]
+
+Langfuse stores observations in a ClickHouse `ReplacingMergeTree` and, by default, appends the `FINAL` modifier to public-API observations queries so that the latest version of each row wins at read time.
+This is required when ingestion produces multiple versions of the same observation (e.g. separate start, end, and update events from the legacy SDKs), but it adds query-time merge work and slows reads down.
+
+Projects that ingest **exclusively via OpenTelemetry** (the OTel SDKs or the `/api/public/otel` endpoint) write each observation as a single immutable row, so `FINAL` is unnecessary for them.
+Setting `LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS=true` enables per-project tracking: when a project ingests through the OTel endpoint, Langfuse marks it in Redis with a 24-hour TTL, and subsequent observations reads for that project (in `GET /api/public/observations` and the observations CTE in `GET /api/public/traces`) skip the `FINAL` modifier.
+The TTL refreshes on every OTel ingestion call, and the marker expires automatically if a project stops sending OTel traffic, so the behavior reverts safely if a project switches back to legacy ingestion.
+
+This is the recommended way to benefit from the optimization on mixed deployments where only some projects are on OTel.
+
+<Callout type="info">
+
+If you are certain that **every** project on the instance ingests via OTel only, you can instead set `LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL=true` to drop the `FINAL` modifier globally, without the Redis lookup. This flag takes precedence over the per-project logic. Do not enable it if any project still uses the legacy ingestion path, as observations reads may otherwise return stale or duplicate rows.
+
+</Callout>
+
 ## Increasing Disk Usage
 
 LLM tracing data may contain large payloads due to inputs and outputs being tracked.


### PR DESCRIPTION
## Summary
- Add a new "Skipping the FINAL modifier for OTel projects" subsection to the self-hosting scaling guide, under "Slow UI queries or API calls".
- Document `LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS` as the recommended, per-project (Redis-tracked, 24h TTL) way to drop the `ReplacingMergeTree` `FINAL` modifier on observations reads in `GET /api/public/observations` and the observations CTE of `GET /api/public/traces`.
- Mention `LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL=true` as a side note for all-OTel deployments, with a warning that it can return stale/duplicate rows if any project still ingests via the legacy path.

Both flags were previously undocumented despite being shipped in the Langfuse codebase.

## Test plan
- [ ] `pnpm dev` and visually verify `/self-hosting/configuration/scaling#skip-final-otel-projects` renders correctly with the `<Callout>` component
- [ ] Confirm the new anchor resolves and is reachable from the in-page table of contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents two previously undocumented environment variables — `LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS` and `LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL` — as a new subsection under the "Slow UI queries or API calls" section of the self-hosting scaling guide.

- `LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS=true` enables per-project Redis tracking (24 h TTL) to skip the `FINAL` modifier on `ReplacingMergeTree` reads for projects confirmed to ingest exclusively via OTel, with automatic reversion when OTel traffic stops.
- `LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL=true` is documented as a global override for all-OTel deployments, with a callout warning about stale/duplicate rows if any project still uses the legacy path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no runtime code is modified. The new section is accurate for its primary use case but omits a warning about concurrent mixed-mode ingestion where FINAL could be silently skipped while legacy rows are still in flight.

The per-project Redis marker is set whenever OTel traffic arrives, but it cannot distinguish a project that is exclusively on OTel from one that is simultaneously sending through both OTel and the legacy SDK. During such an overlap, FINAL is skipped even though multi-version rows exist, which can surface stale or duplicate observations to API consumers. This edge case is not covered by the current warning text, and operators running gradual migrations are the most likely to hit it.

content/self-hosting/configuration/scaling.mdx — the new subsection on lines 82–97 needs an explicit warning about concurrent mixed-mode ingestion.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/self-hosting/configuration/scaling.mdx:88-89
**Silent data inconsistency during concurrent mixed-mode ingestion**

The Redis marker is set whenever OTel traffic arrives, but it does not track whether legacy ingestion is also active at the same time. If a project simultaneously routes spans through both the OTel endpoint and the legacy SDK (a common pattern during migrations), the marker will be present and `FINAL` will be skipped — yet the legacy path still produces multi-version rows that require `FINAL` for correct deduplication. The current text only addresses the "project fully switches back" scenario ("the marker expires automatically if a project stops sending OTel traffic"), but a project that never stops legacy traffic while also sending OTel will silently receive stale or duplicate rows for the entire duration of that concurrent period.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Document FINAL-modifier skip for OTel pr..."](https://github.com/langfuse/langfuse-docs/commit/171efdedcbdd9576be420c9865ccea4ff5ef8e63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31994975)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->