### PR TITLE
docs(enterprise): align uptime SLA with official Langfuse Cloud SLA

### DIFF
--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -182,13 +182,21 @@ Here are our general SLOs of our support for our Enterprise Cloud customers. The
 <Details>
 <Summary>Uptime SLA for our enterprise customers</Summary>
 
-Our Enterprise Cloud customers get an uptime SLA:
+Our Enterprise Cloud customers get an uptime SLA on Langfuse Cloud:
 
-- Guaranteed 99.9% uptime
-- 99.00% to 99.89% inclusive - 10% credit
-- Less than 99% - 20% credit
+**Target:** 99.9% Monthly Uptime Percentage.
 
-If Langfuse fails to maintain an uptime percentage of greater than 99% for any 3 months in a 6 month period, Customer may terminate their agreement upon 10 days written notice to Langfuse. The calculations of uptime do not include: Delays to data ingestion or scheduled maintenance.
+**Service credits** apply when monthly uptime falls below target:
+
+- Below 99.9% but at or above 99.0% — 5% credit
+- Below 99.0% but at or above 95.0% — 10% credit
+- Below 95.0% — 25% credit
+
+Langfuse Cloud is considered "Unavailable" for a one-minute interval when at least three authenticated trace-ingestion API requests were made during that interval and none were accepted. Uptime calculations exclude downtime caused by force majeure events, third-party services outside our control, customer misconfiguration or improper use, planned maintenance announced at least 72 hours in advance, and beta or experimental features.
+
+To claim a credit, open a support case within 24 hours of discovering the unavailability and submit the claim by the end of the month following the affected month, including the incident dates, times, and supporting evidence.
+
+See the full [Langfuse Cloud Service Level Agreement](https://clickhouse.com/legal/agreements/langfuse-service-level-agreement) for the authoritative terms.
 
 </Details>
 


### PR DESCRIPTION
## What changed

Updates the **Uptime SLA** section on the [/enterprise](https://langfuse.com/enterprise) page to match the official [Langfuse Cloud Service Level Agreement](https://clickhouse.com/legal/agreements/langfuse-service-level-agreement).

- Reframe the target as **99.9% Monthly Uptime Percentage**
- Replace the credit tiers with the official ones:
  - Below 99.9% but ≥ 99.0% → **5%** credit
  - Below 99.0% but ≥ 95.0% → **10%** credit
  - Below 95.0% → **25%** credit
- Add the official **"Unavailable"** definition (≥3 authenticated trace-ingestion requests in a 1-min interval, none accepted)
- Add the exclusions (force majeure, third-party services, customer misconfiguration, 72h-notice planned maintenance, beta features)
- Add the credit-claim process (open a case within 24h, claim by end of the following month)
- Remove the outdated "terminate after 3 of 6 months <99%" clause, which is not part of the current SLA, and link to the authoritative document

## Why

The previous values (99.00–99.89% → 10%, <99% → 20%, plus a termination clause) predate the official Langfuse Cloud SLA now hosted on clickhouse.com. This brings the public page in line with the governing legal terms.

## Reviewer notes

- **Support SLO section was intentionally left unchanged.** The standard [ClickHouse Support Services Policy](https://clickhouse.com/legal/support-services-policy) table currently lists only Severity 3 (24 business hours) for Langfuse Cloud and marks Sev 1/2 as "not available" — but that table is outdated: Enterprise Langfuse Cloud users can now submit SEV-1 incidents. The existing 24/7 Sev 1 / 1-hour acknowledgement wording already reflects current reality, so it was kept as-is.
- Heads up for whoever owns the legal pages: the Support Services Policy page is stale relative to what we offer (SEV-1 submission) and contradicts this marketing page — worth updating at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Uptime SLA section on the `/enterprise` marketing page to match the official [Langfuse Cloud Service Level Agreement](https://clickhouse.com/legal/agreements/langfuse-service-level-agreement) now hosted on clickhouse.com, replacing outdated pre-acquisition credit tiers and a termination clause that are no longer part of the governing legal terms.

- Replaces the old 10% / 20% credit tiers and the "terminate after 3 of 6 months" clause with the current official tiers (5% / 10% / 25%) and the formal "Unavailable" definition.
- Adds the credit-claim process summary (24-hour support case + end-of-following-month submission) and links to the authoritative SLA document.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that aligns a marketing page with the published legal SLA; the SLA URL resolves and the credit tiers, unavailability definition, and claim process all match the official document.

The new credit tiers (5% / 10% / 25%), the 'Unavailable' definition (≥3 authenticated trace-ingestion requests in a 1-min interval, none accepted), and the 24-hour / end-of-following-month claim procedure are consistent with the live Langfuse Cloud SLA at clickhouse.com. The authoritative-document link is present and resolves correctly. No code, logic, or data paths are touched.

No files require special attention; the single changed file (content/marketing/enterprise.mdx) is a straightforward prose update.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Customer
    participant L as Langfuse Cloud
    participant S as ClickHouse Support

    Note over L: Uptime falls below 99.9%<br/>in a calendar month

    C->>S: Open support case within 24h
    C->>S: "Submit full claim by end of<br/>following month (dates, times, evidence)"
    S->>S: Confirm unavailability claim
    S->>C: "Issue Service Credit in next<br/>billing cycle"

    Note over C,S: Credit tiers<br/>< 99.9% but >= 99.0% = 5%<br/>< 99.0% but >= 95.0% = 10%<br/>< 95.0% = 25%
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Customer
    participant L as Langfuse Cloud
    participant S as ClickHouse Support

    Note over L: Uptime falls below 99.9%<br/>in a calendar month

    C->>S: Open support case within 24h
    C->>S: "Submit full claim by end of<br/>following month (dates, times, evidence)"
    S->>S: Confirm unavailability claim
    S->>C: "Issue Service Credit in next<br/>billing cycle"

    Note over C,S: Credit tiers<br/>< 99.9% but >= 99.0% = 5%<br/>< 99.0% but >= 95.0% = 10%<br/>< 95.0% = 25%
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(enterprise): align uptime SLA with ..."](https://github.com/langfuse/langfuse-docs/commit/d79a85114036c1e031dc4986a21d21d8ead8aaa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37870696)</sub>

<!-- /greptile_comment -->