### PR TITLE
docs(observability): add Full-Text Search feature page

### DIFF
--- a/content/changelog/2025-05-19-full-text-search.mdx
+++ b/content/changelog/2025-05-19-full-text-search.mdx
@@ -6,6 +6,7 @@ author: Max
 ogVideo: https://static.langfuse.com/docs-videos/2025-05-19-ft-search.mp4
 badge: Launch Week 3 🚀
 showOgInHeader: false
+canonical: https://langfuse.com/docs/observability/features/full-text-search
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
@@ -32,8 +33,8 @@ import { Search } from "lucide-react";
 
 <Cards num={1}>
   <Card
-    title="Observability"
-    href="/docs/observability/overview"
+    title="Full-Text Search"
+    href="/docs/observability/features/full-text-search"
     icon={<Search />}
   />
 </Cards>

--- a/content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx
+++ b/content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx
@@ -4,6 +4,7 @@ badge: Launch Week 5 🚀
 title: "Full-Text Search"
 description: Langfuse Cloud is rolling out ClickHouse full-text search, improving UI search and adding the matches operator to Observations API v2.
 author: Valeriy Meleshkin
+canonical: https://langfuse.com/docs/observability/features/full-text-search
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
@@ -72,3 +73,5 @@ Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/pub
 ## More full-text search improvements to come
 
 This is the beginning of our full-text search work in Fast Mode. We are continuing to tune the rollout, expand coverage, and improve search behavior for more query shapes.
