### PR TITLE
docs: add OpenAI on Bedrock changelog

### DIFF
--- a/content/changelog/2026-06-02-openai-on-amazon-bedrock.mdx
+++ b/content/changelog/2026-06-02-openai-on-amazon-bedrock.mdx
@@ -1,0 +1,32 @@
+---
+date: 2026-06-02
+title: Use OpenAI models on Amazon Bedrock
+description: Connect Bedrock-hosted OpenAI models to Langfuse LLM Connections with OpenAI Responses API support.
+author: tobiaswochinger
+canonical: /docs/administration/llm-connection
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Langfuse LLM Connections now support OpenAI-compatible Responses API endpoints. You can use OpenAI models hosted on Amazon Bedrock, including `openai.gpt-5.5` and `openai.gpt-5.4`, in the Langfuse Playground, LLM-as-a-Judge evaluators, and prompt experiments.
+
+Create an OpenAI LLM Connection, enable **Use Responses API**, add your Bedrock API key, configure the Bedrock Mantle endpoint for your AWS Region, and add the Bedrock model IDs you want to use.
+
+## Setup [#setup]
+
+In **Project Settings** > **LLM Connections**, add a new connection with:
+
+- **Provider**: OpenAI
+- **API Key**: your Amazon Bedrock API key
+- **Base URL**: `https://bedrock-mantle.<aws-region>.api.aws/openai/v1`
+- **Custom model names**: `openai.gpt-5.5`, `openai.gpt-5.4`, or another OpenAI model ID available in your Bedrock account
+- **Use Responses API**: enabled
+
+## Learn more [#learn-more]
+
+- [LLM Connections](/docs/administration/llm-connection)
+- [Amazon Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html)
+- [Inference using Responses API on Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
+- [OpenAI GPT-5.5 and GPT-5.4 models on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock/)

--- a/content/docs/administration/llm-connection.mdx
+++ b/content/docs/administration/llm-connection.mdx
@@ -295,3 +295,16 @@ curl -X POST 'https://<host set in project settings>/chat/completions' \
   ]
 }'
 ```
+
+### OpenAI Responses API endpoints
+
+Some OpenAI-compatible providers expose the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) instead of the Chat Completions API. For these providers, enable **Use Responses API** on the OpenAI LLM Connection so Langfuse sends Playground, LLM-as-a-Judge, and prompt experiment requests through the Responses API.
+
+For example, to use OpenAI models on Amazon Bedrock through the Bedrock Mantle endpoint:
+
+1. Navigate to **Project Settings** > **LLM Connections** and click **Add new LLM API key**.
+2. Select **OpenAI** as the provider.
+3. Enter your [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
+4. Under **Advanced Settings**, set the **Base URL** to `https://bedrock-mantle.<aws-region>.api.aws/openai/v1`.
+5. Enable **Use Responses API**.
+6. Add the **custom model names** available in your Bedrock account, for example `openai.gpt-5.5` or `openai.gpt-5.4`.


### PR DESCRIPTION
## Summary

- Add a changelog entry for OpenAI-compatible Responses API support in LLM Connections, focused on using OpenAI models hosted on Amazon Bedrock.
- Document the Bedrock Mantle setup on the LLM Connections page so users can configure the OpenAI provider with a Bedrock API key, Responses API enabled, and Bedrock model IDs.

## Linear

- [LFE-10099](https://linear.app/langfuse/issue/LFE-10099/openai-in-bedrock-compatibility)

## Review Focus

- Check that the Bedrock Mantle base URL, model IDs, and setup wording match the intended product behavior.
- Confirm whether the changelog title and docs section placement are the right level of prominence.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a changelog entry and extends the LLM Connections documentation to cover using OpenAI models hosted on Amazon Bedrock via the Bedrock Mantle Responses API endpoint. The changes are documentation-only and follow the established structure.

- **New changelog** (`content/changelog/2026-06-02-openai-on-amazon-bedrock.mdx`): announces Responses API support in Langfuse LLM Connections with a step-by-step Bedrock Mantle setup guide and reference links.
- **Docs update** (`content/docs/administration/llm-connection.mdx`): adds an \"OpenAI Responses API endpoints\" subsection under Advanced Configurations, mirroring the gateway walkthrough pattern already present in the file, with Bedrock as the concrete example.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after the base URL format is confirmed against the Langfuse backend implementation — if it's wrong, users who follow the docs will get 404s on every request.

Both changed files document the same Bedrock Mantle base URL as `https://bedrock-mantle.<aws-region>.api.aws/openai/v1/responses`. The official AWS documentation uses `https://bedrock-mantle.<region>.api.aws/v1`, and the existing gateway documentation in the same file shows Langfuse appending the endpoint name to the base URL. If the "Use Responses API" toggle follows the same pattern and appends `/responses` to the configured base URL, the actual request would target `…/responses/responses` and fail for all users who follow these instructions.

Both `content/changelog/2026-06-02-openai-on-amazon-bedrock.mdx` and `content/docs/administration/llm-connection.mdx` carry the same base URL value and need verification before going live.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Langfuse as Langfuse LLM Connection
    participant Bedrock as Amazon Bedrock Mantle

    User->>Langfuse: Configure OpenAI connection (Base URL, Bedrock API key, Use Responses API enabled)
    User->>Langfuse: Trigger Playground or LLM-as-a-Judge or Prompt Experiment
    Langfuse->>Langfuse: Resolve base URL and append endpoint path
    Langfuse->>Bedrock: POST to Responses API endpoint with Bearer Bedrock API key and model openai.gpt-5.5 or openai.gpt-5.4
    Bedrock-->>Langfuse: Responses API result
    Langfuse-->>User: Model response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/changelog/2026-06-02-openai-on-amazon-bedrock.mdx:23
**Potentially incorrect Base URL — `/responses` suffix may cause double-path requests**

The base URL is documented as `https://bedrock-mantle.<aws-region>.api.aws/openai/v1/responses`. The official AWS documentation for Bedrock Mantle consistently uses `https://bedrock-mantle.<region>.api.aws/v1` as the base URL (see [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)). Langfuse's gateway pattern (evidenced in the existing `llm-connection.mdx` docs) takes a base URL and appends the endpoint path — e.g. `<base>/chat/completions`. If the "Use Responses API" toggle works the same way and appends `/responses` to the configured base URL, setting the base URL to `…/openai/v1/responses` would result in a request to `…/openai/v1/responses/responses`, which would fail. The base URL likely needs to end at `/v1` (or at most `/openai/v1`), not include the endpoint name.

### Issue 2 of 2
content/docs/administration/llm-connection.mdx:308
**Base URL inconsistency with AWS official docs**

The base URL `https://bedrock-mantle.<aws-region>.api.aws/openai/v1/responses` diverges from the AWS-documented format in two ways: AWS uses `/v1` (not `/openai/v1`), and the `/responses` endpoint name is part of the request path, not the base URL. The sibling gateway example in this same file uses `https://your-litellm-instance.com/v1` as the base URL and shows Langfuse appending `/chat/completions` from there. If `Use Responses API` follows the same pattern and appends `/responses` to the configured base, the effective call URL would be `…/openai/v1/responses/responses` and every request would 404. Please verify whether the Langfuse backend uses this value as a literal endpoint or as a prefix before the endpoint path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add OpenAI on Bedrock changelog"](https://github.com/langfuse/langfuse-docs/commit/f488918f98976434dc54cfaa1e6ade5aaa8658b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35147168)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->