### PR TITLE
Revise Langfuse integration guide for Quarkus

### DIFF
--- a/content/integrations/frameworks/quarkus-langchain4j.mdx
+++ b/content/integrations/frameworks/quarkus-langchain4j.mdx
@@ -7,93 +7,65 @@ description: Learn how to integrate Langfuse with Quarkus LangChain4j using Open
 
 # Integrating Langfuse with Quarkus LangChain4j
 
-This guide shows how to integrate [Langfuse](/) with [Quarkus LangChain4j](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) using OpenTelemetry.
+This guide shows how to integrate [Langfuse](/) with [Quarkus LangChain4j](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) using the [Quarkus Langfuse extension](https://docs.quarkiverse.io/quarkus-langfuse/dev/index.html).
 
-**Quarkus LangChain4j**: A [Quarkus](https://quarkus.io/) based integration of [LangChain4j](https://docs.langchain4j.dev/) for AI development with built-in OTel tracing for AI calls.
-
-**Langfuse**: Open source AI engineering platform for observability, evals and prompt management.
+- **Quarkus LangChain4j**: A [Quarkus](https://quarkus.io/) based integration of [LangChain4j](https://docs.langchain4j.dev/) for AI development with built-in OTel tracing for AI calls.
+- **Quarkus Langfuse**: A [Quarkus](https://quarkus.io/) based integration of [Langfuse](/) providing seamless integrations between LangChain4j, Langfuse, and OpenTelemetry.
+- **Langfuse**: Open source AI engineering platform for observability, evals and prompt management.
 
 <Callout type="info" emoji="🐞">
   Please raise an Issue on [GitHub](/issues) if you face any issues with this
   integration.
 </Callout>
 
-## Step 1: Enable OpenTelemetry in Quarkus LangChain4j
+## Step 1: Add Dependencies
 
-**Add Quarkus OpenTelemetry Dependency** (Maven):
-
-For Maven, add the following to your `pom.xml` (Gradle users can include equivalent coordinates in Gradle):
+Add the `quarkus-opentelemetry` and `quarkus-langfuse` dependencies toyour `pom.xml` (Gradle users can include equivalent coordinates in Gradle):
 
 ```xml
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-opentelemetry</artifactId>
 </dependency>
+<dependency>
+    <groupId>io.quarkiverse.langfuse</groupId>
+    <artifactId>quarkus-langfuse</artifactId>
+</dependency>
 ```
 
-**Configure OpenTelemetry exporter** (`application.properties`):
+## Step 2: Configure Langfuse Connection
+
+Sign up for [Langfuse Cloud](https://cloud.langfuse.com/) or [self-host Langfuse](https://langfuse.com/self-hosting), then configure the connection in `application.properties`:
 
 ```properties
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+quarkus.langfuse.base-url=https://cloud.langfuse.com
+quarkus.langfuse.username=<your public key>
+quarkus.langfuse.password=<your secret key>
 ```
 
-With these configurations and dependencies in place, your Quarkus application is ready to produce OpenTelemetry traces. Quarkus LangChain4j internal calls (e.g. when you invoke a chat model) will be recorded as spans.
+That’s it. The `quarkus-langfuse` extension automatically configures:
+- The OTLP trace exporter endpoint (derived from `base-url`)
+- Authorization headers (Basic auth from `username`/`password`)
+- Span filtering — by default only `gen_ai` spans and their ancestors are exported (`AI_ONLY` mode)
+- Prompt and completion tracing (`include-prompt`, `include-completion`, `include-tool-arguments`, `include-tool-result` all set to `true`)
+- Automatically set Langfuse’s specific `input` and `output` span attributes for better trace visualization in Langfuse
+- Dual exporting to both a standard LGTM stack AND langfuse
 
-Each span will carry attributes like `gen_ai.operation.name`, `gen_ai.system` (the provider, e.g. “openai”), model names, token usage, etc.
-To enable events for the prompt and response content you need to activate the langchain4j prompt tracing.
+|     |                                                                                                                                                                                                                                               |
+|-----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Tip | In dev and test mode, [Langfuse DevServices](https://docs.quarkiverse.io/quarkus-langfuse/dev/#devservices) automatically starts a local Langfuse instance and configures the connection properties for you — no manual configuration needed. |
 
-**Configure Langchain4j prompt tracing** (`application.properties`):
+|      |                                                                                                                                                                                                                 |
+|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Note | See the [Quarkus Langfuse documentation](https://docs.quarkiverse.io/quarkus-langfuse/dev/all-config.html) for additional configuration options, such as changing the span filter mode or customizing timeouts. |
 
-```properties
-quarkus.langchain4j.tracing.include-prompt=true
-quarkus.langchain4j.tracing.include-completion=true
-```
-
-## Step 2: Configure Langfuse
-
-Now that your Quarkus application is emitting OpenTelemetry trace data, the next step is to direct that data to Langfuse.
-
-Langfuse will act as the “backend” for OpenTelemetry in this setup – essentially replacing a typical Jaeger/Zipkin/OTel-Collector with Langfuse’s trace ingestion API.
-
-**Langfuse Setup**
-
-- Sign up for [Langfuse Cloud](https://langfuse.com/cloud) or [self-hosted Langfuse](https://langfuse.com/self-hosting).
-- Set the OTLP endpoint (e.g. `https://cloud.langfuse.com/api/public/otel`) and API keys.
-
-<Tabs items={["Env Variables", "Configuration in `application.properties`"]}>
-<Tab>
-
-Configure these via environment variables:
-
-```bash
-QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: set this to the Langfuse OTLP URL (e.g. https://cloud.langfuse.com/api/public/otel).
-QUARKUS_OTEL_EXPORTER_OTLP_HEADERS: set this to Authorization=Basic <base64 public:secret>,x-langfuse-ingestion-version=4.
-```
-
-</Tab>
-<Tab>
-
-Making the following configuration in `application.properties`:
-
-```bash
-quarkus.otel.exporter.otlp.headers=Authorization=Basic <base64 of public:key>,x-langfuse-ingestion-version=4
-quarkus.otel.exporter.otlp.endpoint=https://cloud.langfuse.com/api/public/otel
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
-```
-
-</Tab>
-</Tabs>
-
-<Callout type="info">
-  You can find more on authentication via Basic Auth
-  [here](/docs/opentelemetry/get-started).
-</Callout>
+<a id="_step_3_run_a_test_ai_operation"></a>
 
 ## Step 3: Run a Test AI Operation
 
-Start your Quarkus application. Trigger an AI operation that Quarkus LangChain4j handles – for example, call a service or controller that uses a `ChatModel` to generate a completion.
+Start your Quarkus application. Trigger an AI operation that Quarkus LangChain4j handles — for example, call a service or controller that uses a `ChatModel` to generate a completion.
 
-**Note**: A complete example can be found [here](https://github.com/langfuse/langfuse-examples/tree/main/applications/quarkus-langchain4j-demo)
+A complete example can be found [here](https://github.com/langfuse/langfuse-examples/tree/main/applications/quarkus-langchain4j-demo).
 
 ```java
 @RegisterAiService(tools = EmailService.class)
@@ -119,7 +91,7 @@ public interface MyAiService {
 public class Startup {
 
     public void writeAPoem(@Observes StartupEvent event, MyAiService service) {
-        System.out.println(service.writeAPoem("Langfuse", 4));
+        System.out.println(service.writeAPoem("LangFuse", 4));
     }
 }
 ```
@@ -129,4 +101,28 @@ public class Startup {
 **No Traces:**
 
 - Check the logs of the application for potential clues
-- Check [Troubleshooting](/faq/all/self-hosting-missing-events-after-ingestion) page
+
+- Check
+  [Troubleshooting](https://langfuse.com/self-hosting/troubleshooting#missing-events-after-post-apipublicingestion)
+  page
+
+## Manual Configuration (without `quarkus-langfuse`)
+
+If you prefer not to use the `quarkus-langfuse` extension, you can configure the OpenTelemetry exporter manually to point to Langfuse’s OTLP endpoint:
+
+```properties
+quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+quarkus.otel.exporter.otlp.endpoint=https://cloud.langfuse.com/api/public/otel
+quarkus.otel.exporter.otlp.headers=Authorization=Basic <base64 of public_key:secret_key>
+```
+
+You will also need to manually enable prompt tracing:
+
+```properties
+quarkus.langchain4j.tracing.include-prompt=true
+quarkus.langchain4j.tracing.include-completion=true
+quarkus.langchain4j.tracing.include-tool-arguments=true
+quarkus.langchain4j.tracing.include-tool-result=true
+```
+
+See the [Langfuse OpenTelemetry documentation](https://langfuse.com/docs/opentelemetry/get-started) for more details on authentication and manual setup.


### PR DESCRIPTION
Updated the integration guide for Langfuse with Quarkus LangChain4j to include the Quarkus Langfuse extension and improved clarity in configuration steps.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR revises the Quarkus LangChain4j integration guide to lead with the new `quarkus-langfuse` Quarkiverse extension instead of manual OpenTelemetry configuration, significantly simplifying the setup steps from ~5 config properties down to 3. The old manual OTel approach is preserved as a "Manual Configuration" appendix.

- **New primary path**: Adds `quarkus-langfuse` as the recommended dependency, documents the three `application.properties` keys (`base-url`, `username`, `password`), and lists everything the extension auto-configures (OTLP endpoint, auth headers, span filtering, prompt/completion tracing, DevServices support).
- **Frontmatter not updated**: The page `title` and `description` still say "Using OpenTelemetry", which no longer reflects the primary approach described in the guide.
- **Minor copy issues**: A word-boundary typo ("toyour") on line 23 and a brand-name capitalisation regression ("LangFuse" → should be "Langfuse") in the code example on line 94.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the three small copy issues — none affect runtime behaviour.

The content changes are accurate and well-structured. The only issues are a typo ("toyour"), a brand-name capitalisation regression in the code sample ("LangFuse" instead of "Langfuse"), and frontmatter that still advertises the OpenTelemetry-first approach the guide has just moved away from. All three are easy one-line fixes.

content/integrations/frameworks/quarkus-langchain4j.mdx — frontmatter title/description, line 23 typo, and line 94 capitalisation.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Quarkus App
    participant Ext as quarkus-langfuse extension
    participant OTel as OTel SDK (quarkus-opentelemetry)
    participant LF as Langfuse Cloud / Self-hosted

    App->>OTel: AI call (ChatModel invocation)
    OTel->>Ext: "Span produced (gen_ai.* attributes)"
    Ext->>Ext: Filter spans (AI_ONLY mode), set input/output attributes
    Ext->>LF: Export via OTLP/HTTP (Basic auth)
    LF-->>App: Traces visible in Langfuse UI

    note over Ext,LF: In dev/test mode, DevServices auto-starts a local Langfuse instance
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/integrations/frameworks/quarkus-langchain4j.mdx:23
Missing space between "to" and "your" — "toyour" is a typo.

```suggestion
Add the `quarkus-opentelemetry` and `quarkus-langfuse` dependencies to your `pom.xml` (Gradle users can include equivalent coordinates in Gradle):
```

### Issue 2 of 3
content/integrations/frameworks/quarkus-langchain4j.mdx:94
The product name is "Langfuse" (not "LangFuse"). Every other occurrence in the document and across the repo uses the lowercase-f form. This diff introduced the capitalisation change — worth reverting so the example stays consistent with the brand name.

```suggestion
        System.out.println(service.writeAPoem("Langfuse", 4));
```

### Issue 3 of 3
content/integrations/frameworks/quarkus-langchain4j.mdx:2-5
The frontmatter `title` and `description` still describe the integration as primarily OpenTelemetry-based ("Using OpenTelemetry"), but the guide now leads with the `quarkus-langfuse` extension and pushes raw OTel configuration to a "Manual Configuration" appendix. A reader landing on this page from a search or sidebar will see a misleading title.

```suggestion
title: Integrating Langfuse with Quarkus LangChain4j
sidebarTitle: Quarkus LangChain4j
logo: /images/integrations/langchain4j_icon.svg
description: Learn how to integrate Langfuse with Quarkus LangChain4j using the Quarkus Langfuse extension for enhanced observability and performance monitoring in your AI applications.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revise Langfuse integration guide for Qu..."](https://github.com/langfuse/langfuse-docs/commit/98544aad1685e907c54f2b8bfa65d3b5613407ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35433778)</sub>

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime impact; minor markdown breakage and copy inconsistencies may confuse readers until fixed.
> 
> **Overview**
> **Reframes the Quarkus LangChain4j integration guide** so the recommended path is the **Quarkus Langfuse extension**, not hand-rolled OpenTelemetry exporter settings.
> 
> Setup is shortened to adding **`quarkus-opentelemetry`** and **`quarkus-langfuse`**, then three **`quarkus.langfuse.*`** properties (`base-url`, `username`, `password`). The doc explains what the extension auto-wires (OTLP endpoint, Basic auth, `AI_ONLY` span export, prompt/completion/tool tracing, Langfuse input/output attributes, DevServices in dev/test).
> 
> The **previous manual OTLP/env and LangChain4j tracing properties** are moved to a **“Manual Configuration (without quarkus-langfuse)”** appendix. Troubleshooting links and intro bullets are updated accordingly.
> 
> **Copy/structure nits left in the diff:** a **“toyour”** typo, **“LangFuse”** in the sample, frontmatter still says **“Using OpenTelemetry”**, and **orphaned `</Tab>` / `</Tabs>` blocks** with legacy manual OTel instructions still sit mid-page after the new Step 2 content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f6687e1b91cceeb06e4398ca956eaf90216129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->