### PR TITLE
docs: fix annotation queues typo

### DIFF
--- a/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
+++ b/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
@@ -5,7 +5,7 @@ description: Manage your annotation tasks with ease using our new workflow tooli
 
 # Annotation Queues [#annotation-queues]
 
-Annotation Queues are a manual [evaluation method](/docs/evaluation/core-concepts#evaluation-methods) which is build for domain experts to add [scores](/docs/evaluation/scores/overview) and comments to traces, observations or sessions.
+Annotation Queues are a manual [evaluation method](/docs/evaluation/core-concepts#evaluation-methods) which is built for domain experts to add [scores](/docs/evaluation/scores/overview) and comments to traces, observations, or sessions.
 
 <Video
   src="https://static.langfuse.com/docs-videos/2025-12-19-annotation-queues.mp4"


### PR DESCRIPTION
## Problem

`langfuse/langfuse#13802` reports a typo on the Annotation Queues docs page: "which is build" should read "which is built".

## Solution

Updated the Annotation Queues introduction sentence to use the correct verb form and added the serial comma in the same list for grammar consistency.

## Validation

- `git diff --check`
- Confirmed no open PR currently targets this typo via `gh pr list` search.

## Confidence

Score: 85/100
Category: docs/typo

Fixes langfuse/langfuse#13802

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a grammatical typo in the Annotation Queues documentation page and adds a serial comma for consistency.

- Changes "which is build" to "which is built" in the introductory sentence of `annotation-queues.mdx`.
- Adds a serial comma before "or sessions" in the same list for grammar consistency.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-sentence documentation correction with no functional impact.

The change corrects a verb form ("build" → "built") and adds a serial comma in one documentation sentence. No code, configuration, or logic is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["annotation-queues.mdx"] --> B["Fix: 'build' → 'built'"]
    A --> C["Fix: add serial comma before 'or sessions'"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix annotation queues typo"](https://github.com/langfuse/langfuse-docs/commit/563a944641e5dd1b66e0100bf7ba9640524d4806) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33515051)</sub>

<!-- /greptile_comment -->