### PR TITLE
Update banner from launch week day 5 to launch week recap

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -4,14 +4,14 @@ import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 export function Banner() {
   return (
     <FumadocsBanner
-      id="fd-top-banner-launch-week-5-day-5"
+      id="fd-top-banner-launch-week-5-recap"
       height="2rem"
       className="bg-black text-white [&_a]:text-white [&_button]:text-white"
     >
       <Link href="/launch">
-        <span className="sm:hidden">Launch Week 5 · Day 5: Langfuse MCP →</span>
+        <span className="sm:hidden">Launch Week 5 recap →</span>
         <span className="hidden sm:inline">
-          Langfuse Launch Week 5 · Day 5: Langfuse MCP, expanded →
+          Langfuse Launch Week 5 recap: all announcements →
         </span>
       </Link>
     </FumadocsBanner>


### PR DESCRIPTION
Updates the website banner to show the launch week recap message instead of the day 5 announcement. The banner still links to `/launch`.

## Changes
- Banner ID updated from `fd-top-banner-launch-week-5-day-5` to `fd-top-banner-launch-week-5-recap`
- Mobile text: "Launch Week 5 recap →"
- Desktop text: "Langfuse Launch Week 5 recap: all announcements →"

https://claude.ai/code/session_01QRaypn98HDjEm8Pd48UivE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRaypn98HDjEm8Pd48UivE)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the website banner from the "Launch Week 5 Day 5" announcement to a recap message. The banner ID is changed so users who dismissed the previous banner will see the updated one.

- Banner `id` changes from `fd-top-banner-launch-week-5-day-5` to `fd-top-banner-launch-week-5-recap`, resetting dismissal state for returning visitors.
- Copy updated on both mobile (\"Launch Week 5 recap →\") and desktop (\"Langfuse Launch Week 5 recap: all announcements →\"), while the `/launch` link destination is unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-file, copy-only change to the top banner with no logic, data, or API surface affected.

The change swaps three strings and the banner's dismissal ID. The new ID intentionally re-shows the banner to users who dismissed the Day 5 version, which matches the stated intent of surfacing the recap. No business logic, routing, or data handling is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits site] --> B{Banner ID seen before?}
    B -- "fd-top-banner-launch-week-5-day-5 (dismissed)" --> C[New ID: fd-top-banner-launch-week-5-recap\nBanner shown again]
    B -- "fd-top-banner-launch-week-5-recap (not seen)" --> C
    B -- "fd-top-banner-launch-week-5-recap (dismissed)" --> D[Banner hidden]
    C --> E[Banner displays recap text]
    E --> F[User clicks → /launch]
    E --> G[User dismisses banner]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update website banner from launch week d..."](https://github.com/langfuse/langfuse-docs/commit/064bc1f946d7bd40f12315a9fd4908d35fee485f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35327353)</sub>

<!-- /greptile_comment -->