### PR TITLE
docs: replace removed v2 `langfuse_context` with v3 `get_client()` in empty-trace FAQ

### DIFF
--- a/content/faq/all/empty-trace-input-and-output.mdx
+++ b/content/faq/all/empty-trace-input-and-output.mdx
@@ -77,7 +77,7 @@ langfuse.flush()
 If using the `@observe()` decorator:
 
 ```python
-from langfuse import observe, langfuse_context
+from langfuse import observe, get_client
 
 @observe()
 def main():
@@ -85,7 +85,7 @@ def main():
     pass
 
 main()
-langfuse_context.flush()
+get_client().flush()
 ```
 
 </Tab>


### PR DESCRIPTION
## What does this PR do?

The "Empty trace input and output" FAQ page mixes SDK versions. The first Python tab correctly uses the v3+ API:

```python
from langfuse import get_client
langfuse = get_client()
langfuse.flush()
```

…but the `@observe()` decorator example just below it still uses the **removed v2 API**:

```python
from langfuse import observe, langfuse_context
...
langfuse_context.flush()
```

`langfuse_context` is not importable from the `langfuse` package in v3/v4 (in v2 it lived under `langfuse.decorators`, never top-level), so copying this snippet raises `ImportError`. This PR aligns it with the v3+ pattern already used elsewhere on the same page:

```python
from langfuse import observe, get_client
...
get_client().flush()
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist
- [x] Self-reviewed; single hand-authored MDX file; consistent with the v3 usage already in this file.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a single MDX documentation file where the `@observe()` decorator example incorrectly imported and called the removed v2 `langfuse_context` API instead of the v3+ `get_client()` pattern already used everywhere else on the same page.

- Replaces `from langfuse import observe, langfuse_context` → `from langfuse import observe, get_client` to match the v3 import convention used in the surrounding snippets.
- Replaces `langfuse_context.flush()` → `get_client().flush()`, making the flush call consistent with the standalone (non-decorator) Python example directly above it.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line docs-only change that removes a broken import/call and replaces it with the correct v3 pattern already used on the same page.

The change is minimal and targeted — two lines in one MDX file. The replacement get_client().flush() is the canonical v3 flush pattern and is used correctly outside any function (after main() returns), matching the singleton-client pattern already demonstrated in the snippet directly above it. No logic, config, or runtime code is touched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User Script
    participant Observe as @observe() decorator
    participant Client as get_client()
    participant Queue as Background Queue
    participant API as Langfuse API

    User->>Observe: main()
    Observe->>Queue: enqueue span/trace data
    Observe-->>User: return
    User->>Client: get_client().flush()
    Client->>Queue: drain all pending events
    Queue->>API: POST /ingestion (batch)
    API-->>Queue: 200 OK
    Client-->>User: flush complete
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: replace removed v2 langfuse\_contex..."](https://github.com/langfuse/langfuse-docs/commit/a8278b4b65b6cbab68950062a7fca538fc28ef00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37497932)</sub>

<!-- /greptile_comment -->