### PR TITLE
docs: PostHog and Mixpanel adopt the 2026-05-20 enriched-observations cutoff

### DIFF
--- a/content/changelog/2026-05-20-blob-storage-enriched-default.mdx
+++ b/content/changelog/2026-05-20-blob-storage-enriched-default.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-05-20
-title: "Enriched observations is the default for new blob storage exports"
-description: New Langfuse Cloud projects export blob storage data as enriched observations. The legacy traces/observations sources stay available on existing projects and self-hosted deployments.
+title: "Enriched observations is the default for new Cloud projects"
+description: New Langfuse Cloud projects use enriched observations for blob storage, PostHog, and Mixpanel exports. The legacy traces/observations sources stay available on existing projects and self-hosted deployments.
 author: Niklas
 ---
 
@@ -9,13 +9,15 @@ import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
 
 <ChangelogHeader />
 
-Blob storage integrations on Cloud projects created on or after **2026-05-20** use the **Enriched observations (recommended)** source. The **Traces and observations (legacy)** and **Traces and observations (legacy) and enriched observations** sources are hidden from the UI for these projects; the REST API rejects them with `400 BAD_REQUEST`.
+Blob storage, PostHog, and Mixpanel integrations on Cloud projects created on or after **2026-05-20** use the **Enriched observations (recommended)** source. The **Traces and observations (legacy)** and **Traces and observations (legacy) and enriched observations** sources are hidden from the UI for these projects.
+
+For blob storage, the REST API also rejects legacy values for post-cutoff projects with `400 BAD_REQUEST`. PostHog and Mixpanel have no public REST surface.
 
 What this means in practice:
 
 - **One row per observation, with trace context inlined** — `user_id`, `session_id`, `tags`, `release`, `trace_name`, and `environment` ride along on the same row. No warehouse-side join needed.
-- **Per-column control** — pair the source with [field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) to keep just the columns your pipeline needs.
-- **Fewer files per window** — only `observations_v2/` and `scores/`, instead of `traces/`, `observations/`, and `scores/`.
+- **Per-column control** (blob storage) — pair the source with [field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) to keep just the columns your pipeline needs.
+- **Fewer files per window** (blob storage) — only `observations_v2/` and `scores/`, instead of `traces/`, `observations/`, and `scores/`.
 
 Nothing changes for **existing projects** (Cloud or self-hosted) or **self-hosted deployments**: all three sources remain available. The legacy sources are still supported there for backwards compatibility, but the recommendation is the same — switch to Enriched observations when you're ready.
 

--- a/content/integrations/analytics/mixpanel.mdx
+++ b/content/integrations/analytics/mixpanel.mdx
@@ -78,11 +78,17 @@ Available options:
 - `Traces and observations (legacy) and enriched observations`
 - `Enriched observations (recommended)`
 
+<Callout type="info">
+**Cloud projects created on or after 2026-05-20** will not see the Export Source selector — new Cloud projects use `Enriched observations (recommended)` automatically. Pre-cutoff Cloud projects and all self-hosted deployments keep the full choice.
+</Callout>
+
 <Callout type="warning">
 `Traces and observations (legacy)` sources may be deprecated in the future. All new export jobs should use `Enriched observations (recommended)`, and existing legacy jobs are strongly recommended to upgrade.
 </Callout>
 
 ### Upgrade path for existing configurations
+
+This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
 
 Existing integrations continue to use `Traces and observations (legacy)` until changed.
 

--- a/content/integrations/analytics/posthog.mdx
+++ b/content/integrations/analytics/posthog.mdx
@@ -55,11 +55,17 @@ Available options:
 - `Traces and observations (legacy) and enriched observations`
 - `Enriched observations (recommended)`
 
+<Callout type="info">
+**Cloud projects created on or after 2026-05-20** will not see the Export Source selector — new Cloud projects use `Enriched observations (recommended)` automatically. Pre-cutoff Cloud projects and all self-hosted deployments keep the full choice.
+</Callout>
+
 <Callout type="warning">
 `Traces and observations (legacy)` sources may be deprecated in the future. All new export jobs should use `Enriched observations (recommended)`, and existing legacy jobs are strongly recommended to upgrade.
 </Callout>
 
 ### Upgrade path for existing configurations
+
+This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
 
 Existing integrations continue to use `Traces and observations (legacy)` until changed.
 


### PR DESCRIPTION
## Summary

Stacked on #2954. Pairs with langfuse/langfuse#13684 (extend legacy export source cutoff gate to PostHog and Mixpanel).

