### PR TITLE
docs: refresh Spring AI integration page

### DIFF
--- a/content/integrations/frameworks/spring-ai.mdx
+++ b/content/integrations/frameworks/spring-ai.mdx
@@ -33,14 +33,14 @@ You’ll also need the Micrometer -> OpenTelemetry bridge and an OTLP exporter. 
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-bom</artifactId>
-            <version>2.17.0</version>
+            <version>2.28.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-bom</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.9</version> <!-- Check for the latest 1.0.x release -->
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -56,7 +56,7 @@ You’ll also need the Micrometer -> OpenTelemetry bridge and an OTLP exporter. 
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
-    <!-- Spring AI needs a reactive web server to run for some reason-->
+    <!-- Web server context required for Spring Boot auto-configuration and the actuator observability endpoints -->
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
@@ -193,7 +193,7 @@ public class ChatModelCompletionContentObservationFilter implements ObservationF
 
 With these configurations and dependencies in place, your Spring Boot application is ready to produce OpenTelemetry traces. Spring AI’s internal calls (e.g. when you invoke a chat model or generate an embedding) will be recorded as spans.
 
-Each span will carry attributes like `gen_ai.operation.name`, `gen_ai.system` (the provider, e.g. “openai”), model names, token usage, etc., and – since we enabled them – events for the prompt and response content​
+Each span will carry attributes like `gen_ai.operation.name`, `gen_ai.system` (the provider, e.g. “openai”), model names, token usage, etc., and – since we enabled them – events for the prompt and response content.
 
 ## Step 2: Configure Langfuse
 
