### PR TITLE
fix(tweet): render react-tweet client-only to keep prerender stable

### DIFF
--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -1,6 +1,12 @@
+"use client";
+
 import { cn } from "@/lib/utils";
 import { Tweet as ReactTweet } from "react-tweet";
 
+// Client-only so react-tweet resolves to its `./dist/index.client.js` entry
+// (SWR-based, fetches on the client). The server entry fetches at build time
+// and crashes the prerender if X.com's syndication payload shape drifts —
+// see https://github.com/langfuse/langfuse-docs (autoresearch post incident).
 export const Tweet = ({
   id,
   className,


### PR DESCRIPTION
react-tweet's default server entry fetches tweet data at build time. When X.com's syndication payload omits a field the library expects (e.g. entities.urls), the prerender crashes with `TypeError: c is not iterable` and blocks the whole prod build — a class of failure with no source-code change. The `react-tweet` package ships a separate client entry (`./dist/index.client.js`) that fetches via SWR after hydration. Marking our wrapper as a Client Component opts into that entry, so an upstream shape change can no longer break the build. Small SEO/social-preview hit on tweet embeds is acceptable for a blog component.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `"use client"` directive to `components/Tweet.tsx` so that `react-tweet` resolves to its SWR-based client entry (`./dist/index.client.js`) instead of the server entry that fetches tweet data at build time. The motivation is that an upstream shape change in X.com's syndication API (a missing `entities.urls` field) caused `TypeError: c is not iterable` to crash the entire production prerender.

- **Build resilience**: Moving tweet fetching to the client means X.com API shape drift can no longer block CI/CD or the static build.
- **Trade-off acknowledged**: Tweets will be blank on initial SSR/static HTML and hydrate via SWR after JS loads, which the PR explicitly accepts as a minor SEO/social-preview regression for a blog component.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the single-line change adds 'use client' to the Tweet wrapper, which is the correct way to opt into react-tweet's SWR-based client entry and prevent build-time fetch failures.

The change is minimal and well-scoped: one directive added to one component. The root cause (upstream API shape drift crashing the static build) is correctly diagnosed, the fix matches how react-tweet's dual-entry package.json is designed to work, and the SEO trade-off is explicitly acknowledged. No imports are misplaced, no types are changed, and no other files are affected.

No files require special attention. components/Tweet.tsx is the only changed file and the change is straightforward.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Server
    participant XCom as X.com Syndication API

    Note over NextJS,XCom: Before (server entry — broken build path)
    NextJS->>XCom: Fetch tweet at build time
    XCom-->>NextJS: Payload missing entities.urls
    NextJS--xNextJS: TypeError: c is not iterable (build crash)

    Note over Browser,XCom: After (client entry — this PR)
    NextJS->>Browser: Serve static HTML (tweet div is empty)
    Browser->>Browser: Hydrate React + mount Tweet component
    Browser->>XCom: Fetch tweet via SWR
    XCom-->>Browser: Tweet payload
    Browser->>Browser: Render tweet
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tweet): render react-tweet client-on..."](https://github.com/langfuse/langfuse-docs/commit/fb3b4d46e4d26b6ac0205cea42fbab2a43e7fe0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33441783)</sub>

<!-- /greptile_comment -->