### PR TITLE
docs(evaluation): document LLM-as-a-Judge programmatic setup via API

### DIFF
--- a/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
+++ b/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-08
+date: 2026-04-15
 title: Manage LLM-as-a-Judge evaluators via the API
 description: Create, version, and update LLM-as-a-Judge evaluators and evaluation rules programmatically through the (unstable) public API.
 author: Marlies

--- a/content/changelog/2026-06-08-llm-as-a-judge-api.mdx
+++ b/content/changelog/2026-06-08-llm-as-a-judge-api.mdx
@@ -1,0 +1,50 @@
+---
+date: 2026-06-08
+title: Manage LLM-as-a-Judge evaluators via the API
+description: Create, version, and update LLM-as-a-Judge evaluators and evaluation rules programmatically through the (unstable) public API.
+author: Marlies
+canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book, Code } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now set up and manage LLM-as-a-Judge evaluation programmatically through the public API, in addition to the Langfuse UI. This lets you define how data is scored and what data gets evaluated entirely in code, so your evaluation setup can live in version control and roll out the same way across projects.
+
+Common things this unlocks:
+
+- **Version-control your evaluators** — keep judge prompts, output definitions, and model configuration in your repo and create new versions through CI.
+- **Replicate setups across projects** — script the same evaluators and rules into staging and production instead of recreating them by hand.
+- **Automate rollouts** — enable, pause, or repoint evaluation rules as part of a deployment pipeline.
+
+The endpoints are designed to be explored and consumed by coding agents. Point an agent at the API reference and let it create evaluators and wire up evaluation rules for you, rather than clicking through the UI.
+
+The API splits the setup into two resources:
+
+- **Evaluators** define _how_ to score data: the judge prompt, its `{{variables}}`, the structured output definition (numeric, boolean, or categorical), and the optional model configuration. Evaluators are versioned — creating one under an existing name produces the next version, and active rules automatically move to it.
+- **Evaluation rules** define _what_ gets evaluated: the target (live observations or experiments), filters, sampling rate, and the mapping from your data onto the evaluator's variables. Each rule references an evaluator family by `name` and `scope`.
+
+```
+POST   /api/public/unstable/evaluators
+GET    /api/public/unstable/evaluators
+GET    /api/public/unstable/evaluators/{evaluatorId}
+
+POST   /api/public/unstable/evaluation-rules
+GET    /api/public/unstable/evaluation-rules
+GET    /api/public/unstable/evaluation-rules/{evaluationRuleId}
+PUT    /api/public/unstable/evaluation-rules/{evaluationRuleId}
+DELETE /api/public/unstable/evaluation-rules/{evaluationRuleId}
+```
+
+<Callout type="info">
+  These endpoints are **unstable** and may change while the underlying evaluation data model is being redesigned. The UI workflow remains fully supported.
+</Callout>
+
+## Get started
+
+<Cards num={2}>
+  <Card title="LLM-as-a-Judge documentation" href="/docs/evaluation/evaluation-methods/llm-as-a-judge" icon={<Book />} />
+  <Card title="Evaluators API reference" href="https://api.reference.langfuse.com/#tag/unstableevaluators" icon={<Code />} />
+</Cards>

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -374,6 +374,23 @@ You can show the LLM-as-a-Judge execution traces by filtering for the environmen
 
 </Details>
 
