### PR TITLE
fix: Disable inkeep if no API key is provided

### DIFF
--- a/components/inkeep/InkeepSearchBar.tsx
+++ b/components/inkeep/InkeepSearchBar.tsx
@@ -22,6 +22,12 @@ type InkeepSearchButtonProps = {
 };
 
 export function InkeepSearchButton({ className }: InkeepSearchButtonProps) {
+  const settings = useInkeepSettings();
+
+  if (!settings) {
+    return null;
+  }
+
   return (
     <Button
       data-inkeep-modal-trigger
@@ -34,8 +40,14 @@ export function InkeepSearchButton({ className }: InkeepSearchButtonProps) {
 }
 
 export default function InkeepSearchBar({ className }: InkeepSearchProps) {
+  const settings = useInkeepSettings();
+
+  if (!settings) {
+    return null;
+  }
+
   const { baseSettings, aiChatSettings, searchSettings, modalSettings } =
-    useInkeepSettings();
+    settings;
 
   const searchBarProps: InkeepSearchBarProps = {
     baseSettings: {

--- a/components/inkeep/embedded-chat.tsx
+++ b/components/inkeep/embedded-chat.tsx
@@ -100,7 +100,14 @@ function useAutoScroll(
 }
 
 function InkeepSharedChat() {
-  const { baseSettings, aiChatSettings } = useInkeepSettings();
+  const settings = useInkeepSettings();
+
+  if (!settings) {
+    return null;
+  }
+
+  const { baseSettings, aiChatSettings } = settings;
+
   return (
     <div className="border border-line-structure overflow-hidden flex flex-col h-[min(600px,70vh)]">
       <InkeepEmbeddedChatLazy

--- a/components/inkeep/useInkeepSettings.ts
+++ b/components/inkeep/useInkeepSettings.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type {
   InkeepAIChatSettings,
   InkeepSearchSettings,
@@ -31,12 +32,22 @@ type InkeepSharedSettings = {
   modalSettings: InkeepModalSettings;
 };
 
-const useInkeepSettings = (): InkeepSharedSettings => {
+const useInkeepSettings = (): InkeepSharedSettings | null => {
   const { resolvedTheme } = useTheme();
   const posthog = usePostHog();
 
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_INKEEP_API_KEY) {
+      console.warn("Inkeep API key is missing.");
+    }
+  }, []);
+
+  if (!process.env.NEXT_PUBLIC_INKEEP_API_KEY) {
+    return null;
+  }
+
   const baseSettings: InkeepBaseSettings = {
-    apiKey: process.env.NEXT_PUBLIC_INKEEP_API_KEY! || "",
+    apiKey: process.env.NEXT_PUBLIC_INKEEP_API_KEY,
     primaryBrandColor: "#E11312",
     organizationDisplayName: "Langfuse",
     colorMode: {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a null-safety guard to the `useInkeepSettings` hook so that Inkeep UI components gracefully return `null` instead of crashing when `NEXT_PUBLIC_INKEEP_API_KEY` is absent. The hook's return type changes from `InkeepSharedSettings` to `InkeepSharedSettings | null`, and all three consumers (`InkeepSearchBar`, `InkeepSearchButton`, `InkeepSharedChat`) are updated to handle the new null case.

- `useInkeepSettings.ts`: returns `null` early when the API key env var is missing, adds a `useEffect` mount warning, and removes the non-null assertion (`!`) from the `apiKey` field.
- `InkeepSearchBar.tsx`: both exported components now perform a null guard on the hook result before rendering.
- `embedded-chat.tsx`: `InkeepSharedChat` adds the same null guard so the Inkeep embedded chat widget is suppressed when unconfigured.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a straightforward guard that suppresses Inkeep widgets when no API key is configured, and the React hooks order is correct throughout.

All three consumer components handle the new null return correctly, and the hooks (useTheme, usePostHog, useEffect) are all called before the early return in useInkeepSettings, so hook ordering is valid. No logic paths are broken by this change.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: Disable inkeep if no API key is pro..."](https://github.com/langfuse/langfuse-docs/commit/55fa4b2b291f92a16ba9eaf5803c5cefc8d6b2d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34345340)</sub>

<!-- /greptile_comment -->