### PR TITLE
docs(academy): link practical guides from academy pages

### DIFF
--- a/components/academy/ManualGuideList.tsx
+++ b/components/academy/ManualGuideList.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import Link from "next/link";
+
+export interface ManualGuideListItem {
+  href: string;
+  topic: string;
+  lede?: React.ReactNode;
+}
+
+export interface ManualGuideListProps {
+  /** Label shown in the ribbon header. Defaults to "Guides". */
+  title?: string;
+  /** Guides to render as rows. */
+  guides: ManualGuideListItem[];
+}
+
+export function ManualGuideList({
+  title = "Guides",
+  guides,
+}: ManualGuideListProps) {
+  return (
+    <>
+      <section className="manual-guide-list not-prose corner-box-corners">
+        <header className="manual-guide-list__ribbon">
+          <div className="manual-guide-list__ribbon-lead">
+            <span className="manual-guide-list__mark" aria-hidden="true">
+              <svg width="11" height="11" viewBox="0 0 13 13" fill="none">
+                <path
+                  d="M3 3.5h7M3 6.5h7M3 9.5h4"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </span>
+            <span className="manual-guide-list__ribbon-prefix">{title}</span>
+          </div>
+        </header>
+
+        <ul className="manual-guide-list__items">
+          {guides.map((guide) => (
+            <li key={guide.href} className="manual-guide-list__item">
+              <GuideRow {...guide} />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <style>{`
+        .manual-guide-list {
+          position: relative;
+          display: block;
+          margin: 32px 0;
+          background: var(--surface-bg);
+          color: var(--text-primary);
+          border: 1px solid var(--line-structure);
+          border-radius: 0;
+          font-family: var(--font-sans);
+        }
+
+        .manual-guide-list__ribbon {
+          background: var(--surface-beige-accent);
+          border-bottom: 1px solid var(--line-structure);
+          padding: 9px 20px;
+          display: flex;
+          align-items: center;
+          gap: 16px;
+          font-family: var(--font-mono);
+          font-size: 11px;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: var(--text-primary);
+        }
+
+        .manual-guide-list__ribbon-lead {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .manual-guide-list__ribbon-prefix {
+          color: var(--text-secondary);
+        }
+
+        .manual-guide-list__mark {
+          width: 18px;
+          height: 18px;
+          background: var(--text-primary);
+          color: var(--surface-beige-accent);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 1px;
+          flex-shrink: 0;
+        }
+
+        .manual-guide-list__items {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+        }
+
+        .manual-guide-list__item + .manual-guide-list__item {
+          border-top: 1px solid var(--line-structure);
+        }
+
+        .manual-guide-list__row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 20px;
+          padding: 14px 24px;
+          color: var(--text-primary);
+          text-decoration: none;
+          transition: background-color 0.15s ease;
+        }
+
+        .manual-guide-list__row:hover {
+          background: var(--surface-beige-accent);
+        }
+
+        .manual-guide-list__row:hover .manual-guide-list__row-arrow {
+          transform: translateX(3px);
+          color: var(--text-primary);
+        }
+
+        .manual-guide-list__row-main {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          min-width: 0;
+        }
+
+        .manual-guide-list__row-topic {
+          font-family: var(--font-sans);
+          font-size: 14.5px;
+          font-weight: 500;
+          color: var(--text-primary);
+        }
+
+        .manual-guide-list__row-lede {
+          font-family: var(--font-sans);
+          font-size: 13.5px;
+          line-height: 1.5;
+          color: var(--text-tertiary);
+          margin: 0;
+          max-width: 560px;
+        }
+
+        .manual-guide-list__row-arrow {
+          color: var(--text-secondary);
+          flex-shrink: 0;
+          transition: transform 0.15s, color 0.15s;
+        }
+
+        @media (max-width: 720px) {
+          .manual-guide-list__row {
+            padding: 12px 18px;
+          }
+        }
+      `}</style>
+    </>
+  );
+}
+
+function GuideRow({ href, topic, lede }: ManualGuideListItem) {
+  const isExternal = /^https?:/i.test(href);
+
+  const content = (
+    <>
+      <div className="manual-guide-list__row-main">
+        <span className="manual-guide-list__row-topic">{topic}</span>
+        {lede && <p className="manual-guide-list__row-lede">{lede}</p>}
+      </div>
+      <span className="manual-guide-list__row-arrow" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M3 8h10M8 3l5 5-5 5"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    </>
+  );
+
+  return isExternal ? (
+    <a
+      href={href}
+      className="manual-guide-list__row"
+      target="_blank"
+      rel="noreferrer"
+    >
+      {content}
+    </a>
+  ) : (
+    <Link href={href} className="manual-guide-list__row">
+      {content}
+    </Link>
+  );
+}

--- a/content/academy/datasets.mdx
+++ b/content/academy/datasets.mdx
@@ -149,6 +149,12 @@ Start with the most concrete examples you have, then expand coverage once you kn
 2. **Add hand-written cases** based on predefined requirements, edge cases, or behaviors your agent must handle reliably.
 3. **Generate synthetic examples** with AI once you know which dimensions you want to cover more broadly.
 
+<ManualGuideCallout
+  href="/guides/cookbook/example_synthetic_datasets"
+  topic="synthetic datasets"
+  lede="Generate synthetic examples with AI to expand dataset coverage."
+/>
+
 ## What comes next
 
 Once you have a dataset, the next step is running your system against it to see how changes affect output quality. This is what [experiments](/academy/experiments) are for.

--- a/content/academy/evaluate.mdx
+++ b/content/academy/evaluate.mdx
@@ -24,6 +24,12 @@ The rest of this page covers the different kinds of evaluation in detail. In pra
 Manual evaluation is not a one-and-done step. Good production setups incorporate continuous review by human experts to catch new failure modes and keep automated evaluators calibrated.
 </Callout>
 
+<ManualGuideCallout
+  href="/guides/cookbook/error-analysis-llm-applications"
+  topic="error analysis"
+  lede="Select your sample data, build an annotation queue, cluster failure categories, quantify failure rates, and decide what to do."
+/>
+
 ## Evaluation methods [#three-kinds-of-evaluation]
 
 There are three main ways to evaluate: manually, with code, or with an LLM. Each is suited to different kinds of quality checks.
@@ -149,3 +155,29 @@ If the results are good enough, you can ship the change. Once it is live, the lo
 Some evaluators should also move beyond offline experiments. Reference-free evaluators, user feedback signals, and other production-safe checks can be applied to live traffic to confirm that quality in production matches what you saw before deployment.
 
 If production behavior matches expectations, you can keep scaling with more confidence. If it does not, capture those cases in traces, turn them into [dataset](/academy/datasets) items, and run the next round of [experiments](/academy/experiments). That is how you close the loop.
+
+<ManualGuideList
+  title="More guides"
+  guides={[
+    {
+      href: "/guides/cookbook/evaluation_of_rag_with_ragas",
+      topic: "RAG evaluation with RAGAS",
+      lede: "Score retrieval and generation quality for a RAG application.",
+    },
+    {
+      href: "/guides/cookbook/example_external_evaluation_pipelines",
+      topic: "external evaluation pipelines",
+      lede: "Fetch production traces, evaluate them outside Langfuse, and post scores back via the API.",
+    },
+    {
+      href: "/guides/cookbook/example_evaluating_multi_turn_conversations",
+      topic: "evaluating multi-turn conversations",
+      lede: "Score quality across conversation turns in chat applications.",
+    },
+    {
+      href: "/guides/cookbook/example_simulated_multi_turn_conversations",
+      topic: "simulated multi-turn conversations",
+      lede: "Generate and evaluate simulated multi-turn scenarios.",
+    },
+  ]}
+/>

--- a/content/academy/experiments.mdx
+++ b/content/academy/experiments.mdx
@@ -63,3 +63,9 @@ Start with a small, manual comparison before building more infrastructure. A few
 ## What comes next
 
 To see whether your experiment led to an improvement, you need to evaluate your results. Learn more about [evaluation methods](/academy/evaluate) in the next section.
+
+<ManualGuideCallout
+  href="/docs/evaluation/experiments/experiments-ci-cd"
+  topic="experiments in CI/CD"
+  lede="Integrate experiments into your release process to test consistently before shipping."
+/>

--- a/content/academy/monitoring/index.mdx
+++ b/content/academy/monitoring/index.mdx
@@ -64,7 +64,7 @@ Implicit:  extracted field manually edited before approval
 </Tab>
 </Tabs>
 
-Both register as scores, so they feed into the same dashboards, trend charts, and signal rules as your other evaluation data.
+Both register as scores, so they feed into the same dashboards, trend charts, and signal rules as your other evaluation data. To figure out which feedback signals are worth turning into automated evaluators in the first place, see our deeper dive into [Error analysis](/academy/monitoring/error-analysis).
 
 <Callout type="info">
 There are two types of automated evaluators to attach scores to traces: 
@@ -74,12 +74,6 @@ There are two types of automated evaluators to attach scores to traces:
 More on both can be found in the [Evaluate](/academy/evaluate) section.
 
 </Callout>
-
-<ManualGuideCallout
-  href="/blog/2026-04-01-llm-as-a-judge-production-monitoring"
-  topic="monitoring implicit feedback"
-  lede="Using LLM-as-a-judge to detect user frustration in a customer support agent."
-/>
 
 ## Where to start
 

--- a/content/academy/monitoring/index.mdx
+++ b/content/academy/monitoring/index.mdx
@@ -75,6 +75,12 @@ More on both can be found in the [Evaluate](/academy/evaluate) section.
 
 </Callout>
 
+<ManualGuideCallout
+  href="/blog/2026-04-01-llm-as-a-judge-production-monitoring"
+  topic="monitoring implicit feedback"
+  lede="Using LLM-as-a-judge to detect user frustration in a customer support agent."
+/>
+
 ## Where to start
 
 Start small and build your monitoring setup from real traces rather than abstract ideas about what might matter.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -21,6 +21,7 @@ import { DatasetFieldsDiagram } from "@/components/academy/DatasetFieldsDiagram"
 import { ErrorAnalysisProcessDiagram } from "@/components/academy/ErrorAnalysisProcessDiagram";
 import { AgentPromptCallout } from "@/components/academy/AgentPromptCallout";
 import { ManualGuideCallout } from "@/components/academy/ManualGuideCallout";
+import { ManualGuideList } from "@/components/academy/ManualGuideList";
 import { Details, Summary } from "@/components/Details";
 
 // Lazy-load Video so @vidstack/react (~800 KB) is NOT bundled on every MDX page.
@@ -81,6 +82,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     ErrorAnalysisProcessDiagram,
     AgentPromptCallout,
     ManualGuideCallout,
+    ManualGuideList,
     details: Details,
     summary: Summary,
     ...components,


### PR DESCRIPTION
## Summary

- Add `ManualGuideCallout`s to the monitoring, datasets, experiments, and evaluation academy pages, pointing readers to the most relevant practical guide on each.
- Introduce a new `ManualGuideList` component that groups multiple related guides into a single card with a shared ribbon, used on the evaluation page to surface four advanced evaluation cookbooks without stacking four separate cards.

## Links added

- Monitoring → [Rage Clicks of LLM Apps blog post](/blog/2026-04-01-llm-as-a-judge-production-monitoring)
- Datasets → [Synthetic datasets cookbook](/guides/cookbook/example_synthetic_datasets)
- Experiments → [Experiments in CI/CD](/docs/evaluation/experiments/experiments-ci-cd)
- Evaluation (How evaluation typically evolves) → [Error analysis cookbook](/guides/cookbook/error-analysis-llm-applications)
- Evaluation (end of page) → grouped list: RAG evaluation with RAGAS, external evaluation pipelines, evaluating multi-turn conversations, simulated multi-turn conversations

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches four Langfuse Academy pages (monitoring, datasets, experiments, evaluate) with contextual guide callouts and introduces a new `ManualGuideList` component that groups multiple cookbook links under a single ribbon card.

- **`ManualGuideList` component** is added following the same design system and inline-style pattern as the existing `ManualGuideCallout`, with individual rows rendered as `<a>` or Next.js `<Link>` depending on whether the href is external. The component is registered in `mdx-components.tsx` so it can be used directly from MDX.
- **Four `ManualGuideCallout`s** and one `ManualGuideList` (with four cookbook entries) are wired into their respective academy pages; all referenced routes (`/blog/…`, `/docs/…`, `/guides/cookbook/…`) resolve to existing content files in the repo.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive documentation and UI changes with no logic paths that could break existing pages.

All linked routes resolve to existing content files; the new ManualGuideList component follows the same patterns as the existing ManualGuideCallout (inline styles, external-link detection, Next.js Link); imports are correctly placed at the module top; no state, side-effects, or data-fetching logic is involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MDX Academy Page] --> B{Component type}
    B -->|single guide| C[ManualGuideCallout]
    B -->|multiple guides| D[ManualGuideList]

    C --> E{href type}
    E -->|external https| F["&lt;a target=_blank rel=noreferrer&gt;"]
    E -->|internal path| G["&lt;Link href=...&gt;"]

    D --> H[Ribbon header with title]
    D --> I[ul.manual-guide-list__items]
    I --> J["GuideRow x n"]
    J --> K{href type}
    K -->|external https| L["&lt;a target=_blank rel=noreferrer&gt;"]
    K -->|internal path| M["&lt;Link href=...&gt;"]

    C -.-> N["/blog/2026-04-01-llm-as-a-judge
/guides/cookbook/error-analysis"]
    D -.-> O["/guides/cookbook/evaluation_of_rag_with_ragas
/guides/cookbook/example_external_evaluation_pipelines
/guides/cookbook/example_evaluating_multi_turn
/guides/cookbook/example_simulated_multi_turn"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(academy): link practical guides fro..."](https://github.com/langfuse/langfuse-docs/commit/f94fb28eb2a97c5069c95da99969850c9e280068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32085362)</sub>

<!-- /greptile_comment -->