### PR TITLE
docs: add OpenClaw x Langfuse plugin as primary tracing method

### DIFF
--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -52,7 +52,7 @@ Enable the plugin in `openclaw.json` and provide your Langfuse credentials:
 ```json
 {
   "plugins": {
-    "allow": ["langfuse-bridge"],
+    "allow": ["langfuse-bridge", "...any-other-plugins-you-have..."],
     "entries": {
       "langfuse-bridge": {
         "enabled": true,
@@ -65,7 +65,6 @@ Enable the plugin in `openclaw.json` and provide your Langfuse credentials:
     }
   }
 }
-```
 
 `baseUrl` selects your Langfuse data region: 🇪🇺 EU `https://cloud.langfuse.com`, 🇺🇸 US `https://us.cloud.langfuse.com`, 🇯🇵 Japan `https://jp.cloud.langfuse.com`, ⚕️ HIPAA `https://hipaa.cloud.langfuse.com`, or your own URL for a 🏠 local deployment (e.g. `http://localhost:3000`).
 

--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -2,7 +2,7 @@
 title: "Trace OpenClaw with Langfuse"
 sidebarTitle: OpenClaw
 logo: /images/integrations/openclaw_icon.svg
-description: "Trace your OpenClaw AI agent with Langfuse using OpenClaw's native OpenTelemetry export for full visibility into prompts, reasoning, tool calls, and costs."
+description: "Trace your OpenClaw AI agent with Langfuse using the OpenClaw x Langfuse plugin, or OpenClaw's native OpenTelemetry export for full visibility into prompts, reasoning, tool calls, and costs."
 category: Integrations
 ---
 
@@ -18,9 +18,78 @@ category: Integrations
 - **Improve your agent.** Identify where the agent gets confused so you can tweak skills, system prompts, and configurations.
 - **Track costs.** Monitor spending across models and sessions.
 
-## Trace OpenClaw via OpenTelemetry
+## Set up tracing
 
-OpenClaw has built-in [OpenTelemetry](https://docs.openclaw.ai/gateway/opentelemetry) export, and Langfuse is an [OpenTelemetry backend](/integrations/native/opentelemetry). Point OpenClaw's exporter directly at Langfuse's OTLP endpoint and traces flow in with no SDK, no proxy, and no code changes.
+There are two ways to send OpenClaw data to Langfuse. Pick the one that fits your needs:
+
+- **OpenClaw x Langfuse plugin** _(recommended)_ — install a plugin from [ClawHub](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin), paste your Langfuse keys, and you're done. It forwards model usage as Langfuse generations grouped by session, including token counts, costs, and errors.
+- **OpenTelemetry export** — point OpenClaw's native OTLP exporter at Langfuse for the full span tree (model calls, tool execution, skill usage, harness lifecycle, and context assembly). Choose this when you want complete agent observability rather than usage and cost tracking alone.
+
+<Tabs items={["OpenClaw x Langfuse plugin (recommended)", "OpenTelemetry export"]}>
+
+<Tab>
+
+The [OpenClaw x Langfuse plugin](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin) (the "Langfuse Bridge") subscribes to OpenClaw's internal diagnostics bus and translates `model.usage` and error events into Langfuse generations, grouped by OpenClaw session. Input and output text is recovered from session transcripts when available.
+
+<Steps>
+
+### Set up Langfuse
+
+Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting). Create a project and copy your public and secret API keys from the project settings.
+
+### Install the plugin
+
+Install the plugin from ClawHub:
+
+```bash
+openclaw plugins install clawhub:openclaw-x-langfuse-plugin
+```
+
+### Configure the plugin
+
+Enable the plugin in `openclaw.json` and provide your Langfuse credentials:
+
+```json
+{
+  "plugins": {
+    "allow": ["langfuse-bridge"],
+    "entries": {
+      "langfuse-bridge": {
+        "enabled": true,
+        "config": {
+          "publicKey": "pk-lf-...",
+          "secretKey": "sk-lf-...",
+          "baseUrl": "https://cloud.langfuse.com"
+        }
+      }
+    }
+  }
+}
+```
+
+`baseUrl` selects your Langfuse data region: 🇪🇺 EU `https://cloud.langfuse.com`, 🇺🇸 US `https://us.cloud.langfuse.com`, 🇯🇵 Japan `https://jp.cloud.langfuse.com`, ⚕️ HIPAA `https://hipaa.cloud.langfuse.com`, or your own URL for a 🏠 local deployment (e.g. `http://localhost:3000`).
+
+You can also supply the credentials through the `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` environment variables instead of putting them in `openclaw.json`.
+
+### Restart the gateway
+
+Apply the configuration by restarting the OpenClaw gateway:
+
+```bash
+openclaw gateway restart
+```
+
+### View traces in Langfuse
+
+Run OpenClaw as usual. Open your Langfuse project to see generations grouped by session, with token usage, costs, and any forwarded errors.
+
+</Steps>
+
+</Tab>
+
+<Tab>
+
+OpenClaw has built-in [OpenTelemetry](https://docs.openclaw.ai/gateway/opentelemetry) export, and Langfuse is an [OpenTelemetry backend](/integrations/native/opentelemetry). Point OpenClaw's exporter directly at Langfuse's OTLP endpoint and traces flow in with no plugin, no proxy, and no code changes.
 
 Because the export happens inside OpenClaw itself, it is **model-agnostic** (it works whether you call Claude, GPT, DeepSeek, or a local model) and captures OpenClaw's full span tree: model calls, tool execution, skill usage, harness lifecycle, and context assembly, along with `gen_ai.*` attributes for model, token usage, and cost.
 
@@ -82,12 +151,17 @@ Run OpenClaw as usual. Open your Langfuse project to see captured traces, where 
 
 </Steps>
 
+</Tab>
+
+</Tabs>
+
 <Callout type="info" title="Did you know?">
   Already routing OpenClaw's LLM calls through [OpenRouter](https://openrouter.ai/)? You can also capture traces without touching OpenClaw's config by connecting your Langfuse keys in [OpenRouter settings](https://openrouter.ai/settings) to enable [Broadcast](/integrations/gateways/openrouter#broadcast). Note that this only traces the LLM calls routed through OpenRouter, not OpenClaw's tool and skill spans.
 </Callout>
 
 ## Learn more
 
+- [OpenClaw x Langfuse plugin](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin): Install and configuration details on ClawHub
 - [Langfuse OpenTelemetry endpoint](/integrations/native/opentelemetry): Endpoint, authentication, and supported protocols
 - [Getting started with Langfuse](/docs/observability/get-started): Setting up API keys and projects
 - [OpenClaw OpenTelemetry docs](https://docs.openclaw.ai/gateway/opentelemetry): Full list of OTel configuration options

--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -65,6 +65,7 @@ Enable the plugin in `openclaw.json` and provide your Langfuse credentials:
     }
   }
 }
