### PR TITLE
Add Kiro CLI integration page

### DIFF
--- a/content/integrations/other/kiro-cli.mdx
+++ b/content/integrations/other/kiro-cli.mdx
@@ -1,0 +1,164 @@
+---
+title: "Trace Kiro CLI with Langfuse"
+sidebarTitle: Kiro CLI
+logo: /images/integrations/kiro_icon.png
+description: "Trace Kiro CLI AI agent activity — prompts, tool use, and completions — with Langfuse for comprehensive observability of your terminal coding sessions."
+category: Integrations
+---
+
+# Kiro CLI Tracing with Langfuse
+
+> **What is Kiro CLI?** [**Kiro CLI**](https://kiro.dev) is a terminal-based AI coding tool by AWS that runs AI agents to help you write, edit, and understand code from the command line. Kiro CLI provides a [hooks system](https://kiro.dev/docs/cli/hooks/) that lets you run custom commands at different lifecycle points during agent activity.
+
+> **What is Langfuse?** [**Langfuse**](https://langfuse.com/) is an open-source AI engineering platform. It helps teams trace LLM applications, debug issues, evaluate quality, and monitor costs in production.
+
+## What Can This Integration Trace?
+
+Using [Kiro CLI hooks](https://kiro.dev/docs/cli/hooks/), this integration captures agent activity during coding sessions and sends traces to Langfuse. Five hook types are supported:
+
+| Kiro CLI Hook      | What It Traces                       |
+| ------------------ | ------------------------------------ |
+| `agentSpawn`       | Agent initialization                 |
+| `userPromptSubmit` | User prompts and queries             |
+| `preToolUse`       | Tool invocations before execution    |
+| `postToolUse`      | Tool results and execution time      |
+| `stop`             | Agent completion with a status score |
+
+Key observability features include:
+
+- **Traces grouped by conversation**: Each conversation gets its own trace in Langfuse.
+- **Sessions grouped by workspace**: All traces from the same workspace folder are grouped into a [session](/docs/observability/features/sessions).
+- **Dynamic tagging**: Automatic `kiro` and event-based tags so you can filter quickly.
+- **Completion status scoring**: A `completion_status` score (`1` completed, `0.5` aborted, `0` error) is recorded when the agent stops.
+- **Non-blocking error handling**: Tracing never interferes with your coding flow — failures fail open.
+
+## How It Works
+
+Kiro CLI runs a shell command on each hook event. This integration registers a single Node.js handler (`hooks/hook-handler.js`) that reads the event payload from stdin and forwards it to Langfuse via the [JS/TS SDK](/docs/observability/sdk/overview).
+
+```
+Kiro CLI triggers a hook event
+    → Shell command runs hook-handler.js
+    → Reads event payload from stdin
+    → Creates or updates the Langfuse trace for the conversation
+    → Routes to the event-specific handler
+    → Creates generations, spans, events, and scores in Langfuse
+    → Flushes data before exit
+```
+
+### Trace Hierarchy
+
+Each conversation produces one trace (keyed by the conversation ID) with the following structure:
+
+- **Trace** — one per conversation, grouped into a **session** by workspace folder
+  - **Generation** (`User Prompt`) — the prompt you submitted, with the model used
+  - **Spans** (`Tool: <name>`, `Tool Result: <name>`) — tool invocations and their outputs, including duration
+  - **Events** (`Agent Spawned`, `Agent Stopped`) — lifecycle markers
+  - **Score** (`completion_status`) — recorded when the agent stops
+
+## Quick Start
+
+<Steps>
+
+### Set Up Langfuse
+
+1. Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting).
+2. Create a new project and copy your API keys from the project settings.
+
+### Copy the Integration Files to Your Project
+
+Clone the [kiro-cli-langfuse](https://github.com/dhanpraja231/kiro-cli-langfuse) repository and copy the agent definition and hook handler into your project:
+
+```bash
+git clone https://github.com/dhanpraja231/kiro-cli-langfuse.git
+
+cp -r kiro-cli-langfuse/.kiro/agents/ your-project/.kiro/agents/
+cp -r kiro-cli-langfuse/hooks/ your-project/hooks/
+```
+
+This adds:
+
+- `.kiro/agents/langfuse-observer.json` — a Kiro CLI agent definition that wires the hooks to the handler
+- `hooks/` — the Node.js handler code and Langfuse client
+
+### Install Dependencies
+
+```bash
+cd your-project/hooks && npm install
+```
+
+### Configure Langfuse Credentials
+
+Create a `.env` file in your project root with your Langfuse API keys:
+
+```bash
+# Langfuse credentials - get these from https://cloud.langfuse.com
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+
+# Optional: self-hosted or non-EU Langfuse URL (defaults to cloud.langfuse.com)
+# LANGFUSE_BASE_URL=https://your-langfuse-instance.com
+```
+
+**Environment Variables:**
+
+| Variable              | Description                                                                                                                                                                 | Required            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `LANGFUSE_PUBLIC_KEY` | Your Langfuse public key                                                                                                                                                    | Yes                 |
+| `LANGFUSE_SECRET_KEY` | Your Langfuse secret key                                                                                                                                                    | Yes                 |
+| `LANGFUSE_BASE_URL`   | Langfuse base URL. EU: `https://cloud.langfuse.com`, US: `https://us.cloud.langfuse.com`, Japan: `https://jp.cloud.langfuse.com`, HIPAA: `https://hipaa.cloud.langfuse.com` | No (defaults to EU) |
+
+### Activate the Langfuse Observer Agent
+
+Switch to the `langfuse-observer` agent inside Kiro CLI:
+
+```bash
+/agent swap langfuse-observer
+```
+
+Alternatively, merge the `hooks` field from `langfuse-observer.json` into your existing agent configuration so tracing runs without switching agents.
+
+### View Traces in Langfuse
+
+Use Kiro CLI as usual. Open your [Langfuse dashboard](https://cloud.langfuse.com) and navigate to **Traces**. You can:
+
+- Filter by the `kiro` tag to see all Kiro CLI traces.
+- Open the [Sessions](/docs/observability/features/sessions) tab and filter by your workspace folder to see traces from a specific project.
+- Click a trace to see the full conversation breakdown with nested spans, generations, events, and the completion score.
+
+</Steps>
+
+## Customization
+
+### Filter Specific Tools
+
+By default the agent runs the handler for every tool. To trace only specific tools, edit `.kiro/agents/langfuse-observer.json` and add a `matcher` to the `preToolUse` (and/or `postToolUse`) hook:
+
+```json
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "fs_write",
+        "command": "node hooks/hook-handler.js"
+      }
+    ]
+  }
+}
+```
+
+Supported matchers include `fs_write`, `fs_read`, `execute_bash`, `use_aws`, `@git`, `@git/status`, or `*` for all tools.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v18+
+- [Kiro CLI](https://kiro.dev) installed
+- A [Langfuse](https://langfuse.com) account (cloud or self-hosted)
+
+## Resources
+
+- [kiro-cli-langfuse Repository](https://github.com/dhanpraja231/kiro-cli-langfuse)
+- [Kiro CLI Hooks Documentation](https://kiro.dev/docs/cli/hooks/)
+- [Trace Kiro IDE with Langfuse](/integrations/other/kiro)
+- [Langfuse JS/TS SDK](/docs/observability/sdk/overview)
+- [Langfuse Sessions](/docs/observability/features/sessions)

--- a/content/integrations/other/meta.json
+++ b/content/integrations/other/meta.json
@@ -11,6 +11,7 @@
     "hermes",
     "inferable",
     "kiro",
+    "kiro-cli",
     "librechat",
     "mcp-use",
     "milvus",


### PR DESCRIPTION
## What

Adds a new integration page for tracing the **AWS Kiro CLI** with Langfuse, based on the [dhanpraja231/kiro-cli-langfuse](https://github.com/dhanpraja231/kiro-cli-langfuse) guide.

- **New page**: `content/integrations/other/kiro-cli.mdx` — route `/integrations/other/kiro-cli`
- **Nav**: added `kiro-cli` to `content/integrations/other/meta.json`
- **Logo**: reuses the existing `/images/integrations/kiro_icon.png`

## Why

Kiro CLI is a hook-based terminal coding tool, so it follows the repo's established pattern for CLI coding tools (hand-authored MDX like `claude-code.mdx` / `codex.mdx`) rather than a cookbook notebook — `cookbook/_routes.json` is intentionally untouched.

It is a **distinct product** from the existing Kiro IDE page (`kiro.mdx`): the CLI uses `.kiro/agents/` + `/agent swap langfuse-observer`, whereas the IDE uses `.kiro/hooks/` + the Hook UI. The two pages cross-link.

The page documents the 5 supported CLI hooks (`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop`), the trace hierarchy (verified against the source repo's `handlers.js` / `langfuse-client.js`), a `<Steps>` quick start, tool-filter customization, prerequisites, and resources.

## Reviewer notes

- Verified: Prettier passes, exactly one real H1, all internal links resolve (`/docs/observability/sdk/overview`, `/docs/observability/features/sessions`, `/self-hosting`, `/integrations/other/kiro`).
- Worth confirming: the `kiro.dev/docs/cli/hooks/` docs URL (taken from the handler source comments), and whether to point readers at an official `langfuse/langfuse-examples` copy instead of the third-party repo (as the IDE page does).
- No example-trace screenshot is embedded yet — the trace structure is described in text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new integration documentation page for tracing the Kiro CLI (a terminal-based AI coding tool by AWS) with Langfuse, and registers it in the nav.

- The new `kiro-cli.mdx` follows the established MDX pattern of existing tool pages (`kiro.mdx`, `claude-code.mdx`), correctly documents the 5 supported hook types, trace hierarchy, and environment variables, and the Kiro CLI hooks URL (`kiro.dev/docs/cli/hooks/`) is confirmed valid.
- The Quick Start instructs users to clone a personal, uncontrolled GitHub repo (`dhanpraja231/kiro-cli-langfuse`) rather than the official `langfuse/langfuse-examples` org repo used by the existing Kiro IDE page, creating a supply-chain trust inconsistency that the PR author themselves flagged as unresolved.
- `kiro.mdx` is not updated to add the return cross-link to the new page, despite the PR description claiming both pages cross-link.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after resolving the third-party repo reference or accepting it as a community contribution with explicit disclaimers.

The page's Quick Start directs readers to clone and run code from a personal GitHub repo that the Langfuse team does not control, while the comparable Kiro IDE page uses an official org repo. That gap remains open per the PR author's own notes. The promised cross-link from the existing kiro.mdx page is also missing. The rest of the page — frontmatter, nav entry, hook table, trace hierarchy, env variable table, and external URLs — is accurate and well-structured.

content/integrations/other/kiro-cli.mdx — the third-party repo reference in the Quick Start and the missing back-link from kiro.mdx need resolution before publishing.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Developer (Terminal)
    participant Kiro as Kiro CLI
    participant Handler as hook-handler.js (Node.js)
    participant LF as Langfuse SDK
    participant LFAPI as Langfuse API

    User->>Kiro: Start coding session
    Kiro->>Handler: agentSpawn event (stdin JSON)
    Handler->>LF: createTrace(conversationId)
    LF-->>Handler: trace handle
    Handler->>LF: createEvent("Agent Spawned")

    User->>Kiro: Submit prompt
    Kiro->>Handler: userPromptSubmit event
    Handler->>LF: createGeneration("User Prompt", model, input)

    Kiro->>Handler: preToolUse event (tool_name, tool_input)
    Handler->>LF: createSpan("Tool: name")

    Kiro->>Handler: postToolUse event (tool_response, duration)
    Handler->>LF: createSpan("Tool Result: name")

    Kiro->>Handler: stop event (status)
    Handler->>LF: createEvent("Agent Stopped")
    Handler->>LF: createScore("completion_status", 0/0.5/1)
    Handler->>LFAPI: flush()
    LFAPI-->>Handler: ack
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/other/kiro-cli.mdx:84-91
**Third-party repo in official docs**

The Quick Start instructs users to clone `dhanpraja231/kiro-cli-langfuse` — a personal, uncontrolled repo — and copy its files directly into their projects. The existing Kiro IDE page (`kiro.mdx`) references the official `langfuse/langfuse-examples` org repo instead. Pointing users to a personal repo in official docs means the Langfuse team cannot audit or roll back future changes, and any modification to that repo (including malicious ones) would be implicitly endorsed by this page. The PR description itself flags this as "worth confirming." Either migrate the source into `langfuse/langfuse-examples` and update the link, or at minimum add a disclaimer that this is a community-maintained repo.

### Issue 2 of 2
content/integrations/other/kiro-cli.mdx:155-157
**Back-link from kiro.mdx is missing**

The PR description states "the two pages cross-link," but `kiro.mdx` is not modified in this PR — it has no link pointing to the new `kiro-cli` page. Only the new page links to `kiro.mdx`. The cross-link in `kiro.mdx` needs to be added for the claim to hold.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Kiro CLI integration page"](https://github.com/langfuse/langfuse-docs/commit/8a2ba830ddbf7185b4b4c53362c1af22e4101ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36193696)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->