@@ -206,16 +206,22 @@ Langfuse will act as the “backend” for OpenTelemetry in this setup – essen
 - Sign up for [Langfuse Cloud](https://langfuse.com/cloud) or [self-hosted Langfuse](https://langfuse.com/self-hosting).
 - Set the OTLP endpoint (e.g. `https://cloud.langfuse.com/api/public/otel`) and API keys.
 
-Configure these via environment variables:
+Authentication uses HTTP Basic Auth: build the credential by base64-encoding your `public_key:secret_key` pair, then pass it (along with the ingestion-version header) via the standard OpenTelemetry environment variables:
 
 ```bash
-OTEL_EXPORTER_OTLP_ENDPOINT: set this to the Langfuse OTLP URL (e.g. https://cloud.langfuse.com/api/public/otel).
-OTEL_EXPORTER_OTLP_HEADERS: set this to Authorization=Basic <base64 public:secret>,x-langfuse-ingestion-version=4.
+# Build the Basic Auth string from your Langfuse API keys
+AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64 -w0) # macOS: drop -w0
+
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+# Other regions: 🇺🇸 US https://us.cloud.langfuse.com/api/public/otel, 🇯🇵 Japan https://jp.cloud.langfuse.com/api/public/otel, ⚕️ HIPAA https://hipaa.cloud.langfuse.com/api/public/otel
+# Self-hosted (>= v3.22.0): http://localhost:3000/api/public/otel
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
 ```
 
 <Callout type="info">
-  You can find more on authentication via Basic Auth in the
-  [here](/docs/opentelemetry/get-started).
+  See [OpenTelemetry: Get
+  Started](/docs/opentelemetry/get-started) for more on Basic Auth and the
+  `x-langfuse-ingestion-version` header.
 </Callout>
 
 ## Step 3: Run a Test AI Operation
@@ -236,7 +242,7 @@ public void testAiCall() {
 ## Setting userId and sessionId
 
 This section covers how to associate spans from Spring AI with [users](/docs/tracing-features/users) and [sessions](/docs/tracing-features/sessions).
-Create a custom span and set the Langfuse-specific attributes directly:
+Create a custom span and set the Langfuse-specific attributes directly. The `tracer` below is an injected OpenTelemetry `Tracer` (`io.opentelemetry.api.trace.Tracer`), auto-configured by the `opentelemetry-spring-boot-starter`, and `Scope` / `Span` come from the OpenTelemetry API (`io.opentelemetry.context.Scope`, `io.opentelemetry.api.trace.Span`):
 
 ```java
 public String processUserRequest(String userInput, String userId) {
@@ -266,8 +272,8 @@ private String performAiOperation(String userInput) {
     messages.add(new UserMessage(userInput));
 
     Prompt prompt = new Prompt(messages);
-    ChatResponse response = chatClient.call(prompt);
-    return response.getResult().getOutput().getContent();
+    ChatResponse response = chatModel.call(prompt);
+    return response.getResult().getOutput().getText();
 }
 ```
 

--- a/content/integrations/frameworks/spring-ai.mdx
+++ b/content/integrations/frameworks/spring-ai.mdx
@@ -210,12 +210,13 @@ Authentication uses HTTP Basic Auth: build the credential by base64-encoding you
 
 ```bash
 # Build the Basic Auth string from your Langfuse API keys
-AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64 -w0) # macOS: drop -w0
+export AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64 -w0) # Linux
+# macOS (BSD base64 has no -w0): export AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64)
 
-OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
 # Other regions: 🇺🇸 US https://us.cloud.langfuse.com/api/public/otel, 🇯🇵 Japan https://jp.cloud.langfuse.com/api/public/otel, ⚕️ HIPAA https://hipaa.cloud.langfuse.com/api/public/otel
 # Self-hosted (>= v3.22.0): http://localhost:3000/api/public/otel
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
 ```
 
 <Callout type="info">


### PR DESCRIPTION
- Bump spring-ai-bom 1.0.0 -> 1.0.9 and opentelemetry-instrumentation-bom 2.17.0 -> 2.28.1
- Fix outdated/inconsistent API usage: getOutput().getContent() ->
  getText() (matches the observation filter and current Spring AI)
- Rewrite Step 2 env-var block as real exportable statements showing how to build the Basic Auth string, plus US/JP/HIPAA/self-hosted endpoints
- Replace inaccurate "reactive web server for some reason" pom comment
- Fix broken auth callout grammar and stray invisible character
- Clarify that `tracer`/`Span`/`Scope` come from the OpenTelemetry API

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the Spring AI integration documentation by bumping both BOMs (`spring-ai-bom` 1.0.0 → 1.0.9, `opentelemetry-instrumentation-bom` 2.17.0 → 2.28.1), fixing the API call from the removed `getContent()` to `getText()` and from `chatClient` to `chatModel`, and rewriting the Step 2 configuration block to show how to construct the Basic Auth string interactively.

- **Version bumps** keep the quickstart in line with current releases and add a reminder comment to check for the latest patch.
- **API fix** (`getContent()` → `getText()`, `chatClient` → `chatModel`) aligns the sample code with Spring AI 1.0.x and removes the previous inconsistency with the observation filter already present in the file.
- **Step 2 env-var block** adds region variants and a self-hosted endpoint note, but the two `OTEL_*` variable assignments are missing `export`, so they would not be visible to a child process (e.g. the JVM) when a user pastes the block into their shell.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are confined to one documentation file and the edits are accurate, with a single shell-snippet omission that could trip up users following the guide literally.

The API and version corrections are correct and consistent with the rest of the file. The only substantive issue is the missing `export` on the two OTEL environment variables in the new bash block — a user copying that snippet and then running their Spring Boot app from the same shell would have no OTLP endpoint configured and receive no tracing output, making the integration appear broken. The cross-platform `base64` note is a minor clarity gap. Neither issue affects production code.

The bash configuration block in the Step 2 section of `content/integrations/frameworks/spring-ai.mdx` needs the `export` keyword added before the `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` assignments.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Spring Boot App
    participant SAI as Spring AI (ChatModel)
    participant Mic as Micrometer / OTel Bridge
    participant Exp as OTLP Exporter
    participant LF as Langfuse OTLP Endpoint

    App->>SAI: chatModel.call(prompt)
    SAI->>Mic: "Observation started (gen_ai.*)"
    SAI-->>App: ChatResponse (getText())
    Mic->>Mic: ChatModelCompletionContentObservationFilter (adds gen_ai.prompt / gen_ai.completion)
    Mic->>Exp: Completed span with attributes
    Exp->>LF: HTTP POST /api/public/otel (Authorization: Basic base64, x-langfuse-ingestion-version: 4)
    LF-->>Exp: 200 OK
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/frameworks/spring-ai.mdx:215-218
Missing `export` on environment variable assignments — without it, variables assigned in a shell session are not passed to child processes (e.g. `mvn spring-boot:run` or `java -jar`). A user copying this block verbatim will find that their Spring Boot application sees no OTLP endpoint and silently sends no traces.

```suggestion
export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # 🇪🇺 EU data region
# Other regions: 🇺🇸 US https://us.cloud.langfuse.com/api/public/otel, 🇯🇵 Japan https://jp.cloud.langfuse.com/api/public/otel, ⚕️ HIPAA https://hipaa.cloud.langfuse.com/api/public/otel
# Self-hosted (>= v3.22.0): http://localhost:3000/api/public/otel
export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
```

### Issue 2 of 2
content/integrations/frameworks/spring-ai.mdx:213
The `-w0` flag is not available on macOS's BSD `base64` (it will error with "invalid option"). The inline comment tells users to drop it, but they still need to run a slightly different command manually. A cross-platform one-liner using `openssl` or a clear two-command alternative would be more copy-paste friendly.

```suggestion
# Linux:
AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64 -w0)
# macOS:
# AUTH_STRING=$(echo -n "pk-lf-...:sk-lf-..." | base64)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: refresh Spring AI integration page"](https://github.com/langfuse/langfuse-docs/commit/22adb3cbc7d2ee8b011b970f19ba56241d846afb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37604812)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->