### PR TITLE
[codex] Fix formatting on main

### DIFF
--- a/components/launch-week-5/LaunchWeek5Landing.tsx
+++ b/components/launch-week-5/LaunchWeek5Landing.tsx
@@ -501,18 +501,19 @@ function Day3Unveiling() {
         </h2>
         <p className="lw5-body">
           Production traces pile up fast. A high-traffic app can produce
-          millions of observations in a week, and when something looks wrong
-          you need to pull the one trace that says “refund failed” out of
-          hundreds of gigabytes in a fraction of a second. A scroll-and-hope
-          UI does not cut it at that scale.
+          millions of observations in a week, and when something looks wrong you
+          need to pull the one trace that says “refund failed” out of hundreds
+          of gigabytes in a fraction of a second. A scroll-and-hope UI does not
+          cut it at that scale.
         </p>
         <p className="lw5-body">
-          Day 3 rolls out full-text search to Langfuse Cloud. In our benchmarks, large input/output searches
-          that took 18 seconds and scanned 494 GB now return in under half a
-          second and read less than a gigabyte. Metadata-heavy queries dropped
-          from 1.6s to 0.2s. The UI gets faster for humans hunting a bug, and
-          the new <code>matches</code> operator on Observations API v2 gives
-          agents and scripts the same token-based search programmatically.
+          Day 3 rolls out full-text search to Langfuse Cloud. In our benchmarks,
+          large input/output searches that took 18 seconds and scanned 494 GB
+          now return in under half a second and read less than a gigabyte.
+          Metadata-heavy queries dropped from 1.6s to 0.2s. The UI gets faster
+          for humans hunting a bug, and the new <code>matches</code> operator on
+          Observations API v2 gives agents and scripts the same token-based
+          search programmatically.
         </p>
         <p className="lw5-body">
           Built on top of ClickHouse’s new{" "}
@@ -524,9 +525,9 @@ function Day3Unveiling() {
           >
             full-text search release
           </Link>
-          , we worked closely with the ClickHouse team on the underlying
-          engine, so features like this land in Langfuse days after they ship
-          in ClickHouse core.
+          , we worked closely with the ClickHouse team on the underlying engine,
+          so features like this land in Langfuse days after they ship in
+          ClickHouse core.
         </p>
       </div>
 

--- a/content/integrations/other/hermes.mdx
+++ b/content/integrations/other/hermes.mdx
@@ -20,7 +20,6 @@ The steps below follow Hermes' [official Langfuse plugin docs](https://hermes-ag
 <Steps>
 ## Step 1: Install Dependencies
 
-
 ```python
 %pip install git+https://github.com/NousResearch/hermes-agent.git langfuse -U
 ```
@@ -42,7 +41,6 @@ The plugin also accepts the standard SDK env vars (`LANGFUSE_PUBLIC_KEY`, `LANGF
 
 The cell below sets the same credentials inside this Python kernel so we can quickly verify them with the Langfuse SDK. **Note:** these `os.environ` values are scoped to the notebook process and will not be visible to a `hermes chat` command run in a separate terminal — use `~/.hermes/.env` for that.
 
-
 ```python
 import os
 
@@ -58,8 +56,6 @@ os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU reg
 ```
 
 With the environment variables set, initialize the Langfuse client to confirm your credentials work. Hermes uses its own internal client, so this step is purely a sanity check that your keys are valid.
-
-
 
 ```python
 from langfuse import get_client
@@ -84,7 +80,6 @@ The plugin hooks into Hermes lifecycle events (`pre_api_request` / `post_api_req
 - One tool observation per tool call
 
 Session grouping uses the Hermes session ID (or task ID for sub-agents), so every turn within a `hermes chat` session lives under one Langfuse session. The plugin is also **fail-open**: missing SDK, missing credentials, or a transient Langfuse error all turn into a silent no-op — the agent loop is never impacted.
-
 
 ```python
 # Enable the Langfuse plugin (run this in your terminal, not in a notebook)
@@ -113,7 +108,6 @@ With the plugin enabled and credentials set, every Hermes conversation turn is a
 
 You can start a conversation from the CLI:
 
-
 ```python
 # Send a one-off message (traces are sent automatically):
 # hermes chat -q "hello"
@@ -126,13 +120,13 @@ You can start a conversation from the CLI:
 
 The Hermes Langfuse plugin supports several optional environment variables:
 
-| Variable | Description | Default |
-|---|---|---|
-| `HERMES_LANGFUSE_ENV` | Environment tag (e.g. `production`, `staging`) | — |
-| `HERMES_LANGFUSE_RELEASE` | Release/version tag | — |
-| `HERMES_LANGFUSE_SAMPLE_RATE` | Sampling rate `0.0`–`1.0` | `1.0` |
-| `HERMES_LANGFUSE_MAX_CHARS` | Max characters per traced field | `12000` |
-| `HERMES_LANGFUSE_DEBUG` | Verbose plugin logging (`true`/`false`) | `false` |
+| Variable                      | Description                                    | Default |
+| ----------------------------- | ---------------------------------------------- | ------- |
+| `HERMES_LANGFUSE_ENV`         | Environment tag (e.g. `production`, `staging`) | —       |
+| `HERMES_LANGFUSE_RELEASE`     | Release/version tag                            | —       |
+| `HERMES_LANGFUSE_SAMPLE_RATE` | Sampling rate `0.0`–`1.0`                      | `1.0`   |
+| `HERMES_LANGFUSE_MAX_CHARS`   | Max characters per traced field                | `12000` |
+| `HERMES_LANGFUSE_DEBUG`       | Verbose plugin logging (`true`/`false`)        | `false` |
 
 Set these in `~/.hermes/.env` or export them in your shell before starting Hermes.
 


### PR DESCRIPTION
## Summary

- Run Prettier on files that failed `pnpm run format:check` on `main`
- Fix formatting in the Launch Week 5 landing component and Hermes integration page

## Validation

- `pnpm run format:check` passed

Note: the local environment used Node `v24.14.0`, while the repo declares Node `22`, so pnpm printed an engine warning. No link validation was run, per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies Prettier formatting fixes to two files that were failing `format:check` on `main`. No functional or content changes are introduced.

- **`LaunchWeek5Landing.tsx`**: Paragraph text is rewrapped to respect the configured print width; no JSX structure or content is altered.
- **`hermes.mdx`**: Extra blank lines before code fences are removed, and the optional-config markdown table is reformatted with Prettier-style column padding — text content is identical.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure formatting-only changes with no logic, content, or structure modifications — safe to merge.

Both changed files contain only whitespace and line-length adjustments produced by Prettier. The text rendered in the browser and the MDX content displayed in docs are byte-for-byte identical to before; only the source formatting changed.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix formatting on main"](https://github.com/langfuse/langfuse-docs/commit/2982a69613dbc19fc88f3dbd8d2db2ee9efb3bcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34317584)</sub>

<!-- /greptile_comment -->