### PR TITLE
[codex] Show workshop lessons in sidebar

### DIFF
--- a/scripts/sync-workshop.mjs
+++ b/scripts/sync-workshop.mjs
@@ -729,7 +729,8 @@ async function main() {
     pages: ["index", "learner", "instructor"],
   });
   await writeJson("learner/meta.json", {
-    title: "Learner",
+    title: "Lessons",
+    defaultOpen: true,
     pages: learnerPages,
   });
   await writeJson("instructor/meta.json", {


### PR DESCRIPTION
## What changed

- Renames the generated workshop learner sidebar folder from `Learner` to `Lessons`.
- Sets the generated `Lessons` folder to `defaultOpen: true` so lesson links are visible immediately.
- Leaves `For Instructors` as the separate folder below it.

## Stack

Stacked on #3003 (`codex/workshop-site`).

## Validation

- `pnpm workshop:sync`
- `pnpm exec prettier --check scripts/sync-workshop.mjs`
- Opened `http://127.0.0.1:3333/workshop` locally and verified the sidebar shows expanded `Lessons` above collapsed `For Instructors`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes a small targeted update to the workshop sync script, renaming the learner sidebar folder label from "Learner" to "Lessons" and expanding it by default so visitors see lesson links immediately without needing to click.

- `learner/meta.json` now writes `title: \"Lessons\"` and `defaultOpen: true`, while the `instructor/meta.json` is left unchanged, keeping "For Instructors" collapsed by default.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line update to a JSON-writing helper call with no risk to data or logic.

The only thing changed is a label string ("Learner" → "Lessons") and a boolean property (`defaultOpen: true`) in one `writeJson` call. The rest of the sync script is untouched, imports stay at the top of the module, and the instructor folder behaviour is intentionally left as-is per the PR description. No edge cases or regressions are introduced.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Show workshop lessons in sidebar"](https://github.com/langfuse/langfuse-docs/commit/dd3a8a7eb1ce5e4236d5dd7e70a2ea75c1069429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33862355)</sub>

<!-- /greptile_comment -->