### PR TITLE
feat(launch-week-5): day 1 — experiments in CI/CD

### DIFF
--- a/components/launch-week-5/LaunchWeek5Landing.tsx
+++ b/components/launch-week-5/LaunchWeek5Landing.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { LaunchWeek5Styles } from "./styles";
 import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
+import { Video } from "@/components/Video";
 
 const cornerBoxBase =
   "relative bg-surface-bg border border-line-structure lw5-corners";
@@ -12,10 +13,18 @@ type DayCard = {
   weekday: string;
   date: string;
   hint?: string;
+  title?: string;
+  href?: string;
 };
 
 const DAYS: DayCard[] = [
-  { n: "01", weekday: "Monday", date: "May 25", hint: "Ship faster" },
+  {
+    n: "01",
+    weekday: "Monday",
+    date: "May 25",
+    title: "Experiments in CI/CD",
+    href: "/changelog/2026-05-25-experiment-ci-cd-gates",
+  },
   { n: "02", weekday: "Tuesday", date: "May 26", hint: "Built for agents" },
   { n: "03", weekday: "Wednesday", date: "May 27", hint: "Find anything" },
   { n: "04", weekday: "Thursday", date: "May 28", hint: "Evals as code" },
@@ -331,6 +340,114 @@ function HeroArt() {
   );
 }
 
