### PR TITLE
docs(monitors): add monitor documentation page

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -135,6 +135,7 @@ Please check the following:
 - We never use `.gif` files, only `.mp4` files uploaded to `static.langfuse.com/docs-videos` to optimize for size and performance.
 - When deep-linking to a section via a link that uses the `#` anchor, make sure the anchor is explicitly defined in the source page via `[#anchor]` at the end of the header line, e.g. `## Get Started [#get-started]`.
 - If a page/route includes a top-of-file comment that points to an `md-override` source, verify both files are kept in sync whenever either side is edited.
+- When linking to a Langfuse app page from docs, use `https://cloud.langfuse.com/project/~/[path]` — the `~` sentinel redirects to the reader's last-used project and region automatically.
 
 ## Cursor Cloud specific instructions
 

--- a/.github/workflows/update-github-discussions.yml
+++ b/.github/workflows/update-github-discussions.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run load_github_discussions.py
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run --with requests --python 3.11 -- python scripts/load_github_discussions.py
+        run: uv run --with requests --python 3.12 -- python scripts/load_github_discussions.py
 
       - name: Commit and push if changed
         run: |

--- a/content/docs/metrics/features/meta.json
+++ b/content/docs/metrics/features/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "custom-dashboards",
     "metrics-api",
+    "monitors",
     "external:[Export to PostHog ↗](/integrations/analytics/posthog)",
     "external:[Export to Mixpanel ↗](/integrations/analytics/mixpanel)"
   ]

--- a/content/docs/metrics/features/monitors.mdx
+++ b/content/docs/metrics/features/monitors.mdx
@@ -88,9 +88,9 @@ Each monitor carries a **severity** that updates after every evaluation.
 
 **When alerts fire:**
 
-- Alert (`* → WARNING | ALERT`): always notifies.
+- Alert (`UNKNOWN | OK → WARNING | ALERT`): always notifies.
 - Recovery (`WARNING | ALERT → OK`): always notifies.
-- No data (`NO_DATA ↔ WARNING | ALERT | OK`): only notifies when no-data mode is **Notify after sustained NO DATA**.
+- No data (`NO_DATA ↔ WARNING | ALERT | OK | UNKNOWN`): only notifies when no-data mode is **Notify after sustained `NO_DATA`**.
 - Sustained severity (`WARNING → WARNING`, `ALERT → ALERT`): fires only when **Renotify** is enabled.
 
 ## Pause and resume [#pause]
