### PR TITLE
fix: Missing padding on code blocks of invalid language

### DIFF
--- a/content/blog/2025-11-25-vibe-coding-custom-annotation-ui.mdx
+++ b/content/blog/2025-11-25-vibe-coding-custom-annotation-ui.mdx
@@ -53,7 +53,7 @@ The workflow started by having Claude filter the [Langfuse API reference](https:
 
 Next came v0.dev with a critical advantage: I told it the exact data shapes it would receive. Here's what worked (and here's my real prompt):
 
-```file filename="prompt.txt"
+```txt filename="prompt.txt"
 I'm building an annotation interface for LLM traces.
 Here are the API endpoints I'll use:
 - GET /queues → returns {id, name, scoreConfigIds}

--- a/content/integrations/gateways/helicone.mdx
+++ b/content/integrations/gateways/helicone.mdx
@@ -33,7 +33,7 @@ pip install langfuse openai python-dotenv
 
 2. Then, create a `.env` file in your project and add your environment variables:
 
-```env
+```txt filename=".env"
 HELICONE_API_KEY=sk-helicone-... # Get it from your Helicone dashboard
 
 LANGFUSE_SECRET_KEY=sk-lf-...
@@ -54,7 +54,7 @@ npm install langfuse openai
 
 2. Create a `.env` file in your project and add your environment variables:
 
-```env
+```txt filename=".env"
 HELICONE_API_KEY=sk-helicone-... # Get it from your Helicone dashboard
 
 LANGFUSE_SECRET_KEY=sk-lf-...

--- a/content/integrations/other/cognee.mdx
+++ b/content/integrations/other/cognee.mdx
@@ -31,7 +31,7 @@ pip install cognee  # langfuse is declared as a dependency and will be installed
 
 Create a `.env` file or export the variables directly in your shell:
 
-```env
+```txt filename=".env"
 LANGFUSE_PUBLIC_KEY=<your public key>
 LANGFUSE_SECRET_KEY=<your secret key>
 LANGFUSE_HOST=https://cloud.langfuse.com   # 🇪🇺 EU region

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -910,6 +910,16 @@ ul[data-gh-discussions-list] {
   width: 100%;
 }
 
+.shiki .fd-scroll-container > pre:not(:has(.line)) {
+  padding-left: var(--padding-left, calc(var(--spacing) * 4));
+  padding-right: var(--padding-right, calc(var(--spacing) * 4));
+}
+
+.shiki .fd-scroll-container > pre:not(:has(.line)) > code,
+.shiki .fd-scroll-container > pre > code.language-env {
+  display: block;
+}
+
 .prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   border: 1px solid var(--line-structure);
   border-radius: 4px;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes missing padding on code blocks whose language identifier is unrecognized by Shiki (e.g. `env`, `file`), which caused the rendered content to be flush against the block edges. The fix has two parts: a targeted CSS rule for the general case, and updating three MDX files to use valid language identifiers.

- **CSS (`src/overrides.css`)**: Adds `padding-left`/`padding-right` to `pre` elements that contain no `.line` children (Shiki's signal that a language was unrecognized), plus `display: block` on the corresponding `code` elements. A second selector keeps `code.language-env` as an explicit fallback for any remaining `env`-language fences elsewhere in the repo not covered by this PR.
- **MDX files**: Three files are updated — `` ```env `` → `` ```txt filename=".env" `` in `helicone.mdx` and `cognee.mdx`, and `` ```file filename="prompt.txt" `` → `` ```txt filename="prompt.txt" `` in the vibe-coding blog post.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to CSS padding for an edge case and correcting language identifiers in documentation files.

The CSS selectors are well-scoped to Shiki's output structure and only affect code blocks where no `.line` children are present. The MDX changes swap invalid language strings for the recognized `txt` identifier, which is a clean fix. The `code.language-env` fallback in the CSS ensures any remaining `env`-language fences elsewhere in the docs still render correctly without requiring a mass update across the repo in this PR.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MDX code fence] --> B{Language recognized by Shiki?}
    B -- Yes --> C[Shiki wraps lines in .line spans]
    B -- No --> D[Raw content, no .line spans]
    C --> E[Default padding applied]
    D --> F[pre has NO .line children]
    F --> G[New CSS rule adds padding-left and padding-right]
    F --> H[New CSS rule sets display block on code element]
    D --> I{language-env class?}
    I -- Yes --> J[code.language-env fallback sets display block]
    I -- No --> K[Covered by general not-has-line rule]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Missing padding on code blocks of i..."](https://github.com/langfuse/langfuse-docs/commit/f005ebf4277178af2fb05efee613cf68b33d17ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32613264)</sub>

<!-- /greptile_comment -->