### PR TITLE
docs: update Python span masking guidance

### DIFF
--- a/content/docs/observability/features/masking.mdx
+++ b/content/docs/observability/features/masking.mdx
@@ -1,95 +1,222 @@
 ---
 title: Masking
-description: Configure masking to redact sensitive information from inputs, outputs, and metadata sent to the Langfuse server.
+description: Configure masking to redact sensitive information from Langfuse SDK data and OpenTelemetry span attributes before they are sent to Langfuse.
 sidebarTitle: Masking
 ---
 
-# Masking of Sensitive LLM Data
+# Masking sensitive LLM data
 
-Masking is a feature that allows precise control over the [tracing](/docs/tracing/overview) data sent to the Langfuse server. With custom masking functions, you can control and sanitize the data that gets traced and sent to the server. Whether it's for **compliance reasons** or to protect **user privacy**, masking sensitive data is a crucial step in responsible application development. It enables you to:
+Masking gives you control over the [tracing](/docs/tracing/overview) data sent to Langfuse. Use masking functions to redact sensitive information before trace data leaves your application, for example to:
 
 1. Redact sensitive information from trace or observation inputs, outputs, and metadata.
-2. Customize the content of events before transmission.
-3. Implement fine-grained data filtering based on your specific requirements.
+2. Transform OpenTelemetry span attributes before export.
+3. Implement fine-grained data filtering for compliance or privacy requirements.
 
 Learn more about Langfuse's data security and privacy measures concerning the stored data in our [security and compliance overview](/security).
 
-## How it works
+## Configure masking
 
-1. You define a custom masking function and pass it to the Langfuse client constructor.
-2. All event inputs, outputs, and metadata are processed through this function.
-3. The masked data is then sent to the Langfuse server.
+<LangTabs items={["Python SDK", "JS/TS SDK", "LangChain (JS/TS)"]}>
+<Tab title="Python SDK">
 
-This approach ensures that you have complete control over the event input, output, and metadata traced by your application.
+The Python SDK supports two masking hooks. For new Python SDK setups, prefer `mask_otel_spans`.
 
-<LangTabs items={["Python SDK", "JS/TS SDK", "Langchain (JS/TS)"]}>
-<Tab>
+| Method            | Status      | When it runs                                                                                                                  | What it covers                                                                                                              |
+| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `mask_otel_spans` | Recommended | At export stage, after Langfuse decides which OpenTelemetry spans this client should export and after Langfuse media handling | Raw OpenTelemetry span attributes from Langfuse SDK spans and third-party instrumentations exported by this Langfuse client |
+| `mask`            | Legacy      | Synchronously when Langfuse SDK attributes are created                                                                        | Data set through Langfuse SDK APIs such as `start_observation()`, `update()`, and `set_trace_io()`                          |
 
