### PR TITLE
Remove ClickHouse callout from the pricing table

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/components/ui/hover-card";
 import { TrustedBy } from "../components/TrustedBy";
 import { trustedByData } from "@/data/trusted-by";
-import Image from "next/image";
 import { isCloudAppHref } from "@/lib/google-ads";
 
 // Reusable graduated pricing text with calculator link
@@ -237,23 +236,8 @@ const tiers: Record<DeploymentOption, Tier[]> = {
       id: "tier-self-hosted-enterprise",
       href: "/talk-to-us?deployment=self-hosted",
       featured: false,
-      pillClassName: "bg-[#FAFF6A] text-[#1A1A1A]",
       description:
         "Dedicated Langfuse deployment with enterprise capabilities and support.",
-      pill: (
-        <>
-          <span className="inline-flex rounded-sm p-0.5">
-            <Image
-              src="/images/logos/clickhouse_icon.svg"
-              alt=""
-              width={14}
-              height={14}
-              className="size-3.5 rounded-[2px]"
-            />
-          </span>
-          ClickHouse Cloud / BYOC / Private
-        </>
-      ),
       price: "Custom Pricing",
       mainFeatures: [
         "All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs",


### PR DESCRIPTION
## Summary
- Removed the ClickHouse badge/callout from the self-hosted Enterprise pricing card.
- Dropped the now-unused `next/image` import from the pricing table component.

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the ClickHouse badge/callout (`pill` and `pillClassName` fields) from the self-hosted Enterprise pricing card and cleans up the now-unused `next/image` import.

- The `pill` and `pillClassName` fields on the Enterprise tier definition are deleted; both are typed as optional (`?`) in the `Tier` type, so no TypeScript errors are introduced.
- The `next/image` `Image` component import is removed after it was the only consumer of that import.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a straightforward content removal from a pricing card with no functional side-effects.

Both removed fields (pill and pillClassName) are optional in the Tier type, so the component compiles and renders correctly without them. The next/image import cleanup is accurate — Image was only used in the deleted JSX block. No logic, routing, or data-fetching is affected.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/remove-cl..."](https://github.com/langfuse/langfuse-docs/commit/2a09c547336fe5092a55777d3390f112cc9705a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37658999)</sub>

<!-- /greptile_comment -->