### PR TITLE
docs: fix invalid `langfuse.trace()` context manager in OTel setup guide

### DIFF
--- a/content/faq/all/existing-otel-setup.mdx
+++ b/content/faq/all/existing-otel-setup.mdx
@@ -547,7 +547,9 @@ This is largely a tradeoff. You can't filter parent spans without affecting the 
 {/* PYTHON */}
 
 ```python
-with langfuse.trace(name="my-operation", user_id="user-123", session_id="session-456") as trace:
+from langfuse import propagate_attributes
+
+with propagate_attributes(trace_name="my-operation", user_id="user-123", session_id="session-456"):
     # Your code here
 ```
 


### PR DESCRIPTION
## What does this PR do?

The Python tab in the "Set trace-level data explicitly" section of the *Using Langfuse with an existing OpenTelemetry setup* FAQ page showed:

```python
with langfuse.trace(name="my-operation", user_id="user-123", session_id="session-456") as trace:
    # Your code here
```

This is not valid: `langfuse.trace()` does not exist in the v3/v4 Python SDK and was never a context manager, so anyone copying the snippet hits an `AttributeError`. The rest of the page already uses the v4 API (the JS/TS tab uses `propagateAttributes`).

This PR replaces it with the canonical v4 `propagate_attributes()` context manager, which is the documented replacement for `update_current_trace()` per the [v3-to-v4 migration guide](https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4) (`name` → `trace_name`), and mirrors the JS/TS tab on the same page:

```python
from langfuse import propagate_attributes

with propagate_attributes(trace_name="my-operation", user_id="user-123", session_id="session-456"):
    # Your code here
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] Self-reviewed the change
- [x] Single hand-authored MDX file (not a generated cookbook page)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a broken Python code snippet in the \"Set trace-level data explicitly\" section of the existing-OTel-setup FAQ by replacing the non-existent `langfuse.trace()` context manager with the correct v4 `propagate_attributes()` API.

- Replaces `langfuse.trace(name=...)` — which does not exist in the v3/v4 SDK — with `from langfuse import propagate_attributes` followed by `propagate_attributes(trace_name=..., user_id=..., session_id=...)`, matching the documented v4 migration path.
- The fix now mirrors the JS/TS tab on the same page that already used `propagateAttributes`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-file documentation fix replacing a non-functional Python snippet with the correct v4 API call — no runtime code is touched and the change is straightforwardly correct.

The replacement uses the right function name (propagate_attributes), the right parameter (trace_name instead of name), includes the necessary import at the top of the snippet, and matches both the JS/TS counterpart on the same page and the official v3→v4 migration guide. No logic, no runtime behavior, and no other files are affected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Developer
    participant SDK as Langfuse v4 SDK
    participant OTel as OpenTelemetry

    User->>SDK: propagate_attributes(trace_name, user_id, session_id)
    SDK->>OTel: Set trace-level attributes on active span context
    OTel-->>SDK: Context propagated
    SDK-->>User: Context manager yields
    User->>OTel: Instrumented code runs within context
    OTel-->>SDK: Spans captured with propagated attributes
    SDK-->>User: Trace visible in Langfuse with correct metadata
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix invalid langfuse.trace() conte..."](https://github.com/langfuse/langfuse-docs/commit/ee789a877f4c00c5c7564cf6c8b1270738a28409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37478671)</sub>

<!-- /greptile_comment -->