### PR TITLE
Remove town hall banner

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -2,20 +2,21 @@ import Link from "next/link";
 import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 
 export function Banner() {
-  return (
-    <FumadocsBanner
-      id="fd-top-banner-town-hall-2026-q2"
-      height="2rem"
-      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
-    >
-      <Link href="https://luma.com/7dny2x72">
-        <span className="sm:hidden">
-          [Virtual] Langfuse Town Hall · Jun 11 →
-        </span>
-        <span className="hidden sm:inline">
-          [Virtual] Langfuse Town Hall · Jun 11, 9am PT: V4, Releases, Roadmap →
-        </span>
-      </Link>
-    </FumadocsBanner>
-  );
+  return null;
+  // return (
+  //   <FumadocsBanner
+  //     id="fd-top-banner-town-hall-2026-q2"
+  //     height="2rem"
+  //     className="bg-black text-white [&_a]:text-white [&_button]:text-white"
+  //   >
+  //     <Link href="https://luma.com/7dny2x72">
+  //       <span className="sm:hidden">
+  //         [Virtual] Langfuse Town Hall · Jun 11 →
+  //       </span>
+  //       <span className="hidden sm:inline">
+  //         [Virtual] Langfuse Town Hall · Jun 11, 9am PT: V4, Releases, Roadmap →
+  //       </span>
+  //     </Link>
+  //   </FumadocsBanner>
+  // );
 }


### PR DESCRIPTION
Comments out the town hall banner in `components/layout/Banner.tsx` since the Jun 11 event has passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aat69Re8snzARmjAvs3sD4)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Disables the post-event town hall banner by having the `Banner` component return `null` early and commenting out the JSX, as the Jun 11 event has passed.

- The `Banner` component now returns `null` unconditionally, hiding the banner site-wide.
- The previous banner markup is left as a comment for reference, but the `Link` and `FumadocsBanner` imports are now unused.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the component now renders nothing, cleanly removing the expired banner from all pages.

This is a minimal, low-risk change: the component unconditionally returns null, and the only follow-up is cleaning up the now-unused imports.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Banner component called] --> B{return null}
    B --> C[Nothing rendered]
    B -.->|commented out| D[FumadocsBanner JSX]
    D -.-> E[Town Hall link displayed]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/layout/Banner.tsx:1-5
Both `Link` and `FumadocsBanner` are now unused since the component unconditionally returns `null` before any JSX is reached. Depending on the project's ESLint/TypeScript config, this can produce lint errors or warnings in CI. Since the commented-out code is only meant as historical reference, it's safest to remove the imports as well.

```suggestion
export function Banner() {
  return null;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove town hall banner"](https://github.com/langfuse/langfuse-docs/commit/3ac2370bd2f8165b77f195c1eb2dcf4155e2f540) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37157861)</sub>

<!-- /greptile_comment -->