@@ -152,7 +152,7 @@ Your endpoint receives a signed JSON body:
 }
 ```
 
-Signature verification works identically to prompt webhooks — see [Webhooks](/docs/prompt-management/features/webhooks-slack-integrations#get-started) for the HMAC validation code.
+Signature verification works identically to prompt webhooks — see [Webhooks](/docs/prompt-management/features/webhooks-slack-integrations) for the HMAC validation code.
 
 ## GitHub Discussions
 

--- a/content/docs/metrics/features/monitors.mdx
+++ b/content/docs/metrics/features/monitors.mdx
@@ -1,0 +1,161 @@
+---
+title: Monitors
+sidebarTitle: Monitors
+description: Set threshold-based alerts on your LLM application metrics and route notifications through automations when thresholds are breached.
+---
+
+# Monitors
+
+<Callout type="info">
+  Monitors are available on [Langfuse Cloud](https://langfuse.com/pricing) only.
+</Callout>
+
+Monitors allow you catch cost and quality issues before they impact your users.
+
+You can receive notifications over Slack, trigger GitHub Actions, or call your own Webhooks.
+
+## Create a monitor [#create]
+
+Navigate to [**Monitors**](https://cloud.langfuse.com/project/~/monitors) in your project and click **New Monitor**.
+
+<Steps>
+
+### Configure the metric
+
+Choose what data the monitor measures.
+
+| Field           | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| **Data source** | `Observations`, `Scores (numeric)`, or `Scores (categorical)`     |
+| **Metric**      | Aggregation + measure — e.g. `avg latency`, `count`, `p95 cost`   |
+| **Filters**     | Narrow the dataset (model name, tags, user ID, environment, etc.) |
+
+### Set alert conditions
+
+Choose what range you expect the metric values to fall within.
+
+| Field                 | Description                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| **Operator**          | `>`, `≥`, `<`, `≤`, `=`, `≠` — direction of the alert condition                          |
+| **Alert threshold**   | Required. Crossing this value sets severity to **ALERT**.                                |
+| **Warning threshold** | Optional. Crossing this value (before the alert threshold) sets severity to **WARNING**. |
+| **Window**            | How far back each evaluation looks (eg `1 hour`, `1 day`, `1 week`)                      |
+
+### Configure advanced settings (optional)
+
+Choose special handling for edge cases when data is missing or when the monitors stay in an unresolved state for extended periods of time.
+
+**No-data handling** — what happens when the query returns no data:
+
+| Mode                                  | Behavior                                                            |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| **Treat missing data as 0** (default) | Treat null as `0` and compare against thresholds                    |
+| **Keep the previous severity**        | Hold the previous severity; emit no alert                           |
+| **Show severity NO_DATA**             | Record `NO_DATA` severity; emit no alert                            |
+| **Notify after sustained NO_DATA**    | Record `NO_DATA` severity; fire an alert after a configurable delay |
+
+**Renotify** — whether to re-alert while severity stays elevated:
+
+| Mode              | Behavior                                                        |
+| ----------------- | --------------------------------------------------------------- |
+| `Off` (default)   | Alert fires once on each severity transition                    |
+| `Every N minutes` | Re-fires every N minutes while severity persists (1–10,080 min) |
+
+### Select a notification channel
+
+Select one or more automations from the **Automations** panel. When an alert fires, Langfuse publishes the event to each selected automation, which dispatches your configured actions (Slack message, webhook, etc.).
+
+See [Automations](#automations) to set up actions before linking them here.
+
+### Name and save
+
+Give the monitor a descriptive name (max 200 characters) and optional tags, then click **Save**. The monitor becomes **ACTIVE** immediately and schedules its first evaluation.
+
+</Steps>
+
+## Alert states [#alert-states]
+
+Each monitor carries a **severity** that updates after every evaluation.
+
+| Severity  | Meaning                                                                                                    |
+| --------- | ---------------------------------------------------------------------------------------------------------- |
+| `UNKNOWN` | Initial state — not yet evaluated                                                                          |
+| `OK`      | Metric is within bounds                                                                                    |
+| `WARNING` | Metric crossed the warning threshold                                                                       |
+| `ALERT`   | Metric crossed the alert threshold                                                                         |
+| `NO_DATA` | Query returned no data and no-data mode is **Show severity NO_DATA** or **Notify after sustained NO_DATA** |
+| `PAUSED`  | Monitor is paused; no evaluations run                                                                      |
+
+**When alerts fire:**
+
+- Alert (`* → WARNING | ALERT`): always notifies.
+- Recovery (`WARNING | ALERT → OK`): always notifies.
+- No data (`NO_DATA ↔ WARNING | ALERT | OK`): only notifies when no-data mode is **Notify after sustained NO DATA**.
+- Sustained severity (`WARNING → WARNING`, `ALERT → ALERT`): fires only when **Renotify** is enabled.
+
+## Pause and resume [#pause]
+
+From the monitor list or detail page, use the row actions menu to **Pause** or **Resume** a monitor. A paused monitor skips all evaluations; its severity is frozen at `PAUSED`. Resuming sets it back to `ACTIVE` and schedules the next evaluation.
+
+## Automations [#automations]
+
+Automations route monitor alerts to external systems. Each automation pairs a **trigger** (when to fire) with an **action** (what to do).
+
+Three action types are available:
+
+| Action             | What it does                                                |
+| ------------------ | ----------------------------------------------------------- |
+| **Slack**          | Posts a formatted alert message to a Slack channel          |
+| **Webhook**        | HTTP POST to your endpoint with an HMAC-signed JSON payload |
+| **GitHub Actions** | Fires a `workflow_dispatch` event on a GitHub repository    |
+
+### Create and link an automation [#automations-setup]
+
+1. Navigate to [**Automations**](https://cloud.langfuse.com/project/~/automations) and create a new automation with event source **Monitor**.
+2. [Create a new monitor](#create) or edit an existing monitor.
+3. Select the new automation in the **Automations** panel.
+
+A monitor fires every linked automation whenever its severity transitions (see [Alert states](#alert-states)).
+
+<Callout type="warn">
+  After **5 consecutive delivery failures**, Langfuse automatically disables the
+  automation's trigger. Re-enable it from the Automations page once the endpoint
+  is restored.
+</Callout>
+
+### Webhook payload [#automations-webhook-payload]
+
+Your endpoint receives a signed JSON body:
+
+```json filename="monitor-alert-payload.json"
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2024-07-10T10:30:00Z",
+  "type": "monitor-alert",
+  "apiVersion": "v1",
+  "payload": {
+    "monitorId": "monitor_abc123",
+    "projectId": "proj_xyz789",
+    "permalink": "https://cloud.langfuse.com/project/proj_xyz789/monitors/monitor_abc123",
+    "message": {
+      "title": "avg latency crossed alert threshold",
+      "body": "avg latency is 1234 ms (threshold: 1000 ms) over the last 1 hour"
+    },
+    "severity": "ALERT",
+    "timestamp": "2024-07-10T10:30:00Z",
+    "fromTimestamp": "2024-07-10T09:30:00Z",
+    "toTimestamp": "2024-07-10T10:30:00Z",
+    "view": "observations",
+    "filters": [],
+    "window": "1h"
+  }
+}
+```
+
+Signature verification works identically to prompt webhooks — see [Webhooks](/docs/prompt-management/features/webhooks-slack-integrations#get-started) for the HMAC validation code.
+
+## GitHub Discussions
+
+import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
+
+<GhDiscussionsPreview labels={["feat-monitors"]} />

--- a/content/docs/metrics/features/monitors.mdx
+++ b/content/docs/metrics/features/monitors.mdx
@@ -10,7 +10,7 @@ description: Set threshold-based alerts on your LLM application metrics and rout
   Monitors are available on [Langfuse Cloud](https://langfuse.com/pricing) only.
 </Callout>
 
-Monitors allow you catch cost and quality issues before they impact your users.
+Monitors allow you to catch cost and quality issues before they impact your users.
 
 You can receive notifications over Slack, trigger GitHub Actions, or call your own Webhooks.
 
@@ -39,11 +39,11 @@ Choose what range you expect the metric values to fall within.
 | **Operator**          | `>`, `≥`, `<`, `≤`, `=`, `≠` — direction of the alert condition                          |
 | **Alert threshold**   | Required. Crossing this value sets severity to **ALERT**.                                |
 | **Warning threshold** | Optional. Crossing this value (before the alert threshold) sets severity to **WARNING**. |
-| **Window**            | How far back each evaluation looks (eg `1 hour`, `1 day`, `1 week`)                      |
+| **Window**            | How far back each evaluation looks (e.g. `1 hour`, `1 day`, `1 week`)                      |
 
 ### Configure advanced settings (optional)
 
-Choose special handling for edge cases when data is missing or when the monitors stay in an unresolved state for extended periods of time.
+Choose special handling for edge cases when data is missing or when a monitor stays in an unresolved state for extended periods of time.
 
 **No-data handling** — what happens when the query returns no data:
 

--- a/content/docs/metrics/features/monitors.mdx
+++ b/content/docs/metrics/features/monitors.mdx
@@ -14,7 +14,7 @@ Monitors allow you to catch cost and quality issues before they impact your user
 
 You can receive notifications over Slack, trigger GitHub Actions, or call your own Webhooks.
 
-## Create a monitor [#create]
+## Create a monitor [#monitor-setup]
 
 Navigate to [**Monitors**](https://cloud.langfuse.com/project/~/monitors) in your project and click **New Monitor**.
 
@@ -39,7 +39,7 @@ Choose what range you expect the metric values to fall within.
 | **Operator**          | `>`, `≥`, `<`, `≤`, `=`, `≠` — direction of the alert condition                          |
 | **Alert threshold**   | Required. Crossing this value sets severity to **ALERT**.                                |
 | **Warning threshold** | Optional. Crossing this value (before the alert threshold) sets severity to **WARNING**. |
-| **Window**            | How far back each evaluation looks (e.g. `1 hour`, `1 day`, `1 week`)                      |
+| **Window**            | How far back each evaluation looks (e.g. `1 hour`, `1 day`, `1 week`)                    |
 
 ### Configure advanced settings (optional)
 
@@ -61,7 +61,7 @@ Choose special handling for edge cases when data is missing or when a monitor st
 | `Off` (default)   | Alert fires once on each severity transition                    |
 | `Every N minutes` | Re-fires every N minutes while severity persists (1–10,080 min) |
 
-### Select a notification channel
+### Select a notification channel [#notification-channel]
 
 Select one or more automations from the **Automations** panel. When an alert fires, Langfuse publishes the event to each selected automation, which dispatches your configured actions (Slack message, webhook, etc.).
 
@@ -99,9 +99,9 @@ From the monitor list or detail page, use the row actions menu to **Pause** or *
 
 ## Automations [#automations]
 
-Automations route monitor alerts to external systems. Each automation pairs a **trigger** (when to fire) with an **action** (what to do).
+Automations route monitor alerts to external systems. Each automation pairs a **trigger** (a monitor severity change) with an **action** (a notification sent to an external system).
 
-Three action types are available:
+Three notification channels are available:
 
 | Action             | What it does                                                |
 | ------------------ | ----------------------------------------------------------- |
@@ -109,11 +109,22 @@ Three action types are available:
 | **Webhook**        | HTTP POST to your endpoint with an HMAC-signed JSON payload |
 | **GitHub Actions** | Fires a `workflow_dispatch` event on a GitHub repository    |
 
-### Create and link an automation [#automations-setup]
+If you would like to see another channel added, please add to the [GitHub discussions](#gh-discussion).
 
-1. Navigate to [**Automations**](https://cloud.langfuse.com/project/~/automations) and create a new automation with event source **Monitor**.
-2. [Create a new monitor](#create) or edit an existing monitor.
-3. Select the new automation in the **Automations** panel.
+### Create a monitor automation [#automation-setup]
+
+1. Navigate to [**Automations**](https://cloud.langfuse.com/project/~/automations) and click **Create Automation**.
+2. Select event source **Monitor**.
+3. Select an action type (**Slack**, **Webhook**, or **GitHub Actions**).
+4. Configure the action: provide a Slack channel, a webhook endpoint URL, or a GitHub repository dispatch URL, event type, and personal access token.
+5. Give the automation a name and click **Save**. It will appear in the [**Automations** panel](#notification-channel) when you create or edit monitors.
+
+### Link a monitor to an automation
+
+1. [Create a new monitor automation](#automation-setup) or edit an existing one.
+2. [Create a new monitor](#monitor-setup) or edit an existing one.
+3. Select the automation from the [**Automations** panel](#notification-channel) found in the **notifications section** of the monitor editor.
+4. Click **Save** to link the monitor to the selected automations.
 
 A monitor fires every linked automation whenever its severity transitions (see [Alert states](#alert-states)).
 
@@ -154,7 +165,7 @@ Your endpoint receives a signed JSON body:
 
 Signature verification works identically to prompt webhooks — see [Webhooks](/docs/prompt-management/features/webhooks-slack-integrations) for the HMAC validation code.
 
-## GitHub Discussions
+## GitHub Discussions [#gh-discussion]
 
 import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
 


### PR DESCRIPTION
## Summary

Monitors lacked a documentation page in the metrics section.

To achieve this we:
- Added `content/docs/metrics/features/monitors.mdx` covering monitor creation, alert states, pause/resume, and automations
- Registered the page in `content/docs/metrics/features/meta.json` so it appears in the sidebar
- Documented the three automation action types (Slack, Webhook, GitHub Actions) with setup steps and the full webhook payload schema

Fixes [LFE-10317](https://linear.app/langfuse/issue/LFE-10317/monitor-documentation)

## Verification

- [x] `pnpm run format`
- [ ] Browser review

## Test plan

- [ ] Navigate to the Monitors docs page and verify all sections render correctly
- [ ] Confirm sidebar entry appears under Metrics > Features
- [ ] Verify all internal anchor links resolve (`#create`, `#alert-states`, `#pause`, `#automations`, `#automations-setup`, `#automations-webhook-payload`)
- [ ] Confirm the Automations link points to the correct page

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new documentation page for the Monitors feature under `content/docs/metrics/features/monitors.mdx` and registers it in the sidebar via `meta.json`. It also extends `AGENTS.md` with a review guideline about using the `~/` project sentinel in Langfuse app links.

