### PR TITLE
docs(handbook): restructure workflow page as "How we ship"

### DIFF
--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -43,10 +43,10 @@ Goal: keep the number of loops per change to a minimum and let individual contri
 ### Larger projects (e.g. supporting agents in Langfuse, rebuilding SDKs…)
 
 1. The engineer does initial investigation, writes a short RFC (in Linear), and schedules a meeting.
-   - Define roles pre project start roles together with your lead:
-      Driver: Engineer
-      Approver: Pod Lead, Max, Marc (involved in decision meeting)
-      Informed: any engineer who may have additional context. Check [Getting help](#getting-help) for this.
+   - Define the roles before the project starts, together with your lead:
+     - **Driver**: the engineer
+     - **Approver**: pod lead, Max, or Marc (those in the decision meeting)
+     - **Informed**: any engineer who may have additional context (see [Getting help](#getting-help))
  
    - Sometimes a 15 min meeting without an RFC can also help to save time. This is up to the engineer to schedule.
 2. In the meeting discussing the RFC:

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -36,40 +36,32 @@ Goal: keep the number of loops per change to a minimum and let individual contri
 ### Small and mid-sized changes (e.g. adding a new filter to a table, a new field to a form…)
 
 - The engineer leads: capture very brief notes in Linear, or just a descriptive title.
-- Feel free to have a brief discussion with your lead, Max, or Marc if it speeds things up and reduces risk/uncertainty.
+- Feel free to have a brief discussion with anyone if it speeds things up and reduces risk/uncertainty.
 - If you plan to have a reviewer for the change, involve them in the planning process.
-- Asking Claude Code or ChatGPT "what am I missing?" or "how would you build this?" is a great, fast way to get feedback and reduce uncertainty.
+- Asking Coding Agents "what am I missing?" or "how would you build this?" is a great, fast way to get feedback and reduce uncertainty.
 
 ### Larger projects (e.g. supporting agents in Langfuse, rebuilding SDKs…)
 
-- The engineer does initial investigation and writes a short RFC (Google Doc or Linear) with the research and a rough spec, then schedules a meeting with their lead, Marc, or Max and other team members who hold relevant context.
-- Pull people in early for insights and feedback (pod lead, Max, Marc); we're always approachable early in a project.
-- The early goal is usually to learn about the most critical and risky items first.
+1. The engineer does initial investigation, writes a short RFC (in Linear), and schedules a meeting.
+   - Define roles pre project start roles together with your lead:
+      Driver: Engineer
+      Approver: Pod Lead, Max, Marc (involved in decision meeting)
+      Informed: any engineer who may have additional context. Check [Getting help](#getting-help) for this.
+ 
+   - Sometimes a 15 min meeting without an RFC can also help to save time. This is up to the engineer to schedule.
+2. In the meeting discussing the RFC:
+   - Each complex engineering project has a few important items. We should focus on them during the meeting and have as much data as possible to make a confident decision.
+   - The meeting is recorded, so it captures the detail needed to generate the spec or issue description.
+   - Discuss timelines and how we can make things faster.
+   - Agree on an implementation plan afterward; sync with your lead if needed.
 
-In the decision meeting:
-
-- **Define the roles before the project starts:**
-  - **Driver**: the engineer
-  - **Approver**: pod lead, Max, or Marc (those in the decision meeting)
-  - **Consulted**: product owners ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)) and anyone with relevant context
-  - **Informed**: any engineer who is impacted
-- De-risk and clarify all the important open questions.
-- Discuss timelines and how we can move faster (e.g. by cutting scope).
-- Agree on an implementation plan; sync with your lead afterward if needed.
-- Meetings are recorded; the captured detail is useful for generating the spec or issue description.
-
-A few notes on larger projects:
-
-- Involve Max if you think it's needed; either way, share the RFC with him for async review.
-- For strategic projects, involve both Max and Marc to align on what and how to build.
-- The engineer owns the Linear project: log the outcome, and any later changes from the meeting or follow-up discussions, to the ticket or project.
-
-### Getting help
+### Getting help [#getting-help]
 
 You can pull in anyone on the team at any time; 15 minutes of shared discussion often improves the output a lot.
 
-- **UI/UX**: for larger UI/UX changes, get input from Max or Marc. Otherwise, draw a small sketch and ask anyone on the team for feedback. We take the time to polish UI/UX.
+- **UI/UX**: for larger UI/UX changes, get input from the designer or Nikita. They are happy to help come up with great UI/UX early on.
 - **ClickHouse**: for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
+- **Product Owners**: if you work in the product area of another engineer it sometimes helps to get their input. 
 
 ## Implementation
 

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -7,9 +7,9 @@ description: How the engineering team prioritizes, plans, builds, and ships at L
 
 ## Prioritization
 
-Our goal is to build a company where we don't spend hours each week triaging and prioritizing tickets. Everyone keeps track of their own priorities and escalates to Max when work piles up. This only works if we all share an understanding of priorities and SLAs. Our near-term direction is set each quarter through the [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping); everyone's day-to-day priorities should align with it.
+Our goal is to build a company where we don't spend hours each week triaging and prioritizing tickets. Everyone keeps track of their own priorities and escalates to their lead when work piles up. This only works if we all share an understanding of priorities and SLAs. Our near-term direction is set each quarter through the [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping); everyone's day-to-day priorities should align with it.
 
-When in doubt, tag Max (24h SLA on the Linear inbox). Everyone should have a clear view of current priorities — the best way is to keep one Linear project or issue for the current main task. For bugs and smaller improvements, use the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues". Every Linear ticket should have a priority set.
+When in doubt, tag your lead (24h SLA on the Linear inbox). Everyone should have a clear view of current priorities — the best way is to keep one Linear project or issue for the current main task. For bugs and smaller improvements, use the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues". Every Linear ticket should have a priority set.
 
 ### Issue states
 

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -15,8 +15,8 @@ When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear proj
 
 | Priority | Timeline | Description | Examples |
 |----------|----------|-------------|----------|
-| **P0 (urgent)** | Immediately — drop everything | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, ClickHouse CPU/memory issues)<br/>- Issues with large-scale impact that break our application | Traces table does not load, login broken |
-| **P1 (high)** | Same week | - Issues with smaller-scale impact<br/>- Improvements that are under 1h of work and have a big impact for many customers — great to move fast on, since users get excited that we ship<br/>- Delighting a user the same day with a small change that helps them | Some edge case does not work for dashboards |
+| **P0 (urgent)** | Immediately, drop everything | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, ClickHouse CPU/memory issues)<br/>- Issues with large-scale impact that break our application | Traces table does not load, login broken |
+| **P1 (high)** | Same week | - Issues with smaller-scale impact<br/>- Improvements that are under 1h of work and have a big impact for many customers; great to move fast on, since users get excited that we ship<br/>- Delighting a user the same day with a small change that helps them | Some edge case does not work for dashboards |
 | **P2 (mid)** | Same month | - Papercut fixes that don't have wide-ranging impact | Trace tree UI breaks when users have many scores |
 | **P3 (low)** | Backlog | - Nice-to-have additions to Langfuse that aren't urgent | Create a new prompt based on a non-latest prompt version |
 
