### PR TITLE
Add marketing page for Langfuse agents integration

### DIFF
--- a/components-mdx/get-started/auto-install.mdx
+++ b/components-mdx/get-started/auto-install.mdx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
 
-Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
+Install the [Langfuse Agent Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
 
 <Tabs items={["Ask your coding agent", "Cursor plugin", "Manual installation"]}>
 
@@ -10,7 +10,7 @@ Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your 
 Ask your coding agent to install the skill by pointing to the [GitHub repository](https://github.com/langfuse/skills).
 
 ```txt filename="Agent instruction"
-"Install the Langfuse AI skill from github.com/langfuse/skills."
+"Install the Langfuse Agent Skill from github.com/langfuse/skills."
 ```
 
 </Tab>

--- a/components/home/GetStartedSection.tsx
+++ b/components/home/GetStartedSection.tsx
@@ -16,17 +16,17 @@ const AGENT_PROMPTS = [
   {
     label: "Tracing:",
     prompt:
-      "Install the Langfuse AI skill from github.com/langfuse/skills and use it to add tracing to this application with Langfuse following best practices.",
+      "Install the Langfuse Agent Skill from github.com/langfuse/skills and use it to add tracing to this application with Langfuse following best practices.",
   },
   {
     label: "Evals:",
     prompt:
-      "Install the Langfuse AI skill from github.com/langfuse/skills and use it to set up evals for this application with Langfuse. Guide me through choosing the right evaluation approach methods.",
+      "Install the Langfuse Agent Skill from github.com/langfuse/skills and use it to set up evals for this application with Langfuse. Guide me through choosing the right evaluation approach methods.",
   },
   {
     label: "Prompt Management:",
     prompt:
-      "Install the Langfuse AI skill from github.com/langfuse/skills and use it to migrate the prompts in this codebase to Langfuse.",
+      "Install the Langfuse Agent Skill from github.com/langfuse/skills and use it to migrate the prompts in this codebase to Langfuse.",
   },
 ];
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -39,6 +39,7 @@ const menuItems: {
       { name: "Prompt Management", href: "/docs/prompt-management/overview" },
       { name: "Evaluations", href: "/docs/evaluation/overview" },
       { name: "Metrics", href: "/docs/metrics/overview" },
+      { name: "Langfuse for Agents", href: "/agents" },
       {
         name: "Playground",
         href: "/docs/prompt-management/features/playground",

--- a/content/docs/api-and-data-platform/features/agent-skill.mdx
+++ b/content/docs/api-and-data-platform/features/agent-skill.mdx
@@ -44,6 +44,7 @@ Once installed, you can prompt your agent with what you want to do. A couple of 
 
 ## Resources [#resources]
 
+- [Langfuse for Agents](/agents) — overview of the skill, CLI, and MCP server for coding agents
 - [Langfuse Skills on GitHub](https://github.com/langfuse/skills)
 - [Langfuse CLI](/docs/api-and-data-platform/features/cli) — the CLI the skill uses under the hood
 - [MCP Server](/docs/api-and-data-platform/features/mcp-server) — alternative protocol-based approach for agents

--- a/content/docs/api-and-data-platform/features/cli.mdx
+++ b/content/docs/api-and-data-platform/features/cli.mdx
@@ -58,4 +58,4 @@ It dynamically wraps the full OpenAPI spec, so every endpoint (traces, prompts, 
 
 ## Pairs with Agent Skills
 
-The CLI is designed to work together with [Agent Skills](/docs/api-and-data-platform/features/agent-skill). The skill teaches agents how to discover endpoints, follow common workflows, and access documentation, all through the CLI. Read more about the full agent story in [the blog post](/blog/2026-02-13-will-you-be-my-cli).
+The CLI is designed to work together with [Agent Skills](/docs/api-and-data-platform/features/agent-skill). The skill teaches agents how to discover endpoints, follow common workflows, and access documentation, all through the CLI. See [Langfuse for Agents](/agents) for the full picture of how the skill, CLI, and MCP server fit together, or read [the blog post](/blog/2026-02-13-will-you-be-my-cli).

--- a/content/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/content/docs/api-and-data-platform/features/mcp-server.mdx
@@ -270,3 +270,4 @@ We'd love to hear about your experience with the Langfuse MCP server. Share your
 - [Prompt Management Overview](/docs/prompt-management/overview) - Learn about Langfuse prompt management
 - [Public API](/docs/api-and-data-platform/features/public-api) - REST API for programmatic access
 - [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill) - Use Langfuse features from your coding agent
+- [Langfuse for Agents](/agents) - Overview of the skill, CLI, and MCP server for coding agents

--- a/content/docs/api-and-data-platform/overview.mdx
+++ b/content/docs/api-and-data-platform/overview.mdx
@@ -51,9 +51,16 @@ import {
   Blocks,
   BarChart3,
   ListTree,
+  Bot,
 } from "lucide-react";
 
 <Cards num={3}>
+  <Card
+    title="Langfuse for Agents"
+    href="/agents"
+    icon={<Bot />}
+    arrow
+  />
   <Card
     title="MCP Server"
     href="/docs/api-and-data-platform/features/mcp-server"

--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -24,7 +24,7 @@ import { Link } from "@/components/ui/link";
 
 ## Agentic installation [#agentic-installation]
 
-Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
+Install the [Langfuse Agent Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
 
 <Tabs items={["Ask your coding agent", "Cursor plugin", "Manual installation"]}>
 
@@ -33,7 +33,7 @@ Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your 
 Ask your coding agent to install the skill by pointing to the [GitHub repository](https://github.com/langfuse/skills) and instruct it to get started with tracing.
 
 ```txt filename="Agent instruction"
-Install the Langfuse AI skill from github.com/langfuse/skills
+Install the Langfuse Agent Skill from github.com/langfuse/skills
 and use it to add tracing to this application with Langfuse
 following best practices.
 ```

--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -19,7 +19,7 @@ import { Link } from "@/components/ui/link";
 
 ## Agentic installation [#agentic-installation]
 
-Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
+Install the [Langfuse Agent Skill](https://github.com/langfuse/skills) to let your coding agent access all Langfuse features.
 
 <Tabs items={["Ask your coding agent", "Cursor plugin", "Manual installation"]}>
 
@@ -28,7 +28,7 @@ Install the [Langfuse AI Skill](https://github.com/langfuse/skills) to let your 
 Ask your coding agent to install the skill by pointing to the [GitHub repository](https://github.com/langfuse/skills) and instruct it to migrate your prompts.
 
 ```txt filename="Agent instruction"
-Install the Langfuse AI skill from github.com/langfuse/skills
+Install the Langfuse Agent Skill from github.com/langfuse/skills
 and use it to migrate the prompts in this codebase to Langfuse.
 ```
 

--- a/content/marketing/agents.mdx
+++ b/content/marketing/agents.mdx
@@ -39,6 +39,8 @@ The [Agent Skill](/docs/api-and-data-platform/features/agent-skill) follows the 
 
 A skill is a self-contained folder with a `SKILL.md` entrypoint plus reference docs for specific workflows. Coding agents produce better results with it installed because they follow Langfuse's documented best practices instead of guessing the API.
 
+Those reference docs include a guide on using the [Langfuse CLI](#cli), so the skill teaches your agent the exact commands to query traces, manage prompts, and run evaluators rather than leaving it to improvise HTTP requests.
+
 The skill uses progressive disclosure: only the frontmatter sits in the agent's context, and the full instructions load on demand when a task is relevant. Context stays small until the agent actually needs the details.
 
 <Cards>

--- a/content/marketing/agents.mdx
+++ b/content/marketing/agents.mdx
@@ -1,0 +1,152 @@
+---
+title: Langfuse for Agents
+seoTitle: Langfuse for Coding Agents (Claude Code, Codex, Cursor)
+description: Give coding agents like Claude Code, Codex, and Cursor direct access to Langfuse. Instrument tracing, query production data, manage prompts, and run evaluations from the editor or terminal via the Agent Skill, CLI, and MCP server.
+---
+
+# Langfuse for agents
+
+Langfuse gives coding agents like **Claude Code**, **Codex**, and **Cursor** direct access to your LLM application data. Hand your agent the Langfuse skill, and it can instrument an app with tracing, query production traces, manage prompts, and set up evaluations, all from the editor or terminal.
+
+There are three ways to connect an agent to Langfuse. They share the same underlying API, so pick the one that fits how your agent works:
+
+- **[Agent Skill](#skill)** — a playbook your coding agent loads to learn how to use Langfuse correctly.
+- **[CLI](#cli)** — full REST API coverage from the command line, for agents that can run bash.
+- **[MCP server](#mcp)** — the Model Context Protocol, for agents that can't run shell commands.
+
+<Callout type="info">
+This page is also available as markdown. Append `.md` to the URL or send an `Accept: text/markdown` header to get a clean, token-efficient version for your agent: [`langfuse.com/agents.md`](https://langfuse.com/agents.md).
+</Callout>
+
+## Start in 30 seconds [#quickstart]
+
+Install the Langfuse Agent Skill, then describe what you want in plain language. The skill teaches your agent how to instrument code, query traces, manage prompts, and run evaluators.
+
+import AutoInstall from "@/components-mdx/get-started/auto-install.mdx";
+
+<AutoInstall />
+
+Once it's installed, prompt your agent directly:
+
+- _Show me the last 10 traces with a score below 0.5_
+- _Add Langfuse tracing to the OpenAI calls in `src/agent.ts`_
+- _Migrate the system prompt in `src/agent.ts` to Langfuse prompt management_
+- _Create a dataset called "edge-cases" and add these three failing traces to it_
+
+## Agent Skill [#skill]
+
+The [Agent Skill](/docs/api-and-data-platform/features/agent-skill) follows the open [Agent Skills](https://github.com/anthropics/skills) standard and works across Claude Code, Cursor, Codex, Windsurf, and other compatible agents. It is open source on [GitHub](https://github.com/langfuse/skills).
+
+A skill is a self-contained folder with a `SKILL.md` entrypoint plus reference docs for specific workflows. Coding agents produce better results with it installed because they follow Langfuse's documented best practices instead of guessing the API.
+
+The skill uses progressive disclosure: only the frontmatter sits in the agent's context, and the full instructions load on demand when a task is relevant. Context stays small until the agent actually needs the details.
+
+<Cards>
+  <Card title="Set up the Agent Skill" href="/docs/api-and-data-platform/features/agent-skill" />
+  <Card title="Skills repository on GitHub" href="https://github.com/langfuse/skills" />
+</Cards>
+
+## CLI [#cli]
+
+The [`langfuse-cli`](/docs/api-and-data-platform/features/cli) wraps the entire Langfuse REST API. It is generated from the OpenAPI spec, so every endpoint becomes a command with proper flags, validation, and help text. The skill uses it under the hood, and your agent can call it directly when it can run bash.
+
+Run it without installing:
+
+```bash
+npx langfuse-cli api <resource> <action>
+```
+
+Agents discover the surface area through built-in help, which keeps token usage low:
+
+```bash
+npx langfuse-cli api __schema                   # list all resources
+npx langfuse-cli api <resource> --help          # list actions for a resource
+npx langfuse-cli api <resource> <action> --help # show args for an action
+```
+
+Because the CLI is generated from the spec, it stays in sync with the API automatically and covers every endpoint, including [full-text search over observations](#fast).
+
+<Cards>
+  <Card title="CLI reference" href="/docs/api-and-data-platform/features/cli" />
+  <Card title="langfuse-cli on npm" href="https://www.npmjs.com/package/langfuse-cli" />
+</Cards>
+
+## MCP server [#mcp]
+
+For agents that can't run shell commands, Langfuse exposes a [Model Context Protocol server](/docs/api-and-data-platform/features/mcp-server). It authenticates with your Langfuse API keys and covers most of the platform: observations, metrics, scores, score configs, datasets, dataset items, dataset runs, dataset run items, prompts, comments, annotation queues, models, media, and health.
+
+Agents such as Claude Cowork, Linear agents, or custom internal tools can investigate a production issue, pull the relevant observation, query metrics, leave a comment for the team, create a score, or stage a dataset item for regression testing, without leaving the chat.
+
+```json filename="MCP client config"
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://cloud.langfuse.com/api/public/mcp",
+      "transport": "streamableHttp",
+      "headers": {
+        "Authorization": "Basic <base64(LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY)>"
+      }
+    }
+  }
+}
+```
+
+To keep an agent read-only, allow-list the lookup tools and leave out the write tools.
+
+<Callout type="info">
+**Skill, CLI, or MCP?** Use the **Skill** to give a coding agent the full Langfuse playbook. Use the **CLI** when the agent can run bash and pre-filter data before it hits the context window. Use the **MCP server** when the agent can't run shell commands.
+</Callout>
+
+<Cards>
+  <Card title="MCP server setup" href="/docs/api-and-data-platform/features/mcp-server" />
+  <Card title="MCP tool reference" href="https://mcp.reference.langfuse.com" />
+</Cards>
+
+## Built to be fast for agents [#fast]
+
+Agents are impatient. They fan out many queries while working through a task, so slow responses waste both wall-clock time and tokens. Langfuse runs on [ClickHouse](/blog/joining-clickhouse), the columnar database built for fast analytical queries, which keeps reads quick even over hundreds of gigabytes of traces.
+
+**Full-text search via API.** The `matches` operator on [Observations API v2](/docs/api-and-data-platform/features/observations-api) gives agents token-based full-text search over trace inputs and outputs. In our benchmarks, a search that previously took 18 seconds and scanned 494 GB now returns in under half a second and reads less than a gigabyte. Your agent can pull the one trace where a refund failed out of millions of observations without scrolling.
+
+**A REST API that covers everything.** Every Langfuse feature has an endpoint, so an agent can read traces, write scores, manage prompts, and run dataset experiments programmatically. The [CLI](#cli) and [MCP server](#mcp) both build on this same API.
+
+## Docs built for agents [#docs]
+
+When an agent integrates Langfuse, it needs to find the right documentation fast and read it without wading through HTML.
+
+- **Markdown endpoints.** Any docs page is available as clean markdown. Append `.md` to the path or send an `Accept: text/markdown` header. Markdown pages are roughly 3 to 5 times smaller in tokens than the HTML equivalent.
+
+  ```bash
+  curl https://langfuse.com/docs/observability/overview.md
+  ```
+
+- **[llms.txt](https://langfuse.com/llms.txt).** A machine-readable index of every docs page, so an agent can orient itself before fetching anything.
+
+  ```bash
+  curl -s https://langfuse.com/llms.txt
+  ```
+
+- **Public docs search.** A RAG endpoint over all docs and indexed GitHub issues and discussions, no authentication required. Useful when the agent doesn't know which page to read.
+
+  ```bash
+  curl -s "https://langfuse.com/api/search-docs?query=How+do+I+trace+LangGraph+agents"
+  ```
+
+- **[Docs MCP server](/docs/docs-mcp).** The same docs search and page retrieval over MCP, for clients that prefer it.
+
+## Wire up evaluation gates [#evaluation]
+
+Once an agent can read and write Langfuse data, it can help you measure quality, not just ship code. A few things worth pointing your agent at:
+
+- **[LLM-as-a-judge calibration](/guides/llm-as-a-judge-calibration-skill).** Have your agent check whether your judge agrees with your human annotators, and report accuracy, F1, precision, and recall.
+- **[Code evaluators](/docs/evaluation/evaluation-methods/code-evaluators).** Deterministic checks like JSON validity, schema conformance, or required tool arguments, written as a small function and scored automatically.
+- **[Experiments in CI/CD](/docs/evaluation/experiments/experiments-ci-cd).** A [GitHub Action](https://github.com/langfuse/experiment-action) that runs your Langfuse experiments on every pull request and fails the build when scores drop below your threshold.
+
+## Resources [#resources]
+
+- [Will you be my CLI?](/blog/2026-02-13-will-you-be-my-cli) — the full story behind the agent skill, CLI, markdown endpoints, and MCP servers
+- [Building Langfuse's MCP server](/blog/2025-12-09-building-langfuse-mcp-server)
+- [Using agent skills to improve your prompts](/blog/2026-02-16-prompt-improvement-claude-skills)
+- [Evaluating AI agent skills](/blog/2026-02-26-evaluate-ai-agent-skills)
+- [Agent Skill docs](/docs/api-and-data-platform/features/agent-skill) · [CLI docs](/docs/api-and-data-platform/features/cli) · [MCP server docs](/docs/api-and-data-platform/features/mcp-server)
+- [Skills on GitHub](https://github.com/langfuse/skills) · [langfuse-cli on npm](https://www.npmjs.com/package/langfuse-cli) · [MCP reference](https://mcp.reference.langfuse.com)

--- a/content/marketing/meta.json
+++ b/content/marketing/meta.json
@@ -2,6 +2,7 @@
   "title": "Marketing",
   "pages": [
     "about",
+    "agents",
     "brand",
     "careers",
     "cn",


### PR DESCRIPTION
## Summary

Adds a new marketing page documenting how coding agents (Claude Code, Codex, Cursor, etc.) can integrate with Langfuse to instrument tracing, query production data, manage prompts, and run evaluations.

## Changes

- **New page**: `content/marketing/agents.mdx` — comprehensive guide covering three integration methods:
  - Agent Skill (playbook for coding agents to learn Langfuse best practices)
  - CLI (`langfuse-cli` for bash-capable agents)
  - MCP server (Model Context Protocol for agents without shell access)
  
  The page includes:
  - 30-second quickstart with example prompts
  - Detailed sections for each integration method with setup links
  - Performance highlights (ClickHouse-backed fast queries, full-text search)
  - Agent-friendly documentation features (markdown endpoints, llms.txt, docs search API, docs MCP server)
  - Evaluation integration guidance
  - Resource links to related docs, blogs, and repositories

- **Updated navigation**: Added `agents` entry to `content/marketing/meta.json` to surface the page in the marketing section

## Implementation notes

- Page follows existing Langfuse documentation patterns with Cards components for related resources
- Includes callout explaining markdown endpoint availability for token-efficient agent access
- Provides decision framework (Skill vs CLI vs MCP) to help users choose the right integration method
- Links to existing feature documentation and GitHub repositories

https://claude.ai/code/session_013jF5Une27T9oMPaN2YoAtd

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new marketing page (`content/marketing/agents.mdx`) documenting how coding agents (Claude Code, Codex, Cursor, etc.) can integrate with Langfuse via an Agent Skill, CLI, or MCP server, and registers the page in the marketing navigation.

- New `agents.mdx` page covers a 30-second quickstart, detailed sections for each integration method, performance highlights, agent-friendly docs features, evaluation gates, and a resource list.
- `meta.json` updated to include `"agents"` in alphabetical order within the marketing pages list.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the 'Claude Cowork' typo, which would appear verbatim on the published marketing page.

The only substantive issue is the 'Claude Cowork' typo on line 78 — it refers to the wrong product name and would be publicly visible to users landing on this marketing page. The import placement issue is minor style cleanup.

content/marketing/agents.mdx — typo on line 78 and import placement.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Coding Agent\ne.g. Claude Code, Codex, Cursor] --> B{Integration Method}
    B --> C[Agent Skill\nSKILL.md playbook]
    B --> D[CLI\nlangfuse-cli / npx]
    B --> E[MCP Server\nstreamableHttp]
    C --> F[Langfuse REST API]
    D --> F
    E --> F
    F --> G[Traces / Observations]
    F --> H[Prompts]
    F --> I[Datasets & Scores]
    F --> J[Evaluations]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/marketing/agents.mdx:78
Typo: "Claude Cowork" should be "Claude Code". The surrounding context (and the entire page) discusses Claude Code, Codex, and Cursor as target coding agents, so this looks like an autocorrect slip.

```suggestion
Agents such as Claude Code, Linear agents, or custom internal tools can investigate a production issue, pull the relevant observation, query metrics, leave a comment for the team, create a score, or stage a dataset item for regression testing, without leaving the chat.
```

### Issue 2 of 2
content/marketing/agents.mdx:5-7
Import statement is placed mid-file after several paragraphs of content. Per the team's rule, imports should be moved to the top of the module (right after the frontmatter block), not embedded within the document body.

```suggestion
---

import AutoInstall from "@/components-mdx/get-started/auto-install.mdx";

# Langfuse for agents
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add /agents landing page for coding agen..."](https://github.com/langfuse/langfuse-docs/commit/ac8e8dead152f134cfaee7511c7073bbe22a08c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35323462)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->