### PR TITLE
ci: fix broken CI

### DIFF
--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,14 +1,61 @@
 import { cn } from "@/lib/utils";
-import { Tweet as ReactTweet } from "react-tweet";
+import { EmbeddedTweet, TweetNotFound } from "react-tweet";
+import { getTweet, type Tweet as TweetData } from "react-tweet/api";
 
-export const Tweet = ({
+type TweetLike = {
+  entities?: Partial<TweetData["entities"]>;
+  quoted_tweet?: TweetData["quoted_tweet"];
+  parent?: TweetData["parent"];
+};
+
+function normalizeTweetEntities<T extends TweetLike>(tweet: T): T {
+  const entities = tweet.entities ?? {};
+
+  return {
+    ...tweet,
+    // Twitter's syndication API may omit empty entity arrays. react-tweet assumes
+    // they are always iterable, so normalize the payload before rendering.
+    entities: {
+      ...entities,
+      hashtags: Array.isArray(entities.hashtags) ? entities.hashtags : [],
+      urls: Array.isArray(entities.urls) ? entities.urls : [],
+      user_mentions: Array.isArray(entities.user_mentions)
+        ? entities.user_mentions
+        : [],
+      symbols: Array.isArray(entities.symbols) ? entities.symbols : [],
+      ...(Array.isArray(entities.media) ? { media: entities.media } : {}),
+    },
+    ...(tweet.quoted_tweet
+      ? { quoted_tweet: normalizeTweetEntities(tweet.quoted_tweet) }
+      : {}),
+    ...(tweet.parent ? { parent: normalizeTweetEntities(tweet.parent) } : {}),
+  } as T;
+}
+
+export const Tweet = async ({
   id,
   className,
 }: {
   id: string;
   className?: string;
-}) => (
-  <div className={cn("mt-2", className)}>
-    <ReactTweet id={id} />
-  </div>
-);
+}) => {
+  let tweet: TweetData | undefined;
+  let error: unknown;
+
+  try {
+    tweet = await getTweet(id);
+  } catch (err) {
+    console.error(err);
+    error = err;
+  }
+
+  return (
+    <div className={cn("mt-2", className)}>
+      {tweet ? (
+        <EmbeddedTweet tweet={normalizeTweetEntities(tweet)} />
+      ) : (
+        <TweetNotFound error={error} />
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## What changed

- Normalize missing tweet entity arrays in `components/Tweet.tsx` before rendering via `react-tweet`.
- Keep the existing embedded tweet UI, including the default not-found fallback.

## Why

The X/Twitter syndication API can omit empty entity arrays such as `hashtags`, `urls`, `user_mentions`, or `symbols`. `react-tweet@3.2.2` assumes those fields are iterable and crashes during server rendering when they are absent. This broke `next build` while prerendering `/blog/2026-03-24-optimizing-ai-skill-with-autoresearch`.

## Validation

- `pnpm build`
- `pnpm run format:check`

Note: local commands ran on Node v24.14.0, while the repo expects Node 22. The production build completed successfully despite the local engine warning.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a build crash caused by the X/Twitter syndication API omitting empty entity arrays (`hashtags`, `urls`, `user_mentions`, `symbols`) that `react-tweet` expects to always be iterable. The fix replaces the all-in-one `<ReactTweet>` component with a manual fetch (`getTweet`) + normalization pass before handing the data to `<EmbeddedTweet>`.

- `normalizeTweetEntities` recursively normalizes the four entity arrays to `[]` when absent, while leaving `media` untouched (intentionally omitted from the `[]` default since `react-tweet` guards its existence separately).
- The `Tweet` component is now an `async` server component that handles fetch errors and not-found states explicitly via `<TweetNotFound>`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is narrowly scoped to entity normalization in a single component and directly addresses the documented build crash.

The normalization logic correctly defaults all four entity arrays to `[]` and recursively handles `quoted_tweet` and `parent`. The only non-blocking concern is the `as T` cast that mutes TypeScript's structural check on the returned object; this won't cause a runtime issue today but could silently hide schema drift in future `react-tweet` upgrades.

components/Tweet.tsx — specifically the generic type cast in `normalizeTweetEntities`
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Next as Next.js SSR
    participant Tweet as Tweet (async SC)
    participant API as getTweet (react-tweet/api)
    participant Normalize as normalizeTweetEntities
    participant Render as EmbeddedTweet / TweetNotFound

    Next->>Tweet: "render({id, className})"
    Tweet->>API: getTweet(id)
    alt tweet found
        API-->>Tweet: TweetData
        Tweet->>Normalize: normalizeTweetEntities(tweet)
        Note over Normalize: Ensure hashtags/urls/user_mentions/symbols are []<br/>Recurse into quoted_tweet and parent
        Normalize-->>Tweet: normalized TweetData
        Tweet->>Render: EmbeddedTweet tweet
    else not found or error thrown
        API-->>Tweet: undefined / throws
        Tweet->>Render: TweetNotFound error
    end
    Render-->>Next: HTML
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/Tweet.tsx:31-32
The `as T` cast on the return statement bypasses TypeScript's structural verification of the reconstructed object. If `TweetData`'s shape changes (e.g., a new required field on `entities`), the compiler won't catch a mismatch here. The cast is currently necessary because of the generic spread, but the effect is that callers assume full type safety when the function is actually unchecked at the boundary. Adding `satisfies TweetLike` before `as T` would at least validate the result conforms to the base constraint, making schema drift detectable at compile time.

```suggestion
    ...(tweet.parent ? { parent: normalizeTweetEntities(tweet.parent) } : {}),
  } satisfies TweetLike as T;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix tweet entity normalization"](https://github.com/langfuse/langfuse-docs/commit/ff0bcfc3d8886e0e6a7481677359d6748487ee9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33441622)</sub>

<!-- /greptile_comment -->