### PR TITLE
fix: Do not initialize PostHog if the key is missing

### DIFF
--- a/components/analytics/PostHogProvider.tsx
+++ b/components/analytics/PostHogProvider.tsx
@@ -6,21 +6,30 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { hsPageView } from "@/components/analytics/hubspot";
 
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "", {
-        api_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
-        ui_host: "https://eu.posthog.com",
-        persistence: "cookie",
-        loaded: (ph) => {
-          if (process.env.NODE_ENV === "development") ph.debug();
-        },
-      });
+    if (typeof window === "undefined") {
+      return;
     }
+
+    if (!posthogKey) {
+      console.warn("PostHog key is not set. PostHog will be disabled.");
+      return;
+    }
+
+    posthog.init(posthogKey, {
+      api_host:
+        process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
+      ui_host: "https://eu.posthog.com",
+      persistence: "cookie",
+      loaded: (ph) => {
+        if (process.env.NODE_ENV === "development") ph.debug();
+      },
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents PostHog from being initialised with an empty key by evaluating `NEXT_PUBLIC_POSTHOG_KEY` once at module level and bailing out early (with a `console.warn`) when the value is absent or whitespace-only. Page-view capture is also skipped in the same condition.

- **Guard on init**: the init `useEffect` now returns early when `posthogKey` is falsy, replacing the previous `?? \"\"` fallback that would silently call `posthog.init` with an empty string.
- **Guard on capture**: the pageview `useEffect` receives the same early-return, so HubSpot page-view tracking is also skipped when PostHog is unconfigured.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only prevents PostHog from being called with a missing key; all other behaviour is unchanged.

The change is small and well-scoped. The only noteworthy point is a dead typeof window check left inside a useEffect, which can never trigger but causes no harm at runtime.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant PostHogProvider
    participant PostHog
    participant HubSpot

    Browser->>PostHogProvider: mount
    PostHogProvider->>PostHogProvider: useEffect (init) fires
    alt posthogKey is missing
        PostHogProvider-->>Browser: console.warn, skip init
    else posthogKey present
        PostHogProvider->>PostHog: posthog.init(posthogKey, options)
    end

    Browser->>PostHogProvider: pathname changes
    PostHogProvider->>PostHogProvider: useEffect (pageview) fires
    alt posthogKey is missing
        PostHogProvider-->>Browser: return early (no capture)
    else posthogKey present
        PostHogProvider->>PostHog: posthog.capture("$pageview")
        PostHogProvider->>HubSpot: hsPageView(pathname)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/analytics/PostHogProvider.tsx:15-19
The `typeof window === "undefined"` guard inside `useEffect` is dead code. `useEffect` only ever runs in the browser, so `window` is always defined at this point — the early return on line 16 can never be reached.

```suggestion
    if (!posthogKey) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Do not initialize PostHog if the ke..."](https://github.com/langfuse/langfuse-docs/commit/caa61530bd022dd04e18716c3e81620ca45c96a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34332934)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->