### PR TITLE
docs(integrations): add Auxen as a model provider

### DIFF
--- a/content/integrations/model-providers/auxen.mdx
+++ b/content/integrations/model-providers/auxen.mdx
@@ -1,0 +1,100 @@
+---
+title: Monitor Auxen with Langfuse
+sidebarTitle: Auxen
+logo: /images/integrations/auxen_icon.svg
+description: Learn how to integrate Auxen with Langfuse using the OpenAI drop-in replacement.
+category: Integrations
+---
+
+# Observability for Auxen with Langfuse
+
+This guide shows you how to integrate [Auxen](https://auxen.ai) with Langfuse. Auxen provisions private AI model endpoints on dedicated GPUs (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral, Command-R). Each instance is OpenAI-compatible, so we use the Langfuse OpenAI drop-in replacement to trace all calls.
+
+> **What is Auxen?** [Auxen](https://auxen.ai) provisions per-customer dedicated GPU instances behind a stable OpenAI-compatible endpoint. Pay per minute of GPU runtime — no subscriptions, no per-token fees, no shared inference. Built for developers who want private models without managing infrastructure.
+
+> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open source LLM engineering platform that helps teams trace API calls, monitor performance, and debug issues in their AI applications.
+
+<Steps>
+
+## Step 1: Install Dependencies
+
+```python
+%pip install openai langfuse
+```
+
+## Step 2: Set Up Environment Variables
+
+Provision an instance at [auxen.ai/dashboard](https://auxen.ai/dashboard). Copy the per-instance endpoint URL and API key.
+
+```python
+import os
+
+# Langfuse — get keys from your project settings:
+# https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
+os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # 🇪🇺 EU region
+# Other regions: 🇺🇸 US https://us.cloud.langfuse.com,
+#                🇯🇵 JP https://jp.cloud.langfuse.com,
+#                ⚕️  HIPAA https://hipaa.cloud.langfuse.com
+
+# Auxen — per-instance URL + key from the Auxen dashboard:
+os.environ["AUXEN_BASE_URL"] = "https://api.auxen.ai/v1/inst_xxx"
+os.environ["AUXEN_API_KEY"] = "auxk_..."
+```
+
+## Step 3: Langfuse OpenAI Drop-in Replacement
+
+Import the wrapped OpenAI client from Langfuse and point it at your Auxen instance. The base URL needs to end at `/v1` (Auxen instances expose the OpenAI-compatible endpoint there).
+
+```python
+# instead of `import openai`:
+from langfuse.openai import openai
+
+client = openai.OpenAI(
+    api_key=os.environ.get("AUXEN_API_KEY"),
+    base_url=f"{os.environ.get('AUXEN_BASE_URL').rstrip('/')}/v1",
+)
+```
+
+The OpenAI drop-in replacement is fully compatible with the [Low-Level Langfuse Python SDK](https://langfuse.com/docs/sdk/python/low-level-sdk) and the [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) to trace all parts of your application.
+
+## Step 4: Run An Example
+
+```python
+response = client.chat.completions.create(
+    model="llama-3.1-8b",  # whatever model your Auxen instance is provisioned with
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+    ],
+)
+print(response.choices[0].message.content)
+```
+
+All API calls are automatically traced by Langfuse — open your Langfuse project to see token counts, latency, and full request/response bodies. Note that Auxen bills per minute of GPU runtime (not per token), so Langfuse's token-based cost estimates are approximations — check your Auxen dashboard for authoritative billing.
+
+## Step 5: Streaming + Tool Calling + Async
+
+Auxen is fully OpenAI-compatible at the wire level, so streaming, tool calling, async, structured outputs, and JSON mode all work as-is through the Langfuse drop-in client. See the [OpenAI integration docs](https://langfuse.com/integrations/model-providers/openai-py) for the full feature surface.
+
+</Steps>
+
+## Pricing
+
+Auxen bills per minute of GPU runtime at the following 1× capacity rates:
+
+| Tier | Models | Rate |
+|---|---|---|
+| Small (≤7B) | gemma2-2b, mistral-7b, llama3.2-3b, phi3-mini | $0.10/hr |
+| Medium (8–14B) | llama3.1-8b, qwen2.5-14b, mistral-nemo-12b | $0.20/hr |
+| Large (24–32B) | mistral-small-24b, qwen2.5-32b, command-r | $0.65/hr |
+| XL (70B+) | llama3.1-70b, qwen2.5-72b, mixtral-8x22b | $1.50/hr |
+
+## Related Resources
+
+- [Auxen homepage](https://auxen.ai)
+- [Auxen docs](https://auxen.ai/docs)
+- [`auxen` Python SDK](https://github.com/auxen-ai/auxen-python) — `pip install auxen`
+- [`@auxen-ai/ai-sdk-provider`](https://github.com/auxen-ai/ai-sdk-provider) — Vercel AI SDK provider
+- [Auxen MCP server](https://github.com/auxen-ai/mcp-server) — provision/manage instances via natural language

--- a/content/integrations/model-providers/auxen.mdx
+++ b/content/integrations/model-providers/auxen.mdx
@@ -38,9 +38,13 @@ os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # 🇪🇺 EU re
 #                🇯🇵 JP https://jp.cloud.langfuse.com,
 #                ⚕️  HIPAA https://hipaa.cloud.langfuse.com
 
-# Auxen — paste the full per-instance base URL from the Auxen dashboard.
-# The dashboard URL ends in /v1 — keep that segment so the OpenAI client
-# can post directly to /chat/completions without any path-stitching.
+# Auxen — paste the full per-instance base URL from the Auxen dashboard
+# exactly as shown. The dashboard URL has two version segments and both
+# are intentional:
+#   - the leading /v1 is Auxen's API version,
+#   - the trailing /v1 is the OpenAI-compatible path inside your instance,
+#     where /chat/completions lives (so the OpenAI client posts directly
+#     to {base_url}/chat/completions without any path-stitching).
 os.environ["AUXEN_BASE_URL"] = "https://api.auxen.ai/v1/inst_xxx/v1"
 os.environ["AUXEN_API_KEY"] = "auxk_..."
 ```

--- a/content/integrations/model-providers/auxen.mdx
+++ b/content/integrations/model-providers/auxen.mdx
@@ -38,14 +38,16 @@ os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # 🇪🇺 EU re
 #                🇯🇵 JP https://jp.cloud.langfuse.com,
 #                ⚕️  HIPAA https://hipaa.cloud.langfuse.com
 
-# Auxen — per-instance URL + key from the Auxen dashboard:
-os.environ["AUXEN_BASE_URL"] = "https://api.auxen.ai/v1/inst_xxx"
+# Auxen — paste the full per-instance base URL from the Auxen dashboard.
+# The dashboard URL ends in /v1 — keep that segment so the OpenAI client
+# can post directly to /chat/completions without any path-stitching.
+os.environ["AUXEN_BASE_URL"] = "https://api.auxen.ai/v1/inst_xxx/v1"
 os.environ["AUXEN_API_KEY"] = "auxk_..."
 ```
 
 ## Step 3: Langfuse OpenAI Drop-in Replacement
 
-Import the wrapped OpenAI client from Langfuse and point it at your Auxen instance. The base URL needs to end at `/v1` (Auxen instances expose the OpenAI-compatible endpoint there).
+Import the wrapped OpenAI client from Langfuse and point it at your Auxen instance. Use `AUXEN_BASE_URL` directly — it already ends at `/v1`, which is where Auxen exposes the OpenAI-compatible endpoint.
 
 ```python
 # instead of `import openai`:
@@ -53,7 +55,7 @@ from langfuse.openai import openai
 
 client = openai.OpenAI(
     api_key=os.environ.get("AUXEN_API_KEY"),
-    base_url=f"{os.environ.get('AUXEN_BASE_URL').rstrip('/')}/v1",
+    base_url=os.environ.get("AUXEN_BASE_URL"),
 )
 ```
 

--- a/content/integrations/model-providers/meta.json
+++ b/content/integrations/model-providers/meta.json
@@ -5,6 +5,7 @@
     "amazon-bedrock",
     "anthropic-js",
     "anthropic",
+    "auxen",
     "baseten",
     "byteplus",
     "cerebras",

--- a/public/images/integrations/auxen_icon.svg
+++ b/public/images/integrations/auxen_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <circle cx="50" cy="50" r="45" stroke="#0099ff" stroke-width="7"/>
+  <circle cx="50" cy="50" r="18" fill="#0099ff"/>
+</svg>


### PR DESCRIPTION
Adds [Auxen](https://auxen.ai) to **Integrations → Model Providers**.

Auxen provisions per-customer dedicated GPU instances behind an OpenAI-compatible endpoint (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral, Command-R). Per-minute pricing, no subscriptions.

The integration uses Langfuse's OpenAI drop-in replacement (`from langfuse.openai import openai`) pointed at the user's per-instance Auxen URL. No Langfuse-side changes — purely docs.

**Files:**
- `content/integrations/model-providers/auxen.mdx` — quickstart with Python OpenAI drop-in, pricing, links to SDKs
- `content/integrations/model-providers/meta.json` — nav entry inserted alphabetically between `anthropic` and `baseten`

**Verification (live):**

```bash
curl -i -X POST https://api.auxen.ai/mcp -H 'Content-Type: application/json' -d '{}'
# HTTP/1.1 401 — OAuth 2.1 + DCR live (correct behavior)
```

**Related Auxen surfaces:**
- [auxen.ai](https://auxen.ai) (homepage)
- [github.com/auxen-ai/auxen-python](https://github.com/auxen-ai/auxen-python) (`pip install auxen`)
- [github.com/auxen-ai/mcp-server](https://github.com/auxen-ai/mcp-server) (MCP server with 10 tools)

Note: the `logo.svg` referenced in frontmatter at `/images/integrations/auxen_icon.svg` would need to be added to `public/` in a follow-up — happy to PR that separately if useful.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new `auxen.mdx` integration page under Model Providers and inserts the nav entry in `meta.json`. The guide uses the Langfuse OpenAI drop-in pointed at a user's per-instance Auxen URL — no Langfuse-side code changes.

- **URL construction inconsistency**: The Step 2 env var example already includes `/v1` in the path (`https://api.auxen.ai/v1/inst_xxx`), but Step 3 appends yet another `/v1` — any user copying the guide verbatim would hit a double-versioned URL. Either the env var example should omit the trailing `/v1` segment, or the code should not append it.
- **Missing logo asset**: `logo: /images/integrations/auxen_icon.svg` is referenced in frontmatter but the SVG is not present in `public/images/integrations/`, which will produce a broken image on the rendered page. The author notes a follow-up PR is planned for this.
- **`meta.json` change** is correct — `auxen` is inserted alphabetically between `anthropic` and `baseten`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The guide has a URL construction bug that would cause the quickstart to silently fail for users following it, and the referenced logo asset is not included in the PR.

Step 2 and Step 3 of the quickstart contradict each other on where `/v1` belongs in the Auxen URL, so a developer copying the code verbatim would produce a malformed base_url and get API errors. The missing logo SVG also means the page renders with a broken image on merge. Both issues should be resolved before this page goes live.

content/integrations/model-providers/auxen.mdx — the URL construction example and the missing logo asset both need attention before this page is safe to publish.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Developer
    participant LF as langfuse.openai (drop-in)
    participant Auxen as Auxen Instance<br/>(OpenAI-compatible endpoint)
    participant LFAPI as Langfuse API

    User->>LF: openai.OpenAI(api_key, base_url)
    User->>LF: client.chat.completions.create(model, messages)
    LF->>Auxen: POST /v1/chat/completions
    Auxen-->>LF: ChatCompletion response
    LF-->>User: response.choices[0].message.content
    LF->>LFAPI: Async trace (tokens, latency, request/response)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/model-providers/auxen.mdx:42
**Contradictory `/v1` in env var vs URL construction** — Step 2 sets `AUXEN_BASE_URL` to `"https://api.auxen.ai/v1/inst_xxx"`, which already contains `/v1`. Step 3 then appends another `/v1`, yielding `https://api.auxen.ai/v1/inst_xxx/v1`. Any user who pastes their dashboard URL verbatim will hit a double-versioned path that will 404. Either the env var example should not include the trailing path segment, or the `/v1` suffix should not be appended in Step 3. The example env var and the URL construction must agree on where `v1` lives in the URL hierarchy.

```suggestion
os.environ["AUXEN_BASE_URL"] = "https://api.auxen.ai/inst_xxx"
```

### Issue 2 of 2
content/integrations/model-providers/auxen.mdx:4
**Missing logo asset** — The frontmatter references `/images/integrations/auxen_icon.svg`, but no such file exists in `public/images/integrations/`. Every other provider in this directory has its SVG committed alongside the MDX file (e.g., `deepseek_icon.svg`, `vllm_icon.svg`). Without the file, the sidebar and any page header that renders the logo will show a broken image. The PR description acknowledges a follow-up PR is planned, but merging without the asset produces a visibly broken page in production.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(integrations): add Auxen as a model..."](https://github.com/langfuse/langfuse-docs/commit/c0ee5d2f3e2a351cb1e9608af83f00a09c095ffe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33545841)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->