### PR TITLE
docs(claude-code): add YouTube video embed to integration page

### DIFF
--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -10,6 +10,17 @@ import { Details, Summary } from "@/components/Details";
 
 # Claude Code Tracing with Langfuse
 
+<iframe
+  width="100%"
+  className="aspect-[16/9] rounded border w-full"
+  src="https://www.youtube-nocookie.com/embed/fsoBHf_WNmQ?si=XFUGjR6dE84oj2Ga"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
+></iframe>
+
 > **What is Claude Code?**: [Claude Code](https://claude.com/product/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, help you write and edit code, execute commands, create and run tests, and help you accomplish complex coding tasks with natural language. Claude Code brings the power of Claude's AI capabilities directly into your development workflow.
 
 > **What is Langfuse?**: [Langfuse](https://langfuse.com/) is an open-source LLM engineering platform. It helps teams trace LLM applications, debug issues, evaluate quality, and monitor costs in production.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a YouTube video embed (using the privacy-enhanced `youtube-nocookie.com` domain) to the Claude Code integration documentation page, placed immediately after the page heading.

- The `<iframe>` markup is identical to the pattern already used in other integration pages (e.g., `goose.mdx`, `langflow.mdx`), including `aspect-[16/9]`, `referrerPolicy`, and `allowFullScreen` attributes.
- No logic changes are introduced; this is a pure documentation update.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single iframe added to a docs page using the same established pattern as other integration pages.

The change is a copy of the same YouTube embed pattern used across multiple other integration docs pages. It uses the privacy-enhanced youtube-nocookie.com domain, correct JSX attribute casing, and a matching Tailwind aspect-ratio class. No logic, no data handling, no API changes.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Visitor
    participant Page as claude-code.mdx
    participant YT as youtube-nocookie.com

    User->>Page: Load integration page
    Page->>YT: Embed iframe (privacy-enhanced)
    YT-->>User: Render video player
    User->>Page: Continue reading docs
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(claude-code): add YouTube video emb..."](https://github.com/langfuse/langfuse-docs/commit/7de487f88ec2c053b7da55cd3cb2d7fd7322ce4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33661721)</sub>

<!-- /greptile_comment -->