### PR TITLE
docs(handbook): add code evaluator Lambda architecture

### DIFF
--- a/content/handbook/product-engineering/architecture.mdx
+++ b/content/handbook/product-engineering/architecture.mdx
@@ -14,12 +14,15 @@ Langfuse's infrastructure continuously evolves to support increasing scale and n
 graph LR
     Web["Langfuse Web<br/>(Next.js UI + API Layer)"]
     Worker["Langfuse Worker<br/>(Async Event Processing)"]
+    CodeEval["AWS Lambda<br/>(Code Evaluator Runners)"]
 
     Web -->|Queue| Worker
+    Worker -->|CodeEvalDispatcher| CodeEval
 ```
 
 - **Web container (NextJs)**: Serves the UI application and all APIs.
-- **Worker container (Express)**: Processes ingestion events in the background and executes async tasks (e.g. exports, LLM as a Judge).
+- **Worker container (Express)**: Processes ingestion events in the background and executes async tasks (e.g. exports, LLM as a Judge, code evaluator orchestration).
+- **Code evaluator Lambda runners**: Execute [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) outside the worker through the `CodeEvalDispatcher` abstraction. Production deployments use tenant-isolated AWS Lambda runners with [AWS Lambda tenant isolation](https://docs.aws.amazon.com/lambda/latest/dg/tenant-isolation.html).
 
 ### Storage Layer
 
@@ -102,6 +105,7 @@ graph TB
         ECS --> S3[S3 Buckets]
         ECS --> Aurora[Aurora PostgreSQL]
         ECS --> CH[ClickHouse Cloud]
+        ECS -->|CodeEvalDispatcher| Lambda["AWS Lambda<br/>(Tenant-Isolated Code Evaluator Runners)"]
     end
 
     subgraph OSS["Managed OSS Deployment Templates"]

--- a/content/handbook/product-engineering/architecture.mdx
+++ b/content/handbook/product-engineering/architecture.mdx
@@ -14,14 +14,26 @@ Langfuse's infrastructure continuously evolves to support increasing scale and n
 graph LR
     Web["Langfuse Web<br/>(Next.js UI + API Layer)"]
     Worker["Langfuse Worker<br/>(Async Event Processing)"]
-    CodeEval["AWS Lambda<br/>(Code Evaluator Runners)"]
 
     Web -->|Queue| Worker
-    Worker -->|CodeEvalDispatcher| CodeEval
 ```
 
 - **Web container (NextJs)**: Serves the UI application and all APIs.
