### PR TITLE
docs: redirect removed OTEL Python SDK cookbook

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1414,6 +1414,11 @@ const v4DashboardChangesMove202605 = [
   ["/docs/metrics/v4-dashboard-changes", "/faq/all/dashboard-changes-in-v4"],
 ];
 
+// Removed OpenTelemetry Python SDK cookbook page - May 2026
+const otelPythonSdkCookbookRedirect202605 = [
+  ["/guides/cookbook/otel_integration_python_sdk", "/docs/sdk/python/sdk-v3"],
+];
+
 // Error analysis blog post moved into the Academy under Monitoring - May 2026
 const errorAnalysisAcademyMove202605 = [
   [
@@ -1452,6 +1457,7 @@ const permanentRedirects = [
   ...blogRedirects202604,
   ...v4DashboardChangesMove202605,
   ...experimentsCiCdRedirects202605,
+  ...otelPythonSdkCookbookRedirect202605,
   ...errorAnalysisAcademyMove202605,
 ];
 


### PR DESCRIPTION
## Problem

Issue #2508 reports that `/guides/cookbook/otel_integration_python_sdk?utm_source=chatgpt.com` returns a broken link. The query string is incidental; the missing route is `/guides/cookbook/otel_integration_python_sdk`.

## Solution

Add a permanent redirect for the removed cookbook path to the current Python SDK v3 docs. That destination is the maintained OpenTelemetry-based Python SDK documentation and already participates in the existing docs redirect chain to the SDK overview.

## Validation

```console
$ node - <<'NODE'
const { permanentRedirects } = require('./lib/redirects.js');
const source = '/guides/cookbook/otel_integration_python_sdk';
const dest = '/docs/sdk/python/sdk-v3';
const matches = permanentRedirects.filter(([s]) => s === source);
console.log(JSON.stringify({matches, ok: matches.length === 1 && matches[0][1] === dest}, null, 2));
if (!(matches.length === 1 && matches[0][1] === dest)) process.exit(1);
NODE
{
  "matches": [
    [
      "/guides/cookbook/otel_integration_python_sdk",
      "/docs/sdk/python/sdk-v3"
    ]
  ],
  "ok": true
}

$ test -f content/docs/observability/sdk/overview.mdx && echo "destination redirect target exists: content/docs/observability/sdk/overview.mdx"
destination redirect target exists: content/docs/observability/sdk/overview.mdx

$ git diff --check
```

## Confidence

Score: 85/100 (docs/broken-link redirect). This is a one-route additive redirect for a reported 404, with the destination mapped to the current maintained OpenTelemetry Python SDK docs.

Closes #2508

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single permanent redirect to resolve a reported 404 for the removed OpenTelemetry Python SDK cookbook page.

- Adds a redirect from `/guides/cookbook/otel_integration_python_sdk` → `/docs/sdk/python/sdk-v3`, which itself already redirects to `/docs/observability/sdk/overview`, creating a two-hop redirect chain rather than pointing directly to the final destination.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the redirect resolves the reported 404 and lands users on a valid page via a double-hop chain.

The redirect is additive and fixes a real broken link. The only concern is that the chosen destination is itself a redirect, so users and crawlers traverse two hops instead of one before reaching the final page at `/docs/observability/sdk/overview`.

lib/redirects.js — specifically the destination URL in the new redirect entry.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Docs as Langfuse Docs Server

    Browser->>Docs: GET /guides/cookbook/otel_integration_python_sdk
    Docs-->>Browser: 301 → /docs/sdk/python/sdk-v3
    Browser->>Docs: GET /docs/sdk/python/sdk-v3
    Docs-->>Browser: 301 → /docs/observability/sdk/overview
    Browser->>Docs: GET /docs/observability/sdk/overview
    Docs-->>Browser: 200 OK (Python SDK overview page)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/redirects.js:1418-1420
The destination `/docs/sdk/python/sdk-v3` is itself a permanent redirect to `/docs/observability/sdk/overview` (line 731 of this file). This creates a double-redirect chain: the browser follows two 301s instead of one. While functionally correct, chained redirects add an extra HTTP round-trip for users and can dilute SEO link equity. Pointing directly to the final destination avoids this.

```suggestion
const otelPythonSdkCookbookRedirect202605 = [
  ["/guides/cookbook/otel_integration_python_sdk", "/docs/observability/sdk/overview"],
];
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect removed otel python sdk c..."](https://github.com/langfuse/langfuse-docs/commit/2ed8d0fe035d792747838d5456b3ccbbe5a7a95c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33427503)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->