+## Programmatic Setup via API [#api]
+
+Beyond the UI, you can set up and manage LLM-as-a-Judge evaluation programmatically through the public API. This is useful for version-controlling your evaluation setup, replicating it across projects, or automating rollouts from a deployment pipeline.
+
+The setup is split into two resources:
+
+- **Evaluators** define _how_ to score data: the judge prompt, its `{{variables}}`, the structured output definition (numeric, boolean, or categorical), and the optional model configuration. Evaluators are versioned—creating one under an existing name produces the next version, and active rules automatically move to it.
+- **Evaluation rules** define _what_ gets evaluated: the target (live observations or experiments), filters, sampling rate, and the mapping from your data onto the evaluator's variables. Each rule references an evaluator family by `name` and `scope`.
+
+A typical flow is to create an evaluator, read back its `variables` and `outputDefinition`, then create one or more evaluation rules that reference it.
+
+The endpoints are designed to be explored and consumed by coding agents. The recommended way to set up evaluators programmatically is to point an agent at the API reference and have it create the evaluators and wire up the evaluation rules for you.
+
+<Callout type="info">
+  These endpoints are currently **unstable** and may change while the underlying evaluation data model is being redesigned. See the [Evaluators](https://api.reference.langfuse.com/#tag/unstableevaluators) and [Evaluation Rules](https://api.reference.langfuse.com/#tag/unstableevaluationrules) API reference for the full request and response schemas.
+</Callout>
+
 ## Advanced Topics
 
 ### Migrating from Trace-Level to Observation-Level Evaluators


### PR DESCRIPTION
## What changed

- **New changelog entry** (`content/changelog/2026-06-08-llm-as-a-judge-api.mdx`) announcing that LLM-as-a-Judge evaluators and evaluation rules can now be created, versioned, and updated programmatically through the (unstable) public API.
- **New "Programmatic Setup via API" section** on the LLM-as-a-Judge docs page (`content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx`).

## Why

We shipped the ability to set up and modify LLM-as-a-Judge evaluation via the API but hadn't documented it yet. This covers both the changelog announcement and the docs page.

## Notes for reviewers

- Both files explain the two-resource model: **evaluators** define *how* to score (prompt, output definition, model config; versioned), and **evaluation rules** define *what* gets evaluated (target, filters, sampling, variable mapping).
- Endpoint list and semantics were pulled from the live OpenAPI spec for accuracy. The endpoints are flagged as **unstable**.
- Both emphasize that the endpoints are designed to be explored and consumed by coding agents — the recommended setup path is to point an agent at the API reference.
- Author set to **Marlies**. No `ogImage` (consistent with other recent API-focused entries).
- API reference tags linked: [unstableevaluators](https://api.reference.langfuse.com/#tag/unstableevaluators) and [unstableevaluationrules](https://api.reference.langfuse.com/#tag/unstableevaluationrules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents the new ability to set up and manage LLM-as-a-Judge evaluation programmatically through Langfuse's unstable public API, adding both a changelog entry and a new docs section.

- **New changelog** (`2026-06-08-llm-as-a-judge-api.mdx`) announces the feature, lists the full set of endpoints, explains the two-resource model (evaluators + evaluation rules), and links to the API reference.
- **New docs section** (`llm-as-a-judge.mdx`) adds "Programmatic Setup via API" covering the same two-resource concept and stability caveat, but without an inline endpoint list—it defers entirely to the external API reference.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

Both files are purely additive documentation. The changelog entry is accurate and complete. The docs section is correct but omits the endpoint list that the changelog includes, leaving the docs page without a quick inline reference for readers who don't follow the external API link.

content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx — the new section would benefit from the endpoint list already present in the changelog.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as API Client / Coding Agent
    participant API as Langfuse Unstable API
    participant Eval as Evaluator (versioned)
    participant Rule as Evaluation Rule

    Client->>API: POST /api/public/unstable/evaluators
    API-->>Client: evaluatorId, name, scope, version

    Client->>API: "GET /api/public/unstable/evaluators/{evaluatorId}"
    API-->>Client: full evaluator schema

    Client->>API: POST /api/public/unstable/evaluation-rules
    API-->>Client: evaluationRuleId

    Note over Client,Rule: Later — update the evaluator (produces next version)
    Client->>API: POST /api/public/unstable/evaluators (same name)
    API-->>Eval: version N+1 created
    Eval-->>Rule: active rules auto-move to new version

    Note over Client,Rule: Manage the rule lifecycle
    Client->>API: "PUT /api/public/unstable/evaluation-rules/{id}"
    Client->>API: "DELETE /api/public/unstable/evaluation-rules/{id}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx:386-388
The docs section describes the API flow in prose but never shows the actual endpoint paths, unlike the changelog which lists them explicitly. A reader who lands here from search or navigation has no quick reference for what to call — they must open the external API reference just to find the route names. Adding a minimal endpoint listing (identical to the one already in the changelog) gives the page standalone utility without duplicating any schema detail.

```suggestion
A typical flow is to create an evaluator, read back its `variables` and `outputDefinition`, then create one or more evaluation rules that reference it.

```
POST   /api/public/unstable/evaluators
GET    /api/public/unstable/evaluators
GET    /api/public/unstable/evaluators/{evaluatorId}

POST   /api/public/unstable/evaluation-rules
GET    /api/public/unstable/evaluation-rules
GET    /api/public/unstable/evaluation-rules/{evaluationRuleId}
PUT    /api/public/unstable/evaluation-rules/{evaluationRuleId}
DELETE /api/public/unstable/evaluation-rules/{evaluationRuleId}
```

The endpoints are designed to be explored and consumed by coding agents. The recommended way to set up evaluators programmatically is to point an agent at the API reference and have it create the evaluators and wire up the evaluation rules for you.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/romantic..."](https://github.com/langfuse/langfuse-docs/commit/8666ce1771ffccdf9b44441b14bb54b9cc5ea0e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36167221)</sub>

<!-- /greptile_comment -->