-- **Worker container (Express)**: Processes ingestion events in the background and executes async tasks (e.g. exports, LLM as a Judge, code evaluator orchestration).
+- **Worker container (Express)**: Processes ingestion events in the background and executes async tasks (e.g. exports, eval execution).
+
+### Evaluation Layer
+
+```mermaid
+graph LR
+    Worker["Langfuse Worker<br/>(Evaluation Orchestration)"]
+    LLM["External LLM Providers<br/>(LLM-as-a-Judge)"]
+    CodeEval["AWS Lambda<br/>(Code Evaluator Runners)"]
+
+    Worker -->|LLM API Calls| LLM
+    Worker -->|CodeEvalDispatcher| CodeEval
+```
+
+- **LLM-as-a-Judge**: The worker calls external LLM providers to execute model-based evaluators.
 - **Code evaluator Lambda runners**: Execute [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) outside the worker through the `CodeEvalDispatcher` abstraction. Production deployments use tenant-isolated AWS Lambda runners with [AWS Lambda tenant isolation](https://docs.aws.amazon.com/lambda/latest/dg/tenant-isolation.html).
 
 ### Storage Layer
@@ -101,11 +113,23 @@ graph TB
 
     subgraph VPN["<span style='display:block; width:100%; text-align:left; white-space: nowrap;'><i>Langfuse Cloud (US, EU, HIPAA)</i></span>"]
         ECS["AWS ECS Fargate (Web + Worker)"]
-        ECS --> ElastiCache["ElastiCache Redis (Clustered)"]
-        ECS --> S3[S3 Buckets]
-        ECS --> Aurora[Aurora PostgreSQL]
-        ECS --> CH[ClickHouse Cloud]
-        ECS -->|CodeEvalDispatcher| Lambda["AWS Lambda<br/>(Tenant-Isolated Code Evaluator Runners)"]
+
+        subgraph StorageInfra["Storage"]
+            ElastiCache["ElastiCache Redis (Clustered)"]
+            S3[S3 Buckets]
+            Aurora[Aurora PostgreSQL]
+            CH[ClickHouse Cloud]
+        end
+
+        subgraph EvaluationInfra["Evaluation Execution"]
+            Lambda["AWS Lambda<br/>(Tenant-Isolated Code Evaluator Runners)"]
+        end
+
+        ECS --> ElastiCache
+        ECS --> S3
+        ECS --> Aurora
+        ECS --> CH
+        ECS -->|CodeEvalDispatcher| Lambda
     end
 
     subgraph OSS["Managed OSS Deployment Templates"]


### PR DESCRIPTION
## Summary

- Update the architecture handbook to show code evaluator execution through AWS Lambda runners.
- Document that worker orchestration uses the `CodeEvalDispatcher` abstraction and that production runners use tenant-isolated AWS Lambda.
- Link to the public code evaluators docs and AWS Lambda tenant isolation docs from the architecture overview.

## Linear

- None

## Review Focus

- Confirm the architecture wording matches the current code evaluator execution model.
- Check that the diagram labels are clear for readers who are not familiar with the implementation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the architecture handbook to document code evaluator execution via AWS Lambda, adding the `CodeEvalDispatcher` abstraction and Lambda runners to both the high-level Application Layer diagram and the production environment diagram.

- The Application Layer diagram gains a `CodeEval` node with a `CodeEvalDispatcher` edge from `Worker`, accurately reflecting the execution path.
- The production environment diagram adds a `Lambda` node inside the Langfuse Cloud subgraph, and the prose description is expanded with links to the code evaluators docs and AWS Lambda tenant isolation guidance.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge after addressing the two minor clarity points.

The changes accurately extend the architecture diagrams and prose with the new Lambda execution path. Two small wording gaps exist: the production diagram's ECS edge (which covers both Web and Worker) may mislead readers into thinking the Web container also dispatches to Lambda, and the phrase 'Production deployments' could be read as covering OSS self-hosted setups rather than being Langfuse Cloud–specific. Neither affects correctness of the implementation, only reader comprehension.

content/handbook/product-engineering/architecture.mdx — specifically line 25 (wording of 'Production deployments') and line 108 (ECS → Lambda edge in the production diagram).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Web as Langfuse Web<br/>(Next.js)
    participant Worker as Langfuse Worker<br/>(Express)
    participant CD as CodeEvalDispatcher
    participant Lambda as AWS Lambda<br/>(Tenant-Isolated)

    Web->>Worker: Queue (async event)
    Worker->>CD: Dispatch code evaluator job
    CD->>Lambda: Invoke tenant-isolated runner
    Lambda-->>CD: Evaluation result
    CD-->>Worker: Return result
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/handbook/product-engineering/architecture.mdx:108
**ECS node implies both Web and Worker dispatch to Lambda**

The production diagram edge `ECS -->|CodeEvalDispatcher| Lambda` originates from the node labeled `AWS ECS Fargate (Web + Worker)`, which may lead readers to believe the Web container is also involved in code evaluator dispatch. In practice, only the Worker uses `CodeEvalDispatcher`. Consider annotating the label or adding a comment to clarify it's a Worker-only concern — e.g. relabeling the edge source as `Worker` or splitting the ECS node — so the diagram stays consistent with the Application Layer diagram above where the arrow correctly leaves the `Worker` node.

### Issue 2 of 2
content/handbook/product-engineering/architecture.mdx:25
**"Production deployments" is ambiguous — this describes Langfuse Cloud, not OSS self-hosted deployments**

The current wording implies all production deployments (including self-hosted OSS) use tenant-isolated AWS Lambda runners, but the OSS deployment templates (Docker Compose, Helm, etc.) in the diagram do not include Lambda. Qualifying this as Langfuse Cloud–specific avoids confusion for self-hosted users who might wonder what code evaluators fall back to in their environment.

```suggestion
- **Code evaluator Lambda runners**: Execute [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) outside the worker through the `CodeEvalDispatcher` abstraction. Langfuse Cloud deployments use tenant-isolated AWS Lambda runners with [AWS Lambda tenant isolation](https://docs.aws.amazon.com/lambda/latest/dg/tenant-isolation.html).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): add code evaluator lambd..."](https://github.com/langfuse/langfuse-docs/commit/2d819515b3d6bb7a5d5a1587e6d82a9b67bc5498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36152976)</sub>

<!-- /greptile_comment -->