### PR TITLE
docs(claude-code): add NEW callout for plugin marketplace install

### DIFF
--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -10,19 +10,6 @@ import { Details, Summary } from "@/components/Details";
 
 # Claude Code Tracing with Langfuse
 
-<Callout type="info" title="NEW: Install via the Claude Code plugin marketplace">
-The easiest way to set this up is now the [Langfuse Observability Plugin](https://github.com/langfuse/Claude-Observability-Plugin). Run these two commands and restart Claude Code:
-
-```bash
-claude plugin marketplace add langfuse/Claude-Observability-Plugin
-claude plugin install langfuse@langfuse-observability
-```
-
-On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Keys are stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
-
-Prefer to wire it up manually? Continue with the steps below.
-</Callout>
-
 <iframe
   width="100%"
   className="aspect-[16/9] rounded border w-full"
@@ -37,6 +24,19 @@ Prefer to wire it up manually? Continue with the steps below.
 > **What is Claude Code?**: [Claude Code](https://claude.com/product/claude-code) is Anthropic's agentic coding tool that lives in your terminal. It can understand your codebase, help you write and edit code, execute commands, create and run tests, and help you accomplish complex coding tasks with natural language. Claude Code brings the power of Claude's AI capabilities directly into your development workflow.
 
 > **What is Langfuse?**: [Langfuse](https://langfuse.com/) is an open-source LLM engineering platform. It helps teams trace LLM applications, debug issues, evaluate quality, and monitor costs in production.
+
+<Callout type="info" title="NEW: Install via the Claude Code plugin marketplace">
+The easiest way to set this up is now the [Langfuse Observability Plugin](https://github.com/langfuse/Claude-Observability-Plugin). Run these two commands and restart Claude Code:
+
+```bash
+claude plugin marketplace add langfuse/Claude-Observability-Plugin
+claude plugin install langfuse@langfuse-observability
+```
+
+On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Keys are stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
+
+Prefer to wire it up manually? Continue with the steps below.
+</Callout>
 
 ## What Can This Integration Trace?
 

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -10,6 +10,19 @@ import { Details, Summary } from "@/components/Details";
 
 # Claude Code Tracing with Langfuse
 
+<Callout type="info" title="NEW: Install via the Claude Code plugin marketplace">
+The easiest way to set this up is now the [Langfuse Observability Plugin](https://github.com/langfuse/Claude-Observability-Plugin). Run these two commands and restart Claude Code:
+
+```bash
+claude plugin marketplace add langfuse/Claude-Observability-Plugin
+claude plugin install langfuse@langfuse-observability
+```
+
+On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Keys are stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
+
+Prefer to wire it up manually? Continue with the steps below.
+</Callout>
+
 <iframe
   width="100%"
   className="aspect-[16/9] rounded border w-full"

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -33,9 +33,9 @@ claude plugin marketplace add langfuse/Claude-Observability-Plugin
 claude plugin install langfuse@langfuse-observability
 ```
 
-On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Keys are stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
+On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Your secret key is stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
 
-Prefer to wire it up manually? Continue with the steps below.
+For AI-assisted or manual setup, see the steps below.
 
 </Callout>
 

--- a/content/integrations/other/claude-code.mdx
+++ b/content/integrations/other/claude-code.mdx
@@ -36,6 +36,7 @@ claude plugin install langfuse@langfuse-observability
 On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Keys are stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.
 
 Prefer to wire it up manually? Continue with the steps below.
+
 </Callout>
 
 ## What Can This Integration Trace?


### PR DESCRIPTION
Surface the Claude Code plugin (langfuse/Claude-Observability-Plugin) at the top of the integration page so users can install via two `claude plugin` commands instead of hand-wiring the hook script.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `Callout` block at the top of `content/integrations/other/claude-code.mdx` to surface the plugin marketplace installation path as a quick alternative to the manual hook-script setup. The `claude plugin` shell commands used are valid per the official CLI reference.

- A new info callout introduces two `claude plugin` shell commands to add the Langfuse plugin marketplace and install the observability plugin, plus a note on prompted credentials and Python/pip prerequisites.
- The callout includes a bridging sentence pointing readers who prefer manual setup to the existing step-by-step instructions below.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code execution risk; the added callout is informational and points to an external plugin repo.

The `claude plugin` CLI commands are confirmed valid by the official CLI reference. The two minor clarity issues — the unexplained name mismatch between the GitHub repo and the install identifier, and duplicate "easiest" superlatives — do not affect correctness, only user comprehension.

content/integrations/other/claude-code.mdx — specifically the new callout's command explanation and its relationship to the existing Quick Start callout.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits Claude Code integration page] --> B{Choose install path}
    B -->|Plugin marketplace NEW| C["claude plugin marketplace add\nlangfuse/Claude-Observability-Plugin"]
    C --> D["claude plugin install\nlangfuse@langfuse-observability"]
    D --> E[Restart Claude Code]
    E --> F[Prompted for LANGFUSE_PUBLIC_KEY,\nLANGFUSE_SECRET_KEY, LANGFUSE_BASE_URL]
    F --> G[Keys stored in OS keychain]
    G --> H[Tracing active for all projects]
    B -->|Manual setup| I[Install langfuse Python SDK]
    I --> J["Create ~/.claude/hooks/langfuse_hook.py"]
    J --> K["Register Stop hook in ~/.claude/settings.json"]
    K --> L["Set TRACE_TO_LANGFUSE=true\nin per-project .claude/settings.json"]
    L --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/other/claude-code.mdx:14-18
**Name mismatch between the two install commands may confuse users**

The first command adds the GitHub repo `langfuse/Claude-Observability-Plugin` as a marketplace source, but the second command references `langfuse@langfuse-observability`. The `langfuse-observability` portion is the internal marketplace name declared in the repo's `marketplace.json`, and `langfuse` is the plugin entry name — neither of which is obvious from the GitHub repo name. Without a brief clarification (e.g. "where `langfuse-observability` is the marketplace name defined in the plugin repo"), users who encounter an error in step two will have no idea why the names differ.

### Issue 2 of 2
content/integrations/other/claude-code.mdx:13
**Competing "easiest" claims in the same document**

The new callout says "The easiest way to set this up is now the Langfuse Observability Plugin", while the existing Quick Start callout at line 66 says "**Easiest path**: have Claude Code set this up for you." Having two separate claims of being the easiest path in the same document is contradictory and may leave users unsure which approach to follow.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(claude-code): apply prettier forma..."](https://github.com/langfuse/langfuse-docs/commit/78353aed99f535ddce176dc51725d14536acdeda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33931957)</sub>

<!-- /greptile_comment -->