### PR TITLE
feat: update banner to promote Langfuse Town Hall

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -10,11 +10,10 @@ export function Banner() {
     >
       <Link href="https://luma.com/7dny2x72">
         <span className="sm:hidden">
-          [Virtual] Langfuse Town Hall · Jun 11 - Register →
+          [Virtual] Langfuse Town Hall · Jun 11 →
         </span>
         <span className="hidden sm:inline">
-          [Virtual] Langfuse Town Hall · Jun 11, 9am PT / 6pm CEST: V4,
-          Releases, Roadmap - Register →
+          [Virtual] Langfuse Town Hall · Jun 11, 9am PT: V4, Releases, Roadmap →
         </span>
       </Link>
     </FumadocsBanner>

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -10,11 +10,11 @@ export function Banner() {
     >
       <Link href="https://luma.com/7dny2x72">
         <span className="sm:hidden">
-          [Virtual] Langfuse Town Hall - Register →
+          [Virtual] Langfuse Town Hall · Jun 11 - Register →
         </span>
         <span className="hidden sm:inline">
-          [Virtual] Langfuse Town Hall: ClickHouse, V4, Latest Releases, Roadmap
-          - Register →
+          [Virtual] Langfuse Town Hall · Jun 11, 9am PT / 6pm CEST: V4,
+          Releases, Roadmap - Register →
         </span>
       </Link>
     </FumadocsBanner>

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -4,14 +4,17 @@ import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 export function Banner() {
   return (
     <FumadocsBanner
-      id="fd-top-banner-launch-week-5-recap"
+      id="fd-top-banner-town-hall-2026-q2"
       height="2rem"
       className="bg-black text-white [&_a]:text-white [&_button]:text-white"
     >
-      <Link href="/launch">
-        <span className="sm:hidden">Launch Week 5 recap →</span>
+      <Link href="https://luma.com/7dny2x72">
+        <span className="sm:hidden">
+          [Virtual] Langfuse Town Hall - Register →
+        </span>
         <span className="hidden sm:inline">
-          Langfuse Launch Week 5 recap: all announcements →
+          [Virtual] Langfuse Town Hall: ClickHouse, V4, Latest Releases, Roadmap
+          - Register →
         </span>
       </Link>
     </FumadocsBanner>


### PR DESCRIPTION
## Summary

- Replaces the Launch Week 5 recap banner with a Town Hall event announcement
- New tagline: `[Virtual] Langfuse Town Hall: ClickHouse, V4, Latest Releases, Roadmap - Register →`
- Links to https://luma.com/7dny2x72
- Updated banner ID to `fd-top-banner-town-hall-2026-q2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces the Launch Week 5 recap top banner with a Town Hall event announcement, updating the link, text, and banner ID.

- The link changes from the internal `/launch` path to the external `https://luma.com/7dny2x72` Luma registration page; both mobile and desktop copy are updated to reflect the Town Hall theme.
- The banner ID is updated to `fd-top-banner-town-hall-2026-q2`, which controls the dismiss-once localStorage key for returning visitors.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — this is a straightforward banner text and link swap with no logic changes.

The change is minimal and low-risk. The only noteworthy point is the external link missing target="_blank", which means clicking the banner navigates users away from the docs site rather than opening a new tab.

components/layout/Banner.tsx — only the target attribute on the external link warrants a look.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/layout/Banner.tsx:11
External link missing `target` and `rel` attributes. Without `target="_blank"`, clicking the banner navigates the user away from the docs site entirely. Adding `rel="noopener noreferrer"` is the standard safety companion for any `_blank` link.

```suggestion
      <Link href="https://luma.com/7dny2x72" target="_blank" rel="noopener noreferrer">
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: update banner to promote Langfuse ..."](https://github.com/langfuse/langfuse-docs/commit/eed2ca216fd88471270b0135ca3baae8f7e12a26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35659127)</sub>

<!-- /greptile_comment -->