@@ -24,10 +24,10 @@ When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear proj
 
 We balance busy work with making progress on the most important project we're driving forward. To keep that balance, we hold ourselves to a few response times:
 
-- **Linear inbox** — clear once a day.
-- **Pylon inbox** — clear twice a day. Acknowledge a user's request ASAP, then look into it or work on a fix.
-- **PR reviews** — if you're a reviewer, turn it around within 24h; if it lands in the morning, review the same day. See [Code review](/handbook/product-engineering/how-we-work/code-review) for details.
-- **Bug fixes and support** — spend at most ~2h/day on bug fixes, support tickets, and similar. Fixing bugs is sometimes critical for the company, but if you consistently spend more than 2h/day, talk to Max to get buy-in or distribute the work across the team.
+- **Linear inbox**: clear once a day.
+- **Pylon inbox**: clear twice a day. Acknowledge a user's request ASAP, then look into it or work on a fix.
+- **PR reviews**: if you're a reviewer, turn it around within 24h; if it lands in the morning, review the same day. See [Code review](/handbook/product-engineering/how-we-work/code-review) for details.
+- **Bug fixes and support**: spend at most ~2h/day on bug fixes, support tickets, and similar. Fixing bugs is sometimes critical for the company, but if you consistently spend more than 2h/day, talk to your lead to get buy-in or distribute the work across the team.
 
 ## Specification
 
@@ -35,7 +35,7 @@ Goal: keep the number of loops per change to a minimum and let individual contri
 
 ### Small and mid-sized changes (e.g. adding a new filter to a table, a new field to a form…)
 
-- The engineer leads — capture very brief notes in Linear, or just a descriptive title.
+- The engineer leads: capture very brief notes in Linear, or just a descriptive title.
 - Feel free to have a brief discussion with your lead, Max, or Marc if it speeds things up and reduces risk/uncertainty.
 - If you plan to have a reviewer for the change, involve them in the planning process.
 - Asking Claude Code or ChatGPT "what am I missing?" or "how would you build this?" is a great, fast way to get feedback and reduce uncertainty.
@@ -43,20 +43,20 @@ Goal: keep the number of loops per change to a minimum and let individual contri
 ### Larger projects (e.g. supporting agents in Langfuse, rebuilding SDKs…)
 
 - The engineer does initial investigation and writes a short RFC (Google Doc or Linear) with the research and a rough spec, then schedules a meeting with their lead, Marc, or Max and other team members who hold relevant context.
-- Pull people in early for insights and feedback (pod lead, Max, Marc) — we're always approachable early in a project.
+- Pull people in early for insights and feedback (pod lead, Max, Marc); we're always approachable early in a project.
 - The early goal is usually to learn about the most critical and risky items first.
 
 In the decision meeting:
 
 - **Define the roles before the project starts:**
