### PR TITLE
docs(agents): add CI format check guidance to AGENTS and cursor rules

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -64,7 +64,7 @@ CI runs three required checks on every PR. Run these locally before pushing to a
 CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commit the result.
 
 - Prettier formats: `.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`. Any change to one of these — including tiny edits like a one-line tweak to an MDX page or a TSX component — can trigger the check.
-- Prettier does **not** format files matched by `.prettierignore` (notebooks, generated cookbook docs, `content/workshop/**`, lockfiles, generated JSON/TXT in `public/`, etc.).
+- Prettier does **not** format files matched by `.prettierignore` (generated cookbook docs in `content/guides/cookbook/**`, `content/workshop/**`, lockfiles, generated JSON/TXT in `public/`, etc.). Source notebooks (`.ipynb` in `cookbook/`) are also skipped because Prettier has no built-in parser for them.
 - Config (`.prettierrc.json`): `proseWrap: "preserve"` (don't reflow Markdown prose), `embeddedLanguageFormatting: "off"` (fenced code blocks are left alone), `trailingComma: "all"`.
 - If you touched only `.prettierignore`'d files (e.g., only a notebook or only a generated file), the check will still pass — no need to run format.
 - When in doubt, just run `pnpm run format` — it's fast and idempotent.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -64,9 +64,9 @@ CI runs three required checks on every PR. Run these locally before pushing to a
 CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commit the result.
 
 - Prettier formats: `.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`. Any change to one of these — including tiny edits like a one-line tweak to an MDX page or a TSX component — can trigger the check.
-- Prettier does **not** format files matched by `.prettierignore` (generated cookbook docs in `content/guides/cookbook/**`, `content/workshop/**`, lockfiles, generated JSON/TXT in `public/`, etc.). Source notebooks (`.ipynb` in `cookbook/`) are also skipped because Prettier has no built-in parser for them.
+- Prettier does **not** format files matched by `.prettierignore` (generated cookbook docs in `content/guides/cookbook/**`, `content/workshop/**`, lockfiles, generated assets in `public/`, etc.). Source notebooks (`.ipynb` in `cookbook/`) are also skipped because Prettier has no built-in parser for them.
 - Config (`.prettierrc.json`): `proseWrap: "preserve"` (don't reflow Markdown prose), `embeddedLanguageFormatting: "off"` (fenced code blocks are left alone), `trailingComma: "all"`.
-- If you touched only `.prettierignore`'d files (e.g., only a notebook or only a generated file), the check will still pass — no need to run format.
+- If you touched only files Prettier skips (e.g., a notebook, or a generated file listed in `.prettierignore`), the check will still pass — no need to run format.
 - When in doubt, just run `pnpm run format` — it's fast and idempotent.
 
 ### 2. H1 heading check (`check_h1` job)

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -63,7 +63,7 @@ CI runs three required checks on every PR. Run these locally before pushing to a
 
 CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commit the result.
 
-- Prettier formats: `.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`. Any change to one of these — including tiny edits like a one-line tweak to an MDX page or a TSX component — can trigger the check.
+- Prettier formats: `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`. Any change to one of these — including tiny edits like a one-line tweak to an MDX page, a TSX component, or `next.config.mjs` — can trigger the check.
 - Prettier does **not** format files matched by `.prettierignore` (generated cookbook docs in `content/guides/cookbook/**`, `content/workshop/**`, lockfiles, generated assets in `public/`, etc.). Source notebooks (`.ipynb` in `cookbook/`) are also skipped because Prettier has no built-in parser for them.
 - Config (`.prettierrc.json`): `proseWrap: "preserve"` (don't reflow Markdown prose), `embeddedLanguageFormatting: "off"` (fenced code blocks are left alone), `trailingComma: "all"`.
 - If you touched only files Prettier skips (e.g., a notebook, or a generated file listed in `.prettierignore`), the check will still pass — no need to run format.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -53,6 +53,33 @@ This repository powers the Langfuse website hosted on `langfuse.com`, including 
 2. Regenerate docs with `bash scripts/update_cookbook_docs.sh`.
 3. Do **not** hand-edit generated files in `content/guides/cookbook/`.
 4. Avoid `pnpm build` for routine edits or small UI/content changes. Prefer targeted checks or `pnpm dev`, and only run the full production build when it is necessary or explicitly requested.
+5. **Always run `pnpm run format` before committing or opening a PR if you edited any file Prettier formats** (see "Passing CI checks on the first try" below). The `format` CI job runs `pnpm run format:check` and fails the build on a single unformatted file.
+
+## Passing CI checks on the first try
+
+CI runs three required checks on every PR. Run these locally before pushing to avoid a re-run cycle:
+
+### 1. Prettier format (`format` job) — this is the check that most often fails
+
+CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commit the result.
+
+- Prettier formats: `.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`. Any change to one of these — including tiny edits like a one-line tweak to an MDX page or a TSX component — can trigger the check.
+- Prettier does **not** format files matched by `.prettierignore` (notebooks, generated cookbook docs, `content/workshop/**`, lockfiles, generated JSON/TXT in `public/`, etc.).
+- Config (`.prettierrc.json`): `proseWrap: "preserve"` (don't reflow Markdown prose), `embeddedLanguageFormatting: "off"` (fenced code blocks are left alone), `trailingComma: "all"`.
+- If you touched only `.prettierignore`'d files (e.g., only a notebook or only a generated file), the check will still pass — no need to run format.
+- When in doubt, just run `pnpm run format` — it's fast and idempotent.
+
+### 2. H1 heading check (`check_h1` job)
+
+CI runs `node scripts/check-h1-headings.js`. It fails if any `.md`/`.mdx` file contains more than one top-level `# ` heading (code-fenced examples are ignored). Use exactly one H1 per markdown file; deeper sections use `##`, `###`, etc.
+
+### 3. Build + link/sitemap checks (`build-and-check-links`, `check-sitemap-links` jobs)
+
+These run `pnpm build` followed by `pnpm link-check` / `pnpm sitemap-check`. The full build is ~10 minutes — don't run it locally for routine edits. Instead, before pushing:
+
+- Check internal links you added/changed point to real pages or anchors.
+- For anchor links (`...#some-id`), make sure the target page defines the anchor explicitly with `[#some-id]` at the end of the heading line.
+- If you renamed or moved a page, also update any references and add a redirect in `next.config.mjs` if needed.
 
 ## Styling and implementation guidelines
 

--- a/.agents/cursor/rules/_general-rules.mdc
+++ b/.agents/cursor/rules/_general-rules.mdc
@@ -20,5 +20,5 @@ alwaysApply: true
 ## Before committing or opening a PR
 
 - Run `pnpm run format` if you edited any file Prettier formats (`.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`). CI runs `pnpm run format:check` and fails on a single unformatted file — this is the format check that most often fails on the first try.
-- Files in `.prettierignore` (notebooks, `content/guides/cookbook/**`, `content/workshop/**`, generated assets in `public/`, lockfiles) are skipped. If you only touched those, no format step is needed.
+- Files in `.prettierignore` (`content/guides/cookbook/**`, `content/workshop/**`, generated assets in `public/`, lockfiles) are skipped, as are source notebooks (`.ipynb` in `cookbook/`) since Prettier has no parser for them. If you only touched those, no format step is needed.
 - Each `.md`/`.mdx` file must have exactly one H1 (`# `) heading; CI's `check_h1` job rejects multiples.

--- a/.agents/cursor/rules/_general-rules.mdc
+++ b/.agents/cursor/rules/_general-rules.mdc
@@ -19,6 +19,6 @@ alwaysApply: true
 
 ## Before committing or opening a PR
 
-- Run `pnpm run format` if you edited any file Prettier formats (`.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`). CI runs `pnpm run format:check` and fails on a single unformatted file — this is the format check that most often fails on the first try.
+- Run `pnpm run format` if you edited any file Prettier formats (`.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`). CI runs `pnpm run format:check` and fails on a single unformatted file — this is the format check that most often fails on the first try.
 - Files in `.prettierignore` (`content/guides/cookbook/**`, `content/workshop/**`, generated assets in `public/`, lockfiles) are skipped, as are source notebooks (`.ipynb` in `cookbook/`) since Prettier has no parser for them. If you only touched those, no format step is needed.
 - Each `.md`/`.mdx` file must have exactly one H1 (`# `) heading; CI's `check_h1` job rejects multiples.

--- a/.agents/cursor/rules/_general-rules.mdc
+++ b/.agents/cursor/rules/_general-rules.mdc
@@ -16,3 +16,9 @@ alwaysApply: true
 ## Frontend
 
 - When using tailwindcss, never use explicit colors, always use the default semantic color tokens.
+
+## Before committing or opening a PR
+
+- Run `pnpm run format` if you edited any file Prettier formats (`.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.css`, `.scss`, `.md`, `.mdx`, `.yaml`/`.yml`, `.html`). CI runs `pnpm run format:check` and fails on a single unformatted file — this is the format check that most often fails on the first try.
+- Files in `.prettierignore` (notebooks, `content/guides/cookbook/**`, `content/workshop/**`, generated assets in `public/`, lockfiles) are skipped. If you only touched those, no format step is needed.
+- Each `.md`/`.mdx` file must have exactly one H1 (`# `) heading; CI's `check_h1` job rejects multiples.


### PR DESCRIPTION
## Summary

The Prettier format check (`pnpm run format:check`) is the CI job that most often fails on the first push of a PR — agents (and humans) frequently forget to run `pnpm run format` after editing MDX, TSX, or JSON files.

This PR adds explicit guidance to the agent instruction files so that new PRs are more likely to pass CI on the first try:

- **`.agents/AGENTS.md`** (canonical, also surfaced as `CLAUDE.md` and `AGENTS.md` via symlinks): adds workflow rule #5 calling out `pnpm run format`, plus a new "Passing CI checks on the first try" section documenting all three required checks (`format`, `check_h1`, `build-and-check-links`/`check-sitemap-links`), which file extensions Prettier formats, and which paths are excluded via `.prettierignore`.
- **`.agents/cursor/rules/_general-rules.mdc`**: adds a short "Before committing or opening a PR" section with the same format/H1 guidance for Cursor agents.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds explicit CI guidance to the agent instruction files (`AGENTS.md` and `_general-rules.mdc`) to help agents pass CI on the first PR push, targeting the most common failure: the Prettier format check.

- **`.agents/AGENTS.md`**: adds workflow rule #5 emphasising `pnpm run format`, and a new "Passing CI checks on the first try" section covering all three required CI jobs (`format`, `check_h1`, `build-and-check-links`/`check-sitemap-links`) with accurate details drawn from `.prettierrc.json` and `.prettierignore`.
- **`.agents/cursor/rules/_general-rules.mdc`**: adds a compact "Before committing or opening a PR" section surfacing the same format/H1 guidance for Cursor agents.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only changes to agent instruction files with no runtime impact.

The changes are accurate guidance against the real repo config, with one minor prose imprecision: notebooks are described as excluded via `.prettierignore` when in practice they are simply skipped by Prettier because no `.ipynb` parser is registered. The `.prettierrc.json` values and `.prettierignore` path patterns are all verified correct.

`.agents/AGENTS.md` line 67 and `.agents/cursor/rules/_general-rules.mdc` line 23 both contain the notebook/.prettierignore imprecision.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/AGENTS.md:67
**Notebooks described as `.prettierignore`-listed, but they aren't**

The `.prettierignore` file does not contain any entry for `cookbook/` or `*.ipynb`. The source notebooks are skipped by Prettier because Prettier has no built-in parser for `.ipynb`, not because they appear in `.prettierignore`. An agent reading this guidance might incorrectly assume `cookbook/` is explicitly excluded, which could cause confusion if e.g., `.md` files were ever placed in `cookbook/`. The description for `_general-rules.mdc` line 23 has the same inaccuracy.

A more accurate phrasing would be something like: "Prettier does **not** format files matched by `.prettierignore` (generated cookbook docs in `content/guides/cookbook/**`, `content/workshop/**`, lockfiles, generated files in `public/`, etc.); source notebooks (`.ipynb`) are also skipped because Prettier has no parser for them."

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add CI format check guidan..."](https://github.com/langfuse/langfuse-docs/commit/68b3246aa8ed49d1c17e1e2df0aa8c021c17cdce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34423687)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->