**Changelog** (`2026-05-20-blob-storage-enriched-default.mdx`)
- Title + description broadened from blob-storage-only to all three integrations.
- Lead sentence now names blob storage, PostHog, and Mixpanel.
- REST API rejection note scoped to blob storage — PostHog and Mixpanel have no public REST surface (confirmed by langfuse/langfuse#13684 Decision #6).
- Blob-storage-specific bullets (`Per-column control`, `Fewer files per window`) labelled as blob storage specifics so they don't read as applying to PostHog/Mixpanel.

**PostHog integration page** (`content/integrations/analytics/posthog.mdx`)
- New info callout after the Available options list: post-cutoff Cloud projects will not see the Export Source selector.
- Upgrade path subsection gets a caveat: the three-step migration only applies to pre-cutoff Cloud projects and self-hosted deployments.

**Mixpanel integration page** (`content/integrations/analytics/mixpanel.mdx`)
- Identical changes.

## Stacking note

Base is `nsemmler/lfe-9456-blob-storage-docs`, not `main` — the changelog entry being edited lives on that branch. When #2954 merges, GitHub will auto-rebase this PR onto `main`.

## Test plan

- [x] `prettier --check` passes on all three edited files.
- [ ] Verify preview renders the new info callout correctly on PostHog and Mixpanel integration pages.
- [ ] Confirm langfuse/langfuse#13684 is merged before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR broadens the `2026-05-20` enriched-observations cutoff changelog entry and the PostHog/Mixpanel integration pages to reflect that the cutoff now applies to all three integrations, not just blob storage.

- The changelog title, description, and lead paragraph are updated to name blob storage, PostHog, and Mixpanel; blob-storage-specific bullets are labelled accordingly; and the REST API rejection note is correctly scoped to blob storage only (PostHog and Mixpanel have no public REST surface).
- Both integration pages gain an info callout explaining that post-cutoff Cloud projects won't see the Export Source selector, and the "Upgrade path" subsection is prefaced with a note restricting the three-step migration to pre-cutoff Cloud projects and self-hosted deployments.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — this is a documentation-only change with no code or schema impact.

All three files accurately reflect the new cutoff behaviour for PostHog and Mixpanel. The two findings are minor consistency gaps: the changelog's closing sentence references a blob-storage-specific link without the '(blob storage)' label used on the bullet points above it, and the pre-existing section intro on the integration pages describes a selector that post-cutoff Cloud project users will never see, which the new callout does not fully resolve. Neither issue affects correctness of the described behaviour.

The closing paragraph in content/changelog/2026-05-20-blob-storage-enriched-default.mdx and the opening intro paragraphs of the Export Source sections in both integration pages would benefit from a light pass for consistency.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sets up PostHog / Mixpanel / Blob Storage export] --> B{Project type?}
    B -- "Cloud project created >= 2026-05-20" --> C[Export Source selector hidden
Enriched observations enforced automatically]
    B -- "Pre-cutoff Cloud project
or self-hosted" --> D[Export Source selector shown]
    D --> E{Selected source}
    E -- "Traces and observations legacy" --> F[Legacy export continues
Upgrade path available]
    E -- "Legacy + Enriched observations" --> G[Both sources exported
Duplicate records by design — use for validation]
    E -- "Enriched observations recommended" --> H[Enriched observations used
Trace context inlined on each row]
    C --> H
    F -- "Migrate when ready" --> G --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/changelog/2026-05-20-blob-storage-enriched-default.mdx:24
**Blob-storage-specific closing paragraph lacks qualifier**

The two bullet points above were correctly annotated with `(blob storage)`, but this closing sentence references `blob-storage-export-fields` without a matching qualifier. A PostHog or Mixpanel user reading the broadened changelog could interpret the export-field-reference link as relevant to their integration, when it only maps blob storage column layouts.

### Issue 2 of 2
content/integrations/analytics/posthog.mdx:47-50
**Intro paragraph contradicts the new info callout for post-cutoff projects**

The intro text says "PostHog integrations now include an `Export Source` selector" and "New integrations default to `Enriched observations (recommended)`", but the callout directly below clarifies that post-cutoff Cloud projects won't see the selector at all. A reader on a post-cutoff Cloud project will encounter an apparent contradiction — the section opens by describing a selector they will never see. The same issue exists in the Mixpanel page at lines 70-71.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: PostHog and Mixpanel adopt the 202..."](https://github.com/langfuse/langfuse-docs/commit/a6ea9014fa00876c31b879855bc47047e1008fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32826112)</sub>

<!-- /greptile_comment -->