### PR TITLE
docs: update deprecated LANGFUSE_HOST references

### DIFF
--- a/components/voiceAgent/livekit-agent/README.md
+++ b/components/voiceAgent/livekit-agent/README.md
@@ -12,7 +12,7 @@ The agent (`agent.py`) is a Python-based LiveKit agent that:
 
 ### OTel tracing
 
-The agent configures an OpenTelemetry `TracerProvider` that exports spans to Langfuse via the OTLP/HTTP exporter. LiveKit's agent SDK automatically instruments LLM calls, STT, TTS, and tool invocations as OTel spans. These are sent to `{LANGFUSE_HOST}/api/public/otel` using Basic auth derived from the Langfuse API keys.
+The agent configures an OpenTelemetry `TracerProvider` that exports spans to Langfuse via the OTLP/HTTP exporter. LiveKit's agent SDK automatically instruments LLM calls, STT, TTS, and tool invocations as OTel spans. These are sent to `{LANGFUSE_BASE_URL}/api/public/otel` using Basic auth derived from the Langfuse API keys.
 
 ## Deployment
 
@@ -22,7 +22,7 @@ The following secrets must be configured on the LiveKit Cloud agent (via `--secr
 
 - `LANGFUSE_PUBLIC_KEY`
 - `LANGFUSE_SECRET_KEY`
-- `LANGFUSE_HOST` (e.g. `https://cloud.langfuse.com`)
+- `LANGFUSE_BASE_URL` (e.g. `https://cloud.langfuse.com`)
 
 `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are injected automatically by LiveKit Cloud.
 

--- a/content/blog/2025-10-21-testing-llm-applications.mdx
+++ b/content/blog/2025-10-21-testing-llm-applications.mdx
@@ -219,7 +219,7 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
         LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
-        LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+        LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
       run: |
         pytest test_geography_experiment.py -v
 ```

--- a/content/blog/2026-02-26-evaluate-ai-agent-skills.mdx
+++ b/content/blog/2026-02-26-evaluate-ai-agent-skills.mdx
@@ -131,7 +131,7 @@ The root cause was in the skill itself. In our example showing how to set enviro
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com  # optional, default is EU
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com
 ```
 
 By changing that one comment to say the host is mandatory, the agent started checking for it upfront and setting it when missing. The number of retries for that specific error went to zero immediately. You can see the before and after in [this commit](https://github.com/langfuse/skills/pull/4/changes/904a0ff1a6b9d4e4cc66ae26eb38d193a53d958b).

--- a/content/changelog/2026-02-17-langfuse-cli.mdx
+++ b/content/changelog/2026-02-17-langfuse-cli.mdx
@@ -64,7 +64,7 @@ Pass an `--env .env` file to load your API key from a file. Alternatively, expor
 ```bash
 export LANGFUSE_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com  # default, supports self-hosted
+export LANGFUSE_BASE_URL=https://cloud.langfuse.com  # default, supports self-hosted
 ```
 
 ## Pairs with Agent Skills

--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -165,7 +165,7 @@ npm install @langfuse/tracing @langfuse/otel @opentelemetry/sdk-node
 
 To authenticate with Langfuse, add your Langfuse credentials as environment variables. You can get your credentials by signing up for a free [Langfuse Cloud](https://langfuse.com/cloud) account or by [self-hosting Langfuse](https://langfuse.com/self-hosting).
 
-If you are self-hosting Langfuse or using a [data region](/security/data-regions) other than the default (EU, https://cloud.langfuse.com), ensure you configure the host argument or the `LANGFUSE_BASE_URL` environment variable.
+If you are self-hosting Langfuse or using a [data region](/security/data-regions) other than the default (EU, https://cloud.langfuse.com), ensure you configure the base URL argument or the `LANGFUSE_BASE_URL` environment variable.
 
 You can also pass the credentials [directly to the constructor](#client-setup).
 

--- a/content/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation.mdx
+++ b/content/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation.mdx
@@ -97,7 +97,7 @@ import os
 
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
-os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"  # EU region
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"  # EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
 os.environ["OPENAI_API_KEY"] = "sk-proj-..."

--- a/content/guides/human-in-the-loop-scoring.mdx
+++ b/content/guides/human-in-the-loop-scoring.mdx
@@ -26,7 +26,7 @@ This guide shows how to connect that custom tooling to Langfuse: pull the traces
 
 - Traces already flowing into Langfuse from your application. See [tracing](/docs/observability/get-started) if you have not set this up yet.
 - A custom annotation or review UI where your reviewers view traces and submit their judgments.
-- The Langfuse SDK installed and credentials (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`) available in your environment.
+- The Langfuse SDK installed and credentials (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`) available in your environment.
 
 ## Walkthrough
 

--- a/content/guides/llm-as-a-judge-calibration-skill.mdx
+++ b/content/guides/llm-as-a-judge-calibration-skill.mdx
@@ -18,7 +18,7 @@ The answer is **judge calibration**. You can do this manually, but the [Langfuse
 
 **A coding agent with the Langfuse skill installed.** You can use any agent (Claude Code, Cursor, Codex, etc.) as long as the [Langfuse skill](https://github.com/langfuse/skills/tree/main/skills/langfuse) is available to it. Make sure your version of the skill includes `references/judge-calibration.md`.
 
-**Langfuse credentials in your environment.** The skill uses the [Langfuse CLI](https://github.com/langfuse/langfuse-cli) under the hood, which reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` from your shell.
+**Langfuse credentials in your environment.** The skill uses the [Langfuse CLI](https://github.com/langfuse/langfuse-cli) under the hood, which reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` from your shell.
 
 ## The setup at a high level
 

--- a/content/integrations/frameworks/langchain-deepagents.mdx
+++ b/content/integrations/frameworks/langchain-deepagents.mdx
@@ -36,7 +36,7 @@ import os
 # Get keys for your project from the project settings page: https://cloud.langfuse.com
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
-os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
 # Your API keys

--- a/content/integrations/frameworks/livekit.mdx
+++ b/content/integrations/frameworks/livekit.mdx
@@ -92,7 +92,7 @@ def setup_langfuse(
 
     if not public_key or not secret_key or not base_url:
         raise ValueError(
-            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be set"
+            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL (or LANGFUSE_HOST) must be set"
         )
 
     trace_provider = TracerProvider()

--- a/content/integrations/frameworks/livekit.mdx
+++ b/content/integrations/frameworks/livekit.mdx
@@ -82,17 +82,17 @@ from livekit.agents.telemetry import set_tracer_provider
 def setup_langfuse(
     metadata: dict[str, AttributeValue] | None = None,
     *,
-    host: str | None = None,
+    base_url: str | None = None,
     public_key: str | None = None,
     secret_key: str | None = None,
 ) -> TracerProvider:
     public_key = public_key or os.getenv("LANGFUSE_PUBLIC_KEY")
     secret_key = secret_key or os.getenv("LANGFUSE_SECRET_KEY")
-    host = host or os.getenv("LANGFUSE_HOST") or os.getenv("LANGFUSE_BASE_URL")
+    base_url = base_url or os.getenv("LANGFUSE_BASE_URL") or os.getenv("LANGFUSE_HOST")
 
-    if not public_key or not secret_key or not host:
+    if not public_key or not secret_key or not base_url:
         raise ValueError(
-            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_HOST (or LANGFUSE_BASE_URL) must be set"
+            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be set"
         )
 
     trace_provider = TracerProvider()
@@ -101,7 +101,7 @@ def setup_langfuse(
     Langfuse(
         public_key=public_key,
         secret_key=secret_key,
-        base_url=host,
+        base_url=base_url,
         tracer_provider=trace_provider,
         should_export_span=lambda span: True,
     )

--- a/content/integrations/other/exa.mdx
+++ b/content/integrations/other/exa.mdx
@@ -34,7 +34,7 @@ import os
 # Get keys for your project from the project settings page: https://cloud.langfuse.com
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
-os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
 # Your Exa API key

--- a/content/integrations/other/parallel-ai.mdx
+++ b/content/integrations/other/parallel-ai.mdx
@@ -32,7 +32,7 @@ import os
 # Get keys for your project from the project settings page: https://cloud.langfuse.com
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
-os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
 # Your Parallel key

--- a/content/security/data-regions.mdx
+++ b/content/security/data-regions.mdx
@@ -27,7 +27,7 @@ All data, user accounts, and infrastructure are completely separated between the
 To connect to a specific data region using the Langfuse SDKs, you need to set the base URL environment variable or pass it during initialization:
 
 - **Python:** Set `LANGFUSE_BASE_URL` environment variable or use the `base_url` parameter.
-- **JS/TS:** Set `LANGFUSE_BASEURL` environment variable or use the `baseUrl` parameter.
+- **JS/TS:** Set `LANGFUSE_BASE_URL` environment variable or use the `baseUrl` parameter.
 
 Example base URLs:
 

--- a/cookbook/example_pydantic_ai_mcp_agent_evaluation.ipynb
+++ b/cookbook/example_pydantic_ai_mcp_agent_evaluation.ipynb
@@ -117,7 +117,7 @@
         "\n",
         "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"pk-lf-...\"\n",
         "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\"\n",
-        "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\"  # EU region\n",
+        "os.environ[\"LANGFUSE_BASE_URL\"] = \"https://cloud.langfuse.com\"  # EU region\n",
         "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
         "\n",
         "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""

--- a/cookbook/integration_exa.ipynb
+++ b/cookbook/integration_exa.ipynb
@@ -49,7 +49,7 @@
     "# Get keys for your project from the project settings page: https://cloud.langfuse.com\n",
     "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"pk-lf-...\" \n",
     "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\" \n",
-    "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
+    "os.environ[\"LANGFUSE_BASE_URL\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
     "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
     "\n",
     "# Your Exa API key\n",

--- a/cookbook/integration_langchain_deepagents.ipynb
+++ b/cookbook/integration_langchain_deepagents.ipynb
@@ -51,7 +51,7 @@
     "# Get keys for your project from the project settings page: https://cloud.langfuse.com\n",
     "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"pk-lf-...\" \n",
     "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\" \n",
-    "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
+    "os.environ[\"LANGFUSE_BASE_URL\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
     "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
     "\n",
     "# Your API keys\n",

--- a/cookbook/integration_parallel.ipynb
+++ b/cookbook/integration_parallel.ipynb
@@ -47,7 +47,7 @@
     "# Get keys for your project from the project settings page: https://cloud.langfuse.com\n",
     "os.environ[\"LANGFUSE_PUBLIC_KEY\"] = \"pk-lf-...\" \n",
     "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\" \n",
-    "os.environ[\"LANGFUSE_HOST\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
+    "os.environ[\"LANGFUSE_BASE_URL\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
     "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
     "\n",
     "# Your Parallel key\n",


### PR DESCRIPTION
## What changed

- Replaced current docs examples that referenced `LANGFUSE_HOST` with `LANGFUSE_BASE_URL`.
- Updated related wording from “host” to “base URL” where the current SDK/API naming expects it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces deprecated `LANGFUSE_HOST` environment variable references with `LANGFUSE_BASE_URL` across docs, blog posts, changelogs, and Jupyter notebooks. It also corrects the JS/TS entry in `data-regions.mdx` from the older `LANGFUSE_BASEURL` (no underscore) to the current `LANGFUSE_BASE_URL`, aligning with the v4+ SDK.

- **Documentation text updates** across 16 files swap `LANGFUSE_HOST` for `LANGFUSE_BASE_URL` in code snippets and prose.
- **`livekit.mdx` code logic change**: the `setup_langfuse` helper renames the `host` keyword argument to `base_url` and reorders the env-var fallback to prefer `LANGFUSE_BASE_URL` over the legacy `LANGFUSE_HOST`, while still accepting the old name for backward compatibility.
- **Incomplete sweep**: several other docs pages (e.g. `cognee.mdx`, `langflow.mdx`, `langserve.md`, `goose.mdx`, and older cookbook notebooks) still reference `LANGFUSE_HOST` and were not touched by this PR.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are documentation and example-code updates with no runtime logic outside of the livekit.mdx helper, which retains its backward-compatible LANGFUSE_HOST fallback.

The bulk of the change is straightforward text substitution in docs and notebooks. The one code-bearing change (livekit.mdx) correctly reorders env-var lookup and keeps the legacy fallback. The only friction is an error message that omits the still-supported LANGFUSE_HOST name, and several docs pages that were not updated, leaving the variable name inconsistent across the site.

content/integrations/frameworks/livekit.mdx (error message vs. actual fallback behavior) and the files not touched by this PR that still contain LANGFUSE_HOST (e.g. cognee.mdx, langflow.mdx, langserve.md).
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/frameworks/livekit.mdx:93-96
The error message no longer mentions `LANGFUSE_HOST`, but the code on the line immediately above still accepts it as a fallback. A user with only `LANGFUSE_HOST` set will never hit this error at runtime, yet if neither variable is set, the message gives no hint that the legacy name also works. It is slightly more helpful to acknowledge the accepted alternative.

```suggestion
    if not public_key or not secret_key or not base_url:
        raise ValueError(
            "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL (or LANGFUSE_HOST) must be set"
        )
```

### Issue 2 of 2
content/integrations/other/cognee.mdx:37
**Incomplete migration — several files still reference `LANGFUSE_HOST`**

This PR updates a subset of docs but leaves a number of files untouched, including `content/integrations/no-code/langflow.mdx`, `content/integrations/frameworks/langserve.md`, `content/integrations/model-providers/openai-assistants-api.md`, several older cookbook notebooks, and blog posts. Readers following those pages will use the deprecated name, while readers following the newly updated pages will use `LANGFUSE_BASE_URL`, creating inconsistency across the docs site. If the intent is an incremental rollout, a note or a follow-up tracking issue would help prevent confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixed typo"](https://github.com/langfuse/langfuse-docs/commit/9321c02a940eccfc1763dab0a5d3ff6461a04558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37226304)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->