- The new page covers monitor creation (metric, thresholds, advanced settings, notification channel), alert severity states, pause/resume, automations (Slack, Webhook, GitHub Actions), and the full webhook payload schema.
- Four issues were found in the new MDX file: a grammar error on the intro sentence, an inconsistent `NO DATA` label (should be `NO_DATA`), a non-standard `Callout type="warn"` (codebase convention is `type="warning"`), and a deep-link to `#get-started` in the webhooks page that lacks an explicit anchor declaration, which may fail the CI link check.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation content is well-structured and accurate, but several small defects in the new MDX file need fixing before the page is ready to publish.

The new page has a grammar error in the very first body sentence, a label inconsistency that could send readers to the wrong UI option (`NO DATA` vs `NO_DATA`), and a deep-link whose target anchor is not explicitly declared — the last of which is likely to break the CI link-check job. The rest of the PR (sidebar registration and AGENTS.md update) is clean.

content/docs/metrics/features/monitors.mdx needs the grammar fix, the NO_DATA label correction, the Callout type update, and the #get-started anchor resolution before merging.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Monitor Evaluation] --> B{Data returned?}
    B -- Yes --> C{Crosses alert threshold?}
    B -- No --> D{No-data mode}
    D -- Treat as 0 --> C
    D -- Keep previous --> E[Hold current severity]
    D -- Show NO_DATA --> F[Severity = NO_DATA]
    D -- Notify after sustained --> G[Severity = NO_DATA, fire alert after delay]
    C -- Yes --> H[Severity = ALERT]
    C -- No --> I{Crosses warning threshold?}
    I -- Yes --> J[Severity = WARNING]
    I -- No --> K[Severity = OK]
    H --> L{Severity transition?}
    J --> L
    K --> L
    F --> L
    G --> L
    L -- Yes, ALERT or WARNING --> M[Fire linked Automations]
    L -- Yes, OK recovery --> M
    L -- No change + Renotify ON --> M
    L -- No change + Renotify OFF --> N[No notification]
    M --> O{Delivery success?}
    O -- Yes --> P[Done]
    O -- No x5 consecutive --> Q[Disable automation trigger]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Monitor Evaluation] --> B{Data returned?}
    B -- Yes --> C{Crosses alert threshold?}
    B -- No --> D{No-data mode}
    D -- Treat as 0 --> C
    D -- Keep previous --> E[Hold current severity]
    D -- Show NO_DATA --> F[Severity = NO_DATA]
    D -- Notify after sustained --> G[Severity = NO_DATA, fire alert after delay]
    C -- Yes --> H[Severity = ALERT]
    C -- No --> I{Crosses warning threshold?}
    I -- Yes --> J[Severity = WARNING]
    I -- No --> K[Severity = OK]
    H --> L{Severity transition?}
    J --> L
    K --> L
    F --> L
    G --> L
    L -- Yes, ALERT or WARNING --> M[Fire linked Automations]
    L -- Yes, OK recovery --> M
    L -- No change + Renotify ON --> M
    L -- No change + Renotify OFF --> N[No notification]
    M --> O{Delivery success?}
    O -- Yes --> P[Done]
    O -- No x5 consecutive --> Q[Disable automation trigger]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
