### PR TITLE
fix(chat): use managed inkeep-qa-expert model for Ask AI

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -98,7 +98,7 @@ export async function POST(req: Request) {
 
   try {
     const result = streamText({
-      model: inkeep("inkeep-qa-sonnet-4") as unknown as Parameters<
+      model: inkeep("inkeep-qa-expert") as unknown as Parameters<
         typeof streamText
       >[0]["model"],
       tools: {


### PR DESCRIPTION
## Problem

The "Ask AI" chat stopped returning answers.

## Root cause

The chat route (`app/api/chat/route.ts`) proxies to Inkeep's OpenAI‑compatible `chat/completions` endpoint and pinned a **specific, now-deprecated model**: `inkeep-qa-sonnet-4`.

```ts
model: inkeep("inkeep-qa-sonnet-4") ...
```

When Inkeep retires a pinned QA model, the upstream call errors during streaming. Because `streamText` surfaces upstream failures inside the stream (not as a synchronous throw), the route's `try/catch` doesn't catch it and the UI simply renders no answer — matching "doesn't give answers anymore."

## Fix

Switch to Inkeep's **managed** QA model, `inkeep-qa-expert`, which is the name Inkeep officially recommends for Question Answer mode and lets Inkeep route to a currently supported underlying model (rather than us hard‑pinning one that can be removed). This matches Inkeep's own Vercel AI SDK example (`openai("inkeep-qa-expert")`).

```ts
model: inkeep("inkeep-qa-expert") ...
```

## Scope

One-line change to the model identifier. No schema, transport, or UI changes. The OpenAI-compatible provider, baseURL (`https://api.inkeep.com/v1`), `provideLinks` tool wiring, and message handling are unchanged.

References:
- [Inkeep — Question Answer mode with the Vercel AI SDK](https://docs.inkeep.com/cloud/ai-api/question-answer-mode/vercel-ai-sdk)
- [Inkeep — Chat Completions API overview](https://docs.inkeep.com/cloud/ai-api/chat-completions-api)

https://claude.ai/code/session_018GTAqsSJNAvyRuJuQEU7kC

---
_Generated by [Claude Code](https://claude.ai/code/session_018GTAqsSJNAvyRuJuQEU7kC)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "Ask AI" chat feature, which had stopped returning answers because it was pinning a deprecated Inkeep model (`inkeep-qa-sonnet-4`). Switching to the managed `inkeep-qa-expert` identifier lets Inkeep route requests to a currently supported underlying model.

- **One-line model swap** in `app/api/chat/route.ts`: `inkeep-qa-sonnet-4` → `inkeep-qa-expert`. No other code paths, schemas, or transports are affected.
- The rest of the route — rate limiting, message parsing, `provideLinks` tool wiring, and streaming — is unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single model-identifier string swap with no risk of breaking other code paths.

The entire change is replacing one model name string with another. The provider configuration, API key, baseURL, tool wiring, rate limiting, and streaming pipeline are all untouched. `inkeep-qa-expert` is Inkeep's officially recommended managed QA model, so the fix directly addresses the reported breakage with minimal blast radius.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Browser / UI
    participant Route as /api/chat (route.ts)
    participant Inkeep as api.inkeep.com/v1

    UI->>Route: "POST /api/chat { messages }"
    Route->>Route: Rate-limit check (in-memory bucket)
    Route->>Route: "Parse & validate body (Zod)"
    Route->>Route: convertToModelMessages()
    Route->>Inkeep: "streamText → chat/completions<br/>model: inkeep-qa-expert  ← changed from inkeep-qa-sonnet-4"
    Inkeep-->>Route: Streamed tokens + provideLinks tool calls
    Route-->>UI: UIMessageStream response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Browser / UI
    participant Route as /api/chat (route.ts)
    participant Inkeep as api.inkeep.com/v1

    UI->>Route: "POST /api/chat { messages }"
    Route->>Route: Rate-limit check (in-memory bucket)
    Route->>Route: "Parse & validate body (Zod)"
    Route->>Route: convertToModelMessages()
    Route->>Inkeep: "streamText → chat/completions<br/>model: inkeep-qa-expert  ← changed from inkeep-qa-sonnet-4"
    Inkeep-->>Route: Streamed tokens + provideLinks tool calls
    Route-->>UI: UIMessageStream response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): use managed inkeep-qa-expert ..."](https://github.com/langfuse/langfuse-docs/commit/dd5b28c94e5094973f6cbda0351b2c6d988ace8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37962885)</sub>

<!-- /greptile_comment -->