### PR TITLE
docs(evaluation): add human-in-the-loop scoring guide and related guides list

### DIFF
--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -922,11 +922,6 @@ If you want to update a score without needing to fetch the list of existing scor
       lede: "Continuously monitor quality by fetching traces, running custom evaluations, and ingesting scores back into Langfuse.",
     },
     {
-      href: "/docs/evaluation/evaluation-methods/code-evaluators",
-      topic: "Code evaluators",
-      lede: "Prefer to author the evaluation logic in Langfuse? Run deterministic Python or TypeScript code evaluators instead of computing scores externally.",
-    },
-    {
       href: "/guides/cookbook/security-and-guardrails",
       topic: "Guardrails and security checks",
       lede: "Check whether output contains a certain keyword, matches a required structure or format, or exceeds a length limit.",

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -923,8 +923,8 @@ If you want to update a score without needing to fetch the list of existing scor
     },
     {
       href: "/docs/evaluation/evaluation-methods/code-evaluators",
-      topic: "External code execution",
-      lede: "Run evaluation code in your own infrastructure, then attach the resulting scores to Langfuse.",
+      topic: "Code evaluators",
+      lede: "Prefer to author the evaluation logic in Langfuse? Run deterministic Python or TypeScript code evaluators instead of computing scores externally.",
     },
     {
       href: "/guides/cookbook/security-and-guardrails",

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -10,23 +10,6 @@ You can use the Langfuse SDKs or API to add [scores](/docs/evaluation/scores/ove
 
 If you want Langfuse to run deterministic Python or TypeScript logic for you, use [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators). Use this page when your application, pipeline, or CI job computes scores and sends them to Langfuse via API or SDK.
 
-## Common Use Cases
-
-- **Collecting user feedback**: collect in-app feedback from your users on application quality or performance. Can be captured in the frontend via our Browser SDK.
-  -> [Example Notebook](/guides/cookbook/user-feedback)
-
-- **Custom evaluation data pipeline**: continuously monitor the quality by fetching traces from Langfuse, running custom evaluations, and ingesting scores back into Langfuse.
-  -> [Example Notebook](/guides/cookbook/example_external_evaluation_pipelines)
-
-- **External code execution**: run evaluation code in your own infrastructure, then attach the resulting scores to Langfuse. If you prefer to author the code in Langfuse, use [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators).
-
-- **Guardrails and security checks**: check if output contains a certain keyword, adheres to a specified structure/format or if the output is longer than a certain length.
-  -> [Example Notebook](/guides/cookbook/security-and-guardrails)
-
-- **Custom internal workflow tooling**: build custom internal tooling that helps you manage human-in-the-loop workflows. Ingest scores back into Langfuse, optionally following your custom schema by referencing a config.
-- **Custom run-time evaluations**: e.g. track whether the generated SQL code actually worked, or if the structured output was valid JSON.
-- **Session-level quality tracking**: score full conversations (for example, support chats or agent threads) by attaching scores via `sessionId` in the SDK/API.
-
 ## Ingesting Scores via API/SDKs
 
 Scores can be attached at different levels of granularity: to individual traces, to specific observations within a trace, or to full sessions.
@@ -923,3 +906,40 @@ For example, let's assume you'd like to ingest a text score to capture **reviewe
 When creating a score, you can provide an optional `id` (JS/TS) / `score_id` (Python) parameter. This will update the score if it already exists within your project.
 
 If you want to update a score without needing to fetch the list of existing scores from Langfuse, you can set your own `id` parameter as an idempotency key when initially creating the score.
+
+## Related guides
+
+<ManualGuideList
+  guides={[
+    {
+      href: "/guides/cookbook/user-feedback",
+      topic: "Collecting user feedback",
+      lede: "Collect in-app feedback from your users on application quality or performance, captured in the frontend via our Browser SDK.",
+    },
+    {
+      href: "/guides/cookbook/example_external_evaluation_pipelines",
+      topic: "Custom evaluation data pipeline",
+      lede: "Continuously monitor quality by fetching traces, running custom evaluations, and ingesting scores back into Langfuse.",
+    },
+    {
+      href: "/docs/evaluation/evaluation-methods/code-evaluators",
+      topic: "External code execution",
+      lede: "Run evaluation code in your own infrastructure, then attach the resulting scores to Langfuse.",
+    },
+    {
+      href: "/guides/cookbook/security-and-guardrails",
+      topic: "Guardrails and security checks",
+      lede: "Check whether output contains a certain keyword, matches a required structure or format, or exceeds a length limit.",
+    },
+    {
+      href: "/guides/human-in-the-loop-scoring",
+      topic: "Custom internal workflow tooling",
+      lede: "Build internal tooling for human-in-the-loop workflows, ingesting scores back into Langfuse following your custom schema.",
+    },
+    {
+      href: "/guides/cookbook/example_evaluating_multi_turn_conversations",
+      topic: "Session-level quality tracking",
+      lede: "Score full conversations, such as support chats or agent threads, by attaching scores via sessionId in the SDK or API.",
+    },
+  ]}
+/>

--- a/content/guides/human-in-the-loop-scoring.mdx
+++ b/content/guides/human-in-the-loop-scoring.mdx
@@ -1,0 +1,199 @@
+---
+title: Build a human-in-the-loop scoring workflow
+sidebarTitle: Human-in-the-loop scoring
+description: Capture human judgments from your own review tooling and ingest them into Langfuse as structured scores, validated against a score config.
+category: Evaluation
+---
+
+# Build a human-in-the-loop scoring workflow
+
+Many teams keep a human in the loop to judge LLM output. Langfuse offers built-in [annotation queues](/docs/evaluation/evaluation-methods/annotation-queues) for this, but sometimes you already have your own internal review tool, or want reviewers to work inside an existing app.
+
+This guide shows how to connect that custom tooling to Langfuse: pull the traces your reviewers should look at, then ingest their judgments back as [scores](/docs/evaluation/scores/overview) via the SDK or API. Standardizing those scores against a [score config](/faq/all/manage-score-configs) keeps them consistent for later analysis.
+
+<Callout type="info">
+  If you do not need to own the review UI, use Langfuse [annotation
+  queues](/docs/evaluation/evaluation-methods/annotation-queues) instead. They
+  give you a built-in reviewer interface, queue management, and score configs
+  without writing any tooling. If you are considering building your own UI
+  because annotation queues are missing a feature you need, we would love to
+  hear about it: please open a [feature
+  request](https://github.com/orgs/langfuse/discussions/new?category=ideas) on
+  GitHub.
+</Callout>
+
+## Prerequisites
+
+- Traces already flowing into Langfuse from your application. See [tracing](/docs/observability/get-started) if you have not set this up yet.
+- A custom annotation or review UI where your reviewers view traces and submit their judgments.
+- The Langfuse SDK installed and credentials (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`) available in your environment.
+
+## Walkthrough
+
+<Steps>
+
+### Define a score config
+
+A [score config](/faq/all/manage-score-configs) standardizes the schema your reviewers score against, so every reviewer submits the same shape of data. This config needs to be created in Langfuse first.
+
+_For example, for a support QA tool you might define a categorical config named `support_quality` with the categories `excellent`, `acceptable`, and `poor`._
+
+See [how to create and manage score configs](/faq/all/manage-score-configs) to set this up, then note the resulting `configId`, which you will reference when ingesting scores.
+
+### Surface traces to your reviewers
+
+Pull the traces your reviewers should look at, then render their inputs and outputs in your tool. You can do this via the SDKs or the [public API](/docs/api-and-data-platform/features/public-api), filtering by name, user, tags, or time range to build a review queue.
+
+<LangTabs items={["Python SDK", "JS/TS SDK", "API"]}>
+<Tab>
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+# List recent traces for review, e.g. all traces of a given name
+response = langfuse.api.trace.list(name="support-conversation", limit=50)
+
+for trace in response.data:
+    # Render trace.input / trace.output in your review tool
+    print(trace.id, trace.input)
+```
+
+_See the [Python SDK reference](https://python.reference.langfuse.com)._
+
+</Tab>
+<Tab>
+
+```ts
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+// List recent traces for review, e.g. all traces of a given name
+const response = await langfuse.api.trace.list({
+  name: "support-conversation",
+  limit: 50,
+});
+
+for (const trace of response.data) {
+  // Render trace.input / trace.output in your review tool
+  console.log(trace.id, trace.input);
+}
+```
+
+_See the [JS/TS SDK reference](https://js.reference.langfuse.com)._
+
+</Tab>
+<Tab>
+
+```bash
+curl -G https://cloud.langfuse.com/api/public/traces \
+  -u "pk-lf-...":"sk-lf-..." \
+  --data-urlencode "name=support-conversation" \
+  --data-urlencode "limit=50"
+```
+
+_See the [API reference](https://api.reference.langfuse.com)._
+
+</Tab>
+</LangTabs>
+
+### Ingest the reviewer's judgment as a score
+
+When a reviewer submits their decision, write it back to Langfuse as a score, referencing the `configId` from step 1 so the value is validated against the schema.
+
+Attach the score to whatever the reviewer is judging: a single response (`trace_id`, and optionally `observation_id` to target a specific step within the trace), or a full [session](/docs/observability/features/sessions) (`session_id`) when they rate a conversation as a whole.
+
+<LangTabs items={["Python SDK", "JS/TS SDK", "API"]}>
+<Tab>
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+# Score a single response
+langfuse.create_score(
+    trace_id="trace_id_here",
+    name="support_quality",
+    value="acceptable",  # must match a category in the config
+    data_type="CATEGORICAL",
+    config_id="your_config_id",  # validates the value against the config
+    comment="Resolved the issue but tone was a bit terse.",
+)
+
+# Or score a full conversation by passing session_id instead of trace_id
+langfuse.create_score(
+    session_id="session_id_here",
+    name="support_quality",
+    value="excellent",
+    data_type="CATEGORICAL",
+    config_id="your_config_id",
+)
+```
+
+_See the [Python SDK reference](https://python.reference.langfuse.com)._
+
+</Tab>
+<Tab>
+
+```ts
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+// Score a single response
+langfuse.score.create({
+  traceId: "trace_id_here",
+  name: "support_quality",
+  value: "acceptable", // must match a category in the config
+  dataType: "CATEGORICAL",
+  configId: "your_config_id", // validates the value against the config
+  comment: "Resolved the issue but tone was a bit terse.",
+});
+
+// Or score a full conversation by passing sessionId instead of traceId
+langfuse.score.create({
+  sessionId: "session_id_here",
+  name: "support_quality",
+  value: "excellent",
+  dataType: "CATEGORICAL",
+  configId: "your_config_id",
+});
+
+// Flush the scores in short-lived environments
+await langfuse.flush();
+```
+
+_See the [JS/TS SDK reference](https://js.reference.langfuse.com)._
+
+</Tab>
+<Tab>
+
+```bash
+curl -X POST https://cloud.langfuse.com/api/public/scores \
+  -u "pk-lf-...":"sk-lf-..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "traceId": "trace_id_here",
+    "name": "support_quality",
+    "value": "acceptable",
+    "dataType": "CATEGORICAL",
+    "configId": "your_config_id",
+    "comment": "Resolved the issue but tone was a bit terse."
+  }'
+```
+
+_See the [API reference](https://api.reference.langfuse.com)._
+
+</Tab>
+</LangTabs>
+
+When you reference a config, Langfuse validates the score before storing it: the name must match the config, a categorical value must map to one of the configured categories, and a numeric value must fall within the configured range. See [enforcing a score config](/docs/evaluation/evaluation-methods/scores-via-sdk#enforcing-a-score-config) for the full validation rules.
+
+</Steps>
+
+## What you can do with the scores
+
+Once reviews are flowing in, the scores appear on the linked traces and sessions in the Langfuse UI. You can filter and slice on them, fetch them via the public API to drive your own dashboards, or use [score analytics](/docs/evaluation/scores/score-analytics) to track reviewer agreement and quality trends over time.

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -31,6 +31,7 @@ import {
   Bot,
   FileCode,
   Wand,
+  Users,
 } from "lucide-react";
 
 <TutorialCards>
@@ -118,6 +119,12 @@ Extend your evaluation approach for complex, multi-step applications.
     description="Test whether your judge prompt agrees with how you would label cases, and iterate until it does."
     href="/guides/llm-as-a-judge-calibration-skill"
     icon={<TestTube />}
+  />
+  <TutorialCard
+    title="Human-in-the-Loop Scoring"
+    description="Capture human judgments from your own review tooling and ingest them into Langfuse as structured scores, validated against a score config."
+    href="/guides/human-in-the-loop-scoring"
+    icon={<Users />}
   />
 </TutorialCards>
 


### PR DESCRIPTION
## Summary

- Adds a new guide, **Human-in-the-loop scoring** (`/guides/human-in-the-loop-scoring`), covering how to ingest reviewer judgments from your own review tooling into Langfuse as structured scores, validated against a score config. Surfaced from the guides index as a tutorial card.
- On the **Scores via API/SDK** page, replaces the "Common Use Cases" bullet list with a **Related guides** section at the end of the page, rendered with the existing `ManualGuideList` component. Each use case now links to a relevant guide (user feedback, external evaluation pipelines, code evaluators, security & guardrails, human-in-the-loop scoring, and multi-turn conversation evaluation).

All internal links and cross-references were verified to resolve, and the affected pages render locally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new **Human-in-the-Loop Scoring** guide (`/guides/human-in-the-loop-scoring`) covering how to connect a custom review UI to Langfuse via SDK/API, and replaces the "Common Use Cases" bullet list on the **Scores via API/SDK** page with a `ManualGuideList` component linking each use case to a relevant guide.

- The new guide is well-structured with prerequisites, a 3-step walkthrough (define a score config → surface traces → ingest scores), and SDK code samples that are consistent with the rest of the documentation.
- The `ManualGuideList` on `scores-via-sdk.mdx` introduces a guide card titled "External code execution" whose destination (`/docs/evaluation/evaluation-methods/code-evaluators`) describes running code inside Langfuse, while the card's own lede describes running code in external infrastructure — the opposite workflow.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after resolving the mismatched link on the "External code execution" card.

The new guide and index card are clean and consistent with existing docs patterns. The one concern is in scores-via-sdk.mdx: the "External code execution" ManualGuideList card sends readers to the code-evaluators page (runs logic inside Langfuse) while its lede describes the opposite — running code externally and pushing results in. A reviewer clicking that card gets guidance on an entirely different workflow than advertised.

content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx — the "External code execution" card href and lede describe different workflows.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RT as Review Tool
    participant LF as Langfuse API/SDK
    participant UI as Langfuse UI

    RT->>LF: GET /api/public/traces (filter by name/tags)
    LF-->>RT: Paginated trace list (id, input, output)
    RT->>RT: Render trace in reviewer interface
    Note over RT: Reviewer submits judgment
    RT->>LF: POST /api/public/scores (traceId/sessionId, configId, value)
    LF->>LF: Validate score against config schema
    LF-->>RT: Score created (200 OK)
    LF->>UI: Score visible on trace / session
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx:924-928
The "External code execution" card links to `/docs/evaluation/evaluation-methods/code-evaluators`, which describes running evaluation logic _inside_ Langfuse — but the card's lede says "Run evaluation code in your own infrastructure, then attach the resulting scores to Langfuse," the exact opposite workflow. A reader who clicks this card expecting guidance on external execution will land on a page about the built-in code evaluator instead. The `href` should point to a guide covering external pipelines, or the lede should reflect that this card directs users to the in-Langfuse alternative.

```suggestion
    {
      href: "/guides/cookbook/example_external_evaluation_pipelines",
      topic: "External code execution",
      lede: "Run evaluation code in your own infrastructure, then attach the resulting scores to Langfuse.",
    },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(evaluation): add human-in-the-loop ..."](https://github.com/langfuse/langfuse-docs/commit/a227f255f4c1b41934dfc0c57549092ecba200dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35746036)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->