### PR TITLE
docs: add Auxen integration page

### DIFF
--- a/content/integrations/model-providers/auxen.mdx
+++ b/content/integrations/model-providers/auxen.mdx
@@ -1,0 +1,126 @@
+---
+title: Observability for Auxen with Langfuse
+sidebarTitle: Auxen
+logo: /images/integrations/openai_icon.svg
+description: Use Langfuse to trace and monitor calls to Auxen — per-customer dedicated, OpenAI-compatible LLM endpoints (Llama, Qwen, Mistral, Gemma, Mixtral, Phi, Command R).
+category: Integrations
+---
+
+# Trace Auxen LLM Calls with Langfuse
+
+[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) on stable HTTPS URLs with an OpenAI-compatible `/v1/chat/completions` API. Each instance is a dedicated GPU billed per-minute of runtime.
+
+Because Auxen instances are OpenAI-wire-compatible, this guide uses Langfuse's drop-in OpenAI SDK wrapper to automatically trace all calls to your Auxen instance — no Auxen-specific Langfuse SDK is required.
+
+<Callout type="info" emoji="ℹ️">
+**Note:** *Langfuse is also natively integrated with [LangChain](https://langfuse.com/integrations/frameworks/langchain), [LlamaIndex](https://langfuse.com/integrations/frameworks/llamaindex), [LiteLLM](https://langfuse.com/integrations/gateways/litellm), and [other frameworks](https://langfuse.com/integrations). Each of these frameworks can call an Auxen instance via its OpenAI-compatible base URL — see the corresponding Langfuse integration page.*
+</Callout>
+
+## Setup
+
+### Provision an Auxen instance
+
+Sign in at [auxen.ai](https://auxen.ai) and provision an LLM instance. You will be issued:
+
+- A per-instance **base URL** of the form `https://api.auxen.ai/v1/inst_xxx/v1`
+- A per-instance **API key** prefixed `auxk_`
+
+### Install Required Packages
+
+```python
+%pip install langfuse openai --upgrade
+```
+
+### Set Environment Variables
+
+```python
+import os
+
+# Langfuse project keys from https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
+os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # 🇪🇺 EU region
+# Other regions: US: https://us.cloud.langfuse.com, Japan: https://jp.cloud.langfuse.com, HIPAA: https://hipaa.cloud.langfuse.com
+
+# Your Auxen instance credentials from https://auxen.ai
+os.environ["AUXEN_API_BASE"] = "https://api.auxen.ai/v1/inst_xxx/v1"
+os.environ["AUXEN_API_KEY"] = "auxk_..."
+```
+
+### Initialize the Langfuse-wrapped OpenAI Client
+
+Instead of importing `openai` directly, import it from `langfuse.openai`. Point the client at your Auxen instance:
+
+```python
+# Drop-in replacement: tracing is automatic
+from langfuse.openai import OpenAI
+from langfuse import observe
+
+client = OpenAI(
+    base_url=os.environ["AUXEN_API_BASE"],
+    api_key=os.environ["AUXEN_API_KEY"],
+)
+```
+
+## Examples
+
+### Chat Completion Request
+
+```python
+completion = client.chat.completions.create(
+    model="llama-3.1-8b",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Why dedicated GPUs for LLMs? Answer in 20 words."},
+    ],
+)
+print(completion.choices[0].message.content)
+```
+
+Every call made through this `client` is automatically captured as a Langfuse trace with prompt, completion, token usage, and latency.
+
+### Group Calls into a Single Trace with `@observe()`
+
+```python
+from langfuse import observe
+from langfuse.openai import OpenAI
+
+client = OpenAI(
+    base_url=os.environ["AUXEN_API_BASE"],
+    api_key=os.environ["AUXEN_API_KEY"],
+)
+
+@observe()
+def translate(text: str, target_language: str) -> str:
+    return client.chat.completions.create(
+        model="llama-3.1-8b",
+        messages=[
+            {"role": "system", "content": f"Translate the text to {target_language}."},
+            {"role": "user", "content": text},
+        ],
+    ).choices[0].message.content
+
+print(translate("Hello, world!", "French"))
+```
+
+### Streaming
+
+Streaming calls are traced the same way:
+
+```python
+stream = client.chat.completions.create(
+    model="llama-3.1-8b",
+    messages=[{"role": "user", "content": "Count from 1 to 5."}],
+    stream=True,
+)
+for chunk in stream:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="", flush=True)
+```
+
+## About Auxen
+
+Auxen-hosted models include: `llama-3.1-8b`, `llama-3.1-70b`, `llama-3.2-3b`, `qwen2.5-7b`, `qwen2.5-14b`, `qwen2.5-32b`, `mistral-7b`, `mistral-nemo-12b`, `mixtral-8x7b`, `gemma2-9b`, `phi-3-mini`, `command-r-7b`.
+
+Pricing is per-minute of dedicated GPU runtime, not per-token. See [auxen.ai/pricing](https://auxen.ai/pricing).

--- a/content/integrations/model-providers/auxen.mdx
+++ b/content/integrations/model-providers/auxen.mdx
@@ -1,7 +1,6 @@
 ---
 title: Observability for Auxen with Langfuse
 sidebarTitle: Auxen
-logo: /images/integrations/openai_icon.svg
 description: Use Langfuse to trace and monitor calls to Auxen — per-customer dedicated, OpenAI-compatible LLM endpoints (Llama, Qwen, Mistral, Gemma, Mixtral, Phi, Command R).
 category: Integrations
 ---

--- a/content/integrations/model-providers/meta.json
+++ b/content/integrations/model-providers/meta.json
@@ -5,6 +5,7 @@
     "amazon-bedrock",
     "anthropic-js",
     "anthropic",
+    "auxen",
     "baseten",
     "byteplus",
     "cerebras",


### PR DESCRIPTION
Adds a Model Provider integration page for [Auxen](https://auxen.ai), which serves per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) with an OpenAI-compatible \`/v1/chat/completions\` API.

The page documents tracing Auxen calls via the existing \`langfuse.openai\` drop-in wrapper — no Auxen-specific Langfuse SDK is required. Each Auxen instance has a per-instance base URL of the form \`https://api.auxen.ai/v1/inst_xxx/v1\` and an \`auxk_*\` bearer token, and the OpenAI client just needs both passed through.

Mirrors the structure of the existing DeepSeek / Together / Fireworks pages and gets added to the Model Providers sidebar in alphabetical position.

## Companion PRs (Auxen distribution series)

- [BerriAI/litellm#28532](https://github.com/BerriAI/litellm/pull/28532) — LiteLLM provider
- [vercel/ai#15536](https://github.com/vercel/ai/pull/15536) — Vercel AI SDK community provider
- [langchain-ai/docs#4146](https://github.com/langchain-ai/docs/pull/4146) — LangChain docs
- [run-llama/llama_index#21764](https://github.com/run-llama/llama_index/pull/21764) — LlamaIndex Python
- [continuedev/continue#12473](https://github.com/continuedev/continue/pull/12473) — Continue.dev provider
- [Helicone/helicone#5685](https://github.com/Helicone/helicone/pull/5685) — Helicone gateway
- npm: [\`@auxen/ai-sdk-provider\`](https://www.npmjs.com/package/@auxen/ai-sdk-provider) (live)

AI agent (Claude) assisted in drafting this PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new Model Provider integration page for [Auxen](https://auxen.ai) and inserts it in the alphabetically correct position in the sidebar `meta.json`. The page documents how to trace Auxen's OpenAI-compatible endpoints using Langfuse's `langfuse.openai` drop-in wrapper.

- `auxen.mdx` follows the structure of the DeepSeek / Together AI / Fireworks AI pages and covers setup, chat completion, `@observe()` grouping, and streaming examples.
- `meta.json` correctly inserts `\"auxen\"` between `\"anthropic\"` and `\"baseten\"`.
- The page currently uses the OpenAI provider logo (`openai_icon.svg`) as a placeholder, which will display the wrong branding in the sidebar; a provider-specific icon should be added or the field left blank.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the logo — the OpenAI icon placeholder actively shows wrong branding on the Auxen page.

The docs content and code examples are correct, but the `logo` frontmatter points to `openai_icon.svg`, so users browsing the Langfuse integrations list will see the OpenAI logo next to the Auxen entry. The missing `LearnMore` component and unused `observe` import are minor polish items.

content/integrations/model-providers/auxen.mdx — logo field and missing LearnMore footer
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as User Application
    participant LF as langfuse.openai (wrapper)
    participant Auxen as Auxen API
    participant LFCloud as Langfuse Cloud

    App->>LF: client.chat.completions.create(model, messages)
    LF->>Auxen: POST /v1/chat/completions
    Auxen-->>LF: ChatCompletion response
    LF-->>App: response (transparent pass-through)
    LF->>LFCloud: Async trace (prompt, completion, tokens, latency)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/integrations/model-providers/auxen.mdx:4
**Wrong logo — OpenAI icon shown on Auxen page**

The `logo` field points to `/images/integrations/openai_icon.svg`, so the OpenAI logo will be rendered in the Langfuse docs sidebar and page header for this Auxen integration. Every other provider page uses a provider-specific icon (e.g., `deepseek_icon.svg`, `fireworks_ai_icon.svg`). Either add an Auxen-specific SVG under `public/images/integrations/` or leave the field empty until one is available.

### Issue 2 of 3
content/integrations/model-providers/auxen.mdx:55-62
The `from langfuse import observe` import in the client-initialization block is unused — `@observe()` isn't called until the next section. Importing something that isn't used in the same snippet may confuse readers who copy just this block.

```suggestion
# Drop-in replacement: tracing is automatic
from langfuse.openai import OpenAI

client = OpenAI(
    base_url=os.environ["AUXEN_API_BASE"],
    api_key=os.environ["AUXEN_API_KEY"],
)
```

### Issue 3 of 3
content/integrations/model-providers/auxen.mdx:126
Every comparable provider page (DeepSeek, Together AI, Fireworks AI, etc.) ends with the `LearnMore` component, which surfaces related Langfuse docs and links to further resources. This page is missing it.

```suggestion
Pricing is per-minute of dedicated GPU runtime, not per-token. See [auxen.ai/pricing](https://auxen.ai/pricing).

import LearnMore from "@/components-mdx/integration-learn-more.mdx";

<LearnMore />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Auxen integration page"](https://github.com/langfuse/langfuse-docs/commit/5dfc6cdf8de5efb24f55a4077018bb81250857c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33506496)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->