### PR TITLE
docs(academy): move three fields intro under heading on datasets page

### DIFF
--- a/content/academy/datasets.mdx
+++ b/content/academy/datasets.mdx
@@ -18,13 +18,15 @@ A dataset is a collection of test cases that you run your application against ea
 
 ## The dataset item
 
-A dataset is made up of items, each item represents one test case: a situation your application should be able to handle. Generally, an item has three fields:
+A dataset is made up of items, each item represents one test case: a situation your application should be able to handle.
+
+### The three fields of a dataset item
+
+Generally, an item has three fields:
 
 - **Input** (required)
 - **Expected output** (optional)
 - **Metadata** (optional)
-
-### The three fields of a dataset item
 
 <DatasetFieldsDiagram />
 


### PR DESCRIPTION
## Summary

On the Academy datasets page, the "The three fields of a dataset item" heading sat after the bullet list, leaving the section that introduced the fields headingless and making the heading itself feel redundant. Moves the intro sentence and bullets under the heading so the section reads coherently.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restructures a single section in `content/academy/datasets.mdx` to fix a heading-placement issue. The introductory sentence and bullet list for the three dataset item fields now appear under the `### The three fields of a dataset item` heading rather than before it.

- The heading is moved up so it precedes its own content, giving the subsection a coherent top-down structure (heading → intro sentence → bullets → diagram).
- No text is added or removed; only the order of existing lines changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure content reordering with no logic, imports, or runtime behaviour involved — safe to merge.

Only the position of an existing heading and its surrounding prose changes; no text is added, removed, or altered. The resulting document structure is correct and coherent.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["## The dataset item\n(section heading)"] --> B["Intro sentence\n'A dataset is made up of items…'"]
    B --> C["### The three fields of a dataset item\n(subsection heading — moved here)"]
    C --> D["'Generally, an item has three fields:'\n+ bullet list"]
    D --> E["DatasetFieldsDiagram component"]
    E --> F["Table: field purposes"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(academy): move three fields intro u..."](https://github.com/langfuse/langfuse-docs/commit/028697d51950b3b7184fa33d6198ca6ba30a0ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32731754)</sub>

<!-- /greptile_comment -->