### PR TITLE
feat(analytics): add LinkedIn, Reddit, and X (Twitter) ad conversion tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,15 @@ import {
 } from "@/lib/og-url";
 import { PostHogProvider } from "@/components/analytics/PostHogProvider";
 import { AISearch } from "@/components/inkeep/search";
+import { Hubspot } from "@/components/analytics/hubspot";
+import { GoogleAds } from "@/components/analytics/google-ads";
+import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
+import { RedditPixel } from "@/components/analytics/reddit-ads";
+import { TwitterPixel } from "@/components/analytics/twitter-ads";
+import { ConversionTracker } from "@/components/analytics/ConversionTracker";
+import "../style.css";
+import "@vidstack/react/player/styles/base.css";
+import "../src/overrides.css";
 
 const interVariable = Inter({
   subsets: ["latin"],
@@ -31,15 +40,6 @@ const f37Analog = localFont({
   display: "swap",
   weight: "500",
 });
-import { Hubspot } from "@/components/analytics/hubspot";
-import { GoogleAds } from "@/components/analytics/google-ads";
-import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
-import { RedditPixel } from "@/components/analytics/reddit-ads";
-import { TwitterPixel } from "@/components/analytics/twitter-ads";
-import { ConversionTracker } from "@/components/analytics/ConversionTracker";
-import "../style.css";
-import "@vidstack/react/player/styles/base.css";
-import "../src/overrides.css";
 
 const defaultOgImageUrl = buildDefaultSiteOgImageUrl();
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,10 @@ const f37Analog = localFont({
 });
 import { Hubspot } from "@/components/analytics/hubspot";
 import { GoogleAds } from "@/components/analytics/google-ads";
+import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
+import { RedditPixel } from "@/components/analytics/reddit-ads";
+import { TwitterPixel } from "@/components/analytics/twitter-ads";
+import { ConversionTracker } from "@/components/analytics/ConversionTracker";
 import "../style.css";
 import "@vidstack/react/player/styles/base.css";
 import "../src/overrides.css";
@@ -92,6 +96,10 @@ export default function RootLayout({
           <>
             <GoogleTagManager gtmId="GTM-NGLK4TZX" />
             <GoogleAds />
+            <LinkedInInsightTag />
+            <RedditPixel />
+            <TwitterPixel />
+            <ConversionTracker />
             <Hubspot />
             <Script
               id="cookieyes"

--- a/components/ContactSalesForm.tsx
+++ b/components/ContactSalesForm.tsx
@@ -28,10 +28,7 @@ import {
   FORM_FIELDS,
   type ContactFormData,
 } from "@/lib/contact-sales-form";
-import {
-  GOOGLE_ADS_CONVERSIONS,
-  reportGoogleAdsConversion,
-} from "@/lib/google-ads";
+import { reportTalkToUsConversion } from "@/lib/ad-conversions";
 
 function RequiredMarker({ required }: { required: boolean }) {
   if (!required) {
@@ -94,7 +91,7 @@ export function ContactSalesForm() {
       }
 
       setIsSuccess(true);
-      reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.talkToUsFormSubmit);
+      reportTalkToUsConversion();
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {

--- a/components/analytics/ConversionTracker.tsx
+++ b/components/analytics/ConversionTracker.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { LAUNCH_APP_CTA_SELECTOR } from "@/lib/google-ads";
+import { reportLaunchAppConversion } from "@/lib/ad-conversions";
+
+// Reports the "launch app" conversion (sign up / sign in) across every ad
+// platform whenever a user clicks a CTA that navigates to the Langfuse cloud
+// app. CTAs opt in via the `data-launch-app-cta` attribute, so incidental
+// cloud.langfuse.com links (e.g. in docs/blog content) are not counted. A
+// single delegated listener keeps this working for every marked CTA.
+export function ConversionTracker() {
+  useEffect(() => {
+    // Capture phase runs before button onClick handlers, so CTAs that
+    // preventDefault to navigate programmatically are still tracked.
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Element | null;
+      if (!target?.closest(LAUNCH_APP_CTA_SELECTOR)) return;
+      reportLaunchAppConversion();
+    };
+
+    document.addEventListener("click", handler, true);
+    return () => document.removeEventListener("click", handler, true);
+  }, []);
+
+  return null;
+}

--- a/components/analytics/google-ads.tsx
+++ b/components/analytics/google-ads.tsx
@@ -1,37 +1,10 @@
-"use client";
-
-import { useEffect } from "react";
 import Script from "next/script";
-import {
-  GOOGLE_ADS_CONVERSIONS,
-  GOOGLE_ADS_ID,
-  LAUNCH_APP_CTA_SELECTOR,
-  reportGoogleAdsConversion,
-} from "@/lib/google-ads";
+import { GOOGLE_ADS_ID } from "@/lib/google-ads";
 
-// Loads the Google Ads global site tag and reports the "launch app" conversion
-// (sign ups / sign ins) whenever a user clicks a CTA that navigates to the
-// Langfuse cloud app. CTAs opt in via the `data-launch-app-cta` attribute, so
-// incidental cloud.langfuse.com links (e.g. in docs/blog content) are not
-// counted as conversions. A delegated listener keeps this working for every
-// marked CTA without touching each button.
+// Google Ads global site tag (gtag.js). Conversions are reported via
+// `reportGoogleAdsConversion` (see lib/ad-conversions.ts), and launch-app CTA
+// clicks are tracked by the shared ConversionTracker.
 export function GoogleAds() {
-  useEffect(() => {
-    // Capture phase runs before button onClick handlers, so CTAs that
-    // preventDefault to navigate programmatically are still tracked.
-    const handler = (event: MouseEvent) => {
-      const target = event.target as Element | null;
-      if (!target?.closest(LAUNCH_APP_CTA_SELECTOR)) return;
-      reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.launchApp, {
-        value: 1.0,
-        currency: "USD",
-      });
-    };
-
-    document.addEventListener("click", handler, true);
-    return () => document.removeEventListener("click", handler, true);
-  }, []);
-
   return (
     <>
       <Script

--- a/components/analytics/linkedin-ads.tsx
+++ b/components/analytics/linkedin-ads.tsx
@@ -1,0 +1,37 @@
+import Script from "next/script";
+import { LINKEDIN_PARTNER_ID, isLinkedInEnabled } from "@/lib/linkedin-ads";
+
+// LinkedIn Insight Tag base script. Conversions are reported via
+// `reportLinkedInConversion` (see lib/ad-conversions.ts).
+export function LinkedInInsightTag() {
+  if (!isLinkedInEnabled) return null;
+
+  return (
+    <>
+      <Script id="linkedin-partner-id" strategy="afterInteractive">
+        {`_linkedin_partner_id = "${LINKEDIN_PARTNER_ID}";
+window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+window._linkedin_data_partner_ids.push(_linkedin_partner_id);`}
+      </Script>
+      <Script id="linkedin-insight" strategy="afterInteractive">
+        {`(function(l) {
+if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+window.lintrk.q=[]}
+var s = document.getElementsByTagName("script")[0];
+var b = document.createElement("script");
+b.type = "text/javascript";b.async = true;
+b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+s.parentNode.insertBefore(b, s);})(window.lintrk);`}
+      </Script>
+      <noscript>
+        <img
+          height="1"
+          width="1"
+          style={{ display: "none" }}
+          alt=""
+          src={`https://px.ads.linkedin.com/collect/?pid=${LINKEDIN_PARTNER_ID}&fmt=gif`}
+        />
+      </noscript>
+    </>
+  );
+}

--- a/components/analytics/reddit-ads.tsx
+++ b/components/analytics/reddit-ads.tsx
@@ -1,0 +1,14 @@
+import Script from "next/script";
+import { REDDIT_PIXEL_ID, isRedditEnabled } from "@/lib/reddit-ads";
+
+// Reddit Pixel base script (initializes the pixel and tracks PageVisit).
+// Conversions are reported via `reportRedditConversion` (see lib/ad-conversions.ts).
+export function RedditPixel() {
+  if (!isRedditEnabled) return null;
+
+  return (
+    <Script id="reddit-pixel" strategy="afterInteractive">
+      {`!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','${REDDIT_PIXEL_ID}');rdt('track','PageVisit');`}
+    </Script>
+  );
+}

--- a/components/analytics/twitter-ads.tsx
+++ b/components/analytics/twitter-ads.tsx
@@ -1,0 +1,14 @@
+import Script from "next/script";
+import { TWITTER_PIXEL_ID, isTwitterEnabled } from "@/lib/twitter-ads";
+
+// X (Twitter) Pixel base script (universal website tag). Conversions are
+// reported via `reportTwitterConversion` (see lib/ad-conversions.ts).
+export function TwitterPixel() {
+  if (!isTwitterEnabled) return null;
+
+  return (
+    <Script id="twitter-pixel" strategy="afterInteractive">
+      {`!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');twq('config','${TWITTER_PIXEL_ID}');`}
+    </Script>
+  );
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -2,6 +2,10 @@ interface Window {
   _hsq?: any[];
   dataLayer?: any[];
   gtag?: (...args: any[]) => void;
+  lintrk?: (...args: any[]) => void;
+  _linkedin_data_partner_ids?: any[];
+  rdt?: (...args: any[]) => void;
+  twq?: (...args: any[]) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/ad-conversions.ts
+++ b/lib/ad-conversions.ts
@@ -1,0 +1,39 @@
+import {
+  GOOGLE_ADS_CONVERSIONS,
+  reportGoogleAdsConversion,
+} from "@/lib/google-ads";
+import {
+  LINKEDIN_CONVERSIONS,
+  reportLinkedInConversion,
+} from "@/lib/linkedin-ads";
+import { REDDIT_EVENTS, reportRedditConversion } from "@/lib/reddit-ads";
+import {
+  TWITTER_CONVERSIONS,
+  reportTwitterConversion,
+} from "@/lib/twitter-ads";
+
+// Central dispatch for the two conversions we track across every ad platform.
+// Each platform's helper no-ops when its tag is not loaded or not configured,
+// so calling these is always safe.
+
+// "Launch app" — sign up / sign in. Fired when a user navigates to the cloud app.
+export function reportLaunchAppConversion() {
+  reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.launchApp, {
+    value: 1.0,
+    currency: "USD",
+  });
+  reportLinkedInConversion(LINKEDIN_CONVERSIONS.launchApp);
+  reportRedditConversion(REDDIT_EVENTS.launchApp);
+  reportTwitterConversion(TWITTER_CONVERSIONS.launchApp, {
+    value: 1.0,
+    currency: "USD",
+  });
+}
+
+// "Talk to us" — lead. Fired on a successful talk-to-us form submission.
+export function reportTalkToUsConversion() {
+  reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.talkToUsFormSubmit);
+  reportLinkedInConversion(LINKEDIN_CONVERSIONS.talkToUs);
+  reportRedditConversion(REDDIT_EVENTS.talkToUs);
+  reportTwitterConversion(TWITTER_CONVERSIONS.talkToUs);
+}

--- a/lib/linkedin-ads.ts
+++ b/lib/linkedin-ads.ts
@@ -6,14 +6,14 @@
 //
 // The Insight Tag only loads when a partner ID is set, and each conversion only
 // fires when its ID is non-zero, so it is safe to ship before the IDs exist.
-export const LINKEDIN_PARTNER_ID: string = ""; // e.g. "1234567"
+export const LINKEDIN_PARTNER_ID: string = "9239642";
 
 export const LINKEDIN_CONVERSIONS: {
   launchApp: number;
   talkToUs: number;
 } = {
-  launchApp: 0, // sign up / sign in
-  talkToUs: 0, // talk-to-us form lead
+  launchApp: 28126114, // "Launch App (Sign up)" conversion
+  talkToUs: 28126122, // "Talk to Us (Lead)" conversion
 };
 
 export const isLinkedInEnabled = LINKEDIN_PARTNER_ID !== "";

--- a/lib/linkedin-ads.ts
+++ b/lib/linkedin-ads.ts
@@ -1,0 +1,31 @@
+// LinkedIn Insight Tag + conversion tracking.
+//
+// Fill in the values below from LinkedIn Campaign Manager:
+//   - LINKEDIN_PARTNER_ID: Account Assets → Insight Tag (numeric partner ID)
+//   - LINKEDIN_CONVERSIONS.*: Account Assets → Conversions (numeric conversion IDs)
+//
+// The Insight Tag only loads when a partner ID is set, and each conversion only
+// fires when its ID is non-zero, so it is safe to ship before the IDs exist.
+export const LINKEDIN_PARTNER_ID: string = ""; // e.g. "1234567"
+
+export const LINKEDIN_CONVERSIONS: {
+  launchApp: number;
+  talkToUs: number;
+} = {
+  launchApp: 0, // sign up / sign in
+  talkToUs: 0, // talk-to-us form lead
+};
+
+export const isLinkedInEnabled = LINKEDIN_PARTNER_ID !== "";
+
+export function reportLinkedInConversion(conversionId: number) {
+  if (
+    !conversionId ||
+    typeof window === "undefined" ||
+    typeof window.lintrk !== "function"
+  ) {
+    return;
+  }
+
+  window.lintrk("track", { conversion_id: conversionId });
+}

--- a/lib/reddit-ads.ts
+++ b/lib/reddit-ads.ts
@@ -18,7 +18,12 @@ export const REDDIT_EVENTS: {
 export const isRedditEnabled = REDDIT_PIXEL_ID !== "";
 
 export function reportRedditConversion(eventName: string) {
-  if (typeof window === "undefined" || typeof window.rdt !== "function") {
+  if (
+    !eventName ||
+    !REDDIT_PIXEL_ID ||
+    typeof window === "undefined" ||
+    typeof window.rdt !== "function"
+  ) {
     return;
   }
 

--- a/lib/reddit-ads.ts
+++ b/lib/reddit-ads.ts
@@ -1,7 +1,8 @@
 // Reddit Pixel + conversion tracking.
 //
-// Fill in the advertiser pixel ID from Reddit Ads Manager
-// (Events Manager → Pixel). It looks like "t2_xxxxxxxx".
+// Fill in the pixel ID from Reddit Ads Manager (Events Manager → Pixel →
+// "Install the Pixel"). It is the `pixel_id` / `rdt('init', …)` value and uses
+// the "a2_" prefix (e.g. "a2_xxxxxxxxx") — not the "t2_" account-ID prefix.
 //
 // Reddit uses standard event names (no per-conversion ID needed). The pixel
 // only loads when the ID is set, so it is safe to ship before the ID exists.

--- a/lib/reddit-ads.ts
+++ b/lib/reddit-ads.ts
@@ -1,0 +1,26 @@
+// Reddit Pixel + conversion tracking.
+//
+// Fill in the advertiser pixel ID from Reddit Ads Manager
+// (Events Manager → Pixel). It looks like "t2_xxxxxxxx".
+//
+// Reddit uses standard event names (no per-conversion ID needed). The pixel
+// only loads when the ID is set, so it is safe to ship before the ID exists.
+export const REDDIT_PIXEL_ID: string = ""; // e.g. "t2_xxxxxxxx"
+
+export const REDDIT_EVENTS: {
+  launchApp: string;
+  talkToUs: string;
+} = {
+  launchApp: "SignUp", // sign up / sign in
+  talkToUs: "Lead", // talk-to-us form lead
+};
+
+export const isRedditEnabled = REDDIT_PIXEL_ID !== "";
+
+export function reportRedditConversion(eventName: string) {
+  if (typeof window === "undefined" || typeof window.rdt !== "function") {
+    return;
+  }
+
+  window.rdt("track", eventName);
+}

--- a/lib/reddit-ads.ts
+++ b/lib/reddit-ads.ts
@@ -5,7 +5,7 @@
 //
 // Reddit uses standard event names (no per-conversion ID needed). The pixel
 // only loads when the ID is set, so it is safe to ship before the ID exists.
-export const REDDIT_PIXEL_ID: string = ""; // e.g. "t2_xxxxxxxx"
+export const REDDIT_PIXEL_ID: string = "a2_j57h34zw84n1";
 
 export const REDDIT_EVENTS: {
   launchApp: string;

--- a/lib/twitter-ads.ts
+++ b/lib/twitter-ads.ts
@@ -1,0 +1,45 @@
+// X (Twitter) Pixel + conversion tracking.
+//
+// Fill in the values below from X Ads → Tools → Events Manager:
+//   - TWITTER_PIXEL_ID: the pixel ID (e.g. "oabc1")
+//   - TWITTER_CONVERSIONS.*: the event ID for each conversion. The full tag X
+//     expects is `tw-${TWITTER_PIXEL_ID}-${eventId}`.
+//
+// The pixel only loads when the pixel ID is set, and each conversion only fires
+// when its event ID is set, so it is safe to ship before the IDs exist.
+export const TWITTER_PIXEL_ID: string = ""; // e.g. "oabc1"
+
+export const TWITTER_CONVERSIONS: {
+  launchApp: string;
+  talkToUs: string;
+} = {
+  launchApp: "", // sign up / sign in
+  talkToUs: "", // talk-to-us form lead
+};
+
+export const isTwitterEnabled = TWITTER_PIXEL_ID !== "";
+
+type TwitterEventOptions = {
+  value?: number;
+  currency?: string;
+};
+
+export function reportTwitterConversion(
+  eventId: string,
+  options: TwitterEventOptions = {},
+) {
+  if (
+    !eventId ||
+    !TWITTER_PIXEL_ID ||
+    typeof window === "undefined" ||
+    typeof window.twq !== "function"
+  ) {
+    return;
+  }
+
+  const params: Record<string, unknown> = {};
+  if (options.value !== undefined) params.value = options.value;
+  if (options.currency !== undefined) params.currency = options.currency;
+
+  window.twq("event", `tw-${TWITTER_PIXEL_ID}-${eventId}`, params);
+}

--- a/lib/twitter-ads.ts
+++ b/lib/twitter-ads.ts
@@ -7,14 +7,14 @@
 //
 // The pixel only loads when the pixel ID is set, and each conversion only fires
 // when its event ID is set, so it is safe to ship before the IDs exist.
-export const TWITTER_PIXEL_ID: string = ""; // e.g. "oabc1"
+export const TWITTER_PIXEL_ID: string = "rcvz2";
 
 export const TWITTER_CONVERSIONS: {
   launchApp: string;
   talkToUs: string;
 } = {
-  launchApp: "", // sign up / sign in
-  talkToUs: "", // talk-to-us form lead
+  launchApp: "rcvz4", // "Launch App (Sign up)" event
+  talkToUs: "rcvz5", // "Talk to Us (Lead)" event
 };
 
 export const isTwitterEnabled = TWITTER_PIXEL_ID !== "";


### PR DESCRIPTION
## Summary

We now run ads on LinkedIn, Reddit, and X (Twitter) in addition to Google. This adds each platform's tracking pixel alongside the existing Google Ads tag and reports the **same two conversions** across all platforms through a single dispatcher:

- **Launch app** (sign up / sign in) — fired when a user clicks a CTA that navigates to the cloud app (`*.cloud.langfuse.com`), via the shared `ConversionTracker`.
- **Talk to us** (lead) — fired on a successful talk-to-us form submission.

### How it's structured
- **Pixel loaders** (`components/analytics/{linkedin,reddit,twitter}-ads.tsx`) load each base tag, mounted in the production-only block in `app/layout.tsx`.
- **Per-platform config + helpers** (`lib/{linkedin,reddit,twitter}-ads.ts`) hold the IDs and the low-level `report*Conversion` functions.
- **`lib/ad-conversions.ts`** is the central dispatcher (`reportLaunchAppConversion` / `reportTalkToUsConversion`) that fans out to every platform incl. Google.
- The launch-app click listener was **consolidated** out of the Google Ads component into the shared `ConversionTracker`, so there's one delegated listener instead of one per platform. CTAs still opt in via the existing `data-launch-app-cta` attribute.

### ⚠️ IDs required before this tracks anything
Each pixel only loads when its ID is set, and each conversion no-ops until configured — **safe to merge as-is**. To activate, fill in:

| Platform | File | Values needed |
|---|---|---|
| LinkedIn | `lib/linkedin-ads.ts` | `LINKEDIN_PARTNER_ID` + `LINKEDIN_CONVERSIONS.{launchApp,talkToUs}` conversion IDs (Campaign Manager → Conversions) |
| Reddit | `lib/reddit-ads.ts` | `REDDIT_PIXEL_ID` (`t2_…`). Events use standard `SignUp` / `Lead`, no extra IDs |
| X (Twitter) | `lib/twitter-ads.ts` | `TWITTER_PIXEL_ID` + `TWITTER_CONVERSIONS.{launchApp,talkToUs}` event IDs (Events Manager) |

### Notes
- Scripts are gated to `NODE_ENV === "production"`, matching the existing analytics block, so they don't run in dev.
- GTM (`GTM-NGLK4TZX`) is also loaded — make sure these same pixels aren't *also* configured inside GTM, or conversions will double-count.

## Test plan
- [ ] Fill in IDs, deploy, and confirm each base pixel loads (LinkedIn Insight Tag Helper, Reddit Pixel Helper, X Pixel Helper).
- [ ] Click a cloud CTA → confirm a launch-app event fires on all platforms.
- [ ] Submit the talk-to-us form → confirm a lead event fires on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds LinkedIn, Reddit, and X (Twitter) ad conversion tracking alongside the existing Google Ads integration, with a new central `ConversionTracker` component that consolidates the click-listener logic previously baked into `google-ads.tsx`.

- **New pixel loaders** (`linkedin-ads.tsx`, `reddit-ads.tsx`, `twitter-ads.tsx`) and their config stubs (`lib/linkedin-ads.ts`, `lib/reddit-ads.ts`, `lib/twitter-ads.ts`) are all gated on non-empty IDs, so the change is safe to merge without any active tracking until the IDs are filled in.
- **`lib/ad-conversions.ts`** is a clean central dispatcher that fans out the two conversion events (`reportLaunchAppConversion` / `reportTalkToUsConversion`) to all four platforms; `ContactSalesForm.tsx` and `ConversionTracker.tsx` now call this dispatcher instead of Google-specific helpers directly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all new pixel loaders no-op until IDs are filled in, so there is no risk of unintended tracking or double-counting in the current state.

The conversion dispatcher and click-listener refactor are straightforward and well-guarded. The only findings are a style-rule violation (imports after variable declarations in layout.tsx) and a minor inconsistency in reddit-ads.ts where reportRedditConversion lacks the eventName guard present in the other helpers. Neither affects runtime behaviour today.

lib/reddit-ads.ts (missing eventName guard) and app/layout.tsx (imports placed after variable declarations)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ConversionTracker
    participant ContactSalesForm
    participant adConversions as lib/ad-conversions.ts
    participant Google as Google Ads
    participant LinkedIn as LinkedIn Insight Tag
    participant Reddit as Reddit Pixel
    participant Twitter as X (Twitter) Pixel

    User->>ConversionTracker: clicks [data-launch-app-cta]
    ConversionTracker->>adConversions: reportLaunchAppConversion()
    adConversions->>Google: reportGoogleAdsConversion(launchApp)
    adConversions->>LinkedIn: reportLinkedInConversion(launchApp)
    adConversions->>Reddit: reportRedditConversion("SignUp")
    adConversions->>Twitter: reportTwitterConversion(launchApp)

    User->>ContactSalesForm: submits talk-to-us form
    ContactSalesForm->>adConversions: reportTalkToUsConversion()
    adConversions->>Google: reportGoogleAdsConversion(talkToUsFormSubmit)
    adConversions->>LinkedIn: reportLinkedInConversion(talkToUs)
    adConversions->>Reddit: reportRedditConversion("Lead")
    adConversions->>Twitter: reportTwitterConversion(talkToUs)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
app/layout.tsx:36-39
**Imports placed after variable declarations**

The four new `import` statements are placed after the `localFont` and `Inter` variable declarations (lines 15–33), rather than at the top of the module. Per the team's style rule, imports should always appear before any executable statements or declarations. The existing `Hubspot` and `GoogleAds` imports on lines 34–35 have the same issue, but this PR adds four more to the same block.

### Issue 2 of 2
lib/reddit-ads.ts:20-25
**Missing guard on empty `eventName`**

`reportLinkedInConversion` and `reportTwitterConversion` both short-circuit on a falsy conversion ID before touching the tracker. `reportRedditConversion` has no equivalent `!eventName` guard. While the current callers always pass the hardcoded `"SignUp"` / `"Lead"` strings, a future caller passing an empty string would silently fire an unrecognised event to the Reddit Pixel.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): add LinkedIn, Reddit, a..."](https://github.com/langfuse/langfuse-docs/commit/7b25484dfefacf775e08cfa53cf568d5d3aadfff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36206492)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->