### PR TITLE
docs(openclaw): trace via native OpenTelemetry export

### DIFF
--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -43,6 +43,7 @@ Langfuse authenticates OTLP requests with [Basic Auth](https://en.wikipedia.org/
 echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
 # Linux / GNU (disable line wrapping)
 echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64 -w 0
+```
 
 ### Enable OpenTelemetry export in OpenClaw
 

--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -39,9 +39,10 @@ Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse]
 Langfuse authenticates OTLP requests with [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Generate the header value by base64-encoding your keys as `public_key:secret_key`:
 
 ```bash
+# macOS / BSD
 echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
-# For long keys on GNU systems, add -w 0 to disable line wrapping
-```
+# Linux / GNU (disable line wrapping)
+echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64 -w 0
 
 ### Enable OpenTelemetry export in OpenClaw
 

--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -2,7 +2,7 @@
 title: "Trace OpenClaw with Langfuse"
 sidebarTitle: OpenClaw
 logo: /images/integrations/openclaw_icon.svg
-description: "Trace your OpenClaw AI agent interactions with Langfuse via OpenRouter for observability into prompts, reasoning, tool calls, and costs."
+description: "Trace your OpenClaw AI agent with Langfuse using OpenClaw's native OpenTelemetry export for full visibility into prompts, reasoning, tool calls, and costs."
 category: Integrations
 ---
 
@@ -12,43 +12,80 @@ category: Integrations
 
 > **What is Langfuse?** [Langfuse](/) is an open-source LLM engineering platform that helps teams trace LLM calls, monitor performance, and debug issues in their AI applications.
 
-## Why Trace OpenClaw?
+## Why trace OpenClaw?
 
 - **Understand agent behavior.** Read the prompts, reasoning traces, and tool calls that OpenClaw makes under the hood.
 - **Improve your agent.** Identify where the agent gets confused so you can tweak skills, system prompts, and configurations.
 - **Track costs.** Monitor spending across models and sessions.
 
-## Tracing via OpenRouter
+## Trace OpenClaw via OpenTelemetry
 
-Since OpenClaw is model-agnostic, you can configure it to route LLM calls through [OpenRouter](https://openrouter.ai/). OpenRouter's [Broadcast feature](/integrations/gateways/openrouter#broadcast) then automatically sends traces to Langfuse, no code changes required.
+OpenClaw has built-in [OpenTelemetry](https://docs.openclaw.ai/gateway/opentelemetry) export, and Langfuse is an [OpenTelemetry backend](/integrations/native/opentelemetry). Point OpenClaw's exporter directly at Langfuse's OTLP endpoint and traces flow in with no SDK, no proxy, and no code changes.
+
+Because the export happens inside OpenClaw itself, it is **model-agnostic** (it works whether you call Claude, GPT, DeepSeek, or a local model) and captures OpenClaw's full span tree: model calls, tool execution, skill usage, harness lifecycle, and context assembly, along with `gen_ai.*` attributes for model, token usage, and cost.
+
+<Callout type="info">
+  OpenClaw exports **OTLP over HTTP (`http/protobuf`)**, which is exactly what Langfuse's OTLP endpoint accepts. OpenClaw ignores `grpc`, and Langfuse does not support gRPC, so no extra configuration is needed.
+</Callout>
 
 <Steps>
 
 ### Set up Langfuse
 
-Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting). Create a project and copy your API keys from the project settings.
+Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting). Create a project and copy your public and secret API keys from the project settings.
 
-### Configure OpenClaw to use OpenRouter
+### Create your Basic Auth header
 
-Set OpenRouter as your LLM provider in your OpenClaw configuration. Point the API base URL to `https://openrouter.ai/api/v1` and use your OpenRouter API key.
+Langfuse authenticates OTLP requests with [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Generate the header value by base64-encoding your keys as `public_key:secret_key`:
 
-### Enable OpenRouter Broadcast to Langfuse
+```bash
+echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
+# For long keys on GNU systems, add -w 0 to disable line wrapping
+```
 
-In your [OpenRouter settings](https://openrouter.ai/settings), connect your Langfuse API keys to enable the Broadcast feature. Once enabled, all LLM requests routed through OpenRouter will be automatically traced in Langfuse.
+### Enable OpenTelemetry export in OpenClaw
 
-<Frame className="my-10" fullWidth>
-  ![OpenRouter settings showing the Langfuse Broadcast
-  configuration](/images/integrations/openrouter-broadcast-langfuse-config.png)
-</Frame>
+Add the `diagnostics.otel` block to your OpenClaw configuration, pointing it at the Langfuse OTLP endpoint and passing the auth header from the previous step:
+
+```json5
+{
+  diagnostics: {
+    enabled: true,
+    otel: {
+      enabled: true,
+      endpoint: "https://cloud.langfuse.com/api/public/otel", // 🇪🇺 EU data region
+      // Other Langfuse data regions: 🇺🇸 US https://us.cloud.langfuse.com/api/public/otel,
+      // 🇯🇵 Japan https://jp.cloud.langfuse.com/api/public/otel, ⚕️ HIPAA https://hipaa.cloud.langfuse.com/api/public/otel
+      // 🏠 Local deployment: http://localhost:3000/api/public/otel
+      protocol: "http/protobuf",
+      traces: true,
+      headers: {
+        Authorization: "Basic <AUTH_STRING>", // the base64 value from the previous step
+        "x-langfuse-ingestion-version": "4", // surfaces spans in real time in Fast Preview
+      },
+    },
+  },
+}
+```
+
+For the richest GenAI attributes, opt in to the latest OpenTelemetry GenAI semantic conventions by setting an environment variable before starting OpenClaw:
+
+```bash
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
 
 ### View traces in Langfuse
 
-Open your Langfuse project to see captured traces. You'll be able to inspect individual LLM calls, token usage, costs, and the full content of prompts and responses.
+Run OpenClaw as usual. Open your Langfuse project to see captured traces, where you can inspect individual LLM calls, tool and skill executions, token usage, costs, and the full content of prompts and responses.
 
 </Steps>
 
-## Learn More
+<Callout type="info" title="Did you know?">
+  Already routing OpenClaw's LLM calls through [OpenRouter](https://openrouter.ai/)? You can also capture traces without touching OpenClaw's config by connecting your Langfuse keys in [OpenRouter settings](https://openrouter.ai/settings) to enable [Broadcast](/integrations/gateways/openrouter#broadcast). Note that this only traces the LLM calls routed through OpenRouter, not OpenClaw's tool and skill spans.
+</Callout>
 
-- [OpenRouter Integration Guide](/integrations/gateways/openrouter): Full details on Broadcast and SDK integration methods
-- [Getting Started with Langfuse](/docs/observability/get-started): Setting up API keys and projects
-- [OpenClaw Documentation](https://docs.openclaw.ai/): Configuring LLM providers in OpenClaw
+## Learn more
+
+- [Langfuse OpenTelemetry endpoint](/integrations/native/opentelemetry): Endpoint, authentication, and supported protocols
+- [Getting started with Langfuse](/docs/observability/get-started): Setting up API keys and projects
+- [OpenClaw OpenTelemetry docs](https://docs.openclaw.ai/gateway/opentelemetry): Full list of OTel configuration options


### PR DESCRIPTION
## What

Reworks the **OpenClaw × Langfuse** integration page to use OpenClaw's **native OpenTelemetry export** as the primary method, pointed directly at Langfuse's OTLP endpoint.

## Why

The page previously routed everything through OpenRouter's Broadcast feature. OpenClaw now ships built-in OTLP/HTTP export ([docs](https://docs.openclaw.ai/gateway/opentelemetry)), and Langfuse is a [native OTLP backend](https://langfuse.com/integrations/native/opentelemetry). Pointing one at the other is fewer steps and a better integration:

| | OpenRouter Broadcast (old) | Native OTLP (new) |
|---|---|---|
| Models | OpenRouter-routed only | Any model OpenClaw uses |
| Captured | LLM call only | Model calls + tools + skills + harness/context spans |
| Dependencies | OpenRouter account + Broadcast | None |

OpenClaw exports `http/protobuf` only and Langfuse accepts exactly that (no gRPC on either side), so the two line up with no glue code.

## Changes

- Lead with a `diagnostics.otel` config block (the config file is required to enable OTel **and** to set Langfuse's Basic Auth header, so it's the natural primary path).
- Document the Basic Auth header generation and the `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` opt-in for richer `gen_ai.*` attributes.
- Keep OpenRouter Broadcast as a short "Did you know?" callout.
- Update frontmatter `description` and the "Learn more" links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the OpenRouter Broadcast–based tracing guide with OpenClaw's built-in OTLP/HTTP export pointed at Langfuse's OTLP endpoint. The rewrite is well-structured, the endpoint URLs and header values are consistent with the canonical `opentelemetry.mdx`, and the OpenRouter path is preserved as a callout rather than being removed.

- The `diagnostics.otel` JSON5 config block, endpoint URLs (EU/US/JP/HIPAA/local), and `x-langfuse-ingestion-version: \"4\"` header all match what Langfuse's own OpenTelemetry documentation uses.
- The `base64` command buries the `-w 0` flag in a code comment rather than offering it as a first-class command variant; real Langfuse keys are long enough that GNU `base64` wraps without it, producing an invalid Authorization header.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only change is a documentation rewrite with accurate endpoint URLs and headers that match the canonical OpenTelemetry guide.

The `base64` step buries the GNU `-w 0` flag as a comment rather than showing it as its own command. Real Langfuse keys are long enough that GNU `base64` will wrap output without it, silently producing an invalid Authorization header for most Linux users.

content/integrations/other/openclaw.mdx — specifically the base64 command in the 'Create your Basic Auth header' step.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant OpenClaw
    participant Langfuse as Langfuse OTLP Endpoint

    User->>OpenClaw: Run agent task
    activate OpenClaw
    OpenClaw->>OpenClaw: Execute model calls, tools, skills
    OpenClaw-->>Langfuse: "POST /api/public/otel/v1/traces (http/protobuf)"
    note over OpenClaw,Langfuse: Authorization Basic header + x-langfuse-ingestion-version 4
    Langfuse-->>OpenClaw: 200 OK
    deactivate OpenClaw
    User->>Langfuse: Open project dashboard
    Langfuse-->>User: Traces with model, tool, skill, and context spans
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/integrations/other/openclaw.mdx:41-44
The `-w 0` note is buried as a comment inside the code block, making it easy to miss. The main Langfuse OpenTelemetry page surfaces the same note as readable prose immediately below the command. Real Langfuse keys (`pk-lf-<32+ chars>:sk-lf-<32+ chars>`) combine to ~77 characters, whose base64 encoding (~104 chars) always exceeds GNU `base64`'s 76-character wrap limit — so this flag is needed by virtually all Linux users, not just those with unusually long keys. Bake it into the command to prevent silent auth failures.

```suggestion
```bash
# macOS / BSD
echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
# Linux / GNU (disable line wrapping)
echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64 -w 0
```
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(openclaw): trace via native OpenTel..."](https://github.com/langfuse/langfuse-docs/commit/d7bfb3254fe95f715633265f659db55f878d2346) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35162307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->