### PR TITLE
Change talk to us page

### DIFF
--- a/app/api/contact-sales/route.ts
+++ b/app/api/contact-sales/route.ts
@@ -3,6 +3,7 @@ import nodemailer from "nodemailer";
 import {
   contactFormSchema,
   generateEmailContent,
+  generateEmailHtmlContent,
 } from "@/lib/contact-sales-form";
 
 export async function POST(request: NextRequest) {
@@ -31,6 +32,7 @@ export async function POST(request: NextRequest) {
 
     const data = validationResult.data;
     const emailContent = generateEmailContent(data);
+    const emailHtmlContent = generateEmailHtmlContent(data);
 
     const transporter = nodemailer.createTransport(smtpUrl);
 
@@ -40,6 +42,7 @@ export async function POST(request: NextRequest) {
       replyTo: "sales@langfuse.com",
       subject: `Langfuse - ${data.company}`,
       text: emailContent,
+      html: emailHtmlContent,
     });
 
     return NextResponse.json({ success: true });

--- a/components/ContactSalesForm.tsx
+++ b/components/ContactSalesForm.tsx
@@ -67,7 +67,7 @@ export function ContactSalesForm() {
         deployment,
       });
     }
-  }, [getValues, reset]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- hydrate from URL once on mount only.
 
   useEffect(() => {
     if (currentSetup !== "other-tool") {
@@ -331,11 +331,7 @@ export function ContactSalesForm() {
                 {FORM_FIELDS.deployment.label}{" "}
                 <RequiredMarker required={FORM_FIELDS.deployment.required} />
               </FormLabel>
-              <Select
-                key={field.value}
-                onValueChange={field.onChange}
-                defaultValue={field.value}
-              >
+              <Select onValueChange={field.onChange} value={field.value}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue

--- a/components/ContactSalesForm.tsx
+++ b/components/ContactSalesForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,14 @@ import {
   reportGoogleAdsConversion,
 } from "@/lib/google-ads";
 
+function RequiredMarker({ required }: { required: boolean }) {
+  if (!required) {
+    return null;
+  }
+
+  return <span className="text-destructive">*</span>;
+}
+
 export function ContactSalesForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -43,22 +51,31 @@ export function ContactSalesForm() {
     defaultValues: defaultFormValues,
   });
 
-  const selectedRequirements = form.watch("enterpriseRequirements");
+  const currentSetup = form.watch(FORM_FIELDS.currentSetup.name);
+  const { getValues, reset, setValue } = form;
 
-  const toggleRequirement = (value: string) => {
-    const current = form.getValues("enterpriseRequirements");
-    if (current.includes(value)) {
-      form.setValue(
-        "enterpriseRequirements",
-        current.filter((v) => v !== value),
-        { shouldValidate: true },
-      );
-    } else {
-      form.setValue("enterpriseRequirements", [...current, value], {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const deployment = params.get(FORM_FIELDS.deployment.name);
+    const isValidDeployment = FORM_FIELDS.deployment.options.some(
+      (option) => option.value === deployment,
+    );
+
+    if (deployment && isValidDeployment) {
+      reset({
+        ...getValues(),
+        deployment,
+      });
+    }
+  }, [getValues, reset]);
+
+  useEffect(() => {
+    if (currentSetup !== "other-tool") {
+      setValue(FORM_FIELDS.currentSetupOther.name, "", {
         shouldValidate: true,
       });
     }
-  };
+  }, [currentSetup, setValue]);
 
   async function onSubmit(data: ContactFormData) {
     setIsSubmitting(true);
@@ -108,9 +125,7 @@ export function ContactSalesForm() {
             <FormItem>
               <FormLabel>
                 {FORM_FIELDS.name.label}{" "}
-                {FORM_FIELDS.name.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                <RequiredMarker required={FORM_FIELDS.name.required} />
               </FormLabel>
               <FormControl>
                 <Input placeholder={FORM_FIELDS.name.placeholder} {...field} />
@@ -127,9 +142,7 @@ export function ContactSalesForm() {
             <FormItem>
               <FormLabel>
                 {FORM_FIELDS.email.label}{" "}
-                {FORM_FIELDS.email.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                <RequiredMarker required={FORM_FIELDS.email.required} />
               </FormLabel>
               <FormControl>
                 <Input
@@ -150,9 +163,7 @@ export function ContactSalesForm() {
             <FormItem>
               <FormLabel>
                 {FORM_FIELDS.company.label}{" "}
-                {FORM_FIELDS.company.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                <RequiredMarker required={FORM_FIELDS.company.required} />
               </FormLabel>
               <FormControl>
                 <Input
@@ -167,21 +178,29 @@ export function ContactSalesForm() {
 
         <FormField
           control={form.control}
-          name={FORM_FIELDS.message.name}
+          name={FORM_FIELDS.building.name}
           render={({ field }) => (
             <FormItem>
               <FormLabel>
-                {FORM_FIELDS.message.label}{" "}
-                {FORM_FIELDS.message.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                {FORM_FIELDS.building.label}{" "}
+                <RequiredMarker required={FORM_FIELDS.building.required} />
               </FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder={FORM_FIELDS.message.placeholder}
-                  {...field}
-                />
-              </FormControl>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={FORM_FIELDS.building.placeholder}
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {FORM_FIELDS.building.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormMessage />
             </FormItem>
           )}
@@ -189,22 +208,119 @@ export function ContactSalesForm() {
 
         <FormField
           control={form.control}
-          name={FORM_FIELDS.usage.name}
+          name={FORM_FIELDS.currentSetup.name}
           render={({ field }) => (
             <FormItem>
               <FormLabel>
-                {FORM_FIELDS.usage.label}{" "}
-                {FORM_FIELDS.usage.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                {FORM_FIELDS.currentSetup.label}{" "}
+                <RequiredMarker required={FORM_FIELDS.currentSetup.required} />
               </FormLabel>
-              <FormControl>
-                <Input placeholder={FORM_FIELDS.usage.placeholder} {...field} />
-              </FormControl>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={FORM_FIELDS.currentSetup.placeholder}
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {FORM_FIELDS.currentSetup.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormMessage />
             </FormItem>
           )}
         />
+
+        {currentSetup === "other-tool" && (
+          <FormField
+            control={form.control}
+            name={FORM_FIELDS.currentSetupOther.name}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {FORM_FIELDS.currentSetupOther.label}{" "}
+                  <RequiredMarker required={currentSetup === "other-tool"} />
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={FORM_FIELDS.currentSetupOther.placeholder}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium">
+            LLM apps or agents - today vs. in 6-12 months{" "}
+            <span className="text-destructive">*</span>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name={FORM_FIELDS.productionAppCount.name}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{FORM_FIELDS.productionAppCount.label}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={
+                            FORM_FIELDS.productionAppCount.placeholder
+                          }
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {FORM_FIELDS.productionAppCount.options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name={FORM_FIELDS.plannedAppCount.name}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{FORM_FIELDS.plannedAppCount.label}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={FORM_FIELDS.plannedAppCount.placeholder}
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {FORM_FIELDS.plannedAppCount.options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
 
         <FormField
           control={form.control}
@@ -213,11 +329,13 @@ export function ContactSalesForm() {
             <FormItem>
               <FormLabel>
                 {FORM_FIELDS.deployment.label}{" "}
-                {FORM_FIELDS.deployment.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                <RequiredMarker required={FORM_FIELDS.deployment.required} />
               </FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select
+                key={field.value}
+                onValueChange={field.onChange}
+                defaultValue={field.value}
+              >
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue
@@ -245,48 +363,24 @@ export function ContactSalesForm() {
             <FormItem>
               <FormLabel>
                 {FORM_FIELDS.userCount.label}{" "}
-                {FORM_FIELDS.userCount.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                <RequiredMarker required={FORM_FIELDS.userCount.required} />
               </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={FORM_FIELDS.userCount.placeholder}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name={FORM_FIELDS.enterpriseRequirements.name}
-          render={() => (
-            <FormItem>
-              <FormLabel>
-                {FORM_FIELDS.enterpriseRequirements.label}{" "}
-                {FORM_FIELDS.enterpriseRequirements.required && (
-                  <span className="text-destructive">*</span>
-                )}
-              </FormLabel>
-              <div className="space-y-2 rounded-[2px] border border-line-structure p-3">
-                {FORM_FIELDS.enterpriseRequirements.options.map((option) => (
-                  <label
-                    key={option.value}
-                    className="flex items-center gap-2 cursor-pointer text-sm"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedRequirements.includes(option.value)}
-                      onChange={() => toggleRequirement(option.value)}
-                      className="h-4 w-4 rounded-[2px] border-line-structure accent-line-cta"
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={FORM_FIELDS.userCount.placeholder}
                     />
-                    {option.label}
-                  </label>
-                ))}
-              </div>
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {FORM_FIELDS.userCount.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormMessage />
             </FormItem>
           )}
@@ -294,18 +388,17 @@ export function ContactSalesForm() {
 
         <FormField
           control={form.control}
-          name={FORM_FIELDS.additionalNotes.name}
+          name={FORM_FIELDS.message.name}
           render={({ field }) => (
             <FormItem>
               <FormLabel>
-                {FORM_FIELDS.additionalNotes.label}{" "}
-                {FORM_FIELDS.additionalNotes.required && (
-                  <span className="text-destructive">*</span>
-                )}
+                {FORM_FIELDS.message.label}{" "}
+                <RequiredMarker required={FORM_FIELDS.message.required} />
               </FormLabel>
               <FormControl>
                 <Textarea
-                  placeholder={FORM_FIELDS.additionalNotes.placeholder}
+                  placeholder={FORM_FIELDS.message.placeholder}
+                  rows={4}
                   {...field}
                 />
               </FormControl>

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -179,7 +179,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
     {
       name: "Enterprise",
       id: "tier-enterprise",
-      href: "/talk-to-us",
+      href: "/talk-to-us?deployment=cloud",
       featured: false,
       description:
         "For large scale teams. Enterprise-grade support and security.",
@@ -235,7 +235,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
     {
       name: "Enterprise",
       id: "tier-self-hosted-enterprise",
-      href: "https://langfuse.app.n8n.cloud/form/edaa0e7f-0244-4b3e-92d6-870179e066f2",
+      href: "/talk-to-us?deployment=self-hosted",
       featured: false,
       pillClassName: "bg-[#FAFF6A] text-[#1A1A1A]",
       description:

--- a/components/watchOrBookDemo/index.tsx
+++ b/components/watchOrBookDemo/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Suspense } from "react";
-import { Header } from "@/components/Header";
 import { ContactSalesForm } from "@/components/ContactSalesForm";
 import { CheckCircle2, ArrowRight } from "lucide-react";
 import { getGitHubStars } from "@/lib/github-stars";
@@ -14,6 +13,7 @@ import { HomeSection } from "@/components/home/HomeSection";
 import { EnterpriseLogoGrid } from "@/components/shared/EnterpriseLogoGrid";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
+import { TextHighlight } from "@/components/ui/text-highlight";
 
 function SwitchToggle({
   checked,
@@ -229,15 +229,18 @@ export function Demo({ page }: { page: "talk-to-us" | "watch-demo" }) {
 
   return (
     <HomeSection>
-      <Header
-        title={isDiscoverOpen ? "See Langfuse in Action" : "Get a Demo"}
-        h="h1"
-        description={
-          isDiscoverOpen
+      <div className="not-prose flex flex-col gap-2 mb-6 items-center text-center text-balance">
+        <Heading as="h1" size="large" className="m-0">
+          <TextHighlight>
+            {isDiscoverOpen ? "See Langfuse in action" : "Get a demo"}
+          </TextHighlight>
+        </Heading>
+        <Text className="m-0">
+          {isDiscoverOpen
             ? "Watch short videos to see how Langfuse helps you build better LLM applications"
-            : "Learn more about Langfuse — talk to us or watch videos"
-        }
-      />
+            : "Learn more about Langfuse — talk to us or watch videos"}
+        </Text>
+      </div>
 
       <div className="w-full max-w-6xl px-4 not-prose">
         <div className="flex flex-col md:flex-row gap-8">

--- a/lib/contact-sales-form.ts
+++ b/lib/contact-sales-form.ts
@@ -103,7 +103,7 @@ export const FORM_FIELDS = {
   },
   productionAppCount: {
     name: "productionAppCount" as const,
-    label: "In production today",
+    label: "In production",
     placeholder: "Select",
     required: true,
     options: LLM_APP_COUNT_OPTIONS,
@@ -234,7 +234,9 @@ export function formatFormDataForEmail(data: ContactFormData): string {
       label: FORM_FIELDS.currentSetup.label,
       value:
         getLabel(CURRENT_SETUP_OPTIONS, data.currentSetup) +
-        (data.currentSetupOther ? ` (${data.currentSetupOther})` : ""),
+        (data.currentSetup === "other-tool" && data.currentSetupOther
+          ? ` (${data.currentSetupOther})`
+          : ""),
     },
     {
       label: FORM_FIELDS.productionAppCount.label,

--- a/lib/contact-sales-form.ts
+++ b/lib/contact-sales-form.ts
@@ -150,6 +150,15 @@ const optionValueSchema = <T extends readonly { value: string }[]>(
     .min(1, message)
     .refine((value) => optionValues(options).includes(value), message);
 
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export const contactFormSchema = z
   .object({
     name: z.string().min(1, "Name is required").max(200),
@@ -216,13 +225,13 @@ export const defaultFormValues: ContactFormData = {
   message: "",
 };
 
-export function formatFormDataForEmail(data: ContactFormData): string {
+function getEmailFields(data: ContactFormData) {
   const getLabel = <T extends readonly { value: string; label: string }[]>(
     options: T,
     value: string,
   ) => options.find((option) => option.value === value)?.label ?? value;
 
-  const fields = [
+  return [
     { label: FORM_FIELDS.name.label, value: data.name },
     { label: FORM_FIELDS.email.label, value: data.email },
     { label: FORM_FIELDS.company.label, value: data.company },
@@ -239,11 +248,11 @@ export function formatFormDataForEmail(data: ContactFormData): string {
           : ""),
     },
     {
-      label: FORM_FIELDS.productionAppCount.label,
+      label: "Agents/LLM features in production today",
       value: getLabel(LLM_APP_COUNT_OPTIONS, data.productionAppCount),
     },
     {
-      label: FORM_FIELDS.plannedAppCount.label,
+      label: "Agents/LLM features planned in the future",
       value: getLabel(LLM_APP_COUNT_OPTIONS, data.plannedAppCount),
     },
     {
@@ -256,8 +265,23 @@ export function formatFormDataForEmail(data: ContactFormData): string {
     },
     { label: FORM_FIELDS.message.label, value: data.message },
   ];
+}
 
-  return fields.map((f) => `**${f.label}**\n${f.value}`).join("\n\n");
+export function formatFormDataForEmail(data: ContactFormData): string {
+  return getEmailFields(data)
+    .map((field) => `${field.label}\n${field.value}`)
+    .join("\n\n");
+}
+
+export function formatFormDataForEmailHtml(data: ContactFormData): string {
+  return getEmailFields(data)
+    .map(
+      (field) =>
+        `<p><strong>${escapeHtml(field.label)}</strong><br />${escapeHtml(
+          field.value,
+        ).replace(/\r?\n/g, "<br />")}</p>`,
+    )
+    .join("\n");
 }
 
 export function generateEmailContent(data: ContactFormData): string {
@@ -273,6 +297,22 @@ Team Langfuse
 ---
 
 Your request:
+
+${formattedData}`;
+}
+
+export function generateEmailHtmlContent(data: ContactFormData): string {
+  const formattedData = formatFormDataForEmailHtml(data);
+
+  return `<p>Dear ${escapeHtml(data.name)},</p>
+
+<p>Thanks for reaching out. We will respond shortly. Feel free to reply to this message if you want to add any additional context.</p>
+
+<p>Best<br />Team Langfuse</p>
+
+<hr />
+
+<p>Your request:</p>
 
 ${formattedData}`;
 }

--- a/lib/contact-sales-form.ts
+++ b/lib/contact-sales-form.ts
@@ -13,112 +13,192 @@ function sanitizeForEmailHeader(input: string): string {
 }
 
 export const DEPLOYMENT_OPTIONS = [
-  { value: "not-decided", label: "Not decided yet" },
-  { value: "self-hosted", label: "Self-Hosted" },
-  { value: "cloud", label: "Cloud (SaaS)" },
+  { value: "cloud", label: "Cloud" },
+  { value: "self-hosted", label: "Self-hosted" },
+  { value: "undecided", label: "Undecided" },
 ] as const;
 
-export const ENTERPRISE_REQUIREMENTS = [
-  { value: "none", label: "None (Want to use Core, Pro, Open Source)" },
-  { value: "legal-dpa", label: "Need for custom legal terms or DPA" },
+export const BUILDING_OPTIONS = [
   {
-    value: "security-review",
-    label: "Must complete a security questionnaire/review",
+    value: "customer-facing-ai",
+    label: "Customer-facing AI product or agent (in or near production)",
   },
   {
-    value: "high-usage",
-    label: "Anticipate very high usage and need custom plan",
+    value: "internal-assistant",
+    label: "Internal assistant/copilot for employees",
   },
   {
-    value: "enterprise-features",
-    label: "Need features in enterprise versions",
+    value: "platform",
+    label: "A platform serving multiple teams building with LLMs",
   },
-  { value: "rfp", label: "Competitive RfP" },
+  {
+    value: "prototyping",
+    label: "Still prototyping — nothing in production yet",
+  },
+] as const;
+
+export const CURRENT_SETUP_OPTIONS = [
+  { value: "langfuse-cloud", label: "Already using Langfuse Cloud" },
+  {
+    value: "langfuse-self-hosted",
+    label: "Already self-hosting Langfuse (OSS)",
+  },
+  { value: "own-tooling", label: "Built our own tracing/eval tooling" },
+  { value: "other-tool", label: "Using another tool" },
+  { value: "nothing-yet", label: "Nothing yet" },
+] as const;
+
+export const LLM_APP_COUNT_OPTIONS = [
+  { value: "0", label: "0" },
+  { value: "1-5", label: "1–5" },
+  { value: "6-20", label: "6–20" },
+  { value: "20-plus", label: "20+" },
+] as const;
+
+export const USER_COUNT_OPTIONS = [
+  { value: "1-5", label: "1–5" },
+  { value: "6-25", label: "6–25" },
+  { value: "26-100", label: "26–100" },
+  { value: "100-plus", label: "100+" },
 ] as const;
 
 export const FORM_FIELDS = {
   name: {
     name: "name" as const,
-    label: "Your name",
+    label: "Name",
     placeholder: "John Doe",
     required: true,
   },
   email: {
     name: "email" as const,
-    label: "Email address",
-    placeholder: "john@company.com",
+    label: "Work email",
+    placeholder: "your.name@acme.com",
     required: true,
   },
   company: {
     name: "company" as const,
-    label: "Company/Project",
+    label: "Company name",
     placeholder: "Acme Inc.",
     required: true,
   },
-  message: {
-    name: "message" as const,
-    label: "What would you like to learn/understand in the conversation?",
-    placeholder:
-      "Please share anything that will help prepare for our meeting.",
+  building: {
+    name: "building" as const,
+    label: "What are you building?",
+    placeholder: "Select an option",
     required: true,
+    options: BUILDING_OPTIONS,
   },
-  usage: {
-    name: "usage" as const,
-    label: "How have you used Langfuse so far?",
-    placeholder: "e.g., Evaluated the product, using in production...",
+  currentSetup: {
+    name: "currentSetup" as const,
+    label: "Your current setup",
+    placeholder: "Select an option",
     required: true,
+    options: CURRENT_SETUP_OPTIONS,
+  },
+  currentSetupOther: {
+    name: "currentSetupOther" as const,
+    label: "Which tool?",
+    placeholder: "e.g., LangSmith, Braintrust, custom internal tool...",
+    required: false,
+  },
+  productionAppCount: {
+    name: "productionAppCount" as const,
+    label: "In production today",
+    placeholder: "Select",
+    required: true,
+    options: LLM_APP_COUNT_OPTIONS,
+  },
+  plannedAppCount: {
+    name: "plannedAppCount" as const,
+    label: "Planned in future",
+    placeholder: "Select",
+    required: true,
+    options: LLM_APP_COUNT_OPTIONS,
   },
   deployment: {
     name: "deployment" as const,
-    label: "Where do you (want to) use Langfuse?",
+    label: "Where do you want to run Langfuse?",
     placeholder: "Select an option",
     required: true,
     options: DEPLOYMENT_OPTIONS,
   },
   userCount: {
     name: "userCount" as const,
-    label: "How many users are you planning to onboard in the next 6 months?",
-    placeholder: "e.g., 10, 50, 100+",
+    label: "How many people would use Langfuse?",
+    placeholder: "Select an option",
     required: true,
+    options: USER_COUNT_OPTIONS,
   },
-  enterpriseRequirements: {
-    name: "enterpriseRequirements" as const,
-    label:
-      "Do you have specific requirements that would necessitate the Enterprise version?",
-    required: true,
-    options: ENTERPRISE_REQUIREMENTS,
-  },
-  additionalNotes: {
-    name: "additionalNotes" as const,
-    label: "Additional Notes",
+  message: {
+    name: "message" as const,
+    label: "What do you want to get out of the conversation?",
     placeholder:
-      "Please share anything that will help prepare for our meeting.",
-    required: false,
+      "e.g. We're scaling 3 agents to production and need better evals + cost tracking across teams.",
+    required: true,
   },
 } as const;
 
-export const contactFormSchema = z.object({
-  name: z.string().min(1, "Name is required").max(200),
-  email: z.string().email("Invalid email address").max(254),
-  // Company is sanitized because it's used in the email subject header
-  company: z
+const optionValues = <T extends readonly { value: string }[]>(options: T) =>
+  options.map((option) => option.value);
+
+const optionValueSchema = <T extends readonly { value: string }[]>(
+  options: T,
+  message: string,
+) =>
+  z
     .string()
-    .min(1, "Company/Project is required")
-    .max(200)
-    .transform(sanitizeForEmailHeader),
-  message: z
-    .string()
-    .min(1, "Please tell us what you'd like to learn")
-    .max(5000),
-  usage: z.string().min(1, "Please describe your Langfuse usage").max(2000),
-  deployment: z.string().min(1, "Please select a deployment option").max(100),
-  userCount: z.string().min(1, "Please provide expected user count").max(100),
-  enterpriseRequirements: z
-    .array(z.string().max(100))
-    .min(1, "Please select at least one option")
-    .max(10),
-  additionalNotes: z.string().max(5000).optional(),
-});
+    .min(1, message)
+    .refine((value) => optionValues(options).includes(value), message);
+
+export const contactFormSchema = z
+  .object({
+    name: z.string().min(1, "Name is required").max(200),
+    email: z.string().email("Invalid email address").max(254),
+    // Company is sanitized because it's used in the email subject header
+    company: z
+      .string()
+      .min(1, "Company name is required")
+      .max(200)
+      .transform(sanitizeForEmailHeader),
+    building: optionValueSchema(
+      BUILDING_OPTIONS,
+      "Please select what you are building",
+    ),
+    currentSetup: optionValueSchema(
+      CURRENT_SETUP_OPTIONS,
+      "Please select your current setup",
+    ),
+    currentSetupOther: z.string().max(200).optional(),
+    productionAppCount: optionValueSchema(
+      LLM_APP_COUNT_OPTIONS,
+      "Please select current production usage",
+    ),
+    plannedAppCount: optionValueSchema(
+      LLM_APP_COUNT_OPTIONS,
+      "Please select planned usage",
+    ),
+    deployment: optionValueSchema(
+      DEPLOYMENT_OPTIONS,
+      "Please select a deployment option",
+    ),
+    userCount: optionValueSchema(
+      USER_COUNT_OPTIONS,
+      "Please select expected user count",
+    ),
+    message: z
+      .string()
+      .min(1, "Please tell us what you want to get out of the conversation")
+      .max(5000),
+  })
+  .superRefine((data, ctx) => {
+    if (data.currentSetup === "other-tool" && !data.currentSetupOther?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["currentSetupOther"],
+        message: "Please tell us which tool you are using",
+      });
+    }
+  });
 
 export type ContactFormData = z.infer<typeof contactFormSchema>;
 
@@ -126,40 +206,53 @@ export const defaultFormValues: ContactFormData = {
   name: "",
   email: "",
   company: "",
-  message: "",
-  usage: "",
+  building: "",
+  currentSetup: "",
+  currentSetupOther: "",
+  productionAppCount: "",
+  plannedAppCount: "",
   deployment: "",
   userCount: "",
-  enterpriseRequirements: [],
-  additionalNotes: "",
+  message: "",
 };
 
 export function formatFormDataForEmail(data: ContactFormData): string {
+  const getLabel = <T extends readonly { value: string; label: string }[]>(
+    options: T,
+    value: string,
+  ) => options.find((option) => option.value === value)?.label ?? value;
+
   const fields = [
     { label: FORM_FIELDS.name.label, value: data.name },
     { label: FORM_FIELDS.email.label, value: data.email },
     { label: FORM_FIELDS.company.label, value: data.company },
-    { label: FORM_FIELDS.message.label, value: data.message },
-    { label: FORM_FIELDS.usage.label, value: data.usage },
+    {
+      label: FORM_FIELDS.building.label,
+      value: getLabel(BUILDING_OPTIONS, data.building),
+    },
+    {
+      label: FORM_FIELDS.currentSetup.label,
+      value:
+        getLabel(CURRENT_SETUP_OPTIONS, data.currentSetup) +
+        (data.currentSetupOther ? ` (${data.currentSetupOther})` : ""),
+    },
+    {
+      label: FORM_FIELDS.productionAppCount.label,
+      value: getLabel(LLM_APP_COUNT_OPTIONS, data.productionAppCount),
+    },
+    {
+      label: FORM_FIELDS.plannedAppCount.label,
+      value: getLabel(LLM_APP_COUNT_OPTIONS, data.plannedAppCount),
+    },
     {
       label: FORM_FIELDS.deployment.label,
-      value:
-        DEPLOYMENT_OPTIONS.find((o) => o.value === data.deployment)?.label ??
-        data.deployment,
-    },
-    { label: FORM_FIELDS.userCount.label, value: data.userCount },
-    {
-      label: FORM_FIELDS.enterpriseRequirements.label,
-      value: data.enterpriseRequirements
-        .map(
-          (v) => ENTERPRISE_REQUIREMENTS.find((o) => o.value === v)?.label ?? v,
-        )
-        .join(", "),
+      value: getLabel(DEPLOYMENT_OPTIONS, data.deployment),
     },
     {
-      label: FORM_FIELDS.additionalNotes.label,
-      value: data.additionalNotes || "N/A",
+      label: FORM_FIELDS.userCount.label,
+      value: getLabel(USER_COUNT_OPTIONS, data.userCount),
     },
+    { label: FORM_FIELDS.message.label, value: data.message },
   ];
 
   return fields.map((f) => `**${f.label}**\n${f.value}`).join("\n\n");

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -37,7 +37,7 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 - Support SLA
 - Billing via AWS Marketplace or invoice
 
-[Talk to sales](https://langfuse.app.n8n.cloud/form/edaa0e7f-0244-4b3e-92d6-870179e066f2) | [Enterprise FAQ](/enterprise)
+[Talk to sales](/talk-to-us?deployment=self-hosted) | [Enterprise FAQ](/enterprise)
 
 ## Feature Comparison (Self-Hosted)
 

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -78,7 +78,7 @@ Optional **Yearly Commitment**:
 - Billing via invoice
 - Vendor onboarding
 
-[Contact sales](/talk-to-us) | [Enterprise FAQ](/enterprise)
+[Contact sales](/talk-to-us?deployment=cloud) | [Enterprise FAQ](/enterprise)
 
 ## Feature Comparison (Cloud)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR overhauls the "Talk to Us" contact form, replacing several free-text fields with structured dropdowns and adds HTML email support. All enterprise CTA links across the pricing pages and markdown overrides are consolidated to the in-app `/talk-to-us` route with `?deployment=cloud` or `?deployment=self-hosted` pre-population.

- **Form restructure**: old fields (`usage`, `enterpriseRequirements`, `additionalNotes`) are replaced with `building`, `currentSetup` (with a conditional `currentSetupOther` input), `productionAppCount`, `plannedAppCount`, and `userCount` dropdowns validated against explicit option lists via a shared `optionValueSchema` helper.
- **HTML email**: adds `generateEmailHtmlContent` with correct `escapeHtml` sanitisation and sends both `text` and `html` parts; the plain-text path is preserved untouched.
- **URL hydration**: a mount-only `useEffect` reads `?deployment=` from `window.location.search` and resets the form field to the validated value, enabling deep-link pre-selection from the pricing tables.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all form field changes are internally consistent across the schema, default values, UI, and email helpers, and user-supplied data is correctly HTML-escaped in the new email path.

Schema validation, conditional logic for `currentSetupOther`, URL-parameter hydration, and HTML email escaping are all implemented correctly. The new option-list validator (`optionValueSchema`) enforces allowlists server-side, and the superRefine cross-field check aligns with the conditional UI rendering. No broken contracts, missing fields, or unescaped output paths were found.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant PricingPage
    participant TalkToUsForm
    participant ContactSalesAPI
    participant SMTP

    User->>PricingPage: Click Enterprise CTA
    PricingPage->>TalkToUsForm: "Navigate to /talk-to-us?deployment=cloud|self-hosted"
    TalkToUsForm->>TalkToUsForm: "useEffect (mount): read ?deployment= from URL,"
    Note over TalkToUsForm: validate against DEPLOYMENT_OPTIONS, reset() with pre-selected value
    User->>TalkToUsForm: Fill in remaining fields
    Note over TalkToUsForm: If currentSetup=other-tool, show currentSetupOther input
    User->>TalkToUsForm: Submit
    TalkToUsForm->>TalkToUsForm: react-hook-form validates via contactFormSchema
    TalkToUsForm->>ContactSalesAPI: POST /api/contact-sales
    ContactSalesAPI->>ContactSalesAPI: safeParse + superRefine cross-field check
    ContactSalesAPI->>ContactSalesAPI: generateEmailContent + generateEmailHtmlContent
    ContactSalesAPI->>SMTP: "sendMail to sales@langfuse.com + data.email"
    SMTP-->>User: Confirmation email
    ContactSalesAPI-->>TalkToUsForm: success: true
    TalkToUsForm-->>User: Success state
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix contact sales email formatting"](https://github.com/langfuse/langfuse-docs/commit/5e2fec0ed3c4eb1f9c922eda4e2de6b620b46cdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35280239)</sub>

<!-- /greptile_comment -->