-  - **Driver** — the engineer
-  - **Approver** — pod lead, Max, or Marc (those in the decision meeting)
-  - **Consulted** — product owners ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)) and anyone with relevant context
-  - **Informed** — any engineer who is impacted
+  - **Driver**: the engineer
+  - **Approver**: pod lead, Max, or Marc (those in the decision meeting)
+  - **Consulted**: product owners ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)) and anyone with relevant context
+  - **Informed**: any engineer who is impacted
 - De-risk and clarify all the important open questions.
 - Discuss timelines and how we can move faster (e.g. by cutting scope).
 - Agree on an implementation plan; sync with your lead afterward if needed.
-- Meetings are recorded — the captured detail is useful for generating the spec or issue description.
+- Meetings are recorded; the captured detail is useful for generating the spec or issue description.
 
 A few notes on larger projects:
 
@@ -66,19 +66,19 @@ A few notes on larger projects:
 
 ### Getting help
 
-You can pull in anyone on the team at any time — 15 minutes of shared discussion often improves the output a lot.
+You can pull in anyone on the team at any time; 15 minutes of shared discussion often improves the output a lot.
 
-- **UI/UX** — for larger UI/UX changes, get input from Max or Marc. Otherwise, draw a small sketch and ask anyone on the team for feedback. We take the time to polish UI/UX.
-- **ClickHouse** — for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
+- **UI/UX**: for larger UI/UX changes, get input from Max or Marc. Otherwise, draw a small sketch and ask anyone on the team for feedback. We take the time to polish UI/UX.
+- **ClickHouse**: for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
 
 ## Implementation
 
-- **No uncertainty** — the engineer understands the challenges of the issue/feature and how to implement it. Go ahead and build.
-- **Uncertainty or questions** — tag Max on the Linear ticket with a clear, specific question to get an answer or buy-in for the change.
+- **No uncertainty**: the engineer understands the challenges of the issue/feature and how to implement it. Go ahead and build.
+- **Uncertainty or questions**: tag your lead on the Linear ticket with a clear, specific question to get an answer or buy-in for the change.
 
 ## Releases
 
-- **Complex changes/projects** — agree on a release plan: which PRs to merge and release, and in what order.
+- **Complex changes/projects**: agree on a release plan: which PRs to merge and release, and in what order.
 - Always write [public docs](/docs) or a [changelog post](/changelog) when you ship something.
 
 ## Tools
@@ -91,7 +91,7 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 - Discuss product requirements and implementation details
 - Understand what work is left to finish a project
 - Triage and prioritize bugs
-- Keep knowledge in one place — reduce the Linear/Slack split by keeping as much as possible in Linear
+- Keep knowledge in one place, reducing the Linear/Slack split by keeping as much as possible in Linear
 - Integrate with other tools (Pylon, GitHub, Cursor, etc.) to smooth the workflow
 
 #### Issue states
@@ -104,12 +104,12 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 
 #### Conventions [#linear-conventions]
 
