### PR TITLE
Fix inline code ligature rendering

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -928,6 +928,10 @@ ul[data-gh-discussions-list] {
   background: var(--surface-2);
   color: var(--text-primary);
   font-variant-numeric: ordinal;
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
 }
 
 /* Links whose primary label is inline <code> (e.g. [`api()`](/ref)): underline


### PR DESCRIPTION
## Summary
- Disable font ligatures for prose inline code so placeholders like `queue-<name>-x-<name>` and `t-<traceId>` render literally.
- Keep Markdown content unchanged; backtick inline code continues to render through the normal Markdown pipeline.

## Checks
- `pnpm exec prettier --experimental-cli --check content/handbook/tools-and-processes/using-slack.mdx src/overrides.css content/faq/all/v3-sdk-observation-lookup-404.mdx`
- `node scripts/check-h1-headings.js`
- `git diff --check`