### PR TITLE
xs mod to pricing page

### DIFF
--- a/components/home/pricing/PricingCalculator.tsx
+++ b/components/home/pricing/PricingCalculator.tsx
@@ -82,15 +82,21 @@ const calculatePricingBreakdown = (events: number): TierBreakdown[] => {
 // Plan configuration
 type PlanConfig = {
   name: string;
-  baseFee: number;
+  baseFee: number | null;
+  priceLabel: string;
 };
 
 const PLAN_CONFIGS: PlanConfig[] = [
-  { name: "Core", baseFee: 29 },
-  { name: "Pro", baseFee: 199 },
-  { name: "Pro + Teams", baseFee: 499 },
-  { name: "Enterprise", baseFee: 2499 },
+  { name: "Core", baseFee: 29, priceLabel: "$29/month" },
+  { name: "Pro", baseFee: 199, priceLabel: "$199/month" },
+  { name: "Pro + Teams", baseFee: 499, priceLabel: "$499/month" },
+  { name: "Enterprise", baseFee: null, priceLabel: "Custom" },
 ];
+
+const DEFAULT_PLAN_CONFIG = PLAN_CONFIGS[0];
+
+const getPlanConfig = (planName: string) =>
+  PLAN_CONFIGS.find((plan) => plan.name === planName) ?? DEFAULT_PLAN_CONFIG;
 
 // Utility functions
 const formatNumber = (num: number) => num.toLocaleString();
@@ -113,11 +119,14 @@ export function PricingCalculator({
 }: {
   initialPlan?: string;
 }) {
+  const initialPlanConfig = getPlanConfig(initialPlan);
   const [monthlyEvents, setMonthlyEvents] = useState<string>("200,000");
-  const [selectedPlan, setSelectedPlan] = useState<string>(initialPlan);
-  const [currentBaseFee, setCurrentBaseFee] = useState<number>(
-    PLAN_CONFIGS.find((p) => p.name === initialPlan)?.baseFee || 0,
+  const [selectedPlan, setSelectedPlan] = useState<string>(
+    initialPlanConfig.name,
   );
+  const [currentPlanConfig, setCurrentPlanConfig] =
+    useState<PlanConfig>(initialPlanConfig);
+  const currentBaseFee = currentPlanConfig.baseFee;
 
   // Calculate pricing breakdown (single source of truth)
   const pricingBreakdown = useMemo(() => {
@@ -135,9 +144,9 @@ export function PricingCalculator({
   }, [pricingBreakdown]);
 
   const handlePlanChange = (value: string) => {
-    const newPlan = PLAN_CONFIGS.find((plan) => plan.name === value);
-    setSelectedPlan(value);
-    setCurrentBaseFee(newPlan?.baseFee || 0);
+    const newPlan = getPlanConfig(value);
+    setSelectedPlan(newPlan.name);
+    setCurrentPlanConfig(newPlan);
   };
 
   const handleEventsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -168,8 +177,7 @@ export function PricingCalculator({
                   <SelectContent>
                     {PLAN_CONFIGS.map((plan) => (
                       <SelectItem key={plan.name} value={plan.name}>
-                        {plan.name}{" "}
-                        {plan.baseFee > 0 ? `($${plan.baseFee}/month)` : ""}
+                        {plan.name} ({plan.priceLabel})
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -196,7 +204,7 @@ export function PricingCalculator({
             </div>
 
             <CornerBox className="p-4 bg-surface-1 sm:p-6 flex items-center justify-center">
-              {currentBaseFee > 0 ? (
+              {currentBaseFee !== null ? (
                 <div className="w-full text-center">
                   <div className="flex flex-col gap-3 justify-center items-center text-base font-medium sm:flex-row sm:gap-4 sm:text-lg">
                     <div className="text-center">
@@ -232,12 +240,22 @@ export function PricingCalculator({
                   </div>
                 </div>
               ) : (
-                <div className="w-full text-center">
+                <div className="w-full max-w-md text-center">
                   <div className="text-2xl font-bold sm:text-3xl text-primary">
-                    {formatCurrency(calculatedPrice)}
+                    Custom pricing
                   </div>
-                  <div className="mt-1 text-sm text-muted-foreground">
-                    Total Usage Cost / Month
+                  <div className="mt-2 text-sm text-muted-foreground">
+                    Contact sales for an enterprise quote. Usage below is shown
+                    at the standard graduated rates, and yearly commitments may
+                    qualify for custom volume pricing.
+                  </div>
+                  <div className="mt-4">
+                    <div className="text-xl font-bold text-primary sm:text-2xl">
+                      {formatCurrency(calculatedPrice)}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Estimated usage / month at standard rates
+                    </div>
                   </div>
                 </div>
               )}

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -182,7 +182,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
       featured: false,
       description:
         "For large scale teams. Enterprise-grade support and security.",
-      price: "$2499",
+      price: "Custom",
       calloutLink: {
         text: "Enterprise FAQ",
         href: "/enterprise",

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -57,7 +57,7 @@ Optional **Teams Add-on** ($300/month):
 
 [Sign up](/cloud)
 
-### Enterprise ($2,499/month)
+### Enterprise (Custom)
 
 For large-scale teams. Enterprise-grade support and security.
 
@@ -213,13 +213,14 @@ Additional usage beyond the included units is billed at graduated rates. Higher 
 
 **Example 5: Enterprise scale (100M units/month on Enterprise)**
 
-- Enterprise base fee: $2,499.00
+- Enterprise pricing: Custom
 - First 100k units: included
 - Next 900k units at $8.00/100k: $72.00
 - Next 9M units at $7.00/100k: $630.00
 - Next 40M units at $6.50/100k: $2,600.00
 - Next 50M units at $6.00/100k: $3,000.00
-- **Total: $8,801.00/month** (custom volume pricing available with yearly commitment)
+- **Usage estimate at standard graduated rates: $6,302.00/month**
+- Contact sales for a custom Enterprise quote. Yearly commitments may qualify for custom volume pricing.
 
 ### Billable Units
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Enterprise cloud tier price label from `"$2499"` to `"Custom"` in the pricing table component.

- The `price` field is typed as `string`, so `"Custom"` is a valid value, and the existing rendering logic at line 1451 already handles non-`$` prices by suppressing the `/ month` unit suffix — no display regressions expected.
- The pattern is consistent with the self-hosted tier, which already uses `"Custom Pricing"` for a similar plan.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-field text update; the rendering path already handles non-dollar price strings correctly, so the change is safe to merge.

Changing "$2499" to "Custom" on the Enterprise tier is a one-line copy update. The component's conditional logic (tier.price.includes("$")) already suppresses the / month suffix for non-dollar strings, and the self-hosted tier already uses "Custom Pricing" as a price, confirming this pattern is supported.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tier.price value] --> B{includes '$'?}
    B -- Yes --> C[Show price + '/ month' or '/ priceUnit']
    B -- No --> D[Show price only, no unit suffix]
    D --> E["'Custom' renders as just 'Custom'"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["xs mod to pricing page"](https://github.com/langfuse/langfuse-docs/commit/f84c5e5c4a01b50dfae36ec8004f18c017a22a64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34169751)</sub>

<!-- /greptile_comment -->