+
+See the [Full-Text Search docs](/docs/observability/features/full-text-search) to learn how to use it in the UI and the API.

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -21,15 +21,6 @@ Use the search bar above the traces and observations tables to search across `in
 
 Search uses [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes). Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).
 
-In our benchmarks, some searches moved from multi-second scans over hundreds of GB to sub-second reads over less than 1 GB:
-
-| Query shape               | Before                                   | With full-text search                |
-| ------------------------- | ---------------------------------------- | ------------------------------------ |
-| Large input/output search | 18.205s, 66,130,828 rows, 493.79 GB read | 0.447s, 140,956 rows, 728.51 MB read |
-| Metadata-heavy search     | 1.612s, 66,130,828 rows, 53.14 GB read   | 0.201s, 58,730 rows, 438.83 MB read  |
-
-These gains depend on the search term and data distribution. Queries with very common tokens or substring-only filters may see more modest gains.
-
 ## Search via the API [#api]
 
 The [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) supports a `matches` operator for token-based full-text search on `input`, `output`, and string `metadata` filters.

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -17,9 +17,9 @@ Full-text search lets you find all occurrences of a specific keyword or phrase a
 
 Use the search bar above the traces and observations tables to search across `input` and `output` content. Matching traces and observations are returned so you can quickly locate the run you are looking for and combine search with the existing filters and time range selectors.
 
-## Fast Mode [#fast-mode]
+## Performance [#performance]
 
-On Langfuse Cloud, search runs on [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes) in **Fast Mode (Preview)**. Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).
+Search uses [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes). Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).
 
 In our benchmarks, some searches moved from multi-second scans over hundreds of GB to sub-second reads over less than 1 GB:
 
@@ -28,11 +28,7 @@ In our benchmarks, some searches moved from multi-second scans over hundreds of 
 | Large input/output search | 18.205s, 66,130,828 rows, 493.79 GB read | 0.447s, 140,956 rows, 728.51 MB read |
 | Metadata-heavy search     | 1.612s, 66,130,828 rows, 53.14 GB read   | 0.201s, 58,730 rows, 438.83 MB read  |
 
-These gains depend on the search term and data distribution. Queries with very common tokens, substring-only filters, or data that has not been indexed yet may see more modest gains.
-
-<Callout type="info">
-Fast Mode is rolling out gradually on Langfuse Cloud. Coverage is being expanded continuously as historical data is backfilled into the text indexes.
-</Callout>
+These gains depend on the search term and data distribution. Queries with very common tokens or substring-only filters may see more modest gains.
 
 ## Search via the API [#api]
 

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -1,0 +1,80 @@
+---
+title: Full-Text Search
+description: Find content across the inputs, outputs, and metadata of your traces and observations with full-text search in Langfuse.
+sidebarTitle: Full-Text Search
+---
+
+# Full-Text Search
+
+Full-text search lets you find all occurrences of a specific keyword or phrase across the inputs, outputs, and metadata of your traces and observations. This is especially useful when debugging complex applications where you remember a piece of content but not which trace it belongs to.
+
+<Video
+  src="https://static.langfuse.com/docs-videos/full-text-search-launch.mp4"
+  aspectRatio={16 / 9}
+/>
+
+## Search in the UI
+
+Use the search bar above the traces and observations tables to search across `input` and `output` content. Matching traces and observations are returned so you can quickly locate the run you are looking for and combine search with the existing filters and time range selectors.
+
+## Fast Mode [#fast-mode]
+
+On Langfuse Cloud, search runs on [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes) in **Fast Mode (Preview)**. Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).
+
+In our benchmarks, some searches moved from multi-second scans over hundreds of GB to sub-second reads over less than 1 GB:
+
+| Query shape               | Before                                   | With full-text search                |
+| ------------------------- | ---------------------------------------- | ------------------------------------ |
+| Large input/output search | 18.205s, 66,130,828 rows, 493.79 GB read | 0.447s, 140,956 rows, 728.51 MB read |
+| Metadata-heavy search     | 1.612s, 66,130,828 rows, 53.14 GB read   | 0.201s, 58,730 rows, 438.83 MB read  |
+
+These gains depend on the search term and data distribution. Queries with very common tokens, substring-only filters, or data that has not been indexed yet may see more modest gains.
+
+<Callout type="info">
+Fast Mode is rolling out gradually on Langfuse Cloud. Coverage is being expanded continuously as historical data is backfilled into the text indexes.
+</Callout>
+
+## Search via the API [#api]
+
+The [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) supports a `matches` operator for token-based full-text search on `input`, `output`, and string `metadata` filters.
+
+When building filters on `/api/public/v2/observations`, prefer `=` when you know the exact value and `matches` when you want token-based search:
+
+- `matches` is **case-insensitive** for `input` and `output`, so `refund failed` can match `Refund Failed`.
+- For metadata filters, `matches` is **case-sensitive** and applies to the string metadata value of the selected key.
+- Substring operators such as `contains`, `starts with`, and `ends with` are rejected with `400` on `input` and `output` filters because they would require slow full-content scans. Use `matches` for token search on these fields instead.
+
+Example `matches` filter for observation output:
+
+```json
+[
+  {
+    "type": "string",
+    "column": "output",
+    "operator": "matches",
+    "value": "refund failed"
+  }
+]
+```
+
+Example exact metadata filter:
+
+```json
+[
+  {
+    "type": "stringObject",
+    "column": "metadata",
+    "key": "environment",
+    "operator": "=",
+    "value": "production"
+  }
+]
+```
+
+Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/public/v2/observations`. See the [Observations API v2 docs](/docs/api-and-data-platform/features/observations-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for the full filter schema.
+
+## GitHub Discussions
+
+import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
+
+<GhDiscussionsPreview labels={["feat-search"]} />

--- a/content/docs/observability/features/meta.json
+++ b/content/docs/observability/features/meta.json
@@ -14,6 +14,7 @@
     "user-feedback",
     "log-levels",
     "agent-graphs",
+    "full-text-search",
     "masking",
     "mcp-tracing",
     "multi-modality",


### PR DESCRIPTION
## What changed

Adds a dedicated docs page for full-text search and makes it the canonical source for the topic.

- **New page** `content/docs/observability/features/full-text-search.mdx`, listed under **Observability › Features › Advanced** (after `agent-graphs`). It covers:
  - Searching across trace/observation `input`, `output`, and `metadata` in the UI (with the launch video)
  - **Fast Mode (Preview)** on Langfuse Cloud — ClickHouse text indexes plus the benchmark table from the changelog
  - **Search via the API** — the `matches` operator on Observations API v2, case-sensitivity rules, why `contains`/`starts with`/`ends with` are rejected on `input`/`output`, and JSON filter examples
  - GitHub Discussions block (`feat-search` label)
- **Canonicalization**: both related changelog entries now point at the new page via `canonical` frontmatter, and their "Learn more" links were repointed to it:
  - `content/changelog/2025-05-19-full-text-search.mdx`
  - `content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx`

## Why

There was no feature docs page for full-text search yet — only changelog entries. This gives the topic a stable, canonical home in the docs.

## Notes for reviewers

- Verified locally: `prettier --check` and `check-h1-headings.js` pass; dev server renders the new page (HTTP 200) with the correct H1, video, and `<link rel="canonical">`, and both changelog pages emit the docs URL as their canonical.
- The page keeps the "Preview" / gradual-rollout framing for Fast Mode. If Fast Mode has since reached GA or self-hosted, the wording (and the `Callout`) should be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a dedicated canonical docs page for full-text search under **Observability › Features**, and updates both related changelog entries to point at it via `canonical` frontmatter and "Learn more" links.

- **New page** (`content/docs/observability/features/full-text-search.mdx`) covers UI search, the Fast Mode (Preview) ClickHouse-backed fast path with benchmark data, and the `matches` operator on Observations API v2 — including case-sensitivity rules and JSON filter examples.
- **Changelog canonicalization** — both the 2025 original launch and the 2026 Fast Mode entry now declare the docs page as their canonical URL; the 2025 card link is also updated from the generic observability overview to the new feature URL.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — only docs and MDX content changes, no runtime code affected.

The import for GhDiscussionsPreview is placed inline at the bottom of the new file rather than hoisted to the top after the frontmatter, which differs from how sibling pages (e.g. agent-graphs.mdx) and the project convention handle imports. Everything else — content accuracy, canonical links, sidebar ordering, and cross-links — looks correct.

content/docs/observability/features/full-text-search.mdx — import placement should be fixed.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User / API client"] -->|"UI search bar"| B["Traces/Observations Table"]
    A -->|"GET /api/public/v2/observations\n?filter=[matches operator]"| C["Observations API v2"]

    B --> D{Fast Mode?}
    C --> D

    D -->|"Yes (Cloud Preview)"| E["ClickHouse full-text index\n(token-based, skip-scan)"]
    D -->|"No"| F["Full content scan"]

    E --> G["Results"]
    F --> G

    subgraph "Docs Canonicalization"
        H["changelog/2025-05-19\nfull-text-search.mdx\ncanonical →"]
        I["changelog/2026-05-27\nclickhouse-fast-mode.mdx\ncanonical →"]
        J["docs/observability/features\nfull-text-search.mdx\n(canonical source)"]
        H --> J
        I --> J
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/observability/features/full-text-search.mdx:7-9
The `GhDiscussionsPreview` import is placed inline in the document body at line 78, but the project convention (see `agent-graphs.mdx` line 7) is to hoist all imports to the top of the file, immediately after the frontmatter block and before the H1. The custom rule for this repo requires imports at module scope, not embedded mid-document.

```suggestion
import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";

# Full-Text Search

Full-text search lets you find all occurrences of a specific keyword or phrase across the inputs, outputs, and metadata of your traces and observations. This is especially useful when debugging complex applications where you remember a piece of content but not which trace it belongs to.
```

### Issue 2 of 2
content/docs/observability/features/full-text-search.mdx:76-80
With the import moved to the top, the inline `import` statement at the bottom of the file should be removed so the component usage stands alone.

```suggestion
## GitHub Discussions

<GhDiscussionsPreview labels={["feat-search"]} />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(observability): add Full-Text Searc..."](https://github.com/langfuse/langfuse-docs/commit/9f269dcac322467f450cbe1cbce4daba04590463) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36402172)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->