### PR TITLE
fix(docs): Adjust scroll anchors to account for optional banner height

### DIFF
--- a/components/inkeep/search-panel.tsx
+++ b/components/inkeep/search-panel.tsx
@@ -458,7 +458,7 @@ export function AISearchPanel() {
           className={cn(
             "overflow-hidden z-50 bg-surface-1 text-text-primary [--ai-chat-width:320px] border-line-structure",
             "max-wide:fixed max-wide:inset-x-4 max-md:bottom-4 max-md:top-4 max-wide:bottom-8 max-wide:top-8 max-wide:border max-wide:border-line-structure max-wide:shadow-xl max-wide:max-w-[600px] max-wide:mx-auto",
-            "wide:sticky wide:top-[var(--fd-nav-height)] wide:h-[calc(100dvh-var(--fd-nav-height)-2px)] wide:border-l wide:ms-auto",
+            "wide:sticky wide:top-[calc(var(--fd-nav-height)+var(--fd-banner-height,0px))] wide:h-[calc(100dvh-var(--fd-nav-height)-var(--fd-banner-height,0px)-2px)] wide:border-l wide:ms-auto",
             "wide:in-[#nd-docs-layout]:[grid-area:toc] wide:in-[#nd-notebook-layout]:row-span-full wide:in-[#nd-notebook-layout]:col-start-5",
             "wide:in-[#home-layout]:top-[calc(var(--fd-banner-height,0px)+var(--lf-nav-primary-height))] wide:in-[#home-layout]:h-[calc(100dvh-var(--fd-banner-height,0px)-var(--lf-nav-primary-height))] wide:in-[#home-layout]:w-(--ai-chat-width) wide:in-[#home-layout]:shrink-0 wide:in-[#home-layout]:border-r",
             open

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -431,7 +431,7 @@
   margin: 0 0 1px 1px;
   border-radius: calc(var(--radius) - 4px);
   background-color: var(--line-structure) !important;
-  top: var(--fd-nav-height);
+  top: calc(var(--fd-nav-height) + var(--fd-banner-height, 0px));
 }
 
 /* Sidebar active link */
@@ -735,8 +735,10 @@
 #nd-toc {
   --text-links: var(--line-cta);
   padding: 0;
-  /* Full viewport minus docs header stack; 2px ≈ outer chrome / rounding */
-  max-height: calc(100dvh - var(--fd-nav-height) - 1px);
+  /* Full viewport minus docs header stack + optional banner; 1px ≈ outer chrome / rounding */
+  max-height: calc(
+    100dvh - var(--fd-nav-height) - var(--fd-banner-height, 0px) - 1px
+  );
   border-bottom-width: 0;
   border-radius: 0 !important;
   z-index: 10;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two CSS rules in `src/overrides.css` so the table-of-contents sidebar correctly accounts for the optional announcement banner when computing its sticky `top` offset and `max-height`. The change is consistent with the pattern already applied to the mobile sidebar drawer and the `--fd-docs-row-1` variable earlier in the same file.

- **`#nd-docs-layout #nd-toc` sticky top** (line 434): adds `var(--fd-banner-height, 0px)` to the existing `var(--fd-nav-height)` expression, mirroring the mobile-drawer treatment at line 129.
- **`#nd-toc` max-height** (line 740): subtracts the banner height from the `100dvh` calculation and also corrects the companion comment from "2px" (which didn't match the actual `1px` value in the original code) to "1px".
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two-line targeted fix with no logic risk.

Both changes apply the same var(--fd-banner-height, 0px) pattern already used in three other places in the same file, and the fallback value of 0px ensures no regression when no banner is present.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page viewport height: 100dvh] --> B[Subtract --fd-nav-height]
    B --> C{Banner present?}
    C -- Yes --> D[Subtract --fd-banner-height]
    C -- No --> E[Subtract 0px fallback]
    D --> F[Subtract 1px chrome/rounding]
    E --> F
    F --> G[TOC max-height]

    H[Sticky top origin] --> I[Add --fd-nav-height]
    I --> J{Banner present?}
    J -- Yes --> K[Add --fd-banner-height]
    J -- No --> L[Add 0px fallback]
    K --> M[TOC sticky top position]
    L --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): Adjust scroll anchors to acco..."](https://github.com/langfuse/langfuse-docs/commit/31fe450cd8bd426856f2f7211915ccc710c39a30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32616393)</sub>

<!-- /greptile_comment -->