### PR TITLE
Enable CI on main and manual trigger + add Slack notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ name: "CI"
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   # Add pre-job to skip duplicate actions in merge queues
@@ -17,7 +21,8 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
         with:
-          do_not_skip: '["workflow_dispatch"]'
+          skip_after_successful_duplicate: "true"
+          do_not_skip: '["workflow_dispatch", "schedule", "merge_group"]'
 
   check_h1:
     needs:
@@ -221,3 +226,51 @@ jobs:
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
         working-directory: .
+      - name: Notify Slack
+        if: failure() && github.event_name == 'push' && (github.ref == 'refs/heads/main')
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ CI failed on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "❌ CI Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n`${{ github.ref_name }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Logs",
+                        "emoji": true
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "danger"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes formatting across three files and enables the CI workflow to run on pushes to `main` and via manual dispatch.

- **`.github/workflows/ci.yml`**: Adds `push` trigger on `main` and `workflow_dispatch` so the CI suite also runs on direct merges to the main branch, not just on pull requests and merge groups.
- **`LaunchWeek5Landing.tsx`**: Reflows paragraph text to consistent line widths — no logic or content changes.
- **`hermes.mdx`**: Removes redundant blank lines between prose and code blocks, and reformats the Markdown table to use aligned column separators.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are purely cosmetic text reformatting and a standard CI trigger addition.

The CI change is a routine addition of push: branches: [main] and workflow_dispatch, which is a standard pattern for ensuring the CI suite also runs on direct commits to the default branch. The TSX and MDX changes are line-wrap adjustments and blank-line removals with no effect on rendered output or runtime behaviour.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request] --> CI
    MG[Merge Group] --> CI
    PUSH[Push to main] --> CI
    WD[workflow_dispatch] --> CI

    CI[CI Workflow]
    CI --> SKIP[Skip Duplicate Check]
    SKIP --> BUILD[Build / Lint / Test Jobs]
    BUILD --> PASS[✅ Pass]
    BUILD --> FAIL[❌ Fail]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Enable CI on push to main and manual tri..."](https://github.com/langfuse/langfuse-docs/commit/0addb282669050ea735dd27f21689ce5a7bea6b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34318760)</sub>

<!-- /greptile_comment -->