### PR TITLE
docs(blog): address review feedback on production agents post

### DIFF
--- a/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
+++ b/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
@@ -97,7 +97,7 @@ The agent runs the broad pass: it queries source tables, identifies drivers, pre
 
 ### Security skill turns daily scans into a triage table
 
-The [`security-review`](https://github.com/langfuse/langfuse/tree/main/.agents/skills/security-review) skill runs DeepSec daily on selected repositories. It scans the repositories and exports a compact findings table for review.
+The `security-review` skill runs DeepSec daily on selected repositories. It scans the repositories and exports a compact findings table for review.
 
 Before assigning work, the agent checks Linear for existing issues so the same vulnerability does not get reported every day. After reviewing the table, we ask the agent to create Linear tickets for the relevant findings. Linear Intelligence assigns those tickets to the right engineer.
 

--- a/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
+++ b/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
@@ -93,7 +93,7 @@ Agents need data access before they need better prompts. For cost analysis, we e
 
 The [`analyze-cloud-costs`](https://github.com/langfuse/langfuse/tree/main/.agents/skills/analyze-cloud-costs) skill does not ask the model to "think about spend." It points the agent at cost marts and asks for the same grain every time: recent complete days versus a baseline, provider/service breakdowns, and cost per 100k ingested billable events.
 
-The agent runs the broad pass: it queries source tables, identifies drivers, preserves caveats such as incomplete current-day AWS Cost and Usage Report rows, and returns the same breakdown every time.
+The agent runs the broad pass: it queries source tables, identifies drivers, preserves caveats such as incomplete current-day rows in the AWS Cost and Usage Reports, and returns the same breakdown every time.
 
 ### Security skill turns daily scans into a triage table
 

--- a/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
+++ b/content/blog/2026-06-05-agentic-setup-for-operational-work.mdx
@@ -23,15 +23,17 @@ We use agents to turn production data into recurring artifacts for engineering r
 2. Cloud cost analysis explains the main infrastructure spend drivers.
 3. Daily repository scans turn security findings into engineering priorities.
 
+The impact is concrete: every week we now find regressions or new error cases that an engineer looks into, instead of letting them slip by unnoticed across our tools and production environments.
+
 With AI, we can generate these reviews without adding bureaucracy for the engineering team. Engineers stay focused on systems judgment instead of weekly evidence collection. They decide whether a cost driver is acceptable, whether a page was customer-impacting, whether a bug needs an owner, whether a monitor is noisy, and whether a DeepSec finding needs an owner.
 
 The data already lived across our tools, like Datadog, Linear, incident.io, and Metabase, spread across four production environments. Nothing pulled the systems together, so reviewing it every week would mean going through each tool and environment by hand.
 
 This post walks through our current setup and how we got there.
 
-## The system combines MCP, repo-owned skills, and fixed output tables
+## The system combines queryable data, MCP, and repo-owned skills
 
-We set up a system with four layers. First, we made the relevant data queryable. Second, we exposed these sources to the agent harness through MCP. Third, we developed and iterated on repo-owned skills. Fourth, each skill defines a fixed output table.
+We set up a system with three layers. First, we made the relevant data queryable. Second, we exposed these sources to the agent harness through MCP. Third, we developed and iterated on repo-owned skills, each of which defines a fixed output table for review.
 
 The workflow lives in [`langfuse/langfuse`](https://github.com/langfuse/langfuse/tree/main/.agents), not in one engineer's local prompt history.
 
@@ -79,7 +81,7 @@ flowchart LR
 
 ### Weekly production review
 
-The `weekly-production-review` skill produces a report from Linear bug tickets, Datadog error signals, and public status-page incidents.
+The [`weekly-production-review`](https://github.com/langfuse/langfuse/tree/main/.agents/skills/weekly-production-review) skill produces a report from Linear bug tickets, Datadog error signals, and public status-page incidents.
 
 The agent returns signals it finds in our production environments. This gives us one weekly pass over the signals that may need action: bugs to prioritize, incidents to discuss, and Datadog errors that should become follow-up issues.
 
@@ -87,15 +89,15 @@ We iterated heavily on this skill. The agent needs to query each source with the
 
 ### Cloud cost analysis depends on warehouse data
 
-Agents need data access before they need better prompts. For cost analysis, we export AWS CUR reports into BigQuery, enrich them with business data using dbt, expose the resulting marts through Metabase, and make the relevant tables accessible through MCP.
+Agents need data access before they need better prompts. For cost analysis, we export AWS Cost and Usage Reports into BigQuery, enrich them with business data using dbt, expose the resulting marts through Metabase, and make the relevant tables accessible through MCP.
 
-The `analyze-cloud-costs` skill does not ask the model to "think about spend." It points the agent at cost marts and asks for the same grain every time: recent complete days versus a baseline, provider/service breakdowns, and cost per 100k ingested billable events.
+The [`analyze-cloud-costs`](https://github.com/langfuse/langfuse/tree/main/.agents/skills/analyze-cloud-costs) skill does not ask the model to "think about spend." It points the agent at cost marts and asks for the same grain every time: recent complete days versus a baseline, provider/service breakdowns, and cost per 100k ingested billable events.
 
-The agent runs the broad pass: it queries source tables, identifies drivers, preserves caveats such as incomplete current-day AWS CUR rows, and returns the same breakdown every time.
+The agent runs the broad pass: it queries source tables, identifies drivers, preserves caveats such as incomplete current-day AWS Cost and Usage Report rows, and returns the same breakdown every time.
 
 ### Security skill turns daily scans into a triage table
 
-The `security-review` skill runs DeepSec daily on selected repositories. It scans the repositories and exports a compact findings table for review.
+The [`security-review`](https://github.com/langfuse/langfuse/tree/main/.agents/skills/security-review) skill runs DeepSec daily on selected repositories. It scans the repositories and exports a compact findings table for review.
 
 Before assigning work, the agent checks Linear for existing issues so the same vulnerability does not get reported every day. After reviewing the table, we ask the agent to create Linear tickets for the relevant findings. Linear Intelligence assigns those tickets to the right engineer.
 


### PR DESCRIPTION
## Summary

Follow-up to [#3060](https://github.com/langfuse/langfuse-docs/pull/3060) (merged) addressing Marc Klingen's [review comments](https://github.com/langfuse/langfuse-docs/pull/3060#pullrequestreview-4504941477) on `content/blog/2026-06-05-agentic-setup-for-operational-work.mdx`:

- **Impact at the top** — added a concrete impact line right after the intro list: every week we now find regressions or new error cases that an engineer looks into.
- **Layers framing** — the fixed output table is part of the skills layer, not a separate one. Reworded "four layers" -> "three layers" (data is queryable -> exposed via MCP -> repo-owned skills that each define a fixed output table) and updated the section heading to match.
- **Skill links** — linked `weekly-production-review`, `analyze-cloud-costs`, and `security-review` to their definitions under `langfuse/langfuse/.agents/skills/`.
- **AWS CUR** — spelled out "AWS Cost and Usage Reports" (both occurrences) instead of the abbreviation.

## Validation

- Verified the page renders at `/blog/2026-06-05-agentic-setup-for-operational-work` on the local dev server (200, no console errors).
- Confirmed all three linked skill directories exist on `langfuse/langfuse@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses follow-up review feedback on the production agents blog post, tightening the narrative around the three-layer system framing and improving discoverability of the referenced skills.

- Added a concrete impact sentence after the intro list; reworded "four layers" → "three layers" by folding fixed output tables into the skills layer, and updated the section heading to match.
- Linked `weekly-production-review`, `analyze-cloud-costs`, and `security-review` skill names to their directories in `langfuse/langfuse`; spelled out "AWS Cost and Usage Reports" in place of the "AWS CUR" abbreviation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change to a blog post; no code, APIs, or configuration are affected.

All changes are prose edits: a new impact sentence, a layer-count correction from four to three, three skill hyperlinks, and two abbreviation expansions. The only inconsistency is "Report" (singular) vs "Reports" (plural) across the two AWS CUR expansions, which has no functional impact.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A["Layer 1: Queryable data\n(Datadog, Metabase,\nincident.io, Pylon)"] --> B["Layer 2: MCP\n(expose sources to\nagent harness)"]
    B --> C["Layer 3: Repo-owned skills\n(weekly-production-review\nanalyze-cloud-costs\nsecurity-review)"]
    C --> D["Fixed output tables\n(Monday engineering review)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
    A["Layer 1: Queryable data\n(Datadog, Metabase,\nincident.io, Pylon)"] --> B["Layer 2: MCP\n(expose sources to\nagent harness)"]
    B --> C["Layer 3: Repo-owned skills\n(weekly-production-review\nanalyze-cloud-costs\nsecurity-review)"]
    C --> D["Fixed output tables\n(Monday engineering review)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/blog/2026-06-05-agentic-setup-for-operational-work.mdx:96
The two expansions of "AWS CUR" are inconsistent: line 92 uses the plural "Reports" (the official AWS product name) while line 96 uses the singular "Report". Both should use the same form — the official product name is "AWS Cost and Usage Reports" (plural).

```suggestion
The agent runs the broad pass: it queries source tables, identifies drivers, preserves caveats such as incomplete current-day AWS Cost and Usage Reports rows, and returns the same breakdown every time.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(blog): address review feedback on p..."](https://github.com/langfuse/langfuse-docs/commit/39817230e326f79de4016b54f8369e386925e680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37952190)</sub>

<!-- /greptile_comment -->