### PR TITLE
docs: correct annotation queues typo

### DIFF
--- a/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
+++ b/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
@@ -5,7 +5,7 @@ description: Manage your annotation tasks with ease using our new workflow tooli
 
 # Annotation Queues [#annotation-queues]
 
-Annotation Queues are a manual [evaluation method](/docs/evaluation/core-concepts#evaluation-methods) which is build for domain experts to add [scores](/docs/evaluation/scores/overview) and comments to traces, observations or sessions.
+Annotation Queues are a manual [evaluation method](/docs/evaluation/core-concepts#evaluation-methods) which is built for domain experts to add [scores](/docs/evaluation/scores/overview) and comments to traces, observations or sessions.
 
 <Video
   src="https://static.langfuse.com/docs-videos/2025-12-19-annotation-queues.mp4"


### PR DESCRIPTION
## Summary

- Corrects a typo in the Annotation Queues docs from "build" to "built".

## Why

- Implements [LFE-9945](https://linear.app/langfuse/issue/LFE-9945/typo-in-annotation-queues-docs).

## Validation

- Ran `git diff --check`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects a single grammatical typo in the Annotation Queues documentation, changing "which is build for" to "which is built for" on the opening line of the page.

- The change is a one-word fix in `annotation-queues.mdx` with no functional or structural impact.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single word grammar fix in a documentation file with no code or configuration changes.

The change touches only one word in a markdown documentation file, correcting 'build' to 'built'. There are no logic, configuration, or API changes involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[annotation-queues.mdx] --> B["'which is build for' (before)"]
    A --> C["'which is built for' (after)"]
    B -->|typo corrected| C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feature/lfe-994..."](https://github.com/langfuse/langfuse-docs/commit/0a4ce66088cb337a8b65c970dc2b76a02ce67008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33774807)</sub>

<!-- /greptile_comment -->