### PR TITLE
fix: Update styling of version label

### DIFF
--- a/components/DocBodyChrome.tsx
+++ b/components/DocBodyChrome.tsx
@@ -58,7 +58,7 @@ export function DocBodyChrome({
           }
         >
           {versionLabel != null && versionLabel !== "" && (
-            <span className="inline-flex items-center px-2 py-1 text-xs font-medium rounded-md bg-secondary text-secondary-foreground">
+            <span className="inline-flex items-center px-2 py-1 text-xs font-medium border bg-stripe-pattern text-text-secondary">
               {versionLabel}
             </span>
           )}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the version label badge styling in `DocBodyChrome.tsx` to align with the project's design system, swapping the generic shadcn/ui token classes for project-specific tokens and a diagonal stripe background.

- Replaces `bg-secondary text-secondary-foreground rounded-md` with `border bg-stripe-pattern text-text-secondary`, adopting the custom `.bg-stripe-pattern` utility (defined in `style.css`) and the Figma-sourced `--color-text-secondary` token.
- Both `bg-stripe-pattern` and `text-text-secondary` are well-defined in the codebase; `bg-stripe-pattern` handles its own `background` shorthand so the `border` utility correctly inherits the global `border-color` from the `* { @apply border-border; }` reset.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change touches only CSS utility classes on a single decorative badge element, using tokens and classes already established in the design system.

Single-line class swap on a conditionally-rendered span. Both replacement classes (bg-stripe-pattern, text-text-secondary) are fully defined in style.css and carry correct light/dark mode values. No logic, props, or data flow is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DocBodyChrome renders] --> B{withProse?}
    B -- No --> C[Return plain flex-1 div]
    B -- Yes --> D[Render DocsBody wrapper]
    D --> E{versionLabel != null AND != empty string?}
    E -- Yes --> F[span version badge: border + bg-stripe-pattern + text-text-secondary]
    E -- No --> G[Skip badge]
    F --> H[CopyMarkdownButton]
    G --> H
    H --> I{cookbook found?}
    I -- Yes --> J[NotebookBanner]
    I -- No --> K[children content]
    J --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Update styling of version label"](https://github.com/langfuse/langfuse-docs/commit/098753d9872123391234fde41eb4b79086cde726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32286070)</sub>

<!-- /greptile_comment -->