### PR TITLE
docs: add Twitter link for Lotte on team page

### DIFF
--- a/components-mdx/team-members.mdx
+++ b/components-mdx/team-members.mdx
@@ -13,7 +13,7 @@
 | **Akio Nuernberger**   | Enterprise & Partnerships  | [Twitter](https://x.com/AkioNuernberger), [LinkedIn](https://www.linkedin.com/in/akio-nuernberger/)                                             |
 | **Nimar Blume**        | Product Engineer           | [Twitter](https://x.com/nimarblu), [LinkedIn](https://www.linkedin.com/in/nimar/), [GitHub](https://github.com/nimarb)                          |
 | **Valeriy Meleshkin**  | Backend Engineer           | [LinkedIn](https://www.linkedin.com/in/valeriy-meleshkin-5610ab58), [GitHub](https://github.com/sumerman)                                       |
-| **Lotte Verheyden**    | Product Marketing Engineer | [LinkedIn](https://www.linkedin.com/in/lotteverheyden/), [GitHub](https://github.com/Lotte-Verheyden)                                           |
+| **Lotte Verheyden**    | Product Marketing Engineer | [Twitter](https://x.com/lotte_verheyden), [LinkedIn](https://www.linkedin.com/in/lotteverheyden/), [GitHub](https://github.com/Lotte-Verheyden) |
 | **Leonard Wolters**    | Ops                        | [LinkedIn](https://www.linkedin.com/in/leonardwolters/), [GitHub](https://github.com/leonardwolters)                                            |
 | **Annabell Schäfer**   | Product Marketing Engineer | [Twitter](https://x.com/annabellschfr), [LinkedIn](https://www.linkedin.com/in/annabell-schaefer/), [GitHub](https://github.com/annabellscha)   |
 | **Tobias Wochinger**   | Product Engineer           | [LinkedIn](https://www.linkedin.com/in/tobiaswochinger/), [GitHub](https://github.com/wochinge)                                                 |

--- a/content/docs/observability/features/tags.mdx
+++ b/content/docs/observability/features/tags.mdx
@@ -12,7 +12,7 @@ Tags allow you to categorize and filter observations and traces in Langfuse.
 
 Tags are strings (max 200 characters each) and an observation may have multiple tags. The full set of tags applied across all observations in a trace are automatically aggregated and added to the trace object in Langfuse. If a tag exceeds 200 characters, it will be dropped.
 
-Because Langfuse uses an immutable data model for observations, tags can't be added or edited in the UI after they're created. 
+Because Langfuse uses an immutable data model for observations, tags can't be added or edited in the UI after they're created.
 
 ## Propagating Tags to Observations
 


### PR DESCRIPTION
Adds the missing X (Twitter) link for Lotte Verheyden in the team members table, matching the existing column order (Twitter, LinkedIn, GitHub).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the missing Twitter/X profile link for Lotte Verheyden in the team members table, placing it before the existing LinkedIn and GitHub links to match the column order used by other team members.

- Adds `[Twitter](https://x.com/lotte_verheyden)` as the first social link in Lotte's row, consistent with the Twitter → LinkedIn → GitHub ordering seen on other rows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line documentation change adding a social media link.

The change adds one social link in the correct position and format, matching the Twitter → LinkedIn → GitHub order used by other team members. No logic, functionality, or structure is affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Team Member Row: Lotte Verheyden] --> B[Twitter]
    A --> C[LinkedIn]
    A --> D[GitHub]
    B --> E["https://x.com/lotte_verheyden"]
    C --> F["https://www.linkedin.com/in/lotteverheyden/"]
    D --> G["https://github.com/Lotte-Verheyden"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Twitter link for Lotte on team..."](https://github.com/langfuse/langfuse-docs/commit/53c4258fc985755416820a816f3dc05f45f6952a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37058708)</sub>

<!-- /greptile_comment -->