-Define a masking function. The masking function will apply to all event inputs, outputs, and metadata regardless of the Langfuse-maintained integration you are using.
+Use `mask_otel_spans` to patch OpenTelemetry span attributes before the Langfuse client exports them. The hook receives read-only snapshots of one OpenTelemetry export batch and returns sparse patches for the spans that should change.
 
 ```python
-def masking_function(data: any, **kwargs) -> any:
-    """Function to mask sensitive data before sending to Langfuse."""
+from typing import Optional
+
+from langfuse import Langfuse
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanPatch,
+)
+
+
+def mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    patches = {}
+
+    for identifier, span in params.spans.items():
+        if span.instrumentation_scope_name == "openai":
+            patches[identifier] = OtelSpanPatch(
+                delete_attributes=(
+                    "gen_ai.prompt.0.content",
+                    "gen_ai.completion.0.content",
+                ),
+                set_attributes={"masking.applied": True},
+            )
+
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
+```
+
+### `mask_otel_spans` behavior
+
+`mask_otel_spans` follows the public Python SDK type contract:
+
+- It receives one OpenTelemetry export batch as `params.spans`. A batch is not guaranteed to contain a complete trace, request, or Langfuse observation tree.
+- Each key is an `OtelSpanIdentifier(trace_id, span_id)`. Reuse the identifier objects from `params.spans` when returning patches.
+- Each value is an `OtelSpanData` snapshot after `should_export_span` filtering and export-stage media handling. Its `attributes` and `resource_attributes` mappings are read-only.
+- Return `None` to leave the whole batch unchanged.
+- Return `MaskOtelSpansResult(span_patches=...)` to delete or replace attributes on selected spans.
+- Patches are sparse. Omit spans that do not need changes.
+- `OtelSpanPatch` deletes `delete_attributes` first and then applies `set_attributes`, so `set_attributes` wins when the same key appears in both.
+- `set_attributes` values must be valid OpenTelemetry attribute values: strings, booleans, integers, floats, or homogeneous sequences of those scalar types.
+- The hook can only change span attributes. It cannot change the span name, IDs, parent relationship, resource attributes, events, links, or instrumentation scope.
+- The hook affects only spans exported by this Langfuse client. If the same OpenTelemetry spans are sent to another exporter, that exporter receives its own unmodified copy.
+
+<Callout type="warning">
+
+`mask_otel_spans` is synchronous. It usually runs on the OpenTelemetry batch span processor worker thread, so it should not block the main caller thread of your application. During `flush()` and shutdown it may run on the caller thread.
+
+Keep the function deterministic and fast. Network calls are possible, but slow masking backs up the OpenTelemetry export queue and delays span export. Avoid long-running work, unbounded retries, request-local state, the current active span, and async I/O inside the masking function.
+
+</Callout>
+
+If `mask_otel_spans` raises an exception or returns an invalid `MaskOtelSpansResult`, Langfuse drops the whole export batch. If an individual `OtelSpanPatch` is invalid, Langfuse drops only that span from the Langfuse export. Invalid returned attribute values delete only the affected attribute.
+
+### Legacy `mask` behavior
+
+The `mask` parameter is the legacy Python SDK masking hook. It runs synchronously when Langfuse SDK attributes are created and applies only to data set through Langfuse SDK APIs such as `start_observation()`, `update()`, and `set_trace_io()`. It does not inspect final raw OpenTelemetry span attributes from third-party instrumentations.
+
+Use `mask` only when you specifically need to transform data at Langfuse SDK attribute creation time.
+
+```python
+from typing import Any
+
+from langfuse import Langfuse
+
+
+def masking_function(*, data: Any, **kwargs: Any) -> Any:
     if isinstance(data, str) and data.startswith("SECRET_"):
         return "REDACTED"
 
-    # For more complex data structures
-    elif isinstance(data, dict):
-        return {k: masking_function(v) for k, v in data.items()}
-    elif isinstance(data, list):
-        return [masking_function(item) for item in data]
+    if isinstance(data, dict):
+        return {key: masking_function(data=value) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [masking_function(data=item) for item in data]
 
     return data
-```
 
-Apply the masking function when initializing the Langfuse client:
-
-```python
-from langfuse import Langfuse
-
-# Initialize with masking function
-langfuse = Langfuse(mask=masking_function)
-
-# Then get the client
-from langfuse import get_client
-langfuse = get_client()
-```
-
-With the decorator:
-
-```python
-from langfuse import observe
 
 langfuse = Langfuse(mask=masking_function)
+```
+
+For new Python SDK masking setups, prefer `mask_otel_spans`.
+
+### Examples
+
+#### Redact credit card numbers with `mask_otel_spans`
+
+This example scans exported OpenTelemetry string attributes for credit card-like patterns and replaces matches before the span is exported to Langfuse.
+
+```python
+import re
+from typing import Optional
+
+from langfuse import Langfuse, observe
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanPatch,
+)
+
+credit_card_pattern = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+
+
+def mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    patches = {}
+
+    for identifier, span in params.spans.items():
+        replacements = {}
+
+        for key, value in span.attributes.items():
+            if isinstance(value, str):
+                masked_value = credit_card_pattern.sub(
+                    "[REDACTED CREDIT CARD]", value
+                )
+
+                if masked_value != value:
+                    replacements[key] = masked_value
+
+        if replacements:
+            patches[identifier] = OtelSpanPatch(set_attributes=replacements)
+
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
 
 
 @observe()
-def my_function():
-    # This data will be masked before being sent to Langfuse
-    return "SECRET_DATA"
+def process_payment():
+    return "Customer paid with card number 4111 1111 1111 1111."
 
-result = my_function()
-print(result)  # Original: "SECRET_DATA"
 
-# The trace output in Langfuse will have the output masked as "REDACTED"
+result = process_payment()
+
+print(result)
+# Output: Customer paid with card number 4111 1111 1111 1111.
+
+# Flush spans in short-lived applications.
+langfuse.flush()
 ```
 
