### PR TITLE
docs(integrations): add Claude Cowork tracing page

### DIFF
--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -260,6 +260,11 @@ const marqueeRow1: MarqueeItem[] = [
     icon: "/images/integrations/openclaw_icon.svg",
   },
   {
+    label: "Claude Cowork",
+    href: "/integrations/other/cowork",
+    icon: "/images/integrations/claude_icon.png",
+  },
+  {
     label: "Claude Agent SDK (Python)",
     href: "/integrations/frameworks/claude-agent-sdk",
     icon: "/images/integrations/claude_icon.png",

--- a/content/integrations/other/cowork.mdx
+++ b/content/integrations/other/cowork.mdx
@@ -1,0 +1,78 @@
+---
+title: "Trace Claude Cowork with Langfuse"
+sidebarTitle: Claude Cowork
+logo: /images/integrations/claude_icon.png
+description: "Monitor Claude Cowork activity with Langfuse using Cowork's native OpenTelemetry export for full visibility into prompts, tool and MCP calls, skills, and approval decisions."
+category: Integrations
+---
+
+# Trace Claude Cowork with Langfuse
+
+> **What is Claude Cowork?** [Claude Cowork](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry) is a collaborative way to work with Claude in the Claude desktop app, available on Team and Enterprise plans. It can run tools, invoke MCP servers, use skills and plugins, and act on your files, with human approval steps along the way.
+
+> **What is Langfuse?** [Langfuse](/) is an open-source AI engineering platform that helps teams trace LLM calls, monitor performance, and debug issues in their AI applications.
+
+## Why trace Claude Cowork?
+
+- **Understand agent behavior.** Read the prompts, tool and MCP invocations, and skills Claude Cowork uses under the hood.
+- **Audit activity across your organization.** See which tools were called, which files were accessed, and which approval decisions were made.
+- **Track usage and costs.** Monitor API requests, token counts, and errors over time.
+
+## Trace Claude Cowork via OpenTelemetry
+
+Claude Cowork has built-in [OpenTelemetry](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry) export, and Langfuse is an [OpenTelemetry backend](/integrations/native/opentelemetry). Point Cowork's exporter directly at Langfuse's OTLP endpoint and events flow in with no SDK, no proxy, and no code changes.
+
+Because the export happens inside Claude Cowork itself, it captures Cowork's full activity: the user's prompt text, tool and MCP invocations with execution details, file access, skills and plugins that were activated, human approval decisions, and API requests with token counts and errors. A shared `prompt.id` correlates every event that originated from a single user input.
+
+<Callout type="info">
+  Langfuse's OTLP endpoint accepts **OTLP over HTTP** in both `http/protobuf` and `http/json` — the two protocols Claude Cowork offers. Langfuse does not support gRPC, so make sure you select one of the HTTP options in Cowork.
+</Callout>
+
+<Steps>
+
+### Set up Langfuse
+
+Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting). Create a project and copy your public and secret API keys from the project settings.
+
+### Create your Basic Auth header
+
+Langfuse authenticates OTLP requests with [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Generate the header value by base64-encoding your keys as `public_key:secret_key`:
+
+```bash
+# macOS / BSD
+echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
+# Linux / GNU (disable line wrapping)
+echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64 -w 0
+```
+
+### Configure OpenTelemetry export in Claude Cowork
+
+In the Claude desktop app, open **Organization settings → Cowork** and fill in the OpenTelemetry fields ([Cowork requires the Claude desktop app v1.1.4173 or later on a Team or Enterprise plan](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry)):
+
+| Field             | Value                                                                                                                                                                                                                                                                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **OTLP endpoint** | `https://cloud.langfuse.com/api/public/otel` (🇪🇺 EU). For other regions, use `https://us.cloud.langfuse.com/api/public/otel` (🇺🇸 US), `https://jp.cloud.langfuse.com/api/public/otel` (🇯🇵 Japan), or `https://hipaa.cloud.langfuse.com/api/public/otel` (⚕️ HIPAA). For a self-hosted deployment, use `http://localhost:3000/api/public/otel`. |
+| **OTLP protocol** | `HTTP/protobuf` or `HTTP/JSON`                                                                                                                                                                                                                                                                                                                 |
+| **OTLP headers**  | `Authorization: Basic <AUTH_STRING>` (the base64 value from the previous step) and `x-langfuse-ingestion-version: 4` (surfaces events in real time in Fast Preview)                                                                                                                                                                            |
+
+Save the configuration. Events are sent to Langfuse immediately afterwards.
+
+<Callout type="info">
+  If Cowork sends to the endpoint exactly as entered without appending the signal path, use the trace-specific endpoint instead: `https://cloud.langfuse.com/api/public/otel/v1/traces` (adjust the host for your region).
+</Callout>
+
+### View traces in Langfuse
+
+Use Claude Cowork as usual. Open your Langfuse project to see the captured activity, where you can inspect prompts, tool and MCP calls, skill usage, approval decisions, token counts, and errors.
+
+</Steps>
+
+<Callout type="warning" title="Sensitive data is exported by default">
+  Claude Cowork includes user prompt content, tool parameters, and user email addresses in the exported events by default. If you need to redact or drop any of this, filter it at an OpenTelemetry collector placed between Cowork and Langfuse. See Anthropic's [Cowork OpenTelemetry guide](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry) for details.
+</Callout>
+
+## Learn more
+
+- [Langfuse OpenTelemetry endpoint](/integrations/native/opentelemetry): Endpoint, authentication, and supported protocols
+- [Getting started with Langfuse](/docs/observability/get-started): Setting up API keys and projects
+- [Monitor Claude Cowork activity with OpenTelemetry](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry): Anthropic's setup guide

--- a/content/integrations/other/meta.json
+++ b/content/integrations/other/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "claude-code",
     "cognee",
+    "cowork",
     "cursor",
     "exa",
     "firecrawl",


### PR DESCRIPTION
## What

Adds a new integration page for tracing **Claude Cowork** with Langfuse via Cowork's native OpenTelemetry export. Because Cowork is configured through a GUI (no SDK/code), this is a plain `.mdx` page rather than a notebook.

- **New:** `content/integrations/other/cowork.mdx`
- `content/integrations/other/meta.json` — registers `cowork` in the Other sidebar (alphabetical, after `cognee`)
- `components/home/Integrations.tsx` — adds "Claude Cowork" to the home-page integrations marquee

## Page content

Sourced from Anthropic's [Monitor Claude Cowork activity with OpenTelemetry](https://support.claude.com/en/articles/14477985-monitor-claude-cowork-activity-with-opentelemetry) guide. Steps:

1. Set up Langfuse and copy API keys
2. Create the Basic Auth header (base64 `pk:sk`)
3. Configure OTLP export under **Organization settings → Cowork** — endpoint (`/api/public/otel`, all regions), protocol (`HTTP/protobuf` or `HTTP/JSON`, both Langfuse-supported), headers (`Authorization: Basic …` + `x-langfuse-ingestion-version: 4`)
4. View traces in Langfuse

Includes a warning callout that Cowork exports prompt content, tool parameters, and user emails by default (filter at a collector if needed). Reuses the existing `claude_icon.png` logo — no new asset.

## Notes for reviewers

- The page follows the same native-OTLP pattern as the existing `openclaw.mdx`.
- **Endpoint caveat:** Cowork exposes a single OTLP endpoint field. The page uses the base `/api/public/otel` (which OTLP HTTP exporters append `/v1/traces` to) and adds a callout pointing to `/api/public/otel/v1/traces` in case Cowork sends to the URL exactly as entered. Worth confirming against a live Cowork export.

## Verification

- Loaded `/integrations/other/cowork` on a local dev server → HTTP 200, title/steps render, page appears in sidebar, no error overlays.
- `prettier --check` passes on all changed files; single H1 confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new integration documentation page (`content/integrations/other/cowork.mdx`) for tracing Claude Cowork with Langfuse via its native OpenTelemetry export, following the same pattern as the existing `openclaw.mdx`. The page is registered in the sidebar and added to the homepage marquee.

- **New MDX page** walks through obtaining API keys, generating a Basic Auth header, and configuring OTLP export (endpoint, protocol, headers) in Claude Cowork's GUI — no SDK or code required.
- **Sensitive-data warning** is correctly included noting that prompt content, tool parameters, and user emails are exported by default and can be filtered at an OTel collector.
- **Endpoint ambiguity** flagged in the PR description is surfaced as an in-page callout but remains unresolved; readers have no reliable way to know which of the two endpoint paths to use without a test export.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — pure documentation addition with no runtime code paths affected.

All three changed files are documentation or static data. The integration page correctly reuses established patterns from openclaw.mdx, includes the required auth and sensitive-data callouts, and renders without errors locally. The two open items are the product-link destination in the intro blockquote and the unconfirmed OTLP endpoint path, both of which affect documentation accuracy but not site functionality.

content/integrations/other/cowork.mdx — the product link in the intro blockquote and the dual-endpoint callout warrant a second look before this guidance reaches users.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant C as Claude Cowork
    participant COL as OTel Collector
    participant LF as Langfuse

    U->>C: Sends prompt / approves action
    C->>C: Executes tools, MCP calls, skills
    C-->>COL: OTLP HTTP with Basic Auth header
    note over COL: Optional: redact prompt content,<br/>tool params, user emails
    COL-->>LF: Filtered OTLP spans
    C-->>LF: OTLP HTTP direct (no collector path)
    LF-->>U: Traces visible in Langfuse UI
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/other/cowork.mdx:11
**Product link goes to the OTel guide, not a product overview**

The hyperlink on "Claude Cowork" in the intro blockquote resolves to Anthropic's *Monitor Claude Cowork activity with OpenTelemetry* support article rather than a general product or feature page. A reader clicking "Claude Cowork" to understand what the product is will land mid-way through the OTel setup guide instead. Compare `openclaw.mdx`, where the same link pattern points to the product's GitHub repo. If no dedicated product overview exists, consider linking to the main Claude support page or the Team/Enterprise feature announcement instead.

### Issue 2 of 2
content/integrations/other/cowork.mdx:57-60
**Unresolved endpoint ambiguity leaves users guessing**

The main table instructs users to enter `/api/public/otel`, while the callout immediately below says to switch to `/api/public/otel/v1/traces` "if Cowork sends to the endpoint exactly as entered." Because Cowork is GUI-configured and users can't inspect the outgoing request path, this branching advice gives no reliable way to know which value to use before traces either arrive or don't. The PR description notes the correct URL is "worth confirming against a live Cowork export" — until that's verified, the doc leaves readers in trial-and-error mode. Consider picking the confirmed value once it's known, or framing the primary recommendation as the `/v1/traces` path (which is unambiguous) and the secondary as the base path for standard OTLP HTTP client libraries that auto-append the signal suffix.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(integrations): add Claude Cowork tr..."](https://github.com/langfuse/langfuse-docs/commit/329ba1e9efe2f274e2303f90fee414d08b19222e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35376706)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->