### PR TITLE
docs(data-deletion): trace deletion does not remove personal data in prompts or datasets

### DIFF
--- a/content/docs/administration/data-deletion.mdx
+++ b/content/docs/administration/data-deletion.mdx
@@ -24,6 +24,14 @@ Below, we will walk through each of the options and their guarantees.
 
 Note that all trace deletions will delete related entities like scores and observations across all data storages.
 
+<Callout type="info">
+  Trace deletion (e.g. deleting a user's traces by `userId` for a data subject
+  request) removes the traces and their related observations and scores. It does
+  **not** remove personal data that may also be stored in other objects, such as
+  prompts or datasets. To erase a user's data completely, delete those objects as
+  well, or [delete the entire project](#deleting-a-project).
+</Callout>
+
 ### Single Trace
 
 <LangTabs items={["Langfuse UI", "API"]}>


### PR DESCRIPTION
## What

A short clarification on the **Data Deletion** page: deleting traces (including a user's traces by `userId` for a data subject request) removes the traces and their related observations and scores, but **not** personal data that may also be stored in **prompts or datasets**. To erase a user's data completely, delete those objects as well, or delete the entire project.

## Why

The page already notes that trace deletion cascades to scores and observations, and [Managing Personal Data](https://langfuse.com/security/manage-personal-data) points to deleting a user's traces by `userId`. But personal data can also land in prompt templates or dataset items, which trace deletion does not touch — so a GDPR erasure that only deletes traces can leave that data behind. The added callout makes the boundary explicit and points to project deletion for complete erasure.

This was surfaced while verifying GDPR Article 17 erasure on a self-hosted Langfuse v3 with [Sectum AI](https://github.com/sectum-ai/sectum-ai) (open-source multi-tenant isolation verification). Empirically: deleting a user's traces removed them from the API, ClickHouse, and the S3 event blob, while the same user's seeded prompt/dataset rows remained in Postgres until deleted separately.

## Notes

- Docs-only; a single `<Callout type="info">` (the type used widely across these docs), with an in-page anchor to "Deleting a Project" (no external links added).
- AI-assisted contribution; DCO `Signed-off-by` included.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a clarifying `<Callout type="info">` to the Data Deletion page to make explicit that trace deletion (including by `userId` for GDPR erasure) does **not** remove personal data stored in prompts or datasets — users must delete those objects separately or delete the entire project.

- The callout is placed immediately after the existing cascade note under \"Deleting Traces,\" and links correctly to the `#deleting-a-project` anchor in the same page.
- Content is accurate: trace deletion cascades only to observations and scores, leaving Postgres-backed prompt templates and dataset items untouched.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no logic, no code, and no configuration touched — safe to merge.

The change is a single callout block inserted into one MDX file. The anchor link resolves to the correct in-page section, the Callout component type is consistent with the rest of the docs, and the technical claim accurately reflects how trace deletion cascades in Langfuse. Nothing here can break a build or runtime behaviour.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Delete traces by userId\n(GDPR Article 17 request)"] --> B["Traces removed\n(ClickHouse / S3 event blobs)"]
    B --> C["Observations removed\n(cascade)"]
    B --> D["Scores removed\n(cascade)"]
    A --> E["⚠️ Prompts NOT removed\n(Postgres — separate objects)"]
    A --> F["⚠️ Dataset items NOT removed\n(Postgres — separate objects)"]
    E --> G["Must delete manually,\nor delete entire project"]
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(data-deletion): note trace deletion..."](https://github.com/langfuse/langfuse-docs/commit/72db4892dd056a4bc1f1365ef7b89effcdc14013) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36146922)</sub>

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no application code or configuration changes.
> 
> **Overview**
> Adds an **info callout** under **Deleting Traces → Limitations** so admins know trace deletion (including by `userId` for data subject requests) only removes traces and cascaded observations and scores.
> 
> The callout states that **personal data in other objects** (e.g. datasets) is **not** removed by trace deletion, and directs readers to delete those objects separately or use [Deleting a Project](#deleting-a-project) for full erasure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7739a9277b06dc7650a6c3102df47bc6b7caaf5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->