### PR TITLE
docs: improve LangGraph cookbook trace clarity

### DIFF
--- a/content/guides/cookbook/integration_langgraph.mdx
+++ b/content/guides/cookbook/integration_langgraph.mdx
@@ -20,10 +20,12 @@ This cookbook demonstrates how [Langfuse](https://langfuse.com/docs) helps to de
 
 
 *   Automatically trace LangGraph application via the Langfuse integration
+*   Add clear trace names, run names, tags, and metadata so traces are easier to find in the Langfuse dashboard
 *   Monitor advanced multi-agent setups
-*   Add scores (like user feedback)
+*   Add scores (like user feedback) to existing LangGraph traces
 *   Manage your prompts used in LangGraph with Langfuse
 
+This cookbook is structured as a trace-quality progression: basic trace, named and filterable trace, managed prompt trace, multi-agent traces, nested agents in one trace, and finally a scored trace. Each graph invocation creates a new trace; the scoring example attaches feedback to an existing trace instead of creating another one.
 
 ## Initialize Langfuse
 
@@ -48,6 +50,7 @@ os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..." 
 os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
+os.environ["LANGFUSE_TRACING_ENVIRONMENT"] = "development"
 
 # Your openai key
 os.environ["OPENAI_API_KEY"] = "sk-proj-..."
@@ -58,9 +61,9 @@ With the environment variables set, we can now initialize the Langfuse client. g
 
 ```python
 from langfuse import get_client
- 
+
 langfuse = get_client()
- 
+
 # Verify connection
 if langfuse.auth_check():
     print("Langfuse client is authenticated and ready!")
@@ -68,14 +71,14 @@ else:
     print("Authentication failed. Please check your credentials and host.")
 ```
 
-## Example 1: Simple chat app with LangGraph
+## Example 1: Basic LangGraph chatbot trace
 
 **What we will do in this section:**
 
 *   Build a support chatbot in LangGraph that can answer common questions
 *   Tracing the chatbot's input and output using Langfuse
 
-We will start with a basic chatbot and build a more advanced multi agent setup in the next section, introducing key LangGraph concepts along the way.
+We will start with a basic chatbot trace, then improve it with better naming and filtering context in the next example.
 
 ### Create Agent
 
@@ -118,9 +121,9 @@ graph_builder.set_finish_point("chatbot")
 graph = graph_builder.compile()
 ```
 
-### Add Langfuse as callback to the invocation
+### Basic trace with Langfuse callback
 
-Now, we will add then [Langfuse callback handler for LangChain](https://langfuse.com/integrations/frameworks/langchain) to trace the steps of our application: `config={"callbacks": [langfuse_handler]}`
+Now, we will add the [Langfuse callback handler for LangChain](https://langfuse.com/integrations/frameworks/langchain) to trace the steps of our application: `config={"callbacks": [langfuse_handler]}`. This is the minimal setup and may create generic names such as `LangGraph` in the dashboard.
 
 
 ```python
@@ -133,13 +136,6 @@ for s in graph.stream({"messages": [HumanMessage(content = "What is Langfuse?")]
                       config={"callbacks": [langfuse_handler]}):
     print(s)
 ```
-
-### View traces in Langfuse
-
-Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4
-
-
-![Trace view of chat app in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_chatapp_trace.png)
 
 ### Visualize the chat app
 
@@ -163,48 +159,147 @@ graph TD;
 	classDef last fill:#bfb6fc
 ```
 
-### Use Langfuse with LangGraph Server
+## Example 2: Named and filterable chatbot trace
 
-You can add Langfuse as callback when using [LangGraph Server](https://langchain-ai.github.io/langgraph/concepts/langgraph_server/)
+For production applications, add a clear trace name, run name, tags, user/session identifiers, and metadata. This example reuses the chatbot from Example 1, but makes the resulting trace easier to find in the Langfuse dashboard and easier to group with related traces.
 
-When using the LangGraph Server, the LangGraph Server handles graph invocation automatically. Therefore, you should add the Langfuse callback when declaring the graph.
+
+```python
+from langfuse import propagate_attributes
+
+with propagate_attributes(
+    trace_name="LangGraph Simple Chatbot",
+    user_id="user-123",
+    session_id="session-abc",
+    tags=["langgraph", "cookbook", "simple-chatbot"],
+    metadata={"example": "simple-chatbot", "framework": "langgraph"},
+):
+    for s in graph.stream(
+        {"messages": [HumanMessage(content="What is Langfuse?")]},
+        config={
+            "callbacks": [langfuse_handler],
+            "run_name": "handle-chatbot-message",
+        },
+    ):
+        print(s)
+```
+
+### View traces in Langfuse
+
+After running Examples 1 and 2, you will see two traces: one basic automatic trace and one named trace. In the dashboard, use the Trace Name column to find `LangGraph Simple Chatbot` and the Name column to find `handle-chatbot-message`.
+
+Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4
+
+
+![Trace view of chat app in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_chatapp_trace.png)
+
+## Example 3: Use a managed prompt in the chatbot trace
+
+This example keeps the same simple chatbot question from Examples 1 and 2, but fetches a system prompt from Langfuse Prompt Management. The managed prompt asks the model to answer in Spanish. This creates one additional simple chatbot trace that you can compare with the named trace from Example 2.
+
+Langfuse prompt management is basically a Prompt CMS (Content Management System). Alternatively, you can also edit and version the prompt in the Langfuse UI.
+
+*   `Name` that identifies the prompt in Langfuse Prompt Management
+*   Prompt with prompt template incl. `{{input variables}}`
+*   `labels` to include `production` to immediately use prompt as the default
+
+In this example, we create a system prompt for an assistant that answers every user message in Spanish.
+
+
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+langfuse.create_prompt(
+    name="spanish_answer_system-prompt",
+    prompt="You are an assistant that answers every user message in Spanish.",
+    labels=["production"]
+)
+```
+
+![View prompt in Langfuse UI](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_prompt_example.png)
+
+Use the utility method `.get_langchain_prompt()` to transform the Langfuse prompt into a string that can be used in Langchain.
+
+
+**Context:** Langfuse declares input variables in prompt templates using double brackets (`{{input variable}}`). Langchain uses single brackets for declaring input variables in PromptTemplates (`{input variable}`). The utility method `.get_langchain_prompt()` replaces the double brackets with single brackets. In this example, however, we don't use any variables in our prompt.
+
+
+```python
+# Get current production version of prompt and transform the Langfuse prompt into a string that can be used in Langchain
+langfuse_system_prompt = langfuse.get_prompt("spanish_answer_system-prompt")
+langchain_system_prompt = langfuse_system_prompt.get_langchain_prompt()
+
+print(langchain_system_prompt)
+```
+
+Now we can use the new system prompt string to update our assistant.
 
 
 ```python
 from typing import Annotated
-
 from langchain_openai import ChatOpenAI
 from typing_extensions import TypedDict
-
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
 
-from langfuse.langchain import CallbackHandler
-
 class State(TypedDict):
-  messages: Annotated[list, add_messages]
+    messages: Annotated[list, add_messages]
 
 graph_builder = StateGraph(State)
 
 llm = ChatOpenAI(model = "gpt-4o", temperature = 0.2)
 
+# Add the system prompt for our Spanish-answering assistant
+system_prompt = {
+    "role": "system",
+    "content": langchain_system_prompt
+}
+
 def chatbot(state: State):
-  return {"messages": [llm.invoke(state["messages"])]}
+    messages_with_system_prompt = [system_prompt] + state["messages"]
+    response = llm.invoke(messages_with_system_prompt)
+    return {"messages": [response]}
 
 graph_builder.add_node("chatbot", chatbot)
 graph_builder.set_entry_point("chatbot")
 graph_builder.set_finish_point("chatbot")
+graph = graph_builder.compile()
+```
+
+
+```python
+from langfuse import propagate_attributes
+from langfuse.langchain import CallbackHandler
 
 # Initialize Langfuse CallbackHandler for Langchain (tracing)
 langfuse_handler = CallbackHandler()
 
-# Call "with_config" from the compiled graph.
-# It returns a "CompiledGraph", similar to "compile", but with callbacks included.
-# This enables automatic graph tracing without needing to add callbacks manually every time.
-graph = graph_builder.compile().with_config({"callbacks": [langfuse_handler]})
+with propagate_attributes(
+    trace_name="LangGraph Managed Prompt Chatbot",
+    user_id="user-123",
+    session_id="session-abc",
+    tags=["langgraph", "cookbook", "managed-prompt"],
+    metadata={"example": "managed-prompt-chatbot", "framework": "langgraph"},
+):
+    for s in graph.stream(
+        {"messages": [HumanMessage(content="What is Langfuse?")]},
+        config={
+            "callbacks": [langfuse_handler],
+            "run_name": "answer-with-managed-prompt",
+        },
+    ):
+        print(s)
 ```
 
-## Example 2: Multi agent application with LangGraph
+### View trace in Langfuse
+
+After running Example 3, use the Trace Name column to find `LangGraph Managed Prompt Chatbot` and the Name column to find `answer-with-managed-prompt`.
+
+
+## Example 4: Multi-agent traces with supervisor routing
 
 **What we will do in this section**:
 
@@ -379,43 +474,6 @@ workflow.add_edge(START, "supervisor")
 graph_2 = workflow.compile()
 ```
 
-### Add Langfuse as callback to the invocation
-
-Add [Langfuse handler](https://langfuse.com/integrations/frameworks/langchain) as callback: `config={"callbacks": [langfuse_handler]}`
-
-
-```python
-from langfuse.langchain import CallbackHandler
-
-# Initialize Langfuse CallbackHandler for Langchain (tracing)
-langfuse_handler = CallbackHandler()
-
-# Add Langfuse handler as callback: config={"callbacks": [langfuse_handler]}
-# You can also set an optional 'run_name' that will be used as the trace name in Langfuse
-for s in graph_2.stream({"messages": [HumanMessage(content = "How does photosynthesis work?")]},
-                      config={"callbacks": [langfuse_handler]}):
-    print(s)
-    print("----")
-```
-
-
-```python
-# Add Langfuse handler as callback: config={"callbacks": [langfuse_handler]}
-for s in graph_2.stream({"messages": [HumanMessage(content = "What time is it?")]},
-                      config={"callbacks": [langfuse_handler]}):
-    print(s)
-    print("----")
-```
-
-### See traces in Langfuse
-
-Example traces in Langfuse:
-
-1. [How does photosynthesis work?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/7d5f970573b8214d1ca891251e42282c)
-2. [What time is it?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/3a69fe4998df50d42054f8944bd6a8d9)
-
-![Trace view of multi agent in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_multiagent_traces.png)
-
 ### Visualize the agent
 
 You can visualize the graph using the `get_graph` method along with a "draw" method
@@ -444,19 +502,80 @@ graph TD;
 	classDef last fill:#bfb6fc
 ```
 
-## Multiple LangGraph Agents
+### Add Langfuse as callback to the invocation
 
-There are setups where one LangGraph agent uses one or multiple other LangGraph agents. To combine all corresponding spans in one single trace for the multi agent execution, we can pass a custom `trace_id`. 
+Add [Langfuse handler](https://langfuse.com/integrations/frameworks/langchain) as callback: `config={"callbacks": [langfuse_handler]}`. This section runs the graph twice, so you will see two traces in Langfuse: one for the research question and one for the current-time question.
+
+
+```python
+from langfuse import propagate_attributes
+from langfuse.langchain import CallbackHandler
+
+# Initialize Langfuse CallbackHandler for Langchain (tracing)
+langfuse_handler = CallbackHandler()
+
+with propagate_attributes(
+    trace_name="LangGraph Research Agent",
+    user_id="user-123",
+    session_id="session-abc",
+    tags=["langgraph", "cookbook", "multi-agent", "research"],
+    metadata={"example": "multi-agent", "route": "research"},
+):
+    for s in graph_2.stream(
+        {"messages": [HumanMessage(content="How does photosynthesis work?")]},
+        config={
+            "callbacks": [langfuse_handler],
+            "run_name": "answer-research-question",
+        },
+    ):
+        print(s)
+        print("----")
+```
+
+
+```python
+with propagate_attributes(
+    trace_name="LangGraph Time Agent",
+    user_id="user-123",
+    session_id="session-abc",
+    tags=["langgraph", "cookbook", "multi-agent", "tool-calling"],
+    metadata={"example": "multi-agent", "route": "current-time"},
+):
+    for s in graph_2.stream(
+        {"messages": [HumanMessage(content="What time is it?")]},
+        config={
+            "callbacks": [langfuse_handler],
+            "run_name": "answer-time-question",
+        },
+    ):
+        print(s)
+        print("----")
+```
+
+### See traces in Langfuse
+
+Use the Trace Name column to find `LangGraph Research Agent` and `LangGraph Time Agent`. Use the Name column to find `answer-research-question` and `answer-time-question`.
+
+Example traces in Langfuse:
+
+1. [How does photosynthesis work?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/7d5f970573b8214d1ca891251e42282c)
+2. [What time is it?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/3a69fe4998df50d42054f8944bd6a8d9)
+
+![Trace view of multi agent in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_multiagent_traces.png)
+
+## Example 5: Nested LangGraph agents in one trace
+
+There are setups where one LangGraph agent uses one or multiple other LangGraph agents. To combine all corresponding spans in one single trace for the multi agent execution, we can pass a custom `trace_id`. This section creates one trace named `LangGraph Nested Agent` that contains the main agent, the research tool, and the sub-agent call.
 
 First, we generate a trace_id that can be used for both agents to group the agent executions together in one Langfuse trace.
 
 
 ```python
-from langfuse import get_client, Langfuse
+from langfuse import get_client, Langfuse, propagate_attributes
 from langfuse.langchain import CallbackHandler
- 
+
 langfuse = get_client()
- 
+
 # Generate deterministic trace ID from external system
 predefined_trace_id = Langfuse.create_trace_id()
 
@@ -502,15 +621,21 @@ def langgraph_research(question):
   """Conducts research for various topics."""
 
   with langfuse.start_as_current_observation(
-      name="🤖-sub-research-agent",
+      as_type="span",
+      name="call-research-sub-agent",
       trace_context={"trace_id": predefined_trace_id}
   ) as span:
       span.update(input=question)
 
-      response = sub_agent.invoke({"messages": [HumanMessage(content = question)]},
-                        config={"callbacks": [langfuse_handler]})
-    
-      span.update(output= response["messages"][1].content)
+      response = sub_agent.invoke(
+          {"messages": [HumanMessage(content=question)]},
+          config={
+              "callbacks": [langfuse_handler],
+              "run_name": "research-sub-agent",
+          },
+      )
+
+      span.update(output=response["messages"][1].content)
 
   return response["messages"][1].content
 ```
@@ -536,169 +661,111 @@ user_question = "What is Langfuse?"
 
 # Use the predefined trace ID with trace_context
 with langfuse.start_as_current_observation(
-    name="🤖-main-agent",
+    as_type="span",
+    name="run-nested-langgraph-agent",
     trace_context={"trace_id": predefined_trace_id}
 ) as span:
-    span.update(input=user_question)
- 
-    # LangChain execution will be part of this trace
-    response = main_agent.invoke({"messages": [{"role": "user", "content": user_question}]},
-                            config={"callbacks": [langfuse_handler]})
+    with propagate_attributes(
+        trace_name="LangGraph Nested Agent",
+        user_id="user-123",
+        session_id="session-abc",
+        tags=["langgraph", "cookbook", "nested-agent"],
+        metadata={"example": "nested-agent", "framework": "langgraph"},
+    ):
+        span.update(input=user_question)
 
-    span.update(output=response["messages"][1].content)
- 
+        # LangChain execution will be part of this trace
+        response = main_agent.invoke(
+            {"messages": [{"role": "user", "content": user_question}]},
+            config={
+                "callbacks": [langfuse_handler],
+                "run_name": "main-agent",
+            },
+        )
+
+        span.update(output=response["messages"][-1].content)
+
 print(f"Trace ID: {predefined_trace_id}")  # Use this for scoring later
 ```
 
 ### View traces in Langfuse
 
+Use the Trace Name column to find `LangGraph Nested Agent`. This is also the trace we score in the next section.
+
 ![multi agent trace in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/a2a_langgraph.png)
 
 Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4
 
-## Adding scores to traces as scores
+## Example 6: Attach a score to the nested LangGraph trace
 
 [Scores](https://langfuse.com/docs/scores/overview) are used to evaluate single observations or entire traces. They enable you to implement custom quality checks at runtime or facilitate human-in-the-loop evaluation processes.
 
-In the example below, we demonstrate how to score a specific span for `relevance` (a numeric score) and the overall trace for `feedback` (a categorical score). This helps in systematically assessing and improving your application.
+In the example below, we attach user feedback to the `LangGraph Nested Agent` trace created in the previous section. This creates no new trace; it keeps the score connected to a real LangGraph execution instead of creating a separate empty trace.
 
 **→ Learn more about [Custom Scores in Langfuse](https://langfuse.com/docs/scores/custom).**
 
 
 ```python
 from langfuse import get_client
- 
+
 langfuse = get_client()
- 
-# Option 1: Use the yielded span object from the context manager
-with langfuse.start_as_current_observation(
-    as_type="span",
-    name="langgraph-request") as span:
-    # ... LangGraph execution ...
- 
-    # Score using the span object
-    span.score_trace(
-        name="user-feedback",
-        value=1,
-        data_type="NUMERIC",
-        comment="This was correct, thank you"
-    )
- 
-# Option 2: Use langfuse.score_current_trace() if still in context
-with langfuse.start_as_current_observation(as_type="span", name="langgraph-request") as span:
-    # ... LangGraph execution ...
- 
-    # Score using current context
-    langfuse.score_current_trace(
-        name="user-feedback",
-        value=1,
-        data_type="NUMERIC"
-    )
- 
-# Option 3: Use create_score() with trace ID (when outside context)
+
+# Score the trace created in the previous section.
 langfuse.create_score(
     trace_id=predefined_trace_id,
     name="user-feedback",
     value=1,
     data_type="NUMERIC",
-    comment="This was correct, thank you"
+    comment="The answer was helpful and easy to understand."
 )
 ```
 
 ### View trace with score in Langfuse
 
+The score appears on the existing `LangGraph Nested Agent` trace.
+
 Example trace: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/e60a078b828d4fdc7ea22c73193b0fe4
 
 ![Trace view including added score](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_score.png)
 
-## Manage prompts with Langfuse
+## Optional: Configure Langfuse with LangGraph Server
 
-Use [Langfuse prompt management](https://langfuse.com/docs/prompts/example-langchain) to effectively manage and version your prompts. We add the prompt used in this example via the SDK. In production, however, users would update and manage the prompts via the Langfuse UI instead of using the SDK.
-
-Langfuse prompt management is basically a Prompt CMS (Content Management System). Alternatively, you can also edit and version the prompt in the Langfuse UI.
-
-*   `Name` that identifies the prompt in Langfuse Prompt Management
-*   Prompt with prompt template incl. `{{input variables}}`
-*   `labels` to include `production` to immediately use prompt as the default
-
-In this example, we create a system prompt for an assistant that translates every user message into Spanish.
+You can add Langfuse as callback when using [LangGraph Server](https://langchain-ai.github.io/langgraph/concepts/langgraph_server/)
 
 
-```python
-from langfuse import get_client
- 
-langfuse = get_client()
-
-langfuse.create_prompt(
-    name="translator_system-prompt",
-    prompt="You are a translator that translates every input text into Spanish.",
-    labels=["production"]
-)
-```
-
-![View prompt in Langfuse UI](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_prompt_example.png)
-
-Use the utility method `.get_langchain_prompt()` to transform the Langfuse prompt into a string that can be used in Langchain.
-
-
-**Context:** Langfuse declares input variables in prompt templates using double brackets (`{{input variable}}`). Langchain uses single brackets for declaring input variables in PromptTemplates (`{input variable}`). The utility method `.get_langchain_prompt()` replaces the double brackets with single brackets. In this example, however, we don't use any variables in our prompt.
-
-
-```python
-# Get current production version of prompt and transform the Langfuse prompt into a string that can be used in Langchain
-langfuse_system_prompt = langfuse.get_prompt("translator_system-prompt")
-langchain_system_prompt = langfuse_system_prompt.get_langchain_prompt()
-
-print(langchain_system_prompt)
-```
-
-Now we can use the new system prompt string to update our assistant.
+When using the LangGraph Server, the LangGraph Server handles graph invocation automatically. Therefore, you should add the Langfuse callback when declaring the graph.
 
 
 ```python
 from typing import Annotated
+
 from langchain_openai import ChatOpenAI
 from typing_extensions import TypedDict
+
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
 
+from langfuse.langchain import CallbackHandler
+
 class State(TypedDict):
-    messages: Annotated[list, add_messages]
+  messages: Annotated[list, add_messages]
 
 graph_builder = StateGraph(State)
 
 llm = ChatOpenAI(model = "gpt-4o", temperature = 0.2)
 
-# Add the system prompt for our translator assistent
-system_prompt = {
-    "role": "system",
-    "content": langchain_system_prompt
-}
-
 def chatbot(state: State):
-    messages_with_system_prompt = [system_prompt] + state["messages"]
-    response = llm.invoke(messages_with_system_prompt)
-    return {"messages": [response]}
+  return {"messages": [llm.invoke(state["messages"])]}
 
 graph_builder.add_node("chatbot", chatbot)
 graph_builder.set_entry_point("chatbot")
 graph_builder.set_finish_point("chatbot")
-graph = graph_builder.compile()
-```
-
-
-```python
-from langfuse.langchain import CallbackHandler
 
 # Initialize Langfuse CallbackHandler for Langchain (tracing)
 langfuse_handler = CallbackHandler()
 
-# Add Langfuse handler as callback: config={"callbacks": [langfuse_handler]}
-for s in graph.stream({"messages": [HumanMessage(content = "What is Langfuse?")]},
-                      config={"callbacks": [langfuse_handler]}):
-    print(s)
+# Call "with_config" from the compiled graph.
+# It returns a "CompiledGraph", similar to "compile", but with callbacks included.
+# This enables automatic graph tracing without needing to add callbacks manually every time.
+server_graph = graph_builder.compile().with_config({"callbacks": [langfuse_handler]})
 ```
-
-## Add custom spans to a LangGraph trace
-
-Sometimes it is helpful to add custom spans to a LangGraph trace. This [GitHub discussion thread](https://github.com/orgs/langfuse/discussions/2988#discussioncomment-11634600) provides an example of how to do this.

--- a/content/guides/cookbook/integration_langgraph.mdx
+++ b/content/guides/cookbook/integration_langgraph.mdx
@@ -188,8 +188,6 @@ with propagate_attributes(
 
 After running Examples 1 and 2, you will see two traces: one basic automatic trace and one named trace. In the dashboard, use the Trace Name column to find `LangGraph Simple Chatbot` and the Name column to find `handle-chatbot-message`.
 
-Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4
-
 
 ![Trace view of chat app in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_chatapp_trace.png)
 
@@ -693,8 +691,6 @@ print(f"Trace ID: {predefined_trace_id}")  # Use this for scoring later
 Use the Trace Name column to find `LangGraph Nested Agent`. This is also the trace we score in the next section.
 
 ![multi agent trace in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/a2a_langgraph.png)
-
-Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4
 
 ## Example 6: Attach a score to the nested LangGraph trace
 

--- a/content/guides/cookbook/integration_langgraph.mdx
+++ b/content/guides/cookbook/integration_langgraph.mdx
@@ -635,9 +635,9 @@ def langgraph_research(question):
           },
       )
 
-      span.update(output=response["messages"][1].content)
+      span.update(output=response["messages"][-1].content)
 
-  return response["messages"][1].content
+  return response["messages"][-1].content
 ```
 
 Set up a second simple LangGraph agent that uses the new `langgraph_research`. 

--- a/cookbook/integration_langgraph.ipynb
+++ b/cookbook/integration_langgraph.ipynb
@@ -998,9 +998,9 @@
     "          },\n",
     "      )\n",
     "\n",
-    "      span.update(output=response[\"messages\"][1].content)\n",
+    "      span.update(output=response[\"messages\"][-1].content)\n",
     "\n",
-    "  return response[\"messages\"][1].content"
+    "  return response[\"messages\"][-1].content"
    ]
   },
   {

--- a/cookbook/integration_langgraph.ipynb
+++ b/cookbook/integration_langgraph.ipynb
@@ -312,9 +312,7 @@
    "source": [
     "### View traces in Langfuse\n",
     "\n",
-    "After running Examples 1 and 2, you will see two traces: one basic automatic trace and one named trace. In the dashboard, use the Trace Name column to find `LangGraph Simple Chatbot` and the Name column to find `handle-chatbot-message`.\n",
-    "\n",
-    "Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4\n"
+    "After running Examples 1 and 2, you will see two traces: one basic automatic trace and one named trace. In the dashboard, use the Trace Name column to find `LangGraph Simple Chatbot` and the Name column to find `handle-chatbot-message`.\n"
    ]
   },
   {
@@ -1072,9 +1070,7 @@
     "\n",
     "Use the Trace Name column to find `LangGraph Nested Agent`. This is also the trace we score in the next section.\n",
     "\n",
-    "![multi agent trace in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/a2a_langgraph.png)\n",
-    "\n",
-    "Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4"
+    "![multi agent trace in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/a2a_langgraph.png)"
    ]
   },
   {

--- a/cookbook/integration_langgraph.ipynb
+++ b/cookbook/integration_langgraph.ipynb
@@ -43,9 +43,12 @@
     "\n",
     "\n",
     "*   Automatically trace LangGraph application via the Langfuse integration\n",
+    "*   Add clear trace names, run names, tags, and metadata so traces are easier to find in the Langfuse dashboard\n",
     "*   Monitor advanced multi-agent setups\n",
-    "*   Add scores (like user feedback)\n",
-    "*   Manage your prompts used in LangGraph with Langfuse\n"
+    "*   Add scores (like user feedback) to existing LangGraph traces\n",
+    "*   Manage your prompts used in LangGraph with Langfuse\n",
+    "\n",
+    "This cookbook is structured as a trace-quality progression: basic trace, named and filterable trace, managed prompt trace, multi-agent traces, nested agents in one trace, and finally a scored trace. Each graph invocation creates a new trace; the scoring example attaches feedback to an existing trace instead of creating another one."
    ]
   },
   {
@@ -94,6 +97,7 @@
     "os.environ[\"LANGFUSE_SECRET_KEY\"] = \"sk-lf-...\" \n",
     "os.environ[\"LANGFUSE_BASE_URL\"] = \"https://cloud.langfuse.com\" # 🇪🇺 EU region\n",
     "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
+    "os.environ[\"LANGFUSE_TRACING_ENVIRONMENT\"] = \"development\"\n",
     "\n",
     "# Your openai key\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
@@ -113,9 +117,9 @@
    "outputs": [],
    "source": [
     "from langfuse import get_client\n",
-    " \n",
+    "\n",
     "langfuse = get_client()\n",
-    " \n",
+    "\n",
     "# Verify connection\n",
     "if langfuse.auth_check():\n",
     "    print(\"Langfuse client is authenticated and ready!\")\n",
@@ -129,14 +133,14 @@
     "id": "kqYMmi6n9Nh1"
    },
    "source": [
-    "## Example 1: Simple chat app with LangGraph\n",
+    "## Example 1: Basic LangGraph chatbot trace\n",
     "\n",
     "**What we will do in this section:**\n",
     "\n",
     "*   Build a support chatbot in LangGraph that can answer common questions\n",
     "*   Tracing the chatbot's input and output using Langfuse\n",
     "\n",
-    "We will start with a basic chatbot and build a more advanced multi agent setup in the next section, introducing key LangGraph concepts along the way.\n",
+    "We will start with a basic chatbot trace, then improve it with better naming and filtering context in the next example.\n",
     "\n",
     "### Create Agent\n",
     "\n",
@@ -145,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "aGIxgPww6VX6"
    },
@@ -192,9 +196,9 @@
     "id": "IW2SJcRgh7Xo"
    },
    "source": [
-    "### Add Langfuse as callback to the invocation\n",
+    "### Basic trace with Langfuse callback\n",
     "\n",
-    "Now, we will add then [Langfuse callback handler for LangChain](https://langfuse.com/integrations/frameworks/langchain) to trace the steps of our application: `config={\"callbacks\": [langfuse_handler]}`"
+    "Now, we will add the [Langfuse callback handler for LangChain](https://langfuse.com/integrations/frameworks/langchain) to trace the steps of our application: `config={\"callbacks\": [langfuse_handler]}`. This is the minimal setup and may create generic names such as `LangGraph` in the dashboard."
    ]
   },
   {
@@ -217,26 +221,6 @@
     "for s in graph.stream({\"messages\": [HumanMessage(content = \"What is Langfuse?\")]},\n",
     "                      config={\"callbacks\": [langfuse_handler]}):\n",
     "    print(s)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Fdf3ZRnWGZ0N"
-   },
-   "source": [
-    "### View traces in Langfuse\n",
-    "\n",
-    "Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "17Aq7u6_LBR6"
-   },
-   "source": [
-    "![Trace view of chat app in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_chatapp_trace.png)"
    ]
   },
   {
@@ -290,55 +274,229 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Use Langfuse with LangGraph Server\n",
+    "## Example 2: Named and filterable chatbot trace\n",
     "\n",
-    "You can add Langfuse as callback when using [LangGraph Server](https://langchain-ai.github.io/langgraph/concepts/langgraph_server/)"
+    "For production applications, add a clear trace name, run name, tags, user/session identifiers, and metadata. This example reuses the chatbot from Example 1, but makes the resulting trace easier to find in the Langfuse dashboard and easier to group with related traces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langfuse import propagate_attributes\n",
+    "\n",
+    "with propagate_attributes(\n",
+    "    trace_name=\"LangGraph Simple Chatbot\",\n",
+    "    user_id=\"user-123\",\n",
+    "    session_id=\"session-abc\",\n",
+    "    tags=[\"langgraph\", \"cookbook\", \"simple-chatbot\"],\n",
+    "    metadata={\"example\": \"simple-chatbot\", \"framework\": \"langgraph\"},\n",
+    "):\n",
+    "    for s in graph.stream(\n",
+    "        {\"messages\": [HumanMessage(content=\"What is Langfuse?\")]},\n",
+    "        config={\n",
+    "            \"callbacks\": [langfuse_handler],\n",
+    "            \"run_name\": \"handle-chatbot-message\",\n",
+    "        },\n",
+    "    ):\n",
+    "        print(s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fdf3ZRnWGZ0N"
+   },
+   "source": [
+    "### View traces in Langfuse\n",
+    "\n",
+    "After running Examples 1 and 2, you will see two traces: one basic automatic trace and one named trace. In the dashboard, use the Trace Name column to find `LangGraph Simple Chatbot` and the Name column to find `handle-chatbot-message`.\n",
+    "\n",
+    "Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/85b0c53c4414f22ed8bfc9eb35f917c4\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "17Aq7u6_LBR6"
+   },
+   "source": [
+    "![Trace view of chat app in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_chatapp_trace.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6cIQVrYZJVMO"
+   },
+   "source": [
+    "## Example 3: Use a managed prompt in the chatbot trace\n",
+    "\n",
+    "This example keeps the same simple chatbot question from Examples 1 and 2, but fetches a system prompt from Langfuse Prompt Management. The managed prompt asks the model to answer in Spanish. This creates one additional simple chatbot trace that you can compare with the named trace from Example 2.\n",
+    "\n",
+    "Langfuse prompt management is basically a Prompt CMS (Content Management System). Alternatively, you can also edit and version the prompt in the Langfuse UI.\n",
+    "\n",
+    "*   `Name` that identifies the prompt in Langfuse Prompt Management\n",
+    "*   Prompt with prompt template incl. `{{input variables}}`\n",
+    "*   `labels` to include `production` to immediately use prompt as the default\n",
+    "\n",
+    "In this example, we create a system prompt for an assistant that answers every user message in Spanish.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "H0J8-nbhUUz6",
+    "outputId": "ee71e43d-9f77-451d-b71c-f77cd297b065"
+   },
+   "outputs": [],
+   "source": [
+    "from langfuse import get_client\n",
+    "\n",
+    "langfuse = get_client()\n",
+    "\n",
+    "langfuse.create_prompt(\n",
+    "    name=\"spanish_answer_system-prompt\",\n",
+    "    prompt=\"You are an assistant that answers every user message in Spanish.\",\n",
+    "    labels=[\"production\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Dullp4XDXhzg"
+   },
+   "source": [
+    "![View prompt in Langfuse UI](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_prompt_example.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pNboOjf2YQpD"
+   },
+   "source": [
+    "Use the utility method `.get_langchain_prompt()` to transform the Langfuse prompt into a string that can be used in Langchain.\n",
+    "\n",
+    "\n",
+    "**Context:** Langfuse declares input variables in prompt templates using double brackets (`{{input variable}}`). Langchain uses single brackets for declaring input variables in PromptTemplates (`{input variable}`). The utility method `.get_langchain_prompt()` replaces the double brackets with single brackets. In this example, however, we don't use any variables in our prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "z49I82blYeXy",
+    "outputId": "6cf7cd23-6dde-4e7b-ae50-e369db37c2d0"
+   },
+   "outputs": [],
+   "source": [
+    "# Get current production version of prompt and transform the Langfuse prompt into a string that can be used in Langchain\n",
+    "langfuse_system_prompt = langfuse.get_prompt(\"spanish_answer_system-prompt\")\n",
+    "langchain_system_prompt = langfuse_system_prompt.get_langchain_prompt()\n",
+    "\n",
+    "print(langchain_system_prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n3zBULfCt0Wq"
+   },
+   "source": [
+    "Now we can use the new system prompt string to update our assistant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oGQhulyMmvZD"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import Annotated\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from typing_extensions import TypedDict\n",
+    "from langgraph.graph import StateGraph\n",
+    "from langgraph.graph.message import add_messages\n",
+    "\n",
+    "class State(TypedDict):\n",
+    "    messages: Annotated[list, add_messages]\n",
+    "\n",
+    "graph_builder = StateGraph(State)\n",
+    "\n",
+    "llm = ChatOpenAI(model = \"gpt-4o\", temperature = 0.2)\n",
+    "\n",
+    "# Add the system prompt for our Spanish-answering assistant\n",
+    "system_prompt = {\n",
+    "    \"role\": \"system\",\n",
+    "    \"content\": langchain_system_prompt\n",
+    "}\n",
+    "\n",
+    "def chatbot(state: State):\n",
+    "    messages_with_system_prompt = [system_prompt] + state[\"messages\"]\n",
+    "    response = llm.invoke(messages_with_system_prompt)\n",
+    "    return {\"messages\": [response]}\n",
+    "\n",
+    "graph_builder.add_node(\"chatbot\", chatbot)\n",
+    "graph_builder.set_entry_point(\"chatbot\")\n",
+    "graph_builder.set_finish_point(\"chatbot\")\n",
+    "graph = graph_builder.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "YYd7wbttm2ec",
+    "outputId": "fdc18797-3b3b-4cae-9ebb-8b9d946494c1"
+   },
+   "outputs": [],
+   "source": [
+    "from langfuse import propagate_attributes\n",
+    "from langfuse.langchain import CallbackHandler\n",
+    "\n",
+    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
+    "langfuse_handler = CallbackHandler()\n",
+    "\n",
+    "with propagate_attributes(\n",
+    "    trace_name=\"LangGraph Managed Prompt Chatbot\",\n",
+    "    user_id=\"user-123\",\n",
+    "    session_id=\"session-abc\",\n",
+    "    tags=[\"langgraph\", \"cookbook\", \"managed-prompt\"],\n",
+    "    metadata={\"example\": \"managed-prompt-chatbot\", \"framework\": \"langgraph\"},\n",
+    "):\n",
+    "    for s in graph.stream(\n",
+    "        {\"messages\": [HumanMessage(content=\"What is Langfuse?\")]},\n",
+    "        config={\n",
+    "            \"callbacks\": [langfuse_handler],\n",
+    "            \"run_name\": \"answer-with-managed-prompt\",\n",
+    "        },\n",
+    "    ):\n",
+    "        print(s)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the LangGraph Server, the LangGraph Server handles graph invocation automatically. Therefore, you should add the Langfuse callback when declaring the graph."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from typing import Annotated\n",
+    "### View trace in Langfuse\n",
     "\n",
-    "from langchain_openai import ChatOpenAI\n",
-    "from typing_extensions import TypedDict\n",
-    "\n",
-    "from langgraph.graph import StateGraph\n",
-    "from langgraph.graph.message import add_messages\n",
-    "\n",
-    "from langfuse.langchain import CallbackHandler\n",
-    "\n",
-    "class State(TypedDict):\n",
-    "  messages: Annotated[list, add_messages]\n",
-    "\n",
-    "graph_builder = StateGraph(State)\n",
-    "\n",
-    "llm = ChatOpenAI(model = \"gpt-4o\", temperature = 0.2)\n",
-    "\n",
-    "def chatbot(state: State):\n",
-    "  return {\"messages\": [llm.invoke(state[\"messages\"])]}\n",
-    "\n",
-    "graph_builder.add_node(\"chatbot\", chatbot)\n",
-    "graph_builder.set_entry_point(\"chatbot\")\n",
-    "graph_builder.set_finish_point(\"chatbot\")\n",
-    "\n",
-    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
-    "langfuse_handler = CallbackHandler()\n",
-    "\n",
-    "# Call \"with_config\" from the compiled graph.\n",
-    "# It returns a \"CompiledGraph\", similar to \"compile\", but with callbacks included.\n",
-    "# This enables automatic graph tracing without needing to add callbacks manually every time.\n",
-    "graph = graph_builder.compile().with_config({\"callbacks\": [langfuse_handler]})"
+    "After running Example 3, use the Trace Name column to find `LangGraph Managed Prompt Chatbot` and the Name column to find `answer-with-managed-prompt`.\n"
    ]
   },
   {
@@ -347,7 +505,7 @@
     "id": "n2W94eY19TR1"
    },
    "source": [
-    "## Example 2: Multi agent application with LangGraph\n",
+    "## Example 4: Multi-agent traces with supervisor routing\n",
     "\n",
     "**What we will do in this section**:\n",
     "\n",
@@ -385,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "Cet0loyp9p-T"
    },
@@ -429,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "id": "75atiExdqd4P"
    },
@@ -535,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "id": "_LwtCmw_rHVz"
    },
@@ -584,84 +742,6 @@
     "\n",
     "# To be able to run our graph, call \"compile()\" on the graph builder. This creates a \"CompiledGraph\" we can use invoke on our state.\n",
     "graph_2 = workflow.compile()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "w3xfJLJyFwBG"
-   },
-   "source": [
-    "### Add Langfuse as callback to the invocation\n",
-    "\n",
-    "Add [Langfuse handler](https://langfuse.com/integrations/frameworks/langchain) as callback: `config={\"callbacks\": [langfuse_handler]}`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "QsX1gw9kryGP",
-    "outputId": "65d94f3c-17e7-4ad8-88b5-f837676d206b"
-   },
-   "outputs": [],
-   "source": [
-    "from langfuse.langchain import CallbackHandler\n",
-    "\n",
-    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
-    "langfuse_handler = CallbackHandler()\n",
-    "\n",
-    "# Add Langfuse handler as callback: config={\"callbacks\": [langfuse_handler]}\n",
-    "# You can also set an optional 'run_name' that will be used as the trace name in Langfuse\n",
-    "for s in graph_2.stream({\"messages\": [HumanMessage(content = \"How does photosynthesis work?\")]},\n",
-    "                      config={\"callbacks\": [langfuse_handler]}):\n",
-    "    print(s)\n",
-    "    print(\"----\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "AqJnMtP5HDql",
-    "outputId": "69c3d5d6-d44c-4784-a484-c66e4748b522"
-   },
-   "outputs": [],
-   "source": [
-    "# Add Langfuse handler as callback: config={\"callbacks\": [langfuse_handler]}\n",
-    "for s in graph_2.stream({\"messages\": [HumanMessage(content = \"What time is it?\")]},\n",
-    "                      config={\"callbacks\": [langfuse_handler]}):\n",
-    "    print(s)\n",
-    "    print(\"----\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "o4XjtNenH9GF"
-   },
-   "source": [
-    "### See traces in Langfuse\n",
-    "\n",
-    "Example traces in Langfuse:\n",
-    "\n",
-    "1. [How does photosynthesis work?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/7d5f970573b8214d1ca891251e42282c)\n",
-    "2. [What time is it?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/3a69fe4998df50d42054f8944bd6a8d9)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "_-5EEBZAIbwc"
-   },
-   "source": [
-    "![Trace view of multi agent in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_multiagent_traces.png)"
    ]
   },
   {
@@ -719,26 +799,128 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "w3xfJLJyFwBG"
+   },
+   "source": [
+    "### Add Langfuse as callback to the invocation\n",
+    "\n",
+    "Add [Langfuse handler](https://langfuse.com/integrations/frameworks/langchain) as callback: `config={\"callbacks\": [langfuse_handler]}`. This section runs the graph twice, so you will see two traces in Langfuse: one for the research question and one for the current-time question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "QsX1gw9kryGP",
+    "outputId": "65d94f3c-17e7-4ad8-88b5-f837676d206b"
+   },
+   "outputs": [],
+   "source": [
+    "from langfuse import propagate_attributes\n",
+    "from langfuse.langchain import CallbackHandler\n",
+    "\n",
+    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
+    "langfuse_handler = CallbackHandler()\n",
+    "\n",
+    "with propagate_attributes(\n",
+    "    trace_name=\"LangGraph Research Agent\",\n",
+    "    user_id=\"user-123\",\n",
+    "    session_id=\"session-abc\",\n",
+    "    tags=[\"langgraph\", \"cookbook\", \"multi-agent\", \"research\"],\n",
+    "    metadata={\"example\": \"multi-agent\", \"route\": \"research\"},\n",
+    "):\n",
+    "    for s in graph_2.stream(\n",
+    "        {\"messages\": [HumanMessage(content=\"How does photosynthesis work?\")]},\n",
+    "        config={\n",
+    "            \"callbacks\": [langfuse_handler],\n",
+    "            \"run_name\": \"answer-research-question\",\n",
+    "        },\n",
+    "    ):\n",
+    "        print(s)\n",
+    "        print(\"----\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "AqJnMtP5HDql",
+    "outputId": "69c3d5d6-d44c-4784-a484-c66e4748b522"
+   },
+   "outputs": [],
+   "source": [
+    "with propagate_attributes(\n",
+    "    trace_name=\"LangGraph Time Agent\",\n",
+    "    user_id=\"user-123\",\n",
+    "    session_id=\"session-abc\",\n",
+    "    tags=[\"langgraph\", \"cookbook\", \"multi-agent\", \"tool-calling\"],\n",
+    "    metadata={\"example\": \"multi-agent\", \"route\": \"current-time\"},\n",
+    "):\n",
+    "    for s in graph_2.stream(\n",
+    "        {\"messages\": [HumanMessage(content=\"What time is it?\")]},\n",
+    "        config={\n",
+    "            \"callbacks\": [langfuse_handler],\n",
+    "            \"run_name\": \"answer-time-question\",\n",
+    "        },\n",
+    "    ):\n",
+    "        print(s)\n",
+    "        print(\"----\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "o4XjtNenH9GF"
+   },
+   "source": [
+    "### See traces in Langfuse\n",
+    "\n",
+    "Use the Trace Name column to find `LangGraph Research Agent` and `LangGraph Time Agent`. Use the Name column to find `answer-research-question` and `answer-time-question`.\n",
+    "\n",
+    "Example traces in Langfuse:\n",
+    "\n",
+    "1. [How does photosynthesis work?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/7d5f970573b8214d1ca891251e42282c)\n",
+    "2. [What time is it?](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/3a69fe4998df50d42054f8944bd6a8d9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_-5EEBZAIbwc"
+   },
+   "source": [
+    "![Trace view of multi agent in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_multiagent_traces.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Multiple LangGraph Agents\n",
+    "## Example 5: Nested LangGraph agents in one trace\n",
     "\n",
-    "There are setups where one LangGraph agent uses one or multiple other LangGraph agents. To combine all corresponding spans in one single trace for the multi agent execution, we can pass a custom `trace_id`. \n",
+    "There are setups where one LangGraph agent uses one or multiple other LangGraph agents. To combine all corresponding spans in one single trace for the multi agent execution, we can pass a custom `trace_id`. This section creates one trace named `LangGraph Nested Agent` that contains the main agent, the research tool, and the sub-agent call.\n",
     "\n",
     "First, we generate a trace_id that can be used for both agents to group the agent executions together in one Langfuse trace."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langfuse import get_client, Langfuse\n",
+    "from langfuse import get_client, Langfuse, propagate_attributes\n",
     "from langfuse.langchain import CallbackHandler\n",
-    " \n",
+    "\n",
     "langfuse = get_client()\n",
-    " \n",
+    "\n",
     "# Generate deterministic trace ID from external system\n",
     "predefined_trace_id = Langfuse.create_trace_id()\n",
     "\n",
@@ -755,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +976,32 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from langchain_core.tools import tool\n\n@tool\ndef langgraph_research(question):\n  \"\"\"Conducts research for various topics.\"\"\"\n\n  with langfuse.start_as_current_observation(\n      name=\"🤖-sub-research-agent\",\n      trace_context={\"trace_id\": predefined_trace_id}\n  ) as span:\n      span.update(input=question)\n\n      response = sub_agent.invoke({\"messages\": [HumanMessage(content = question)]},\n                        config={\"callbacks\": [langfuse_handler]})\n    \n      span.update(output= response[\"messages\"][1].content)\n\n  return response[\"messages\"][1].content"
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "@tool\n",
+    "def langgraph_research(question):\n",
+    "  \"\"\"Conducts research for various topics.\"\"\"\n",
+    "\n",
+    "  with langfuse.start_as_current_observation(\n",
+    "      as_type=\"span\",\n",
+    "      name=\"call-research-sub-agent\",\n",
+    "      trace_context={\"trace_id\": predefined_trace_id}\n",
+    "  ) as span:\n",
+    "      span.update(input=question)\n",
+    "\n",
+    "      response = sub_agent.invoke(\n",
+    "          {\"messages\": [HumanMessage(content=question)]},\n",
+    "          config={\n",
+    "              \"callbacks\": [langfuse_handler],\n",
+    "              \"run_name\": \"research-sub-agent\",\n",
+    "          },\n",
+    "      )\n",
+    "\n",
+    "      span.update(output=response[\"messages\"][1].content)\n",
+    "\n",
+    "  return response[\"messages\"][1].content"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -805,7 +1012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,13 +1032,45 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "user_question = \"What is Langfuse?\"\n\n# Use the predefined trace ID with trace_context\nwith langfuse.start_as_current_observation(\n    name=\"🤖-main-agent\",\n    trace_context={\"trace_id\": predefined_trace_id}\n) as span:\n    span.update(input=user_question)\n \n    # LangChain execution will be part of this trace\n    response = main_agent.invoke({\"messages\": [{\"role\": \"user\", \"content\": user_question}]},\n                            config={\"callbacks\": [langfuse_handler]})\n\n    span.update(output=response[\"messages\"][1].content)\n \nprint(f\"Trace ID: {predefined_trace_id}\")  # Use this for scoring later"
+   "source": [
+    "user_question = \"What is Langfuse?\"\n",
+    "\n",
+    "# Use the predefined trace ID with trace_context\n",
+    "with langfuse.start_as_current_observation(\n",
+    "    as_type=\"span\",\n",
+    "    name=\"run-nested-langgraph-agent\",\n",
+    "    trace_context={\"trace_id\": predefined_trace_id}\n",
+    ") as span:\n",
+    "    with propagate_attributes(\n",
+    "        trace_name=\"LangGraph Nested Agent\",\n",
+    "        user_id=\"user-123\",\n",
+    "        session_id=\"session-abc\",\n",
+    "        tags=[\"langgraph\", \"cookbook\", \"nested-agent\"],\n",
+    "        metadata={\"example\": \"nested-agent\", \"framework\": \"langgraph\"},\n",
+    "    ):\n",
+    "        span.update(input=user_question)\n",
+    "\n",
+    "        # LangChain execution will be part of this trace\n",
+    "        response = main_agent.invoke(\n",
+    "            {\"messages\": [{\"role\": \"user\", \"content\": user_question}]},\n",
+    "            config={\n",
+    "                \"callbacks\": [langfuse_handler],\n",
+    "                \"run_name\": \"main-agent\",\n",
+    "            },\n",
+    "        )\n",
+    "\n",
+    "        span.update(output=response[\"messages\"][-1].content)\n",
+    "\n",
+    "print(f\"Trace ID: {predefined_trace_id}\")  # Use this for scoring later"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### View traces in Langfuse\n",
+    "\n",
+    "Use the Trace Name column to find `LangGraph Nested Agent`. This is also the trace we score in the next section.\n",
     "\n",
     "![multi agent trace in Langfuse](https://langfuse.com/images/cookbook/integration-langgraph/a2a_langgraph.png)\n",
     "\n",
@@ -844,11 +1083,11 @@
     "id": "uybP4h8wGvWw"
    },
    "source": [
-    "## Adding scores to traces as scores\n",
+    "## Example 6: Attach a score to the nested LangGraph trace\n",
     "\n",
     "[Scores](https://langfuse.com/docs/scores/overview) are used to evaluate single observations or entire traces. They enable you to implement custom quality checks at runtime or facilitate human-in-the-loop evaluation processes.\n",
     "\n",
-    "In the example below, we demonstrate how to score a specific span for `relevance` (a numeric score) and the overall trace for `feedback` (a categorical score). This helps in systematically assessing and improving your application.\n",
+    "In the example below, we attach user feedback to the `LangGraph Nested Agent` trace created in the previous section. This creates no new trace; it keeps the score connected to a real LangGraph execution instead of creating a separate empty trace.\n",
     "\n",
     "**→ Learn more about [Custom Scores in Langfuse](https://langfuse.com/docs/scores/custom).**"
    ]
@@ -866,41 +1105,16 @@
    "outputs": [],
    "source": [
     "from langfuse import get_client\n",
-    " \n",
+    "\n",
     "langfuse = get_client()\n",
-    " \n",
-    "# Option 1: Use the yielded span object from the context manager\n",
-    "with langfuse.start_as_current_observation(\n",
-    "    as_type=\"span\",\n",
-    "    name=\"langgraph-request\") as span:\n",
-    "    # ... LangGraph execution ...\n",
-    " \n",
-    "    # Score using the span object\n",
-    "    span.score_trace(\n",
-    "        name=\"user-feedback\",\n",
-    "        value=1,\n",
-    "        data_type=\"NUMERIC\",\n",
-    "        comment=\"This was correct, thank you\"\n",
-    "    )\n",
-    " \n",
-    "# Option 2: Use langfuse.score_current_trace() if still in context\n",
-    "with langfuse.start_as_current_observation(as_type=\"span\", name=\"langgraph-request\") as span:\n",
-    "    # ... LangGraph execution ...\n",
-    " \n",
-    "    # Score using current context\n",
-    "    langfuse.score_current_trace(\n",
-    "        name=\"user-feedback\",\n",
-    "        value=1,\n",
-    "        data_type=\"NUMERIC\"\n",
-    "    )\n",
-    " \n",
-    "# Option 3: Use create_score() with trace ID (when outside context)\n",
+    "\n",
+    "# Score the trace created in the previous section.\n",
     "langfuse.create_score(\n",
     "    trace_id=predefined_trace_id,\n",
     "    name=\"user-feedback\",\n",
     "    value=1,\n",
     "    data_type=\"NUMERIC\",\n",
-    "    comment=\"This was correct, thank you\"\n",
+    "    comment=\"The answer was helpful and easy to understand.\"\n",
     ")"
    ]
   },
@@ -912,6 +1126,8 @@
    "source": [
     "### View trace with score in Langfuse\n",
     "\n",
+    "The score appears on the existing `LangGraph Nested Agent` trace.\n",
+    "\n",
     "Example trace: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/e60a078b828d4fdc7ea22c73193b0fe4\n",
     "\n",
     "![Trace view including added score](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_score.png)"
@@ -919,163 +1135,57 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "6cIQVrYZJVMO"
-   },
+   "metadata": {},
    "source": [
-    "## Manage prompts with Langfuse\n",
+    "## Optional: Configure Langfuse with LangGraph Server\n",
     "\n",
-    "Use [Langfuse prompt management](https://langfuse.com/docs/prompts/example-langchain) to effectively manage and version your prompts. We add the prompt used in this example via the SDK. In production, however, users would update and manage the prompts via the Langfuse UI instead of using the SDK.\n",
-    "\n",
-    "Langfuse prompt management is basically a Prompt CMS (Content Management System). Alternatively, you can also edit and version the prompt in the Langfuse UI.\n",
-    "\n",
-    "*   `Name` that identifies the prompt in Langfuse Prompt Management\n",
-    "*   Prompt with prompt template incl. `{{input variables}}`\n",
-    "*   `labels` to include `production` to immediately use prompt as the default\n",
-    "\n",
-    "In this example, we create a system prompt for an assistant that translates every user message into Spanish."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "H0J8-nbhUUz6",
-    "outputId": "ee71e43d-9f77-451d-b71c-f77cd297b065"
-   },
-   "outputs": [],
-   "source": [
-    "from langfuse import get_client\n",
-    " \n",
-    "langfuse = get_client()\n",
-    "\n",
-    "langfuse.create_prompt(\n",
-    "    name=\"translator_system-prompt\",\n",
-    "    prompt=\"You are a translator that translates every input text into Spanish.\",\n",
-    "    labels=[\"production\"]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Dullp4XDXhzg"
-   },
-   "source": [
-    "![View prompt in Langfuse UI](https://langfuse.com/images/cookbook/integration-langgraph/integration_langgraph_prompt_example.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pNboOjf2YQpD"
-   },
-   "source": [
-    "Use the utility method `.get_langchain_prompt()` to transform the Langfuse prompt into a string that can be used in Langchain.\n",
-    "\n",
-    "\n",
-    "**Context:** Langfuse declares input variables in prompt templates using double brackets (`{{input variable}}`). Langchain uses single brackets for declaring input variables in PromptTemplates (`{input variable}`). The utility method `.get_langchain_prompt()` replaces the double brackets with single brackets. In this example, however, we don't use any variables in our prompt."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "z49I82blYeXy",
-    "outputId": "6cf7cd23-6dde-4e7b-ae50-e369db37c2d0"
-   },
-   "outputs": [],
-   "source": [
-    "# Get current production version of prompt and transform the Langfuse prompt into a string that can be used in Langchain\n",
-    "langfuse_system_prompt = langfuse.get_prompt(\"translator_system-prompt\")\n",
-    "langchain_system_prompt = langfuse_system_prompt.get_langchain_prompt()\n",
-    "\n",
-    "print(langchain_system_prompt)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "n3zBULfCt0Wq"
-   },
-   "source": [
-    "Now we can use the new system prompt string to update our assistant."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "id": "oGQhulyMmvZD"
-   },
-   "outputs": [],
-   "source": [
-    "from typing import Annotated\n",
-    "from langchain_openai import ChatOpenAI\n",
-    "from typing_extensions import TypedDict\n",
-    "from langgraph.graph import StateGraph\n",
-    "from langgraph.graph.message import add_messages\n",
-    "\n",
-    "class State(TypedDict):\n",
-    "    messages: Annotated[list, add_messages]\n",
-    "\n",
-    "graph_builder = StateGraph(State)\n",
-    "\n",
-    "llm = ChatOpenAI(model = \"gpt-4o\", temperature = 0.2)\n",
-    "\n",
-    "# Add the system prompt for our translator assistent\n",
-    "system_prompt = {\n",
-    "    \"role\": \"system\",\n",
-    "    \"content\": langchain_system_prompt\n",
-    "}\n",
-    "\n",
-    "def chatbot(state: State):\n",
-    "    messages_with_system_prompt = [system_prompt] + state[\"messages\"]\n",
-    "    response = llm.invoke(messages_with_system_prompt)\n",
-    "    return {\"messages\": [response]}\n",
-    "\n",
-    "graph_builder.add_node(\"chatbot\", chatbot)\n",
-    "graph_builder.set_entry_point(\"chatbot\")\n",
-    "graph_builder.set_finish_point(\"chatbot\")\n",
-    "graph = graph_builder.compile()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "YYd7wbttm2ec",
-    "outputId": "fdc18797-3b3b-4cae-9ebb-8b9d946494c1"
-   },
-   "outputs": [],
-   "source": [
-    "from langfuse.langchain import CallbackHandler\n",
-    "\n",
-    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
-    "langfuse_handler = CallbackHandler()\n",
-    "\n",
-    "# Add Langfuse handler as callback: config={\"callbacks\": [langfuse_handler]}\n",
-    "for s in graph.stream({\"messages\": [HumanMessage(content = \"What is Langfuse?\")]},\n",
-    "                      config={\"callbacks\": [langfuse_handler]}):\n",
-    "    print(s)"
+    "You can add Langfuse as callback when using [LangGraph Server](https://langchain-ai.github.io/langgraph/concepts/langgraph_server/)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Add custom spans to a LangGraph trace\n",
+    "When using the LangGraph Server, the LangGraph Server handles graph invocation automatically. Therefore, you should add the Langfuse callback when declaring the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Annotated\n",
     "\n",
-    "Sometimes it is helpful to add custom spans to a LangGraph trace. This [GitHub discussion thread](https://github.com/orgs/langfuse/discussions/2988#discussioncomment-11634600) provides an example of how to do this."
+    "from langchain_openai import ChatOpenAI\n",
+    "from typing_extensions import TypedDict\n",
+    "\n",
+    "from langgraph.graph import StateGraph\n",
+    "from langgraph.graph.message import add_messages\n",
+    "\n",
+    "from langfuse.langchain import CallbackHandler\n",
+    "\n",
+    "class State(TypedDict):\n",
+    "  messages: Annotated[list, add_messages]\n",
+    "\n",
+    "graph_builder = StateGraph(State)\n",
+    "\n",
+    "llm = ChatOpenAI(model = \"gpt-4o\", temperature = 0.2)\n",
+    "\n",
+    "def chatbot(state: State):\n",
+    "  return {\"messages\": [llm.invoke(state[\"messages\"])]}\n",
+    "\n",
+    "graph_builder.add_node(\"chatbot\", chatbot)\n",
+    "graph_builder.set_entry_point(\"chatbot\")\n",
+    "graph_builder.set_finish_point(\"chatbot\")\n",
+    "\n",
+    "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",
+    "langfuse_handler = CallbackHandler()\n",
+    "\n",
+    "# Call \"with_config\" from the compiled graph.\n",
+    "# It returns a \"CompiledGraph\", similar to \"compile\", but with callbacks included.\n",
+    "# This enables automatic graph tracing without needing to add callbacks manually every time.\n",
+    "server_graph = graph_builder.compile().with_config({\"callbacks\": [langfuse_handler]})"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Improves the LangGraph integration cookbook so the generated Langfuse traces are easier to understand in the dashboard.

Stacked on #3103.

Linear: [LF-2204](https://linear.app/langfuse/issue/LF-2204/update-langgraph-cookbook-to-produce-clearer-langfuse-traces)

## Changes

- Restructure the cookbook into a clearer trace progression: basic trace, named/filterable trace, managed prompt trace, multi-agent traces, nested-agent trace, and scored trace.
- Add explicit trace names, run names, tags, user/session identifiers, metadata, and environment separation to make dashboard rows easier to find and compare.
- Clarify which examples create new traces and which example attaches a score to an existing trace.
- Move the LangGraph Server configuration into an optional final section.
- Regenerate `content/guides/cookbook/integration_langgraph.mdx` from the notebook via `bash scripts/update_cookbook_docs.sh`.

## Validation

- Ran the notebook locally against Langfuse and verified the expected dashboard traces.
- Verified notebook JSON and Python code-cell syntax locally.
- Ran `node scripts/check-h1-headings.js content/guides/cookbook/integration_langgraph.mdx`.
- Ran `git diff --check`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restructures the LangGraph integration cookbook into a six-step trace-quality progression — from a minimal callback trace up to named/filterable, managed-prompt, multi-agent, nested-agent, and scored traces — and moves LangGraph Server config into an optional final section.

- Adds `propagate_attributes` with `trace_name`, `user_id`, `session_id`, `tags`, `metadata`, and `run_name` to every graph invocation so dashboard rows are immediately identifiable.
- Replaces the old three-option scoring cell with a single `create_score` call that attaches feedback to the `predefined_trace_id` from Example 5, eliminating the dummy empty-trace anti-pattern.
- Sets `LANGFUSE_TRACING_ENVIRONMENT=development` in the setup cell and regenerates the `.mdx` from the notebook.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The cookbook restructuring is well-executed and the code examples are functionally correct; the two observations are quality-level refinements.

All Python code cells were verified locally per the PR description, and the trace progression is logically coherent. The only items worth addressing before finalising are a stale example trace URL in the new Example 2 section and a minor message-index inconsistency inside the langgraph_research tool that the author partially fixed in the main execution but did not carry through to the tool itself.

The example trace URL in the Example 2 View traces in Langfuse section of integration_langgraph.mdx (and identically in the notebook) should point to an actual Example 2 trace rather than reusing the old Example 1 link.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Example 1: Basic trace - CallbackHandler only"] --> B["Example 2: Named trace - propagate_attributes + run_name"]
    B --> C["Example 3: Managed prompt - Langfuse Prompt Management"]
    C --> D["Example 4: Multi-agent - supervisor routing"]
    D --> E["Example 5: Nested agents - predefined_trace_id"]
    E --> F["Example 6: Score existing trace - create_score"]
    F --> G["Optional: LangGraph Server - compile with_config"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Example 1: Basic trace - CallbackHandler only"] --> B["Example 2: Named trace - propagate_attributes + run_name"]
    B --> C["Example 3: Managed prompt - Langfuse Prompt Management"]
    C --> D["Example 4: Multi-agent - supervisor routing"]
    D --> E["Example 5: Nested agents - predefined_trace_id"]
    E --> F["Example 6: Score existing trace - create_score"]
    F --> G["Optional: LangGraph Server - compile with_config"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/guides/cookbook/integration_langgraph.mdx:191-193
**Stale example trace URL for new Example 2**

The "View traces in Langfuse" section after Examples 1 & 2 reuses the trace ID from the pre-existing Example 1 link (`85b0c53c4414f22ed8bfc9eb35f917c4`). Since Example 2 is a new named/filterable trace that was run locally (per the PR description), this should point to an actual trace that shows `trace_name="LangGraph Simple Chatbot"` in the dashboard so readers can verify the naming behaviour.

### Issue 2 of 2
content/guides/cookbook/integration_langgraph.mdx:638-640
**Inconsistent message index for sub-agent output**

The main execution in Example 5 was updated to use `response["messages"][-1].content` (more robust), but the `langgraph_research` tool still uses the hardcoded index `[1]`. For the current simple chatbot sub-agent the values are equivalent, but using `[-1]` throughout keeps the pattern consistent and avoids a hard failure if the sub-agent graph ever produces additional intermediate messages.

```suggestion
      span.update(output=response["messages"][-1].content)

  return response["messages"][-1].content
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: improve LangGraph cookbook trace c..."](https://github.com/langfuse/langfuse-docs/commit/33b05a14a37c84681e379d95e5d33eb7169dabfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38390042)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->