### PR TITLE
docs(handbook): add Product and Launches to Getting help

### DIFF
--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -62,6 +62,8 @@ You can pull in anyone on the team at any time; 15 minutes of shared discussion 
 - **UI/UX**: for larger UI/UX changes, get input from the designer or Nikita. They are happy to help come up with great UI/UX early on.
 - **ClickHouse**: for more complex ClickHouse queries, get input from the ClickHouse [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0); otherwise we risk performance and maintainability anti-patterns.
 - **Product Owners**: if you work in the product area of another engineer it sometimes helps to get their input.
+- **Product**: engineers drive product decisions, as part of the RFC process.
+- **Launches and marketing**: you know when a feature is ready to launch, so involve the marketing team ahead of time to plan the launch.
 
 ## Implementation
 


### PR DESCRIPTION
## What

Adds two items to the **Getting help** section of the "How we ship" handbook page:

- **Product**: engineers drive product decisions and own the product calls for their work.
- **Launches and marketing**: engineers know when a feature is ready, so they involve the marketing team ahead of time to plan the launch.

Follow-up to #3109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two new bullet points to the "Getting help" section of the `how-we-ship.mdx` handbook page, clarifying engineer ownership over product decisions and launch coordination with marketing.

- **Product bullet**: signals that engineers own product calls for their work and should not wait for others to make those decisions.
- **Launches and marketing bullet**: reminds engineers to loop in the marketing team ahead of time when a feature is nearing launch.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change adding two handbook bullet points with no code, configuration, or logic modifications.

The change is limited to two new list items in a handbook MDX file. Both additions are clear, grammatically consistent with the surrounding list, and introduce no broken links or formatting issues. Nothing here can cause a runtime regression.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Engineer working on a change] --> B{Need help?}
    B -->|UI/UX concerns| C[Consult designer / Nikita]
    B -->|Complex ClickHouse queries| D[Consult ClickHouse DRI]
    B -->|Another engineer's product area| E[Get Product Owner input]
    B -->|Product decisions| F[Engineer takes ownership — no waiting]
    B -->|Feature nearing launch| G[Involve marketing team ahead of time]
    B -->|No help needed| H[Build & ship]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Engineer working on a change] --> B{Need help?}
    B -->|UI/UX concerns| C[Consult designer / Nikita]
    B -->|Complex ClickHouse queries| D[Consult ClickHouse DRI]
    B -->|Another engineer's product area| E[Get Product Owner input]
    B -->|Product decisions| F[Engineer takes ownership — no waiting]
    B -->|Feature nearing launch| G[Involve marketing team ahead of time]
    B -->|No help needed| H[Build & ship]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): add Product and Launches..."](https://github.com/langfuse/langfuse-docs/commit/ee90e355128711521db27c2ce91629f37b5df960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37946405)</sub>

<!-- /greptile_comment -->