+function Day1Unveiling() {
+  return (
+    <section id="day-1" className="lw5-section pt-[80px] pb-10 scroll-mt-24">
+      <div className="flex flex-col items-start gap-3.5 mb-8">
+        <div className="lw5-eyebrow">Day 01 · Monday, May 25, 2026</div>
+        <h2 className="lw5-h2 max-w-[26ch]">
+          <span className="lw5-highlight">Experiments in CI/CD.</span>
+        </h2>
+        <p className="lw5-body">
+          Run your Langfuse experiments inside GitHub Actions. The new action
+          tests every pull request against a Langfuse dataset, fails the
+          workflow when scores drop below the threshold you set, and posts the
+          result back to the PR as a comment. Every run is tracked in Langfuse
+          so you can dig into regressions later.
+        </p>
+      </div>
+
+      <div className="w-full max-w-[920px] mb-8">
+        <Video
+          src="https://static.langfuse.com/docs-videos/ci-experiment.mp4"
+          aspectRatio={16 / 9}
+          className="rounded border border-line-structure"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <span className="lw5-btn-wrap">
+          <Link
+            className="lw5-btn lw5-btn-primary"
+            href="/changelog/2026-05-25-experiment-ci-cd-gates"
+          >
+            <span>Read the changelog</span>
+            <span className="lw5-kbd">↗</span>
+          </Link>
+        </span>
+        <span className="lw5-btn-wrap">
+          <Link
+            className="lw5-btn lw5-btn-secondary"
+            href="/docs/evaluation/experiments/experiments-ci-cd"
+          >
+            <span>Get started in docs</span>
+            <span className="lw5-kbd">↗</span>
+          </Link>
+        </span>
+        <span className="lw5-btn-wrap">
+          <Link
+            className="lw5-btn lw5-btn-secondary"
+            href="https://github.com/langfuse/experiment-action"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span>View the action on GitHub</span>
+            <span className="lw5-kbd">↗</span>
+          </Link>
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function DayCard({ day }: { day: DayCard }) {
+  const live = Boolean(day.href);
+  const content = (
+    <div className="lw5-day-card h-full" data-state={live ? "live" : "locked"}>
+      <div className="flex items-start justify-between">
+        <span className="font-mono text-[11px] uppercase tracking-[.08em] text-text-tertiary">
+          Day {day.n}
+        </span>
+        {live ? (
+          <span className="lw5-pill lw5-pill-live">
+            <span className="lw5-pulse" />
+            Live
+          </span>
+        ) : (
+          <span className="lw5-lock">
+            <LockIcon />
+          </span>
+        )}
+      </div>
+      <div className="lw5-day-num">{day.n}</div>
+      <div className="flex flex-col gap-0.5 mt-auto">
+        <div className="text-[14px] text-text-primary font-medium">
+          {day.weekday}
+        </div>
+        <div className="font-mono text-[11px] text-text-tertiary">
+          {day.date}, 2026
+        </div>
+      </div>
+      <div className="border-t border-line-structure pt-3 mt-1">
+        <div
+          className={`font-mono text-[11px] uppercase tracking-[.06em] ${live ? "text-text-primary" : "text-text-tertiary"}`}
+        >
+          {day.title ?? day.hint ?? "Stay tuned"}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (live && day.href) {
+    return (
+      <Link href={day.href} className="no-underline">
+        {content}
+      </Link>
+    );
+  }
+  return content;
+}
+
 function Schedule() {
   return (
     <section
@@ -353,30 +470,7 @@ function Schedule() {
 
       <div className="grid gap-2 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5">
         {DAYS.map((day) => (
-          <div key={day.n} className="lw5-day-card" data-state="locked">
-            <div className="flex items-start justify-between">
-              <span className="font-mono text-[11px] uppercase tracking-[.08em] text-text-tertiary">
-                Day {day.n}
-              </span>
-              <span className="lw5-lock">
-                <LockIcon />
-              </span>
-            </div>
-            <div className="lw5-day-num">{day.n}</div>
-            <div className="flex flex-col gap-0.5 mt-auto">
-              <div className="text-[14px] text-text-primary font-medium">
-                {day.weekday}
-              </div>
-              <div className="font-mono text-[11px] text-text-tertiary">
-                {day.date}, 2026
-              </div>
-            </div>
-            <div className="border-t border-line-structure pt-3 mt-1">
-              <div className="font-mono text-[11px] uppercase tracking-[.06em] text-text-tertiary">
-                {day.hint ?? "Stay tuned"}
-              </div>
-            </div>
-          </div>
+          <DayCard key={day.n} day={day} />
         ))}
       </div>
     </section>
@@ -390,6 +484,7 @@ export function LaunchWeek5Landing() {
       <div className="max-w-[1440px] mx-auto">
         <Hero />
         <Schedule />
+        <Day1Unveiling />
       </div>
     </div>
   );

--- a/components/launch-week-5/styles.tsx
+++ b/components/launch-week-5/styles.tsx
@@ -182,6 +182,12 @@ export function LaunchWeek5Styles() {
         box-shadow: 0 0 0 0 rgba(83,138,46,0.55);
         animation: lw5-pulse 1.8s ease-out infinite;
       }
+      .lw5-page .lw5-pill.lw5-pill-live {
+        padding: 2px 8px; gap: 5px; font-size: 10px;
+      }
+      .lw5-page .lw5-pill.lw5-pill-live .lw5-pulse {
+        width: 5px; height: 5px;
+      }
       @keyframes lw5-pulse {
         0%   { box-shadow: 0 0 0 0 rgba(83,138,46,0.55); }
         70%  { box-shadow: 0 0 0 10px rgba(83,138,46,0); }
@@ -234,6 +240,11 @@ export function LaunchWeek5Styles() {
         transition: border-color 150ms, transform 150ms;
       }
       .lw5-day-card:hover { border-color: var(--line-cta); }
+      .lw5-day-card[data-state="live"] {
+        background: var(--surface-bg);
+        border-color: var(--line-cta);
+      }
+      .lw5-day-card[data-state="live"] .lw5-day-num { color: var(--text-primary); }
       .lw5-day-card[data-state="locked"] .lw5-day-num { color: var(--text-disabled); }
       .lw5-day-card[data-state="locked"]::before {
         content: ""; position: absolute; inset: 0;

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -4,15 +4,17 @@ import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 export function Banner() {
   return (
     <FumadocsBanner
-      id="fd-top-banner-academy"
+      id="fd-top-banner-launch-week-5-day-1"
       height="2rem"
       className="bg-black text-white [&_a]:text-white [&_button]:text-white"
     >
       <Link href="/launch">
         <span className="sm:hidden">
-          Langfuse Launch Week #5, a week of new features →
+          Launch Week 5 · Day 1: Experiments in CI/CD →
         </span>
-        <span className="hidden sm:inline">Langfuse Launch Week #5 →</span>
+        <span className="hidden sm:inline">
+          Langfuse Launch Week 5 · Day 1: Experiments in CI/CD →
+        </span>
       </Link>
     </FumadocsBanner>
   );

--- a/content/blog/2026-04-30-langfuse-april-update.mdx
+++ b/content/blog/2026-04-30-langfuse-april-update.mdx
@@ -37,7 +37,7 @@ Langfuse Cloud is now live in a dedicated Japan region, hosted in Tokyo (`ap-nor
 
 Experiments are now live alongside Datasets as their own top-level feature. You can run them with or without datasets, compare across runs, and track progress over time.
 
-Additionally, you can trigger experiments in CI with the new [Langfuse Experiments GitHub Action](/changelog/2026-05-05-experiment-ci-cd-gates). Gate PRs on regressions, post deltas as comments.
+Additionally, you can trigger experiments in CI with the new [Langfuse Experiments GitHub Action](/changelog/2026-05-25-experiment-ci-cd-gates). Gate PRs on regressions, post deltas as comments.
 
 → [Read the docs](/changelog/2026-04-13-experiments-rebuild)
 

--- a/content/changelog/2026-05-25-experiment-ci-cd-gates.mdx
+++ b/content/changelog/2026-05-25-experiment-ci-cd-gates.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-05
+date: 2026-05-25
 title: "Experiments CI/CD integration"
 description: Run langfuse experiments in GitHub Actions to catch quality regressions before releasing changes to production.
 author: Tobias Wochinger

--- a/content/changelog/2026-05-25-experiment-ci-cd-gates.mdx
+++ b/content/changelog/2026-05-25-experiment-ci-cd-gates.mdx
@@ -1,5 +1,6 @@
 ---
 date: 2026-05-25
+badge: Launch Week 5 🚀
 title: "Experiments CI/CD integration"
 description: Run langfuse experiments in GitHub Actions to catch quality regressions before releasing changes to production.
 author: Tobias Wochinger

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -951,6 +951,13 @@ const experimentsCiCdRedirects202605 = [
     "/guides/experiments-ci-cd",
     "/docs/evaluation/experiments/experiments-ci-cd",
   ],
+  // Changelog re-dated to 2026-05-25 for Launch Week 5 Day 1. The old slug
+  // was live on main for ~13 days, so anyone who bookmarked or shared the
+  // URL should keep landing on the new one.
+  [
+    "/changelog/2026-05-05-experiment-ci-cd-gates",
+    "/changelog/2026-05-25-experiment-ci-cd-gates",
+  ],
 ];
 
 const handbookRedirects202509 = [


### PR DESCRIPTION
## Day 1 of Launch Week 5

Unveils the Experiments CI/CD GitHub Action on `/launch-week-5`, updates the site-wide banner, and re-dates the changelog to today.

Stacked on top of #2980 (Launch Week 5 teaser page). Will rebase cleanly once that merges.

## What changed

- **`/launch-week-5`** — new Day 1 unveiling section above the schedule with title, body, video placeholder, and three CTAs (changelog, docs, GitHub Action). Schedule's Day 1 card now shows a green "Live" pulse and links to the changelog; days 2–5 stay locked.
- **Banner** (`components/layout/Banner.tsx`) — top docs banner now reads "Langfuse Launch Week 5 · Day 1: Experiments in CI/CD →" and points at `/launch`.
- **Changelog** — renamed `2026-05-05-experiment-ci-cd-gates.mdx` → `2026-05-25-experiment-ci-cd-gates.mdx`, front-matter date bumped to match. Updated the one internal link from `content/blog/2026-04-30-langfuse-april-update.mdx`.

## Social drafts

Voice notes: no em dashes, no marketing AI-speak, specific over abstract.

### X (~260 chars)

```
Day 1 of Langfuse Launch Week 5: a GitHub Action that runs your Langfuse experiments on every PR. Fails the workflow when scores drop below your threshold. Posts the result as a PR comment. Tracks the run in Langfuse.

langfuse.com/launch
```

### LinkedIn

```
Day 1 of Langfuse Launch Week 5.

If you're shipping an LLM app, every prompt change, model swap, or chunking tweak is a potential regression you only catch in production. The new Langfuse Experiment GitHub Action runs your Langfuse experiments on every pull request, tests your application against a dataset you control, fails the workflow when scores drop below the threshold you set, and posts pass/fail directly to the PR.

Every run is tracked in Langfuse, so when something does regress, the failing items are one click away.

Five minutes to set up. Slots into whatever CI you already use.

Get started: langfuse.com/launch
Action source: github.com/langfuse/experiment-action
```

### Hacker News / Reddit

**Title:** `Langfuse Experiment Action: gate PRs on LLM regression scores`

**Body:**

```
We just shipped a GitHub Action that runs Langfuse experiments on every pull request. It tests your application against a dataset of inputs, scores the outputs with the evaluators you've configured (LLM-as-judge, code-based assertions, human review), and fails the workflow if scores drop below a threshold you set.

Pass/fail lands on the PR as a comment so reviewers see the regression before merging. Every run is tracked in Langfuse, so when something does drop you can dig into the failing items.

It's open source: https://github.com/langfuse/experiment-action

The action is part of Langfuse Launch Week 5, five days of releases this week: https://langfuse.com/launch
```

## Test plan

- [x] `/launch-week-5` renders the Day 1 section + live card locally (HTTP 200)
- [x] `/launch` redirects to `/launch-week-5` (HTTP 307)
- [x] `/changelog/2026-05-25-experiment-ci-cd-gates` renders (HTTP 200)
- [x] Banner shows the Day 1 link on all docs pages
- [ ] Vercel preview deploy passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHS7rhTPodyNxpQ7F8TYwW)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lands Day 1 of Launch Week 5, adding the `/launch-week-5` page, wiring the `/launch` redirect to it, updating the site banner, and re-dating the Experiments CI/CD changelog entry to May 25, 2026.

- **New `LaunchWeek5Landing` component** — hero section, Day 1 unveiling with video placeholder, and a 5-day schedule grid; CSS delivered via an injected `<style>` tag in `styles.tsx`.
- **`Tweet.tsx` fallback** — the `react-tweet` embed is replaced with a static link to x.com, sidestepping a build-time SSR crash caused by Twitter's syndication endpoint returning non-JSON.
- **Changelog rename** — `2026-05-05-experiment-ci-cd-gates.mdx` → `2026-05-25-experiment-ci-cd-gates.mdx` with the corresponding internal blog-post link updated.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe to merge, but the hero SVG art renders bright-white card rectangles in dark mode due to a hardcoded fill="white" — this will be immediately visible to any dark-mode visitor on launch day.

The landing page is the main deliverable for Day 1 of a public launch week. The hardcoded fill="white" on the hero SVG card rects will produce jarring white boxes in dark mode rather than blending with the site's surface tokens. The primary-button hover also uses a fixed dark hex that inverts unexpectedly in dark mode. Both issues are in the most-visited path (the hero section of the launch page), making them likely to be noticed by users during the announcement window.

components/launch-week-5/LaunchWeek5Landing.tsx (SVG card fill and responsive border logic) and components/launch-week-5/styles.tsx (primary button hover colour).
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits /launch"] -->|"307 redirect"| B["launch-week-5 page"]
    B --> C["LaunchWeek5Landing component"]
    C --> D["Hero section"]
    C --> E["Day1Unveiling section"]
    C --> F["Schedule section"]
    E --> G["changelog entry"]
    E --> H["docs page"]
    E --> I["GitHub Action repo"]
    F --> J["Day 01 card - changelog link"]
    F --> K["Days 02-05 locked"]
    L["Site-wide Banner"] -->|"href=/launch"| B
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
components/launch-week-5/LaunchWeek5Landing.tsx:115-122
**`DayCard` type and component share the same identifier**

The `type DayCard` declared on line 115 and the `function DayCard` on line 524 share the same name. TypeScript keeps these in separate namespaces (type vs. value), so there's no compile error, but editors like VS Code will show the component as both a type and a value, which can confuse autocompletion and "go to definition". Renaming the type to `DayCardItem` or `DayEntry` would eliminate the ambiguity.

### Issue 2 of 4
components/launch-week-5/LaunchWeek5Landing.tsx:254-282
**SVG card rect uses `fill="white"` — invisible in dark mode**

The outer day-card rectangle is hardcoded `fill="white"`. In dark mode the page background is dark, so these cards will look like bright white squares floating in the hero art instead of blending with the page's surface tokens. The inner square already uses the correct CSS variable `fill="var(--surface-1)"`. The outer rect should use the same token (or `var(--surface-bg)`) to stay theme-aware.

### Issue 3 of 4
components/launch-week-5/styles.tsx:105-106
**Primary button hover is hardcoded dark, breaks in dark mode**

`.lw5-btn-primary` uses `var(--text-primary)` as its background, which in dark mode resolves to a light/near-white color. The `:hover` rule overrides that with `#2b2a27` (near-black), so hovering a primary button in dark mode produces a jarring color flip and likely fails contrast. Adding a dark-mode variant keeps the behavior consistent.

```suggestion
      .lw5-btn-primary { background: var(--text-primary); color: var(--surface-bg); border-color: var(--text-secondary); }
      .lw5-btn-primary:hover { background: #2b2a27; }
      :root[class~="dark"] .lw5-btn-primary:hover { background: #d4d0cb; }
```

### Issue 4 of 4
components/launch-week-5/LaunchWeek5Landing.tsx:254-279
**Stats grid `borderRight` doesn't adapt to the 2-column mobile layout**

The inline `borderRight` is derived purely from index (`i < 3`), which is correct for the desktop 4-column layout but not for the `grid-cols-2` layout on mobile. On mobile, items at index 1 and 2 are at the right edge of their respective rows yet still carry `borderRight: "1px solid ..."`, creating a dangling border that overlaps the outer container's own right border. Consider using Tailwind responsive classes or a CSS `nth-child` rule that accounts for both column counts.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(launch-week-5): day 1 — experiments..."](https://github.com/langfuse/langfuse-docs/commit/7206e99d26dd04e1aae651f56a634b4b1974795c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33704985)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->