### PR TITLE
docs(self-hosting): document AWS SES email transport

### DIFF
--- a/content/self-hosting/configuration/transactional-emails.mdx
+++ b/content/self-hosting/configuration/transactional-emails.mdx
@@ -14,10 +14,40 @@ These are used for password resets, project/organization invitations, and notifi
 
 To enable transactional emails, set the following environment variables on the application containers:
 
-| Variable              | Description                                                                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SMTP_CONNECTION_URL` | Configure optional SMTP server connection for transactional email. Connection URL is passed to Nodemailer ([docs](https://nodemailer.com/smtp)). |
-| `EMAIL_FROM_ADDRESS`  | Configure from address for transactional email. Required if `SMTP_CONNECTION_URL` is set.                                                        |
+| Variable              | Description                                                                                                                                                                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SMTP_CONNECTION_URL` | Connection URL for transactional email. Accepts a standard SMTP URL (`smtp://` or `smtps://`) that is passed to Nodemailer ([docs](https://nodemailer.com/smtp)), or `ses://<region>` (e.g. `ses://us-east-1`) to send via [AWS SES](#aws-ses) using the default AWS credential chain (IAM role, SSO, env vars). |
+| `EMAIL_FROM_ADDRESS`  | Configure from address for transactional email. Required if `SMTP_CONNECTION_URL` is set.                                                                                                                                                                                                                    |
+
+## AWS SES [#aws-ses]
+
+When `SMTP_CONNECTION_URL` is set to `ses://<region>`, Langfuse sends transactional emails through [AWS SES](https://aws.amazon.com/ses/) using the SESv2 API.
+No additional configuration variables are required — credentials are resolved through the [default AWS credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) (IAM role, IRSA, ECS task role, SSO, `AWS_PROFILE`, or environment variables), which mirrors the credential handling used for [S3 blob storage](/self-hosting/deployment/infrastructure/blobstorage).
+
+If Langfuse is running on AWS, we recommend attaching an IAM role to the Langfuse container with permission to send via SES:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["ses:SendEmail"],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "LangfuseSendEmail"
+    }
+  ]
+}
+```
+
+Make sure the `EMAIL_FROM_ADDRESS` is a [verified identity](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html) in the same region, and that your account is out of the SES sandbox if you need to send to arbitrary recipients.
+
+Example configuration:
+
+```yaml
+SMTP_CONNECTION_URL=ses://us-east-1
+EMAIL_FROM_ADDRESS=no-reply@example.com
+```
 
 ## FAQ
 

--- a/content/self-hosting/configuration/transactional-emails.mdx
+++ b/content/self-hosting/configuration/transactional-emails.mdx
@@ -14,10 +14,10 @@ These are used for password resets, project/organization invitations, and notifi
 
 To enable transactional emails, set the following environment variables on the application containers:
 
-| Variable              | Description                                                                                                                                                                                                                                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Variable              | Description                                                                                                                                                                                                                                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SMTP_CONNECTION_URL` | Connection URL for transactional email. Accepts a standard SMTP URL (`smtp://` or `smtps://`) that is passed to Nodemailer ([docs](https://nodemailer.com/smtp)), or `ses://<region>` (e.g. `ses://us-east-1`) to send via [AWS SES](#aws-ses) using the default AWS credential chain (IAM role, SSO, env vars). |
-| `EMAIL_FROM_ADDRESS`  | Configure from address for transactional email. Required if `SMTP_CONNECTION_URL` is set.                                                                                                                                                                                                                    |
+| `EMAIL_FROM_ADDRESS`  | Configure from address for transactional email. Required if `SMTP_CONNECTION_URL` is set.                                                                                                                                                                                                                        |
 
 ## AWS SES [#aws-ses]
 


### PR DESCRIPTION
Document the `ses://<region>` value for `SMTP_CONNECTION_URL` introduced in langfuse/langfuse#13670, including the AWS default credential chain behavior and the recommended IAM policy for `ses:SendEmail`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents the new `ses://<region>` value for `SMTP_CONNECTION_URL`, which routes transactional email through AWS SES using the SESv2 API and the default AWS credential chain. It adds an `## AWS SES` section with setup instructions, an IAM policy sample, and an example configuration block.

- Adds `ses://<region>` (e.g. `ses://us-east-1`) as a recognized value for `SMTP_CONNECTION_URL`, with the credential-chain resolution explained alongside a link to the equivalent S3 blob-storage credential behavior.
- Includes a minimal IAM policy granting `ses:SendEmail` and notes about verified identities and the SES sandbox requirement.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change that is safe to merge; the two findings are minor style and hardening suggestions that do not affect correctness.

The IAM action (ses:SendEmail) is verified correct for SESv2, and the credential-chain description is accurate. The example config block is mislabeled as yaml when it contains dotenv/shell syntax — readers copying it into a YAML file will get a parse error. The IAM policy uses Resource: "*" where a scoped identity ARN would be tighter, though "*" is functional. Neither issue blocks users from setting up SES email, but both are worth cleaning up before merge.

content/self-hosting/configuration/transactional-emails.mdx — the example config code-fence label and the IAM policy resource scope.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Langfuse App
    participant Creds as AWS Credential Chain
    participant SES as AWS SES v2
    participant Rcpt as Email Recipient

    App->>Creds: Resolve credentials (IAM role / IRSA / env vars / SSO)
    Creds-->>App: AWS credentials
    App->>SES: SendEmail via SESv2 API in configured region
    Note over App,SES: From address must be a verified SES identity
    SES-->>App: Message ID
    SES->>Rcpt: Deliver email
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/self-hosting/configuration/transactional-emails.mdx:29-41
**IAM Resource scope is overly broad**

The policy grants `ses:SendEmail` against `"Resource": "*"`, which allows sending from any identity in the account. The AWS service-authorization reference for SESv2 marks `identity` as a required resource type, so the resource can be scoped to the specific verified identity ARN (e.g., `arn:aws:ses:us-east-1:ACCOUNT_ID:identity/no-reply@example.com`). Using `*` works, but a tighter resource helps enforce the principle of least privilege and is consistent with the advice directly below the policy to use a specific verified identity. Consider adding a note that `*` can be narrowed to the specific identity ARN.

### Issue 2 of 2
content/self-hosting/configuration/transactional-emails.mdx:47-50
**Incorrect code fence language**

The block is labeled as `yaml` but the content uses dotenv/shell syntax (key-equals-value pairs), not YAML syntax (which uses colon-space pairs). Anyone copying these lines into a YAML file will see a parse error. The fence language should be `bash` or `dotenv` to match the actual format.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document AWS SES ema..."](https://github.com/langfuse/langfuse-docs/commit/be07237bdbfdd30bee2059420dfc13fb66781680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34356091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->