-Using context managers:
+The function result printed in your application is unchanged. The exported span attributes sent to Langfuse contain the redacted value.
+
+#### Redact email addresses and phone numbers
 
 ```python
+import re
+from typing import Optional
+
 from langfuse import Langfuse
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanPatch,
+)
 
-langfuse = Langfuse(mask=masking_function)
+email_pattern = re.compile(r"\b[\w.-]+?@[\w.-]+?\.\w+?\b")
+phone_pattern = re.compile(r"\b\d{3}[-. ]?\d{3}[-. ]?\d{4}\b")
 
-with langfuse.start_as_current_observation(
-    as_type="span",
-    name="sensitive-operation",
-    input="SECRET_INPUT_DATA"
-) as span:
-    # ... processing ...
-    span.update(output="SECRET_OUTPUT_DATA")
 
-# Both input and output will be masked as "REDACTED" in Langfuse
+def mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    patches = {}
+
+    for identifier, span in params.spans.items():
+        replacements = {}
+
+        for key, value in span.attributes.items():
+            if isinstance(value, str):
+                masked_value = email_pattern.sub("[REDACTED EMAIL]", value)
+                masked_value = phone_pattern.sub("[REDACTED PHONE]", masked_value)
+
+                if masked_value != value:
+                    replacements[key] = masked_value
+
+        if replacements:
+            patches[identifier] = OtelSpanPatch(set_attributes=replacements)
+
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
 ```
 
 </Tab>
@@ -105,11 +232,11 @@ import { LangfuseSpanProcessor } from "@langfuse/otel";
 
 const spanProcessor = new LangfuseSpanProcessor({
   mask: ({ data }) => {
-    // A simple regex to mask credit card numbers
     const maskedData = data.replace(
       /\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b/g,
       "***MASKED_CREDIT_CARD***",
     );
+
     return maskedData;
   },
 });
@@ -124,7 +251,7 @@ sdk.start();
 See [JS/TS SDK docs](/docs/sdk/typescript/guide) for more details.
 
 </Tab>
-<Tab title="Langchain (JS/TS)">
+<Tab title="LangChain (JS/TS)">
 
 When using the [CallbackHandler](/integrations/frameworks/langchain), you can pass `mask` to the constructor:
 
