### PR TITLE
docs(self-hosting): document GOOGLE_CLOUD_UNIVERSE_DOMAIN for native GCS

### DIFF
--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -291,7 +291,16 @@ LANGFUSE_USE_GOOGLE_CLOUD_STORAGE=true
 LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse # Bucket name
 LANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS=<json-credentials OR path-to-credentials.json> # JSON key or path to JSON key file. Optional. Will fallback to environment credentials
 LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/ # Optional prefix to store events within a subpath of the bucket
+GOOGLE_CLOUD_UNIVERSE_DOMAIN=googleapis.com # Optional. Google Cloud universe domain. Defaults to `googleapis.com`
 ```
+
+<Callout type="info">
+
+By default, the native integration connects to the public Google Cloud universe (`googleapis.com`).
+To target a sovereign or private Google Cloud universe (for example, a Google Distributed Cloud or government deployment), set `GOOGLE_CLOUD_UNIVERSE_DOMAIN` to your universe's domain.
+The value applies across all authentication methods (JSON credentials, key file, and environment credentials).
+
+</Callout>
 
 ### Google Cloud Storage (Compatibility Mode)
 


### PR DESCRIPTION
Document the GOOGLE_CLOUD_UNIVERSE_DOMAIN env var (default googleapis.com) added in langfuse/langfuse#13453, which lets the native Google Cloud Storage integration target sovereign or private Google Cloud universes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation for the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable to the native Google Cloud Storage integration section, enabling Langfuse deployments to target sovereign or private Google Cloud universes (e.g., Google Distributed Cloud, government clouds).

- Adds `GOOGLE_CLOUD_UNIVERSE_DOMAIN=googleapis.com` to the GCS native example config block with an inline comment marking it optional and noting the default.
- Adds a `<Callout type=\"info\">` block explaining when and how to override the default public Google Cloud universe.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a docs-only addition with no logic changes.

The change adds one env var line to a code example block and one informational callout. The variable name matches the upstream feature PR, the default value is correctly documented, and the callout accurately describes when to override it. No existing content is modified.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Langfuse starts] --> B{LANGFUSE_USE_GOOGLE_CLOUD_STORAGE=true?}
    B -- No --> C[Use S3 / other storage]
    B -- Yes --> D{GOOGLE_CLOUD_UNIVERSE_DOMAIN set?}
    D -- No --> E[Default: googleapis.com\nPublic Google Cloud]
    D -- Yes --> F[Custom universe domain\ne.g. Google Distributed Cloud\nor government deployment]
    E --> G{Auth method}
    F --> G
    G --> H[JSON credentials\nLANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS]
    G --> I[Key file path\nLANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS]
    G --> J[Environment credentials\ne.g. Workload Identity]
    H --> K[Connect to GCS bucket\nLANGFUSE_S3_EVENT_UPLOAD_BUCKET]
    I --> K
    J --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document GOOGLE\_CLOU..."](https://github.com/langfuse/langfuse-docs/commit/470e68cde44a82d76695735979f6a19311490eb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36423563)</sub>

<!-- /greptile_comment -->