+```
 
 `baseUrl` selects your Langfuse data region: 🇪🇺 EU `https://cloud.langfuse.com`, 🇺🇸 US `https://us.cloud.langfuse.com`, 🇯🇵 Japan `https://jp.cloud.langfuse.com`, ⚕️ HIPAA `https://hipaa.cloud.langfuse.com`, or your own URL for a 🏠 local deployment (e.g. `http://localhost:3000`).
 


### PR DESCRIPTION
## Summary

Updates the [OpenClaw integration page](/integrations/other/openclaw) to document the new [OpenClaw x Langfuse plugin](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin) (the "Langfuse Bridge") on ClawHub, and positions it as the **recommended** tracing method.

- Adds a "Set up tracing" section with a method chooser and a `<Tabs>` block (matching the repo's existing pattern, e.g. `inferable.mdx`).
- **Tab 1 — OpenClaw x Langfuse plugin (recommended):** `plugins install` → configure the `plugins` block in `openclaw.json` (or `LANGFUSE_*` env vars) → `gateway restart` → view session-grouped generations.
- **Tab 2 — OpenTelemetry export:** the previous content, preserved, framed as the full-span-tree alternative (tool/skill/harness spans).
- Updates frontmatter `description` and adds the plugin to "Learn more".

## Note for reviewers

The plugin captures **less** than OTLP — it forwards `model.usage`/error events as session-grouped generations (tokens, cost, errors), whereas OTLP yields the complete span tree. That tradeoff is called out explicitly in both the chooser bullets and the OTLP tab so "recommended" doesn't mislead users who want full agent observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restructures the OpenClaw integration page to offer two tracing paths: a new OpenClaw x Langfuse plugin (recommended for usage and cost tracking) and the existing OpenTelemetry export (for the full span tree), presented in a `<Tabs>` block consistent with other docs in the repo.

- **New plugin tab** documents `openclaw plugins install`, the `openclaw.json` configuration block, and `openclaw gateway restart`, with a note that env vars (`LANGFUSE_*`) can substitute the JSON config.
- **OTel tab** preserves the previous content unchanged, with only a minor wording tweak ("no plugin" instead of "no SDK").
- **Frontmatter and "Learn more"** are updated to surface the new plugin alongside the existing OTel docs link.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is documentation-only and the tab structure matches existing patterns in the repo.

The new plugin tab is well-structured and the tradeoff between plugin and OTLP methods is called out clearly. The one gap is the JSON config snippet presenting the plugins block as a complete replacement — a copy-paste user with existing plugins would silently drop them from the allow-list. Everything else (frontmatter, tab structure, OTLP preservation, env-var note) looks correct.

content/integrations/other/openclaw.mdx — specifically the plugins JSON config block at the 'Configure the plugin' step.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User / Agent
    participant OC as OpenClaw Gateway
    participant Bus as Diagnostics Bus
    participant Plugin as langfuse-bridge Plugin
    participant OTLP as OTLP Exporter
    participant LF as Langfuse

    Note over User,LF: Method 1 — OpenClaw x Langfuse plugin (recommended)
    User->>OC: Run agent task
    OC->>Bus: Emit model.usage + error events
    Bus->>Plugin: Deliver events (subscribed)
    Plugin->>LF: POST generations (session-grouped, tokens, costs, errors)
    LF-->>User: View in Langfuse UI (sessions + generations)

    Note over User,LF: Method 2 — OpenTelemetry export
    User->>OC: Run agent task
    OC->>OTLP: Export full span tree (OTLP/HTTP protobuf)
    OTLP->>LF: POST /api/public/otel (Basic Auth)
    LF-->>User: View in Langfuse UI (full trace tree)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/integrations/other/openclaw.mdx:52-68
The `"allow"` array in the JSON snippet is shown as a complete standalone block containing only `"langfuse-bridge"`. A user who copy-pastes this verbatim will replace their entire plugins allow-list, silently removing any other plugins they have installed. The snippet should note that existing entries must be preserved, or show only the additive change needed.

```suggestion
```json
{
  "plugins": {
    "allow": ["langfuse-bridge", "...any-other-plugins-you-have..."],
    "entries": {
      "langfuse-bridge": {
        "enabled": true,
        "config": {
          "publicKey": "pk-lf-...",
          "secretKey": "sk-lf-...",
          "baseUrl": "https://cloud.langfuse.com"
        }
      }
    }
  }
}
```
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add OpenClaw x Langfuse plugin as ..."](https://github.com/langfuse/langfuse-docs/commit/d61c15f580fd423cd374846c1aac318a3422d33d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37622214)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->