-- **Titles** — keep them precise and brief, so any engineer scanning a list of tickets roughly understands each one. Descriptions are optional; when you add one, keep it short and precise.
-- **Labels** — every issue has a label, and you can use Linear views to see all tickets for a label. Use labels for product areas, and the "feat-..." labels for most issues. Before creating a new label, check that no existing one fits ([labels](https://linear.app/langfuse/settings/issue-labels)); move new labels to the workspace/organization level, since they're created at the project level by default.
-- **Assignment** — enable "assign to self on creation", and assign to self when creating from third-party tools.
-- **Projects** — only create a project for work with a clear end (no endless bucket of tickets).
-- **Pylon** — link Pylon threads to Linear issues with "Thread links". When you close a Linear ticket, resolve the Pylon thread to tell the user we shipped the fix or request — two minutes of effort that shows we ship fast. Snooze threads you want to revisit (e.g. next week).
-- **Internal Slack messages** — for internal (non-user-facing) messages, use the Linear app in Slack to create an issue. This links the Slack thread to the issue, and people are notified when the ticket changes state.
+- **Titles**: keep them precise and brief, so any engineer scanning a list of tickets roughly understands each one. Descriptions are optional; when you add one, keep it short and precise.
+- **Labels**: every issue has a label, and you can use Linear views to see all tickets for a label. Use labels for product areas, and the "feat-..." labels for most issues. Before creating a new label, check that no existing one fits ([labels](https://linear.app/langfuse/settings/issue-labels)); move new labels to the workspace/organization level, since they're created at the project level by default.
+- **Assignment**: enable "assign to self on creation", and assign to self when creating from third-party tools.
+- **Projects**: only create a project for work with a clear end (no endless bucket of tickets).
+- **Pylon**: link Pylon threads to Linear issues with "Thread links". When you close a Linear ticket, resolve the Pylon thread to tell the user we shipped the fix or request. It's two minutes of effort that shows we ship fast. Snooze threads you want to revisit (e.g. next week).
+- **Internal Slack messages**: for internal (non-user-facing) messages, use the Linear app in Slack to create an issue. This links the Slack thread to the issue, and people are notified when the ticket changes state.
 
 ### Slack
 

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -13,12 +13,12 @@ When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear proj
 
 ### Priority levels [#priority-levels]
 
-| Priority | Timeline | Description | Examples |
-|----------|----------|-------------|----------|
-| **P0 (urgent)** | Immediately, drop everything | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, ClickHouse CPU/memory issues)<br/>- Issues with large-scale impact that break our application | Traces table does not load, login broken |
-| **P1 (high)** | Same week | - Issues with smaller-scale impact<br/>- Improvements that are under 1h of work and have a big impact for many customers; great to move fast on, since users get excited that we ship<br/>- Delighting a user the same day with a small change that helps them | Some edge case does not work for dashboards |
-| **P2 (mid)** | Same month | - Papercut fixes that don't have wide-ranging impact | Trace tree UI breaks when users have many scores |
-| **P3 (low)** | Backlog | - Nice-to-have additions to Langfuse that aren't urgent | Create a new prompt based on a non-latest prompt version |
+| Priority        | Timeline                     | Description                                                                                                                                                                                                                                                    | Examples                                                 |
+| --------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **P0 (urgent)** | Immediately, drop everything | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, ClickHouse CPU/memory issues)<br/>- Issues with large-scale impact that break our application                                                                               | Traces table does not load, login broken                 |
+| **P1 (high)**   | Same week                    | - Issues with smaller-scale impact<br/>- Improvements that are under 1h of work and have a big impact for many customers; great to move fast on, since users get excited that we ship<br/>- Delighting a user the same day with a small change that helps them | Some edge case does not work for dashboards              |
+| **P2 (mid)**    | Same month                   | - Papercut fixes that don't have wide-ranging impact                                                                                                                                                                                                           | Trace tree UI breaks when users have many scores         |
+| **P3 (low)**    | Backlog                      | - Nice-to-have additions to Langfuse that aren't urgent                                                                                                                                                                                                        | Create a new prompt based on a non-latest prompt version |
 
 ## Daily responsibilities
 
@@ -47,8 +47,8 @@ Goal: keep the number of loops per change to a minimum and let individual contri
      - **Driver**: the engineer
      - **Approver**: pod lead, Max, or Marc (those in the decision meeting)
      - **Informed**: any engineer who may have additional context (see [Getting help](#getting-help))
- 
    - Sometimes a 15 min meeting without an RFC can also help to save time. This is up to the engineer to schedule.
+
 2. In the meeting discussing the RFC:
    - Each complex engineering project has a few important items. We should focus on them during the meeting and have as much data as possible to make a confident decision.
    - The meeting is recorded, so it captures the detail needed to generate the spec or issue description.
@@ -61,7 +61,7 @@ You can pull in anyone on the team at any time; 15 minutes of shared discussion 
 
 - **UI/UX**: for larger UI/UX changes, get input from the designer or Nikita. They are happy to help come up with great UI/UX early on.
 - **ClickHouse**: for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
-- **Product Owners**: if you work in the product area of another engineer it sometimes helps to get their input. 
+- **Product Owners**: if you work in the product area of another engineer it sometimes helps to get their input.
 
 ## Implementation
 
@@ -88,11 +88,11 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 
 #### Issue states
 
-| State | Description |
-|-------|-------------|
-| **Triage** | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
-| **Backlog** | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See the [conventions below](#linear-conventions) for titles, labels, and Pylon links |
-| **Todo / In progress** | See [Priority levels](#priority-levels) for handling guidelines |
+| State                  | Description                                                                                                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Triage**             | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
+| **Backlog**            | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See the [conventions below](#linear-conventions) for titles, labels, and Pylon links                                 |
+| **Todo / In progress** | See [Priority levels](#priority-levels) for handling guidelines                                                                                                                                                                                                                                                        |
 
 #### Conventions [#linear-conventions]
 

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -7,19 +7,11 @@ description: How the engineering team prioritizes, plans, builds, and ships at L
 
 ## Prioritization
 
-Our goal is to build a company where we don't spend hours each week triaging and prioritizing tickets. Everyone keeps track of their own priorities and escalates to their lead when work piles up. This only works if we all share an understanding of priorities and SLAs. Our near-term direction is set each quarter through the [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping); everyone's day-to-day priorities should align with it.
+To avoid spending hours each week triaging and prioritizing tickets, everyone manages their own priorities and escalates to their lead when work piles up. This only works if we share an understanding of SLAs and the quarterly [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping).
 
-When in doubt, tag your lead (24h SLA on the Linear inbox). Everyone should have a clear view of current priorities — the best way is to keep one Linear project or issue for the current main task. For bugs and smaller improvements, use the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues". Every Linear ticket should have a priority set.
+When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear project or issue for your current main task, and the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues" for smaller work. Every ticket has a priority.
 
-### Issue states
-
-| State | Description |
-|-------|-------------|
-| **Triage** | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
-| **Backlog** | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See [Linear conventions](#linear-conventions) for titles, labels, and Pylon links |
-| **Todo / In progress** | See the priority table below for handling guidelines |
-
-### Priority levels
+### Priority levels [#priority-levels]
 
 | Priority | Timeline | Description | Examples |
 |----------|----------|-------------|----------|
@@ -101,6 +93,14 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 - Triage and prioritize bugs
 - Keep knowledge in one place — reduce the Linear/Slack split by keeping as much as possible in Linear
 - Integrate with other tools (Pylon, GitHub, Cursor, etc.) to smooth the workflow
+
+#### Issue states
+
+| State | Description |
+|-------|-------------|
+| **Triage** | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
+| **Backlog** | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See the [conventions below](#linear-conventions) for titles, labels, and Pylon links |
+| **Todo / In progress** | See [Priority levels](#priority-levels) for handling guidelines |
 
 #### Conventions [#linear-conventions]
 

--- a/content/handbook/product-engineering/how-we-work/meta.json
+++ b/content/handbook/product-engineering/how-we-work/meta.json
@@ -2,7 +2,7 @@
   "title": "How we work",
   "pages": [
     "roadmapping",
-    "workflow",
+    "how-we-ship",
     "onboarding",
     "code-review",
     "product-ops"

--- a/content/handbook/product-engineering/how-we-work/workflow.mdx
+++ b/content/handbook/product-engineering/how-we-work/workflow.mdx
@@ -1,108 +1,116 @@
 ---
-title: Workflow
-description: Engineering workflow and prioritization at Langfuse.
+title: How we ship
+description: How the engineering team prioritizes, plans, builds, and ships at Langfuse.
 ---
 
-# Engineering Workflow
+# How we ship
 
 ## Prioritization
 
-Our goals is to build a company where we do not spend hours each week to triage and prioritize tickets. Therefore, everyone has to keep track of their own priorities and to escalate things with Max if work is getting too much. All of this only works, if we all have a shared understanding of priorities and SLAs.
+Our goal is to build a company where we don't spend hours each week triaging and prioritizing tickets. Everyone keeps track of their own priorities and escalates to Max when work piles up. This only works if we all share an understanding of priorities and SLAs. Our near-term direction is set each quarter through the [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping); everyone's day-to-day priorities should align with it.
 
-In case of uncertainty: Tag Max (24h SLA on Linear inbox). Everyone should have a clear view on what priorities are. The best way to achieve this is by having one Linear project or issue for the current main task. For bugs and smaller improvements, use the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or “My issues”. Tickets in Linear should always have a prioritization:
+When in doubt, tag Max (24h SLA on the Linear inbox). Everyone should have a clear view of current priorities — the best way is to keep one Linear project or issue for the current main task. For bugs and smaller improvements, use the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues". Every Linear ticket should have a priority set.
 
-### Issue States
+### Issue states
 
-| State             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Triage**        | - Unassigned, no labels or prios<br/>- Created via GitHub Issue integration or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage and assign, and add labels, and refine title<br/>- After assignment, Engineer dedupes with existing tickets and handles communications with users                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| **Backlog**       | - Everyone manages their backlogs in Linear<br/>- Issues always have a label. Use Linear views to look at all tickets of a label. We only create projects for work that has a clear end (no endless bucket of tickets)<br/>- Add user feedback to tickets or projects: If via Pylon, use the "Link thread" feature. Link Linear issues to Pylon threads straight from Pylon. Snooze issues in Pylon for which we want to review again e.g. next week<br/>- Only backlog what you plan/hope to do over the next 1-2 Quarters, rest GitHub Discussions<br/>- Add labels to product areas<br/>- Issue titles: Titles have to be good enough so that someone who reads a list of titles knows what each is about. Descriptions are optional. Write short and precise descriptions so everyone understands |
-| **Todo/Progress** | See priority table below for handling guidelines                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| State | Description |
+|-------|-------------|
+| **Triage** | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
+| **Backlog** | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See [Linear conventions](#linear-conventions) for titles, labels, and Pylon links |
+| **Todo / In progress** | See the priority table below for handling guidelines |
 
-### Priority Levels
+### Priority levels
 
-| Priority        | Timeline                | Description                                                                                                                                                                                                                                                                        | Examples                                             |
-| --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| **P0 (urgent)** | Drop everything and fix | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, clickhouse CPU/memory issues)<br/>- Issues that have large scale impact and break our application                                                                                               | Traces table does not load, login broken             |
-| **P1 (high)**   | Same week resolution    | - Issues with smaller scale impact<br/>- Improvements that are \<1h work and have a big impact for many customers; great to move fast on these to make users share more feedback as they are excited that we ship<br/>- Delight a user same day for a small change that helps them | Some edge case does not work for dashboards          |
-| **P2 (mid)**    | Same month resolution   | - Fixes which are papercut for our users but do not have a wide range impact                                                                                                                                                                                                       | Trace tree UI breaks when users have many scores     |
-| **P3 (low)**    | Backlog                 | - Addition to Langfuse which is nice to have but not urgent                                                                                                                                                                                                                        | Create new prompt based on non latest prompt version |
+| Priority | Timeline | Description | Examples |
+|----------|----------|-------------|----------|
+| **P0 (urgent)** | Immediately — drop everything | - Security incidents (e.g. data breach)<br/>- Performance issues (ingestion delay, ClickHouse CPU/memory issues)<br/>- Issues with large-scale impact that break our application | Traces table does not load, login broken |
+| **P1 (high)** | Same week | - Issues with smaller-scale impact<br/>- Improvements that are under 1h of work and have a big impact for many customers — great to move fast on, since users get excited that we ship<br/>- Delighting a user the same day with a small change that helps them | Some edge case does not work for dashboards |
+| **P2 (mid)** | Same month | - Papercut fixes that don't have wide-ranging impact | Trace tree UI breaks when users have many scores |
+| **P3 (low)** | Backlog | - Nice-to-have additions to Langfuse that aren't urgent | Create a new prompt based on a non-latest prompt version |
 
-## Specification on how to build things
+## Daily responsibilities
 
-- We want to ship fast with a small team. To achieve this and maintain quality we need to balance individual agency and being able to move fast and smart design decisions early in the process.
-- As Langfuse has scaled to a platform processing billions of events, implementation strategy of features can have substantial impact on implementation effort, maintainability, user experience, cloud cost, and performance.
-- For such features, getting the right people early in one room is a massive time saver and allows us to ship fast and with high quality.
+We balance busy work with making progress on the most important project we're driving forward. To keep that balance, we hold ourselves to a few response times:
 
-### Small/mid sized changes (e.g. adding a new filter to a table, adding a new field to a form…)
+- **Linear inbox** — clear once a day.
+- **Pylon inbox** — clear twice a day. Acknowledge a user's request ASAP, then look into it or work on a fix.
+- **PR reviews** — if you're a reviewer, turn it around within 24h; if it lands in the morning, review the same day. See [Code review](/handbook/product-engineering/how-we-work/code-review) for details.
+- **Bug fixes and support** — spend at most ~2h/day on bug fixes, support tickets, and similar. Fixing bugs is sometimes critical for the company, but if you consistently spend more than 2h/day, talk to Max to get buy-in or distribute the work across the team.
 
-- Engineer creates a Linear ticket with very brief notes or just a descriptive title
-- Open to do brief discussions with Max if helpful to speed process up and reduce risk/uncertainty
-- If you plan to have a reviewer of a change, please make sure to involve the reviewer in the planning process.
-- Asking Claude Code or ChatGPT "what am I missing?" or "how would you build this?" is a great way to get feedback and reduce risk/uncertainty.
+## Specification
 
-### Large projects (e.g. supporting Agents in Langfuse, rebuilding SDKs ..)
+Goal: keep the number of loops per change to a minimum and let individual contributors make as many decisions as possible. How much upfront alignment a change needs depends on its size and risk.
 
-1. Engineer does initial research and then schedules meeting with Marc/Max and other team members who have a lot of relevant context. Ideally, he creates a google doc or Lineat ticket with the initial research and a rough specification.
-2. Meeting to make decisions and plan the implementation:
-   - Meeting usually starts with everyone reading and commenting to make sure we are all on the same page.
-   - Recorded \-\> meeting includes lots of details, good to generate spec/issue-description/working with Claude Code
-   - Discussion on timelines and how we can cut requirements to build faster
-   - Implementation plan afterwards, spin with Max if needed
-   - If things change in a meeting (also follow-up discussions), small note logged to Linear ticket / project.
-   - Engineer needs to make sure to have relevant people in the room to make a decision ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)).
-   - Engineer needs to manage Linear project based on the outcome of the meeting.
+### Small and mid-sized changes (e.g. adding a new filter to a table, a new field to a form…)
 
-### Ways of pulling help from others
+- The engineer leads — capture very brief notes in Linear, or just a descriptive title.
+- Feel free to have a brief discussion with your lead, Max, or Marc if it speeds things up and reduces risk/uncertainty.
+- If you plan to have a reviewer for the change, involve them in the planning process.
+- Asking Claude Code or ChatGPT "what am I missing?" or "how would you build this?" is a great, fast way to get feedback and reduce uncertainty.
 
-Engineers can ask others any time to help them with their work. 15 minutes of shared discussion can very much improve the overall output.
+### Larger projects (e.g. supporting agents in Langfuse, rebuilding SDKs…)
 
-- UI/UX: For larger UI/UX changes, it is helpful to get input from Max or Marc. Otherwise, draw a small sketch and ask anyone from the team for feedback. We have to take time to polish the UI/UX.
-- Clickhouse: For more complex Clickhouse queries, it is helpful to get input from the Clickhouse ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)). Otherwise, we may end up with anti patterns in performance and maintainability.
+- The engineer does initial investigation and writes a short RFC (Google Doc or Linear) with the research and a rough spec, then schedules a meeting with their lead, Marc, or Max and other team members who hold relevant context.
+- Pull people in early for insights and feedback (pod lead, Max, Marc) — we're always approachable early in a project.
+- The early goal is usually to learn about the most critical and risky items first.
+
+In the decision meeting:
+
+- **Define the roles before the project starts:**
+  - **Driver** — the engineer
+  - **Approver** — pod lead, Max, or Marc (those in the decision meeting)
+  - **Consulted** — product owners ([DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0)) and anyone with relevant context
+  - **Informed** — any engineer who is impacted
+- De-risk and clarify all the important open questions.
+- Discuss timelines and how we can move faster (e.g. by cutting scope).
+- Agree on an implementation plan; sync with your lead afterward if needed.
+- Meetings are recorded — the captured detail is useful for generating the spec or issue description.
+
+A few notes on larger projects:
+
+- Involve Max if you think it's needed; either way, share the RFC with him for async review.
+- For strategic projects, involve both Max and Marc to align on what and how to build.
+- The engineer owns the Linear project: log the outcome, and any later changes from the meeting or follow-up discussions, to the ticket or project.
+
+### Getting help
+
+You can pull in anyone on the team at any time — 15 minutes of shared discussion often improves the output a lot.
+
+- **UI/UX** — for larger UI/UX changes, get input from Max or Marc. Otherwise, draw a small sketch and ask anyone on the team for feedback. We take the time to polish UI/UX.
+- **ClickHouse** — for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
 
 ## Implementation
 
-- No uncertainty: Engineer thinks about the challenges of the issue/feature and has a clear understanding of how to implement it.
-- Uncertainty/questions: Tag Max on the Linear ticket with a clear question for the issue to get an answer / buy-in for the change.
+- **No uncertainty** — the engineer understands the challenges of the issue/feature and how to implement it. Go ahead and build.
+- **Uncertainty or questions** — tag Max on the Linear ticket with a clear, specific question to get an answer or buy-in for the change.
 
 ## Releases
 
-- Complex changes/projects: need a release plan on which PRs to merge and release in which order.
-- Please always write [public docs](/docs) or [changelog posts](/changelog) when shipping something.
+- **Complex changes/projects** — agree on a release plan: which PRs to merge and release, and in what order.
+- Always write [public docs](/docs) or a [changelog post](/changelog) when you ship something.
 
-## Slack
+## Tools
 
-Slack is extremely busy with many noisy channels. We do not want you to have too many slack notifications distracting from core work. Hence, here is a small guide on how to consume [slack channels](/handbook/tools-and-processes/using-slack).
+### Linear
 
-## Time spent throughout the day
-
-We all need to do busy work and at the same time need to make progress on the most important project we want to drive forward. Hence:
-
-- You should spend max 2h/day on coding bug fixes, support tickets and similar. Sometimes it is necessary and super important for our company to fix bugs. Yet, if you continuously spend more time than 2h/day on bug, talk to Max to get buy-in or distribute work in the team.
-- If you are a reviewer on a PR, you have to review within 24h. Please see [Code Review Guidelines](/handbook/product-engineering/how-we-work/code-review) for more details.
-- You are expected to clear out your Pylon inbox 2 times a day. Always acknowledge a request by a user ASAP and then look into it / work on a fix.
-- You are expected to clear out your Linear inbox once a day.
-
-## Linear
-
-We use Linear as internal project planning / ticketing tool. It helps us to:
+We use Linear as our internal project planning and ticketing tool. It helps us:
 
 - Collect user feedback in one place
 - Discuss product requirements and implementation details
 - Understand what work is left to finish a project
 - Triage and prioritize bugs
-- Reduce Linear/Slack knowledge split. Keep as much knowledge in Linear as possible.
-- Integrate with different tools (Pylon, GitHub, Cursor, etc.) to make the workflow smoother.
+- Keep knowledge in one place — reduce the Linear/Slack split by keeping as much as possible in Linear
+- Integrate with other tools (Pylon, GitHub, Cursor, etc.) to smooth the workflow
 
-### Conventions
+#### Conventions [#linear-conventions]
 
-- Precise and brief titles for tickets anyone can understand. Goal: any engineer who reads a list of Linear tickets should be able to roughly understand what this is about.
-- Labels:
-  - Before creating a new label, please check that no existing Label is a match. For this, go to Langfuse settings.
-  - When creating Labels, move them to the organization level. They are initially created on the project level.
-  - Please use the “feat-...” labels for most of the Linear issues you create
-- Enable “assign to self on creation” in linear. Assign to self when creating from 3rd party tools.
-- Use labels everywhere. Before creating a new label, make sure to check first if another label is a good fit ([Link](https://linear.app/langfuse/settings/issue-labels)). Also, make sure to move labels to the workspace level always.
-- Pylon:
-  - Use the “Thread links” to connect Pylon threads to Linear issues. When closing Linear tickets, resolve to tell the user that we fixed the issue / implemented the request. This step is super important as this is 2 minutes of effort and gives the impression that we ship fast
-- For internal (non user facing) Slack messages: use the Linear App in Slack to create an issue. This tracks slack channels on the Linear issues. Whenever we change the state of the ticket, users are notified.
+- **Titles** — keep them precise and brief, so any engineer scanning a list of tickets roughly understands each one. Descriptions are optional; when you add one, keep it short and precise.
+- **Labels** — every issue has a label, and you can use Linear views to see all tickets for a label. Use labels for product areas, and the "feat-..." labels for most issues. Before creating a new label, check that no existing one fits ([labels](https://linear.app/langfuse/settings/issue-labels)); move new labels to the workspace/organization level, since they're created at the project level by default.
+- **Assignment** — enable "assign to self on creation", and assign to self when creating from third-party tools.
+- **Projects** — only create a project for work with a clear end (no endless bucket of tickets).
+- **Pylon** — link Pylon threads to Linear issues with "Thread links". When you close a Linear ticket, resolve the Pylon thread to tell the user we shipped the fix or request — two minutes of effort that shows we ship fast. Snooze threads you want to revisit (e.g. next week).
+- **Internal Slack messages** — for internal (non-user-facing) messages, use the Linear app in Slack to create an issue. This links the Slack thread to the issue, and people are notified when the ticket changes state.
+
+### Slack
+
+Slack is busy and full of noisy channels, and we don't want notifications pulling you away from focused work. See the short guide on [how to consume Slack channels](/handbook/tools-and-processes/using-slack).

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1452,6 +1452,13 @@ const integrationsDeveloperToolsMove202606 = [
   ["/integrations/other/kiro-cli", "/integrations/developer-tools/kiro-cli"],
 ];
 
+const howWeShipRename202606 = [
+  [
+    "/handbook/product-engineering/how-we-work/workflow",
+    "/handbook/product-engineering/how-we-work/how-we-ship",
+  ],
+];
+
 const permanentRedirects = [
   ...selfHostFolders202508,
   ...newSelfHostingSection,
@@ -1484,6 +1491,7 @@ const permanentRedirects = [
   ...experimentsCiCdRedirects202605,
   ...errorAnalysisAcademyMove202605,
   ...integrationsDeveloperToolsMove202606,
+  ...howWeShipRename202606,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };


### PR DESCRIPTION
## What

Restructures the product-engineering handbook workflow page ([`content/handbook/product-engineering/how-we-work/workflow.mdx`](https://langfuse.com/handbook/product-engineering/how-we-work/workflow)) for clearer structure, wording, and titles.

## Changes

- **Renamed** the page title and H1 to "How we ship".
- **Clarified the specification stage** — DACI roles (Driver / Approver / Consulted / Informed), an explicit RFC step, and notes for larger projects.
- **Relocated the daily-cadence SLAs** (Linear/Pylon inboxes, PR turnaround, support cap) into a dedicated "Daily responsibilities" section near the top, next to prioritization.
- **Grouped Linear and Slack** under a new "Tools" section and **deduplicated** the label / title / Pylon-link rules that were previously repeated across the Issue states table and the standalone Linear section.
- **Sentence-cased headings**, fixed the priority table (P0 timeline parity, `<1h` escape), and corrected assorted typos.
- **Linked the quarterly roadmapping process** from Prioritization.

## Verification

Rendered the page in the local dev server: valid heading hierarchy (no skipped levels), the `#linear-conventions` deep-link anchor resolves, both tables render, and no MDX errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restructures the "Workflow" handbook page into "How we ship", improving clarity, grouping related content into logical sections, and adding explicit DACI roles for larger projects.

- **New sections**: "Daily responsibilities" (consolidates the SLA bullet points previously in "Time spent throughout the day") and "Tools" (groups Linear and Slack together); deduplicates label/title/Pylon rules that were previously scattered across the issue-states table and a standalone Linear section.
- **Content improvements**: Sentence-cased headings throughout, corrected the P0/P1 priority table wording, replaced the escaped `\<1h` MDX edge-case with natural prose, and added an anchor (`[#linear-conventions]`) so the Backlog table row can deep-link directly to the Linear conventions section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only restructuring with no executable code changes — safe to merge.

Every internal link resolves to an existing file (roadmapping.mdx, code-review.mdx), the [#linear-conventions] anchor syntax matches the established pattern used across the repo, and no content was dropped — it was either reworded in place or relocated to a more logical section. The author verified heading hierarchy and table rendering in the local dev server.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New work arrives] --> B{Size / risk?}
    B -- Small/mid change --> C[Engineer creates Linear ticket\nwith brief notes or title]
    B -- Large project --> D[Engineer writes RFC\nGoogle Doc or Linear]
    D --> E[Decision meeting\nDriver / Approver / Consulted / Informed]
    E --> F[Implementation plan agreed]
    C --> G[Implementation]
    F --> G
    G --> H{Uncertainty?}
    H -- No --> I[Build & PR]
    H -- Yes --> J[Tag Max on Linear\nwith specific question]
    J --> I
    I --> K[Code review within 24h]
    K --> L{Complex change?}
    L -- Yes --> M[Agree release plan\nordered PR merges]
    L -- No --> N[Merge]
    M --> N
    N --> O[Write public docs\nor changelog post]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[New work arrives] --> B{Size / risk?}
    B -- Small/mid change --> C[Engineer creates Linear ticket\nwith brief notes or title]
    B -- Large project --> D[Engineer writes RFC\nGoogle Doc or Linear]
    D --> E[Decision meeting\nDriver / Approver / Consulted / Informed]
    E --> F[Implementation plan agreed]
    C --> G[Implementation]
    F --> G
    G --> H{Uncertainty?}
    H -- No --> I[Build & PR]
    H -- Yes --> J[Tag Max on Linear\nwith specific question]
    J --> I
    I --> K[Code review within 24h]
    K --> L{Complex change?}
    L -- Yes --> M[Agree release plan\nordered PR merges]
    L -- No --> N[Merge]
    M --> N
    N --> O[Write public docs\nor changelog post]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): restructure engineering ..."](https://github.com/langfuse/langfuse-docs/commit/278073689799b750e252703c032a6722754a5f27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37893922)</sub>

<!-- /greptile_comment -->