@@ -145,185 +272,14 @@ const handler = new CallbackHandler({
 ```
 
 </Tab>
-
 </LangTabs>
 
-## Examples
+## Related resources
 
-Now, we'll show you examples how to use the masking feature. We'll use the Langfuse decorator for this, but you can also use the low-level SDK or the JS/TS SDK analogously.
+- [Data Retention](/docs/administration/data-retention) - Automatically delete traces, observations, scores, and media assets after a configured retention period.
+- [Data Deletion](/docs/administration/data-deletion) - Manually delete individual or batches of traces.
 
-### Example 1: Redacting Credit Card Numbers
-
-In this example, we'll demonstrate how to redact credit card numbers from strings using a [regular expression](https://docs.python.org/3/library/re.html). This helps in complying with PCI DSS by ensuring that credit card numbers are not transmitted or stored improperly.
-
-<Callout type="info">
-
-Langfuse's masking feature allows you to define a custom masking function with parameters, which you then pass to the Langfuse client constructor. This function is applied to **all event inputs, outputs, and metadata**, processing each piece of data to mask or redact sensitive information according to your specifications. By ensuring that all events are processed through your masking function before being sent, Langfuse guarantees that only the masked data is transmitted to the Langfuse server.
-
-</Callout>
-
-**Steps:**
-
-1. **Import necessary modules**.
-2. **Define a masking function** that uses a regular expression to detect and replace credit card numbers.
-3. **Configure the masking function** in Langfuse.
-4. **Create a sample function** to simulate processing sensitive data.
-5. **Observe the trace** to see the masked output.
-
-```python
-import re
-from langfuse import Langfuse, observe, get_client
-
-# Step 2: Define the masking function
-def masking_function(data, **kwargs):
-    if isinstance(data, str):
-        # Regular expression to match credit card numbers (Visa, MasterCard, AmEx, etc.)
-        pattern = r'\b(?:\d[ -]*?){13,19}\b'
-        data = re.sub(pattern, '[REDACTED CREDIT CARD]', data)
-    return data
-
-# Step 3: Configure the masking function
-langfuse = Langfuse(mask=masking_function)
-
-# Step 4: Create a sample function with sensitive data
-@observe()
-def process_payment():
-    # Simulated sensitive data containing a credit card number
-    transaction_info = "Customer paid with card number 4111 1111 1111 1111."
-    return transaction_info
-
-# Step 5: Observe the trace
-result = process_payment()
-
-print(result)
-# Output: Customer paid with card number [REDACTED CREDIT CARD].
-
-# Flush events in short-lived applications
-langfuse.flush()
-```
-
-<Frame>
-  ![Redacted trace in Langfuse 1](/images/docs/masking/masking_example_1.png)
-</Frame>
-
-[Link to the trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/540eb0a1-77dd-42e9-b27f-03cfee9feb12?timestamp=2025-01-17T09%3A13%3A18.335Z)
-
-### Example 2: Using the `llm-guard` library
-
-In this example, we'll use the `Anonymize` scanner from `llm-guard` to remove personal names and other PII from the data. This is useful for anonymizing user data and protecting privacy.
-
-Find our more about the `llm-guard` library in their [documentation](https://protectai.github.io/llm-guard/).
-
-**Steps:**
-
-1. **Install the `llm-guard` library**.
-2. **Import necessary modules**.
-3. **Initialize the Vault and configure the Anonymize scanner**.
-4. **Define a masking function** that uses the Anonymize scanner.
-5. **Configure the masking function** in Langfuse.
-6. **Create a sample function** to simulate processing data with PII.
-7. **Observe the trace** to see the masked output.
-
-```bash
-pip install llm-guard
-```
-
-```python
-from langfuse import Langfuse, observe, get_client
-from llm_guard.vault import Vault
-from llm_guard.input_scanners import Anonymize
-from llm_guard.input_scanners.anonymize_helpers import BERT_LARGE_NER_CONF
-
-# Step 3: Initialize the Vault and configure the Anonymize scanner
-vault = Vault()
-
-def create_anonymize_scanner():
-    scanner = Anonymize(
-        vault,
-        recognizer_conf=BERT_LARGE_NER_CONF,
-        language="en"
-    )
-    return scanner
-
-# Step 4: Define the masking function
-def masking_function(data, **kwargs):
-    if isinstance(data, str):
-        scanner = create_anonymize_scanner()
-        # Scan and redact the data
-        sanitized_data, is_valid, risk_score = scanner.scan(data)
-        return sanitized_data
-    return data
-
-# Step 5: Configure the masking function
-langfuse = Langfuse(mask=masking_function)
-
-# Step 6: Create a sample function with PII
-@observe()
-def generate_report():
-    # Simulated data containing personal names
-    report = "John Doe met with Jane Smith to discuss the project."
-    return report
-
-# Step 7: Observe the trace
-result = generate_report()
-
-print(result)
-# Output: [REDACTED_PERSON] met with [REDACTED_PERSON] to discuss the project.
-
-# Flush events in short-lived applications
-langfuse.flush()
-```
-
-<Frame>
-  ![Redacted trace in Langfuse](/images/docs/masking/masking_example_2.png)
-</Frame>
-
-[Link to the trace in Langfuse 2](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/4abb206f-f8fd-4492-86b9-801602513afd?timestamp=2025-01-17T09%3A30%3A04.127Z)
-
-### Example 3: Masking Email and Phone Numbers
-
-You can extend the masking function to redact other types of PII such as email addresses and phone numbers using regular expressions.
-
-```python
-import re
-from langfuse import Langfuse, observe, get_client
-
-def masking_function(data, **kwargs):
-    if isinstance(data, str):
-        # Mask email addresses
-        data = re.sub(r'\b[\w.-]+?@\w+?\.\w+?\b', '[REDACTED EMAIL]', data)
-        # Mask phone numbers
-        data = re.sub(r'\b\d{3}[-. ]?\d{3}[-. ]?\d{4}\b', '[REDACTED PHONE]', data)
-    return data
-
-langfuse = Langfuse(mask=masking_function)
-
-@observe()
-def contact_customer():
-    info = "Please contact John at john.doe@example.com or call 555-123-4567."
-    return info
-
-result = contact_customer()
-
-print(result)
-# Output: Please contact John at [REDACTED EMAIL] or call [REDACTED PHONE].
-
-# Flush events in short-lived applications
-langfuse.flush()
-```
-
-<Frame>
-  ![Redacted trace in Langfuse 3](/images/docs/masking/masking_example_3.png)
-</Frame>
-
-[Link to the trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/dcc4d640-492e-47a6-b419-922c8b9e0f0f?timestamp=2025-01-17T09%3A38%3A06.814Z)
-
-## Related Resources
-
-- [Data Retention](/docs/administration/data-retention) — Automatically delete traces, observations, scores, and media assets after a configured retention period.
-- [Data Deletion](/docs/administration/data-deletion) — Manually delete individual or batches of traces.
-
-## GitHub Discussions
+## GitHub discussions
 
 import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
 

--- a/content/docs/observability/sdk/advanced-features.mdx
+++ b/content/docs/observability/sdk/advanced-features.mdx
@@ -163,28 +163,52 @@ You can read more about using Langfuse with an existing OpenTelemetry setup [her
 
 ## Mask sensitive data
 
-If your trace data (inputs, outputs, metadata) might contain sensitive information (PII, secrets), you can provide a mask function during client initialization. This function will be applied to all relevant data before it’s sent to Langfuse.
+If your trace data might contain sensitive information such as PII or secrets, configure a masking hook before sending spans to Langfuse. For Python SDK applications, prefer `mask_otel_spans` because it runs at export stage on raw OpenTelemetry span attributes, including spans created by third-party instrumentations.
 
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>
 <Tab title="Python SDK">
 
-The `mask` function should accept data as a keyword argument and return the masked data. The returned data must be JSON-serializable.
+Use `mask_otel_spans` to return sparse patches for the OpenTelemetry spans that should change before export.
 
 ```python
-from langfuse import Langfuse
 import re
+from typing import Optional
 
-def pii_masker(data: any, **kwargs) -> any:
-    if isinstance(data, str):
-        return re.sub(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+", "[EMAIL_REDACTED]", data)
-    elif isinstance(data, dict):
-        return {k: pii_masker(data=v) for k, v in data.items()}
-    elif isinstance(data, list):
-        return [pii_masker(data=item) for item in data]
-    return data
+from langfuse import Langfuse
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanPatch,
+)
 
-langfuse = Langfuse(mask=pii_masker)
+email_pattern = re.compile(r"\b[\w.-]+?@[\w.-]+?\.\w+?\b")
+
+
+def mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    patches = {}
+
+    for identifier, span in params.spans.items():
+        replacements = {}
+
+        for key, value in span.attributes.items():
+            if isinstance(value, str):
+                masked_value = email_pattern.sub("[EMAIL_REDACTED]", value)
+
+                if masked_value != value:
+                    replacements[key] = masked_value
+
+        if replacements:
+            patches[identifier] = OtelSpanPatch(set_attributes=replacements)
+
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
 ```
+
+`mask_otel_spans` is synchronous and usually runs on the OpenTelemetry batch span processor worker thread; during `flush()` and shutdown it may run on the caller thread. Keep the function fast to avoid backing up the export queue. See [masking](/docs/observability/features/masking) for the full behavior, error handling, and legacy `mask` comparison.
 
 </Tab>
 <Tab title="JS/TS SDK">


### PR DESCRIPTION
## Summary

- Make `mask_otel_spans` the recommended Python SDK masking method on the masking feature page.
- Clarify the contrast between export-stage `mask_otel_spans` and legacy SDK-level `mask`.
- Add `mask_otel_spans` examples and caveats for batch shape, worker-thread execution, queue buildup, sparse patches, and error behavior.
- Update the advanced SDK masking section to point Python users to `mask_otel_spans` and link to the full masking page.

## Validation

- `bun x prettier@3.8.4 --experimental-cli --check content/docs/observability/features/masking.mdx content/docs/observability/sdk/advanced-features.mdx`
- `git diff --check`

Note: `pnpm` in this local shell is routed through an nvm Node 22 target that is not installed, so I used the repo's Prettier version range via `bun x` for the targeted formatting check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rewrites the Python masking guidance to recommend `mask_otel_spans` as the preferred hook over the legacy `mask` parameter. It adds a comparison table, a detailed behavior reference (batch shape, worker-thread execution, sparse patches, error handling), and two new end-to-end examples; it also updates the `advanced-features.mdx` masking section to point Python users to the new hook and link to the full reference page.

- **`masking.mdx`**: Replaces the old example-driven layout with a structured reference — comparison table, behavior bullet list, warning callout about worker-thread execution and error semantics — followed by two `mask_otel_spans` examples and a condensed legacy `mask` example.
- **`advanced-features.mdx`**: Swaps the short Python snippet from the legacy `mask` API to `mask_otel_spans` and adds a one-sentence cross-link to the masking reference page.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only changes; no production code is modified. Safe to merge.

The rewrite is accurate and well-structured. The two findings are both documentation-quality issues: the example masking functions only guard `isinstance(value, str)` and silently skip list-typed OTel attributes, and the error-behavior paragraph explains batch drops without suggesting defensive error handling in examples. Neither blocks users from following the guidance correctly, but both could lead to incomplete masking if examples are copied verbatim.

The code samples in `masking.mdx` (credit card and email/phone examples) and the matching sample in `advanced-features.mdx` would benefit from addressing the list-attribute gap before this becomes the canonical reference.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application
    participant LF_SDK as Langfuse SDK (@observe)
    participant BSP as OTel Batch Span Processor (worker thread)
    participant Hook as mask_otel_spans hook
    participant LF as Langfuse Server

    App->>LF_SDK: Traced function call
    LF_SDK->>BSP: Span enqueued
    BSP->>BSP: should_export_span filtering
    BSP->>BSP: Export-stage media handling
    BSP->>Hook: params.spans (read-only batch snapshot)
    alt Returns None
        Hook-->>BSP: None — batch unchanged
    else Returns MaskOtelSpansResult
        Hook-->>BSP: Sparse OtelSpanPatch per span
        BSP->>BSP: Apply delete_attributes, then set_attributes
    else Raises exception / invalid result
        Hook-->>BSP: Exception or invalid MaskOtelSpansResult
        BSP->>BSP: Drop entire export batch
    end
    BSP->>LF: Export patched spans via OTLP
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application
    participant LF_SDK as Langfuse SDK (@observe)
    participant BSP as OTel Batch Span Processor (worker thread)
    participant Hook as mask_otel_spans hook
    participant LF as Langfuse Server

    App->>LF_SDK: Traced function call
    LF_SDK->>BSP: Span enqueued
    BSP->>BSP: should_export_span filtering
    BSP->>BSP: Export-stage media handling
    BSP->>Hook: params.spans (read-only batch snapshot)
    alt Returns None
        Hook-->>BSP: None — batch unchanged
    else Returns MaskOtelSpansResult
        Hook-->>BSP: Sparse OtelSpanPatch per span
        BSP->>BSP: Apply delete_attributes, then set_attributes
    else Raises exception / invalid result
        Hook-->>BSP: Exception or invalid MaskOtelSpansResult
        BSP->>BSP: Drop entire export batch
    end
    BSP->>LF: Export patched spans via OTLP
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/observability/features/masking.mdx:143-157
**Examples only mask scalar string attributes, not list-of-string attributes**

The `isinstance(value, str)` guard skips OTel attributes whose type is a sequence (e.g., a list of strings), which are fully valid per the OTel spec and are emitted by some instrumentations (e.g., multi-turn prompt messages stored as `["role: user", "content: ..."]`). A credit card or email present in any list-typed attribute will not be redacted by the current code, giving users a false sense of security if they copy this example verbatim. The same pattern is repeated in both examples in this file and in `advanced-features.mdx`.

### Issue 2 of 2
content/docs/observability/features/masking.mdx:86
**Whole-batch drop on exception is an aggressive default that deserves a callout**

The prose states that any unhandled exception in `mask_otel_spans` causes Langfuse to drop the entire export batch silently. In practice this means a transient regex error or an unexpected attribute type causes data loss that may not be noticed until traces go missing in the UI. It may be worth adding a `try/except` guard to the example code, or at least a brief callout (similar to the worker-thread warning above) reminding users to handle exceptions defensively inside the hook.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update Python span masking guidanc..."](https://github.com/langfuse/langfuse-docs/commit/6eb8d931394f4f16e64b47007aee32601e08f0fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37843008)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->