### PR TITLE
feat(docs): make breadcrumb segments clickable links

### DIFF
--- a/components/DocsBreadcrumb.tsx
+++ b/components/DocsBreadcrumb.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Fragment, type ReactNode, useMemo } from "react";
+import Link from "fumadocs-core/link";
+import type * as PageTree from "fumadocs-core/page-tree";
+import { useTreeContext, useTreePath } from "fumadocs-ui/contexts/tree";
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type AnyNode = PageTree.Node | PageTree.Root | PageTree.Folder;
+type Crumb = { name: ReactNode; url?: string };
+
+/**
+ * Resolve a link target for a tree node:
+ * - a page links to itself (unless it's an external link),
+ * - a folder links to its index page when it has one,
+ * - otherwise we fall back to the first linkable descendant page.
+ *
+ * The fallback is what makes section/folder crumbs clickable even when the
+ * folder has no dedicated index page (e.g. "Observability", whose landing
+ * page is `overview` rather than `index`).
+ */
+function resolveFirstUrl(node: AnyNode): string | undefined {
+  if ("type" in node && node.type === "page") {
+    return node.external ? undefined : node.url;
+  }
+  if ("type" in node && node.type === "folder" && node.index?.url) {
+    return node.index.url;
+  }
+  const children = "children" in node ? node.children : undefined;
+  if (children) {
+    for (const child of children) {
+      const url = resolveFirstUrl(child);
+      if (url) return url;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Link target for the leading (section) crumb. Prefer the section's landing
+ * page — the shallowest internal child page, e.g. `/docs` over `/docs/demo` —
+ * so the root crumb points at the section index regardless of `meta.json`
+ * ordering. Falls back to the first linkable descendant.
+ */
+function resolveSectionUrl(
+  root: PageTree.Root | PageTree.Folder,
+): string | undefined {
+  let best: string | undefined;
+  for (const child of root.children) {
+    if (child.type !== "page" || child.external) continue;
+    if (
+      best === undefined ||
+      child.url.split("/").length < best.split("/").length
+    ) {
+      best = child.url;
+    }
+  }
+  return best ?? resolveFirstUrl(root);
+}
+
+/**
+ * Drop-in replacement for Fumadocs' `PageBreadcrumb` that renders the same
+ * markup and styling but resolves a URL for every crumb — including the section
+ * root and intermediate folders that lack an index page — so the full
+ * breadcrumb trail is clickable.
+ *
+ * Mirrors Fumadocs' `getBreadcrumbItemsFromPath` with `{ includeRoot: true,
+ * includePage: true }`; the only addition is the `resolveFirstUrl` fallback.
+ */
+export function DocsBreadcrumb() {
+  const path = useTreePath();
+  const { root } = useTreeContext();
+
+  const items = useMemo<Crumb[]>(() => {
+    const result: Crumb[] = [];
+
+    for (let i = 0; i < path.length; i++) {
+      const node = path[i];
+      if (node.type === "page") {
+        result.push({ name: node.name, url: node.url });
+      } else if (node.type === "folder") {
+        // The active root folder is rendered as the leading crumb below.
+        if (node.root) continue;
+        // Fumadocs collapses a folder and its index page into a single crumb.
+        if (i === path.length - 1 || node.index !== path[i + 1]) {
+          result.push({
+            name: node.name,
+            url: node.index?.url ?? resolveFirstUrl(node),
+          });
+        }
+      }
+    }
+
+    result.unshift({ name: root.name, url: resolveSectionUrl(root) });
+    return result;
+  }, [path, root]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-fd-muted-foreground">
+      {items.map((item, i) => {
+        const className = cn(
+          "truncate",
+          i === items.length - 1 && "text-fd-primary font-medium",
+        );
+        return (
+          <Fragment key={i}>
+            {i !== 0 && <ChevronRight className="size-3.5 shrink-0" />}
+            {item.url ? (
+              <Link
+                href={item.url}
+                className={cn(className, "transition-opacity hover:opacity-80")}
+              >
+                {item.name}
+              </Link>
+            ) : (
+              <span className={className}>{item.name}</span>
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/DocsChromePage.tsx
+++ b/components/DocsChromePage.tsx
@@ -6,6 +6,7 @@ import type { TOCItemType } from "fumadocs-core/toc";
 import { DocsTocFooter } from "@/components/DocsTocFooter";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { DocsAndPageFooter } from "@/components/DocsAndPageFooter";
+import { DocsBreadcrumb } from "@/components/DocsBreadcrumb";
 import { getMDXComponents } from "@/mdx-components";
 
 type BodyChromeProps = Omit<ComponentProps<typeof DocBodyChrome>, "children">;
@@ -56,7 +57,7 @@ export async function DocsChromePage({
     <DocsPage
       toc={toc}
       lastUpdate={lastModified}
-      breadcrumb={{ includePage: true, includeRoot: true }}
+      breadcrumb={{ component: <DocsBreadcrumb /> }}
       tableOfContent={{
         footer: (
           <DocsTocFooter pageTitle={data.title} lastModified={lastModified} />


### PR DESCRIPTION
## What

Makes every segment of the docs breadcrumb a clickable link. Previously, the breadcrumb (e.g. `Docs › Observability › Concepts`) only linked the current page — the section root ("Docs") and intermediate folder crumbs ("Observability") rendered as plain, non-clickable text.

## Why

Fumadocs' built-in `PageBreadcrumb` only renders a crumb as a link when its page-tree node has a URL:
- The **root** crumb gets a URL only when `includeRoot` is passed as an object with a `url` — we passed `includeRoot: true`, so it had none.
- A **folder** crumb gets a URL only from its `index` page. Folders like `observability/` have no `index.mdx` (their landing page is `overview.mdx`), so they had no URL.

Both therefore rendered as inert text.

## How

New client component [`components/DocsBreadcrumb.tsx`](components/DocsBreadcrumb.tsx) that renders the **same markup and styling** as Fumadocs' default breadcrumb (mirrors `getBreadcrumbItemsFromPath` with `{ includeRoot: true, includePage: true }`) but resolves a URL for every crumb:

- **Root** → the section's landing page, chosen as the shallowest internal child page (e.g. `/docs`, `/self-hosting`) so it's correct regardless of `meta.json` ordering.
- **Folder** → its `index` page if present, otherwise its first descendant page.
- **Current page** → itself (unchanged).

Wired in through the shared [`components/DocsChromePage.tsx`](components/DocsChromePage.tsx) via `breadcrumb={{ component: <DocsBreadcrumb /> }}`, so it applies to **all** sidebar sections (docs, self-hosting, integrations, guides, academy, handbook, etc.).

## Testing

Verified locally in the browser preview:

- `/docs/observability/data-model` → `Docs → /docs`, `Observability → /docs/observability/overview`, `Concepts → self`; clicking "Observability" navigates correctly.
- 4-level page `/docs/observability/features/comments` → all four crumbs linked, including the intermediate "Features" folder.
- `/self-hosting/deployment/docker-compose` and `/guides/...` → root crumbs correctly resolve to `/self-hosting` and `/guides`, confirming the cross-section root logic (robust against `meta.json` quirks like non-existent `import` entries).
- Rendering is visually unchanged (same separators, muted styling, bold current page); no new console errors; `tsc --noEmit` and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces Fumadocs' built-in `PageBreadcrumb` with a custom `DocsBreadcrumb` client component so that every crumb in the breadcrumb trail — the section root, intermediate folders, and the current page — becomes a clickable link.

- **`DocsBreadcrumb.tsx`** (new): Mirrors Fumadocs' `getBreadcrumbItemsFromPath` logic but adds `resolveFirstUrl` and `resolveSectionUrl` helpers to find a linkable URL for every node, falling back to the first descendant page when a folder has no dedicated index page.
- **`DocsChromePage.tsx`** (modified): Swaps `breadcrumb={{ includePage: true, includeRoot: true }}` for `breadcrumb={{ component: <DocsBreadcrumb /> }}`, applying the new component across all sidebar sections.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive and well-scoped; a visual regression or broken link would be immediately obvious in the browser.

The URL-resolution logic is correct and the component correctly mirrors Fumadocs' traversal semantics. The two findings are minor: an unreachable early-return guard and missing ARIA breadcrumb semantics (`nav` role, `aria-label`, `aria-current="page"`) that should be added to match accessibility best practices.

components/DocsBreadcrumb.tsx — the ARIA attributes and the unreachable guard on line 100 are both worth a quick fix before landing.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DocsChromePage (Server Component)"] -->|"breadcrumb={{ component: DocsBreadcrumb }}"| B["DocsPage (fumadocs-ui)"]
    B --> C["DocsBreadcrumb (Client Component)"]
    C --> D["useTreePath() + useTreeContext()"]
    D --> E["path: AnyNode[]"]
    E --> F{"For each node in path"}
    F -->|"type === 'page'"| G["Push {name, url}"]
    F -->|"type === 'folder' && !root"| H{"Collapse check\nnode.index === path[i+1]?"}
    H -->|"No (render folder crumb)"| I["resolveFirstUrl(folder)\n→ index.url or first descendant"]
    H -->|"Yes (collapse with index page)"| J["Skip folder crumb"]
    F -->|"type === 'folder' && root"| K["Skip (added via unshift)"]
    G --> L["result array"]
    I --> L
    L --> M["unshift root crumb\nresolveSectionUrl(root)\n→ shallowest direct page child\nor first descendant"]
    M --> N["Render div with Links + ChevronRight separators"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["DocsChromePage (Server Component)"] -->|"breadcrumb={{ component: DocsBreadcrumb }}"| B["DocsPage (fumadocs-ui)"]
    B --> C["DocsBreadcrumb (Client Component)"]
    C --> D["useTreePath() + useTreeContext()"]
    D --> E["path: AnyNode[]"]
    E --> F{"For each node in path"}
    F -->|"type === 'page'"| G["Push {name, url}"]
    F -->|"type === 'folder' && !root"| H{"Collapse check\nnode.index === path[i+1]?"}
    H -->|"No (render folder crumb)"| I["resolveFirstUrl(folder)\n→ index.url or first descendant"]
    H -->|"Yes (collapse with index page)"| J["Skip folder crumb"]
    F -->|"type === 'folder' && root"| K["Skip (added via unshift)"]
    G --> L["result array"]
    I --> L
    L --> M["unshift root crumb\nresolveSectionUrl(root)\n→ shallowest direct page child\nor first descendant"]
    M --> N["Render div with Links + ChevronRight separators"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/DocsBreadcrumb.tsx:102-126
**Missing breadcrumb ARIA semantics**

The component renders a plain `<div>` with no landmark role or accessibility attributes. The ARIA breadcrumb pattern (WAI-ARIA Authoring Practices) requires the container to be a `<nav aria-label="Breadcrumb">` element and the current-page crumb to carry `aria-current="page"`. Without these, screen readers cannot announce the region as a breadcrumb trail or identify which crumb represents the active page. If Fumadocs' built-in `PageBreadcrumb` had these attributes, this is a regression.

### Issue 2 of 2
components/DocsBreadcrumb.tsx:100
**Unreachable guard**

`result.unshift({ name: root.name, url: resolveSectionUrl(root) })` unconditionally prepends the root crumb before this check, so `items` always has at least one element and this guard can never fire. It reads like a meaningful early-return but is dead code, which may confuse future readers into thinking there's a case where the list can be empty.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(docs): make breadcrumb segments cli..."](https://github.com/langfuse/langfuse-docs/commit/99d5a103e3e054a4e9ffffbac45da2bfa19946b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38082172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->