content/docs/metrics/features/monitors.mdx:13
Missing `to` makes this sentence ungrammatical. The AGENTS.md review guidelines explicitly require American English grammatical correctness.

```suggestion
Monitors allow you to catch cost and quality issues before they impact your users.
```

### Issue 2 of 4
content/docs/metrics/features/monitors.mdx:93
The mode name in this bullet uses `NO DATA` (space) while every other occurrence in the document — including the table on line 55 and the severity table on line 86 — uses `NO_DATA` (underscore). If this is meant to match a UI label, the inconsistency could confuse readers trying to find the setting.

```suggestion
- No data (`NO_DATA ↔ WARNING | ALERT | OK`): only notifies when no-data mode is **Notify after sustained NO_DATA**.
```

### Issue 3 of 4
content/docs/metrics/features/monitors.mdx:120-124
The rest of the docs codebase uses `type="warning"` (31 occurrences across 14 files); `type="warn"` appears in only one other file. Using the non-standard variant risks the callout rendering incorrectly or not at all if the component doesn't recognise `"warn"` as an alias.

```suggestion
<Callout type="warning">
  After **5 consecutive delivery failures**, Langfuse automatically disables the
  automation's trigger. Re-enable it from the Automations page once the endpoint
  is restored.
</Callout>
```

### Issue 4 of 4
content/docs/metrics/features/monitors.mdx:155
**Anchor link may fail CI link check**

The link targets `webhooks-slack-integrations#get-started`, but the `webhooks-slack-integrations.mdx` file has `## Get started` with no explicit `[#get-started]` anchor appended. Per the AGENTS.md rule, deep-links require the anchor to be explicitly declared on the target heading (`## Get started [#get-started]`). Without it, the `pnpm run link-check` CI step may reject the link.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(monitors): add monitor documentatio..."](https://github.com/langfuse/langfuse-docs/commit/191685083450fcca8bf6ad4dcd9503dd6f31c07d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38264743)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->