### PR TITLE
feat(docs): add RAG observability cookbook example

### DIFF
--- a/content/guides/cookbook/meta.json
+++ b/content/guides/cookbook/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "error-analysis-llm-applications",
+    "rag_observability_example",
     "evaluation_of_rag_with_ragas",
     "evaluation_with_langchain",
     "evaluation_with_uptrain",

--- a/content/guides/cookbook/rag_observability_example.mdx
+++ b/content/guides/cookbook/rag_observability_example.mdx
@@ -1,0 +1,219 @@
+---
+title: RAG Observability with Langfuse
+sidebarTitle: RAG Observability
+description: Learn how to trace and observe RAG (Retrieval-Augmented Generation) pipelines with Langfuse using the @observe decorator and the retriever observation type.
+category: Observability
+---
+
+# RAG Observability with Langfuse
+
+This cookbook shows you how to instrument a Retrieval-Augmented Generation (RAG) pipeline with Langfuse to get full visibility into retrieval and generation steps. You'll trace each stage — document retrieval, context building, and LLM generation — so you can debug quality issues, measure latency, and compare configurations.
+
+Related resources:
+
+- [RAG Observability and Evals blog post](/blog/2025-10-28-rag-observability-and-evals) — broader workflow including experiments
+- [RAG evaluation with RAGAS](/guides/cookbook/evaluation_of_rag_with_ragas) — automated quality scoring with RAGAS metrics
+
+## Step 1: Install dependencies
+
+```python
+%pip install langfuse langchain langchain-openai langchain-community faiss-cpu --upgrade
+```
+
+## Step 2: Configure environment
+
+Get your Langfuse API keys from the project settings page.
+
+```python
+import os
+
+# Get keys for your project from the project settings page: https://cloud.langfuse.com
+os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
+os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # 🇪🇺 EU region
+# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
+
+os.environ["OPENAI_API_KEY"] = "sk-proj-..."
+```
+
+Initialize the Langfuse client and verify the connection.
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+if langfuse.auth_check():
+    print("Langfuse client is authenticated and ready!")
+else:
+    print("Authentication failed. Please check your credentials and host.")
+```
+
+## Step 3: Build the RAG pipeline with tracing
+
+Langfuse captures your RAG pipeline at two levels:
+
+1. **The full request** — traced with `@observe()`, capturing the question and the final answer
+2. **The retrieval step** — traced with `start_as_current_observation(as_type="retriever")`, recording which documents were fetched and from where
+
+The LangChain `CallbackHandler` automatically traces the LLM call inside LangChain chains, capturing the prompt, model, token usage, and response.
+
+```python
+from langfuse import get_client, observe
+from langfuse.langchain import CallbackHandler
+from langchain_community.document_loaders import WebBaseLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+from langchain_community.vectorstores import FAISS
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+langfuse = get_client()
+langfuse_handler = CallbackHandler()  # Traces LangChain LLM calls automatically
+
+SYSTEM_PROMPT = (
+    "Answer the question using only the context below. "
+    "If the context does not contain enough information, say so.\n\n"
+    "Context:\n{context}"
+)
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", SYSTEM_PROMPT),
+    ("human", "{question}"),
+])
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+answer_chain = prompt | llm | StrOutputParser()
+
+
+def build_retriever(urls: list[str], chunk_size: int = 512, chunk_overlap: int = 50):
+    loader = WebBaseLoader(urls)
+    docs = loader.load()
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+    splits = splitter.split_documents(docs)
+    vectorstore = FAISS.from_documents(splits, OpenAIEmbeddings())
+    return vectorstore.as_retriever(search_kwargs={"k": 4})
+
+
+@observe()  # Creates a Langfuse trace for each call
+def rag_pipeline(question: str, urls: list[str]) -> dict:
+    retriever = build_retriever(urls)
+
+    # Trace the retrieval step with the "retriever" observation type
+    with langfuse.start_as_current_observation(
+        as_type="retriever",
+        name="retrieve_documents",
+        input=question,
+    ) as retriever_span:
+        docs = retriever.invoke(question)
+        retriever_span.update(
+            output=[
+                {"content": doc.page_content, "source": doc.metadata.get("source", "")}
+                for doc in docs
+            ]
+        )
+
+    context = "\n\n".join(doc.page_content for doc in docs)
+
+    # The CallbackHandler traces the LLM call inside the chain automatically
+    answer = answer_chain.invoke(
+        {"context": context, "question": question},
+        config={"callbacks": [langfuse_handler]},
+    )
+
+    return {"answer": answer, "num_docs": len(docs)}
+```
+
+## Step 4: Run the pipeline
+
+```python
+urls = ["https://langfuse.com/docs"]
+
+result = rag_pipeline(
+    question="What is Langfuse and what are its main features?",
+    urls=urls,
+)
+
+print(result["answer"])
+langfuse.flush()  # Ensure all events are sent before the script exits
+```
+
+## What you'll see in Langfuse
+
+Open your Langfuse project and navigate to **Traces**. Each call to `rag_pipeline` creates one trace with three nested observations:
+
+| Observation | Type | What it captures |
+|---|---|---|
+| `rag_pipeline` | span (root) | Question as input, final answer as output |
+| `retrieve_documents` | retriever | Query as input, list of retrieved chunks with source URLs as output |
+| LLM call | generation | Full prompt, model name, token usage, and raw response |
+
+The `retriever` observation type renders with a distinct icon in the Langfuse UI, making it easy to filter all retrieval steps across your traces and spot quality issues in your document retrieval.
+
+![RAG trace in Langfuse](/images/docs/tracing-rag.png)
+
+## Step 5: Add user and session context
+
+Tag traces with user and session identifiers to make filtering and debugging easier in production.
+
+```python
+from langfuse import observe, propagate_attributes
+
+@observe()
+def rag_pipeline_with_context(
+    question: str,
+    urls: list[str],
+    user_id: str | None = None,
+    session_id: str | None = None,
+) -> dict:
+    # Propagate user/session context to all nested observations
+    with propagate_attributes(
+        user_id=user_id,
+        session_id=session_id,
+        tags=["rag"],
+        metadata={"urls": urls},
+    ):
+        retriever = build_retriever(urls)
+
+        with langfuse.start_as_current_observation(
+            as_type="retriever",
+            name="retrieve_documents",
+            input=question,
+            metadata={"chunk_size": 512, "top_k": 4},
+        ) as retriever_span:
+            docs = retriever.invoke(question)
+            retriever_span.update(
+                output=[
+                    {"content": doc.page_content, "source": doc.metadata.get("source", "")}
+                    for doc in docs
+                ]
+            )
+
+        context = "\n\n".join(doc.page_content for doc in docs)
+        answer = answer_chain.invoke(
+            {"context": context, "question": question},
+            config={"callbacks": [langfuse_handler]},
+        )
+
+    return {"answer": answer, "num_docs": len(docs)}
+
+
+result = rag_pipeline_with_context(
+    question="How do I get started with Langfuse tracing?",
+    urls=["https://langfuse.com/docs"],
+    user_id="user-42",
+    session_id="session-abc123",
+)
+
+langfuse.flush()
+```
+
+## Next steps
+
+With tracing in place, the natural next step is evaluation:
+
+- **Score retrieval quality** — Run [Experiments](/docs/evaluation/experiments/experiments-via-sdk) comparing different chunk sizes or embedding models to find the optimal retrieval configuration
+- **Automate answer scoring** — Set up [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) to continuously score faithfulness and answer relevance on production traces
+- **RAGAS metrics** — See the [RAG evaluation with RAGAS cookbook](/guides/cookbook/evaluation_of_rag_with_ragas) for metric-based evaluation including faithfulness, answer relevancy, and context precision
+- **Datasets and baselines** — Create a [Langfuse Dataset](/docs/evaluation/experiments/datasets) from your traces to build a regression suite as your RAG pipeline evolves

--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -493,5 +493,10 @@
     "notebook": "integration_qwen.ipynb",
     "docsPath": "integrations/model-providers/qwen",
     "isGuide": false
+  },
+  {
+    "notebook": "rag_observability_example.ipynb",
+    "docsPath": null,
+    "isGuide": true
   }
 ]

--- a/cookbook/rag_observability_example.ipynb
+++ b/cookbook/rag_observability_example.ipynb
@@ -1,0 +1,24 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- NOTEBOOK_METADATA title: \"RAG Observability with Langfuse\" sidebarTitle: \"RAG Observability\" description: \"Learn how to trace and observe RAG (Retrieval-Augmented Generation) pipelines with Langfuse using the @observe decorator and the retriever observation type.\" category: \"Observability\" -->"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a new cookbook guide covering how to instrument a RAG pipeline with Langfuse using @observe, start_as_current_observation(as_type="retriever"), and the LangChain CallbackHandler. Includes user/session context propagation and links to the RAGAS evaluation cookbook and Experiments docs as next steps.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new RAG observability cookbook guide demonstrating how to instrument a retrieval-augmented generation pipeline with Langfuse using `@observe`, `start_as_current_observation(as_type="retriever")`, and the LangChain `CallbackHandler`.

- **MDX guide** (`rag_observability_example.mdx`): Five well-structured steps covering dependency installation, environment setup, pipeline tracing, user/session context propagation, and next-step evaluation links. Code uses correct Langfuse v3 APIs throughout.
- **Notebook stub** (`rag_observability_example.ipynb`): Contains only a metadata markdown cell — no executable code cells — while the companion MDX holds all the actual examples. The route entry registers this as an interactive guide (`isGuide: true`, `docsPath: null`), so users who download or open the notebook will find it empty.
- **Routing/sidebar entries**: `_routes.json` and `meta.json` additions are consistent with existing patterns.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The MDX guide is correct but the notebook shipped is an empty stub — users who download it get nothing runnable.

The MDX content and API usage are well-structured and correct. However, the .ipynb file has no code cells at all; every comparable guide in the repo ships with actual content in the notebook. Because _routes.json registers this as a guide with no separate docs path, the notebook is the primary interactive artifact and it is empty.

cookbook/rag_observability_example.ipynb needs the full code content added before merge.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant rag_pipeline as rag_pipeline() @observe
    participant build_retriever as build_retriever()
    participant FAISS as FAISS VectorStore
    participant LangfuseCtx as Langfuse Context (retriever span)
    participant LLMChain as answer_chain (LangChain)
    participant OpenAI as OpenAI LLM
    participant Langfuse as Langfuse Backend

    User->>rag_pipeline: question, urls
    Note over rag_pipeline,Langfuse: @observe() opens root trace
    rag_pipeline->>build_retriever: urls
    build_retriever->>FAISS: WebBaseLoader + chunk + embed
    FAISS-->>rag_pipeline: retriever
    rag_pipeline->>LangfuseCtx: "start_as_current_observation(as_type=retriever)"
    LangfuseCtx->>FAISS: retriever.invoke(question)
    FAISS-->>LangfuseCtx: docs[]
    LangfuseCtx->>Langfuse: update output (chunks + sources)
    rag_pipeline->>LLMChain: "invoke({context, question}, callbacks=[CallbackHandler])"
    LLMChain->>OpenAI: prompt + context
    OpenAI-->>LLMChain: answer
    LLMChain->>Langfuse: generation span (prompt, tokens, response)
    LLMChain-->>rag_pipeline: answer string
    rag_pipeline-->>User: "{answer, num_docs}"
    rag_pipeline->>Langfuse: "flush (root trace closed by @observe)"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cookbook/rag_observability_example.ipynb:1-24
**Notebook is an empty stub with no runnable code**

The `.ipynb` file contains only a single metadata markdown cell. Every other cookbook registered under `_routes.json` with `isGuide: true` — including `error-analysis-llm-applications.ipynb` and `evaluation_of_rag_with_ragas.ipynb` — ships with actual content cells. When a user downloads this notebook from the cookbook page, they receive a file with zero executable code, while all the actual examples live only in the accompanying MDX. The route registration (`"isGuide": true`, `"docsPath": null`) signals this notebook is the primary guide artifact, making the missing content a real gap for anyone trying to run the cookbook interactively.

### Issue 2 of 2
content/guides/cookbook/rag_observability_example.mdx:146-185
**Step 5 silently depends on variables initialized in Step 3**

`rag_pipeline_with_context` calls `build_retriever`, uses `answer_chain` and `langfuse_handler`, and invokes `langfuse.start_as_current_observation` — all defined or initialized in Step 3's code block. There is no note directing the reader to run Step 3 first, and `langfuse_handler` is never re-declared in Step 5. A reader who navigates directly to Step 5 (e.g., via a search or link) will get `NameError` on first execution with no obvious hint about the missing setup.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(docs): add RAG observability cookbo..."](https://github.com/langfuse/langfuse-docs/commit/f10231dc38716fd5eca6f533e7559f00aa7f6611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35998031)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->