### PR TITLE
fix: Make `PageFooterNav` links consistent in height

### DIFF
--- a/components/PageFooterNav.tsx
+++ b/components/PageFooterNav.tsx
@@ -27,14 +27,14 @@ function PageFooterNavLink({ item, direction }: PageFooterNavLinkProps) {
 
   return (
     <Link
-      className="relative flex items-center p-1 group button-wrapper cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      className="group relative flex h-full min-h-18 items-center p-1 group button-wrapper cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       href={item.url}
       aria-label={`${label}: ${item.name}`}
     >
       <HoverCorners />
       <div
         className={cn(
-          "group w-full flex min-h-18 min-w-0 items-center gap-3 border border-line-structure bg-surface-bg p-4 no-underline shadow-lg/5 transition-colors hover:border-line-cta hover:bg-surface-1",
+          "w-full h-full flex min-w-0 items-center gap-3 border border-line-structure bg-surface-bg p-4 no-underline shadow-lg/5 transition-colors hover:border-line-cta hover:bg-surface-1",
           direction === "next" ? "justify-end text-right" : "text-left",
         )}
       >
@@ -73,7 +73,10 @@ export function PageFooterNav({
   if (!previous && !next) return null;
 
   return (
-    <div className={cn("grid gap-3 sm:grid-cols-2", className)} {...props}>
+    <div
+      className={cn("grid auto-rows-fr gap-3 sm:grid-cols-2", className)}
+      {...props}
+    >
       {previous ? (
         <PageFooterNavLink item={previous} direction="previous" />
       ) : (


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes unequal heights between the "Previous" and "Next" footer nav links when one card has more text than the other.

- `auto-rows-fr` is added to the grid container so both columns share the same fractional row height, and `h-full min-h-18` is moved to the outer `<Link>` while `h-full` is added to the inner card `<div>`, ensuring the card always fills the available row height.
- `group` was consolidated from the inner `<div>` onto the outer `<Link>`, but a duplicate `group` token was left in the class string — harmless at runtime, but should be removed for cleanliness.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, focused layout fix with no logic or data-handling implications.

The only finding is a duplicate `group` Tailwind class that is inert at runtime. The core layout approach — `auto-rows-fr` on the grid combined with `h-full` propagated down through `<Link>` to the inner card `<div>` — is correct and achieves the stated goal.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PageFooterNav (grid auto-rows-fr)"] --> B["PageFooterNavLink (previous)"]
    A --> C["PageFooterNavLink (next)"]
    B --> D["Link: h-full min-h-18\n(outer wrapper)"]
    C --> E["Link: h-full min-h-18\n(outer wrapper)"]
    D --> F["div: h-full\n(card — stretches to fill link)"]
    E --> G["div: h-full\n(card — stretches to fill link)"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/PageFooterNav.tsx:30
The `group` class is duplicated in the `className` string — it appears once near the start and again after `p-1`. Duplicate Tailwind classes are harmless at runtime, but this is a dead leftover from the refactor that moved `group` from the inner `<div>` to the outer `<Link>`.

```suggestion
      className="group relative flex h-full min-h-18 items-center p-1 button-wrapper cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Make \`PageFooterNav\` links consiste..."](https://github.com/langfuse/langfuse-docs/commit/80e0578321944fe7ebe145102ff5d56c71af3095) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32817125)</sub>

<!-- /greptile_comment -->