### PR TITLE
fix(notebook-banner): label JS cookbook notebooks as TypeScript

### DIFF
--- a/components/NotebookBanner.tsx
+++ b/components/NotebookBanner.tsx
@@ -5,7 +5,7 @@ export const NotebookBanner: React.FC<{ src: string; className?: string }> = ({
   src,
   className,
 }) => {
-  // Check if this is a Deno notebook by looking at the filename
+  // Check if this is a TypeScript notebook (Deno kernel) by looking at the filename
   const isDenoNotebook = src.includes("/js_") && src.endsWith(".ipynb");
 
   // Extract the notebook filename from the src path for Binder URL
@@ -16,7 +16,7 @@ export const NotebookBanner: React.FC<{ src: string; className?: string }> = ({
     <div className={className}>
       <Callout type="info">
         <div className="flex flex-wrap gap-1 md:justify-between md:items-center">
-          <span>This is a {isDenoNotebook ? "Deno" : "Jupyter"} notebook</span>
+          <span>This is a {isDenoNotebook ? "TypeScript" : "Jupyter"} notebook</span>
           <div className="flex gap-2 flex-wrap">
             <a
               href={`https://github.com/langfuse/langfuse-docs/blob/main${src}`}

--- a/components/NotebookBanner.tsx
+++ b/components/NotebookBanner.tsx
@@ -16,7 +16,9 @@ export const NotebookBanner: React.FC<{ src: string; className?: string }> = ({
     <div className={className}>
       <Callout type="info">
         <div className="flex flex-wrap gap-1 md:justify-between md:items-center">
-          <span>This is a {isDenoNotebook ? "TypeScript" : "Jupyter"} notebook</span>
+          <span>
+            This is a {isDenoNotebook ? "TypeScript" : "Jupyter"} notebook
+          </span>
           <div className="flex gap-2 flex-wrap">
             <a
               href={`https://github.com/langfuse/langfuse-docs/blob/main${src}`}


### PR DESCRIPTION
## Summary

- The notebook banner on JS cookbook pages (e.g. [Vercel AI SDK](https://langfuse.com/integrations/frameworks/vercel-ai-sdk)) said _"This is a Deno notebook"_, which readers misread as a typo for "demo".
- These notebooks are actually TypeScript executed via the Deno Jupyter kernel, so labeling them as **TypeScript** is clearer and avoids the confusion.
- "Open in Binder" behavior is unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the `NotebookBanner` component to display "TypeScript" instead of "Deno" for JS cookbook notebooks, addressing user confusion about the label. The underlying detection logic and Binder/Colab behavior are unchanged.

- The display label in the callout is changed from `"Deno"` to `"TypeScript"`, accurately reflecting that these notebooks run TypeScript via the Deno Jupyter kernel.
- The internal variable `isDenoNotebook` and its detection heuristic (`/js_` path segment + `.ipynb` extension) remain the same.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, cosmetic label change with no impact on behavior or logic.

The only change is the user-facing string "Deno" → "TypeScript" in the callout, and a matching comment update. Detection logic, button rendering, and Binder/Colab URLs are all untouched. The only minor inconsistency is the internal variable `isDenoNotebook` still carrying the old terminology, which has no runtime effect.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[NotebookBanner receives src prop] --> B{isDenoNotebook?\nsrc includes '/js_' && ends with '.ipynb'}
    B -- Yes --> C[Label: 'This is a TypeScript notebook']
    B -- No --> D[Label: 'This is a Jupyter notebook']
    C --> E[Show: Open on GitHub + Open in Binder]
    D --> F[Show: Open on GitHub + Run on Google Colab]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/NotebookBanner.tsx:9
The variable name `isDenoNotebook` is now slightly misaligned with the user-facing label "TypeScript". While the implementation is still correct (Deno is the kernel), renaming the variable to something like `isTypeScriptNotebook` would keep the code internally consistent with the label change and make the intent clearer to future maintainers.

```suggestion
  const isTypeScriptNotebook = src.includes("/js_") && src.endsWith(".ipynb");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notebook-banner): label JS cookbook ..."](https://github.com/langfuse/langfuse-docs/commit/834c58c58c46cdd82b0f9ffbfe4c70cf9a5ae5c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34421306)</sub>

<!-- /greptile_comment -->