### PR TITLE
feat: Improve styling of previous/next links in footer

### DIFF
--- a/components/PageFooterNav.tsx
+++ b/components/PageFooterNav.tsx
@@ -1,6 +1,7 @@
+import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { HoverCorners } from "./ui/corner-box";
 
 export type PageFooterNavItem = {
   name: string;
@@ -15,6 +16,53 @@ type PageFooterNavProps = React.ComponentProps<"div"> & {
   };
 };
 
+type PageFooterNavLinkProps = {
+  item: PageFooterNavItem;
+  direction: "previous" | "next";
+};
+
+function PageFooterNavLink({ item, direction }: PageFooterNavLinkProps) {
+  const label = direction === "next" ? "Next" : "Previous";
+  const Icon = direction === "next" ? ArrowRight : ArrowLeft;
+
+  return (
+    <Link
+      className="relative flex items-center p-1 group button-wrapper cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      href={item.url}
+      aria-label={`${label}: ${item.name}`}
+    >
+      <HoverCorners />
+      <div
+        className={cn(
+          "group w-full flex min-h-18 min-w-0 items-center gap-3 border border-line-structure bg-surface-bg p-4 no-underline shadow-lg/5 transition-colors hover:border-line-cta hover:bg-surface-1",
+          direction === "next" ? "justify-end text-right" : "text-left",
+        )}
+      >
+        {direction === "previous" ? (
+          <Icon
+            className="h-4 w-4 shrink-0 text-text-tertiary transition-colors group-hover:text-text-secondary"
+            aria-hidden
+          />
+        ) : null}
+        <span className="min-w-0">
+          <span className="block text-xs font-medium leading-5 text-text-tertiary">
+            {label}
+          </span>
+          <span className="block text-sm font-medium leading-6 text-text-primary wrap-break-word">
+            {item.name}
+          </span>
+        </span>
+        {direction === "next" ? (
+          <Icon
+            className="h-4 w-4 shrink-0 text-text-tertiary transition-colors group-hover:text-text-secondary"
+            aria-hidden
+          />
+        ) : null}
+      </div>
+    </Link>
+  );
+}
+
 export function PageFooterNav({
   items,
   className,
@@ -25,37 +73,14 @@ export function PageFooterNav({
   if (!previous && !next) return null;
 
   return (
-    <div
-      className={cn("flex flex-col gap-2 sm:flex-row", className)}
-      {...props}
-    >
+    <div className={cn("grid gap-3 sm:grid-cols-2", className)} {...props}>
       {previous ? (
-        <Button
-          href={previous.url}
-          variant="secondary"
-          size="small"
-          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%]"
-          icon={<ArrowLeft className="h-3.5 w-3.5" />}
-        >
-          {previous.name}
-        </Button>
+        <PageFooterNavLink item={previous} direction="previous" />
       ) : (
-        <div className="hidden flex-1 sm:block" />
+        <div className="hidden sm:block" />
       )}
 
-      {next ? (
-        <Button
-          href={next.url}
-          variant="secondary"
-          size="small"
-          className="!justify-end"
-          wrapperClassName="flex-1 min-w-0 sm:max-w-[50%] sm:ml-auto"
-          icon={<ArrowRight className="h-3.5 w-3.5" />}
-          iconPosition="end"
-        >
-          {next.name}
-        </Button>
-      ) : null}
+      {next ? <PageFooterNavLink item={next} direction="next" /> : null}
     </div>
   );
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous/next footer nav buttons (which used a shared `Button` component) with a bespoke `PageFooterNavLink` component built on Next.js `Link`, featuring styled card-like blocks with animated hover corners and directional arrow icons.

- The layout switches from a flex row to a two-column CSS grid, and the new link card renders a label ("Previous"/"Next"), the page title, and a directional arrow icon with hover color transitions.
- `HoverCorners` is composed inside the new link for animated corner bracket decoration on hover.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a self-contained UI restyle with no data or logic impact; safe to merge after fixing the focus ring placement.

The custom focus-visible ring styles are applied to an inner div that can never receive focus, so the designed keyboard-focus indicator is never shown. The link is still reachable by keyboard via the browser default outline, but the intentional ring styling is broken.

components/PageFooterNav.tsx — the focus-visible class placement on the inner div vs. the outer Link.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PageFooterNav\n{ items }"] --> B{previous AND next\nboth absent?}
    B -- Yes --> C[return null]
    B -- No --> D["Render grid container\n(grid gap-3 sm:grid-cols-2)"]
    D --> E{previous?}
    E -- Yes --> F["PageFooterNavLink\ndirection=previous"]
    E -- No --> G["hidden placeholder div\n(reserves grid column on sm+)"]
    D --> H{next?}
    H -- Yes --> I["PageFooterNavLink\ndirection=next"]
    H -- No --> J[null]
    F --> K["next/link + HoverCorners\n+ styled card div\n+ ArrowLeft icon (left)"]
    I --> L["next/link + HoverCorners\n+ styled card div\n+ ArrowRight icon (right)"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/PageFooterNav.tsx:37
The `focus-visible:outline-none`, `focus-visible:ring-2`, `focus-visible:ring-ring`, and `focus-visible:ring-offset-2` classes are on the inner `div`, but keyboard focus is received by the outer `<Link>` (an `<a>` tag) — not the div. A `div` is not a focusable element, so these `focus-visible:` modifiers will never activate. The custom ring will never render; only the browser's default link outline will appear.

```suggestion
          "group w-full flex min-h-18 min-w-0 items-center gap-3 border border-line-structure bg-surface-bg p-4 no-underline shadow-lg/5 transition-colors hover:border-line-cta hover:bg-surface-1 disabled:pointer-events-none disabled:opacity-50",
```

### Issue 2 of 2
components/PageFooterNav.tsx:30
The `focus-visible:*` ring styles need to be on the focusable `<Link>` element itself (and `outline-none` added there to suppress the browser default), not on the non-focusable inner div.

```suggestion
      className="relative flex items-center p-1 group button-wrapper cursor-pointer has-disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Improve styling of previous/next l..."](https://github.com/langfuse/langfuse-docs/commit/abaf39577a9d1904a632c3061cca55aef4dad1fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32615589)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->