### PR TITLE
fix: add separator between overview and security section

### DIFF
--- a/content/security/meta.json
+++ b/content/security/meta.json
@@ -2,6 +2,7 @@
   "title": "Security",
   "pages": [
     "index",
+    "---",
     "---Security---",
     "auth",
     "[Audit Logs ↗](/docs/administration/audit-logs)",


### PR DESCRIPTION
### Motivation
- Add a visual separator in the Security navigation to separate the Overview page from the Security section, matching the pattern used in other site sections.

### Description
- Insert an unlabeled separator entry (`"---"`) between `index` and `---Security---` in `content/security/meta.json` so the Security menu shows a divider above the Security section.

### Testing
- No automated tests were run because this is a content/config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0d85e27bb8832f8674b9f7952dc440)