### PR TITLE
fix: redirect Python SDK v4 docs URL

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1203,6 +1203,10 @@ const sdkReferenceRedirects202512 = [
     "/docs/observability/sdk/upgrade-path/python-v2-to-v3",
   ],
   [
+    "/docs/sdk/python/sdk-v4",
+    "/docs/observability/sdk/upgrade-path/python-v3-to-v4",
+  ],
+  [
     "/docs/observability/sdk/python/troubleshooting-and-faq",
     "/docs/observability/sdk/troubleshooting-and-faq",
   ],


### PR DESCRIPTION
## Summary

Fixes the broken Python SDK v4 docs URL reported in #2917 by adding a redirect from the old `/docs/sdk/python/sdk-v4` path to the current Python v3 -> v4 migration guide.

## Why

The TypeScript SDK v4 legacy path already has a redirect, but the equivalent Python SDK v4 URL currently returns 404 after the docs restructure.

## Checks

- `node -c lib/redirects.js`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single redirect entry mapping the broken `/docs/sdk/python/sdk-v4` path to the current Python v3→v4 migration guide (`/docs/observability/sdk/upgrade-path/python-v3-to-v4`), fixing a 404 reported in issue #2917. The destination page exists and contains the correct content.

- The redirect destination (`python-v3-to-v4.mdx`) was verified to exist and is the appropriate landing page for users following old links.
- The new entry uses the legacy `/docs/sdk/python/` path prefix, which is already grouped under a `// Legacy SDK patterns` comment at the end of the same array — placing it there would be more consistent with the file's existing organization.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the redirect destination exists and the change is a one-line fix for a documented 404.

The fix is correct and the target page is live. A potential gap exists if `/docs/observability/sdk/python/sdk-v4` was ever a real URL — the v3 equivalent has redirects for both path forms, but v4 only gets one.

lib/redirects.js — review whether the companion `/docs/observability/sdk/python/sdk-v4` path also needs a redirect entry.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/docs/sdk/python/sdk-v4\n(old URL, was 404)"] -->|new redirect| B["/docs/observability/sdk/upgrade-path/python-v3-to-v4\n(migration guide, exists)"]
    C["/docs/observability/sdk/python/sdk-v4\n(intermediate URL, no redirect yet)"] -->|❌ still 404?| D[404]
    E["/docs/sdk/python/sdk-v3\n(old URL)"] -->|existing redirect| F["/docs/observability/sdk/overview"]
    G["/docs/observability/sdk/python/sdk-v3\n(intermediate URL)"] -->|existing redirect| F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/redirects.js:1205-1208
**Possible missing companion redirect**

The v3 upgrade path has redirects for both the old `/docs/sdk/python/sdk-v3` form (line 731) and the intermediate `/docs/observability/sdk/python/sdk-v3` form (line 866). If the Python v4 docs ever existed at `/docs/observability/sdk/python/sdk-v4` before the current restructure, that path would still 404. Worth checking whether a companion entry for `/docs/observability/sdk/python/sdk-v4` is needed.

### Issue 2 of 2
lib/redirects.js:1201-1212
This new entry uses the older `/docs/sdk/python/` URL prefix, the same pattern as the entries grouped under the `// Legacy SDK patterns (commonly linked)` comment near the end of `sdkReferenceRedirects202512`. Placing it there keeps all old-format paths together and makes the grouping easier to follow.

```suggestion
  [
    "/docs/observability/sdk/python/upgrade-path",
    "/docs/observability/sdk/upgrade-path/python-v2-to-v3",
  ],
  [
    "/docs/observability/sdk/python/troubleshooting-and-faq",
    "/docs/observability/sdk/troubleshooting-and-faq",
  ],
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redirect Python SDK v4 docs URL"](https://github.com/langfuse/langfuse-docs/commit/55032bf785484377ed2c866709b28b7cd6bbdb3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32385046)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->