### PR TITLE
add architecture diagram to architecture page

### DIFF
--- a/content/handbook/product-engineering/architecture.mdx
+++ b/content/handbook/product-engineering/architecture.mdx
@@ -6,6 +6,16 @@ title: Architecture
 
 Langfuse's infrastructure continuously evolves to support increasing scale and new product features. We started on Vercel and Supabase with Next.js and Postgres, and have evolved to the distributed architecture described below. As our product and scale requirements grow, we'll continue to mature our infrastructure to meet those needs.
 
+Langfuse only depends on open source components and can be deployed locally, on cloud infrastructure, or on-premises.
+
+import ArchitectureDiagram from "@/components-mdx/architecture-diagram-v3.mdx";
+
+<ArchitectureDiagram />
+
+import ArchitectureDescription from "@/components-mdx/architecture-description-v3.mdx";
+
+<ArchitectureDescription />
+
 ## Infrastructure Components
 
 ### Application Layer


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR embeds the v3 architecture diagram and component description into the handbook architecture page by reusing the two shared MDX components (`architecture-diagram-v3.mdx` and `architecture-description-v3.mdx`) that are already in use on several other pages.

- Adds a short introductory sentence and imports `ArchitectureDiagram` + `ArchitectureDescription` mid-document — an established pattern already present in `content/self-hosting/index.mdx` and several other pages.
- Both referenced component files exist and are already rendered successfully elsewhere in the repo; no new files are introduced.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; both referenced components exist and already render on other pages.

The two imported components are already used on at least five other pages in the repo without issue, so there is no build or render risk. The mid-document import pattern is an established convention for this Mintlify-based site. No logic or configuration is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["architecture.mdx\n(handbook page)"] --> B["ArchitectureDiagram\n(architecture-diagram-v3.mdx)"]
    A --> C["ArchitectureDescription\n(architecture-description-v3.mdx)"]
    B --> D["Mermaid flowchart\n(VPC, Web, Worker, Postgres,\nClickhouse, Redis, S3, LLM)"]
    C --> E["Prose description\nwith links to self-hosting docs"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["architecture.mdx\n(handbook page)"] --> B["ArchitectureDiagram\n(architecture-diagram-v3.mdx)"]
    A --> C["ArchitectureDescription\n(architecture-description-v3.mdx)"]
    B --> D["Mermaid flowchart\n(VPC, Web, Worker, Postgres,\nClickhouse, Redis, S3, LLM)"]
    C --> E["Prose description\nwith links to self-hosting docs"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["add architecture diagram to architecture..."](https://github.com/langfuse/langfuse-docs/commit/ac50178593b109d80699019a908aa4bd16553571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38094402)</sub>

<!-- /greptile_comment -->