### PR TITLE
docs: move ClickHouse Agentic Data Stack into Other integrations

### DIFF
--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -353,9 +353,9 @@ const marqueeRow2: MarqueeItem[] = [
     icon: "/images/integrations/temporal.svg",
   },
   {
-    label: "Agentic Data Stack",
-    href: "/integrations/agentic-data-stack",
-    icon: "/images/integrations/opentelemetry_icon.svg",
+    label: "ClickHouse Agentic Data Stack",
+    href: "/integrations/other/agentic-data-stack",
+    icon: "/images/integrations/clickhouse_icon.svg",
   },
   {
     label: "Mastra",

--- a/content/integrations/meta.json
+++ b/content/integrations/meta.json
@@ -8,7 +8,6 @@
     "model-providers",
     "gateways",
     "no-code",
-    "agentic-data-stack",
     "analytics",
     "data-platform",
     "developer-tools",

--- a/content/integrations/other/agentic-data-stack.mdx
+++ b/content/integrations/other/agentic-data-stack.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agentic Data Stack: LibreChat + ClickHouse + Langfuse"
-sidebarTitle: Agentic Data Stack
+sidebarTitle: ClickHouse Agentic Data Stack
 logo: /images/logos/clickhouse_icon.svg
 description: Deploy the open-source Agentic Data Stack with ClickHouse, LibreChat, and Langfuse. Full LLM observability for agentic analytics — self-hosted with Docker Compose.
 category: Integrations

--- a/content/integrations/other/meta.json
+++ b/content/integrations/other/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Other",
   "pages": [
+    "agentic-data-stack",
     "cognee",
     "exa",
     "firecrawl",

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1452,6 +1452,14 @@ const integrationsDeveloperToolsMove202606 = [
   ["/integrations/other/kiro-cli", "/integrations/developer-tools/kiro-cli"],
 ];
 
+// Agentic Data Stack page moved from top-level integrations into "Other" - June 2026
+const integrationsAgenticDataStackMove202606 = [
+  [
+    "/integrations/agentic-data-stack",
+    "/integrations/other/agentic-data-stack",
+  ],
+];
+
 const howWeShipRename202606 = [
   [
     "/handbook/product-engineering/how-we-work/workflow",
@@ -1491,6 +1499,7 @@ const permanentRedirects = [
   ...experimentsCiCdRedirects202605,
   ...errorAnalysisAcademyMove202605,
   ...integrationsDeveloperToolsMove202606,
+  ...integrationsAgenticDataStackMove202606,
   ...howWeShipRename202606,
 ];
 


### PR DESCRIPTION
Moves the Agentic Data Stack page out of the top-level integrations nav and into the **Other** folder, where its core component (`librechat.mdx`) already lives. Also renames it to **ClickHouse Agentic Data Stack** to disambiguate it in the nav (it's a ClickHouse product and already uses the ClickHouse logo).

## Changes
- Move `content/integrations/agentic-data-stack.mdx` → `content/integrations/other/agentic-data-stack.mdx` and update both `meta.json` files
- Add a permanent redirect `/integrations/agentic-data-stack` → `/integrations/other/agentic-data-stack`
- Update `sidebarTitle` to "ClickHouse Agentic Data Stack"
- Fix the home-page integrations entry: new label, corrected href, and swap the icon from `opentelemetry_icon.svg` to `clickhouse_icon.svg`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Reorganizes the Agentic Data Stack integration page by moving it from the top-level `/integrations/` nav into the `other/` subfolder, renaming it to "ClickHouse Agentic Data Stack" for clarity, and adding a permanent redirect for the old URL.

- The file is renamed from `content/integrations/agentic-data-stack.mdx` to `content/integrations/other/agentic-data-stack.mdx`, both `meta.json` files are updated accordingly, and the `sidebarTitle` is updated to "ClickHouse Agentic Data Stack".
- The home-page `Integrations.tsx` marquee entry is updated with the new label, corrected `href` (`/integrations/other/agentic-data-stack`), and swapped icon from `opentelemetry_icon.svg` to `clickhouse_icon.svg` (which already exists in the public assets).
- A permanent redirect is added in `lib/redirects.js` so existing links to `/integrations/agentic-data-stack` continue to resolve correctly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all five touched files are internally consistent, the redirect is correctly wired, and the ClickHouse icon asset already exists in the repository.

The change is a straightforward page move with matching updates across the nav metadata, the home-page component, and the redirect list. The new icon (clickhouse_icon.svg) is confirmed present in public/images/integrations/. No logic, API, or data-handling code is affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Old URL: integrations/agentic-data-stack] -->|Permanent redirect| B[New URL: integrations/other/agentic-data-stack]
    C[Home page marquee entry] -->|href, label, icon updated| B
    D[Top-level meta.json] -->|Entry removed| E[No longer listed]
    F[other/meta.json] -->|Entry added| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Old URL: integrations/agentic-data-stack] -->|Permanent redirect| B[New URL: integrations/other/agentic-data-stack]
    C[Home page marquee entry] -->|href, label, icon updated| B
    D[Top-level meta.json] -->|Entry removed| E[No longer listed]
    F[other/meta.json] -->|Entry added| B
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: move ClickHouse Agentic Data Stack..."](https://github.com/langfuse/langfuse-docs/commit/44bd6f590289c048226a13e4afdfd820b99a3441) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38181180)</sub>

<!-- /greptile_comment -->