### PR TITLE
fix(docs): remove auto quotation marks from blockquote callouts

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -1208,3 +1208,18 @@ inkeep-portal .inkeep-widget-vars {
   --ikp-font-family-body: var(--font-sans);
   --ikp-font-family-mono: var(--font-mono);
 }
+
+/*
+ * Blockquote callouts: disable the automatic typographic quotation marks.
+ * fumadocs-ui's prose typography (css/dist/style.css) styles `.prose blockquote`
+ * with `quotes: "\201C""\201D""\2018""\2019"` and injects them via
+ * `content: open-quote` / `content: close-quote` on the first/last paragraph.
+ * We use blockquotes as plain callout boxes, so the marks are unwanted.
+ */
+.prose blockquote {
+  quotes: none;
+}
+.prose blockquote p:first-of-type::before,
+.prose blockquote p:last-of-type::after {
+  content: none;
+}


### PR DESCRIPTION
## Problem

Blockquote callouts across the docs render with automatic typographic quotation marks (`“ … ”`) wrapped around the text.

## Cause

`fumadocs-ui`'s bundled prose typography (`fumadocs-ui/dist/style.css`) styles `.prose blockquote` like Tailwind Typography does:

```css
.prose :where(blockquote) { quotes: "\201C""\201D""\2018""\2019"; … }
.prose :where(blockquote p:first-of-type)…::before { content: open-quote; }
.prose :where(blockquote p:last-of-type)…::after  { content: close-quote; }
```

The `::before`/`::after` pseudo-elements insert the quote glyphs around every blockquote's first/last paragraph. We use blockquotes as plain callout boxes (e.g. the "What is X?" intros on integration pages), so the marks are unwanted.

## Fix

Override it in `src/overrides.css` (already imported in `app/layout.tsx`):

```css
.prose blockquote { quotes: none; }
.prose blockquote p:first-of-type::before,
.prose blockquote p:last-of-type::after { content: none; }
```

`content: none` removes the generated pseudo-elements; `quotes: none` is a defensive belt-and-suspenders. The override's specificity `(0,2,3)` beats the source rule's `(0,1,1)`, so it wins. Scoped to `.prose` so it applies to all rendered MDX content (docs, blog, changelog, integrations) and nothing else.

## Verification

The source rule and `.prose` wrapper were confirmed against the compiled `fumadocs-ui` CSS. The marks are CSS-generated pseudo-content (not in the HTML), so they require a browser render to see — happy to attach a before/after preview screenshot on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a targeted CSS override to `src/overrides.css` that suppresses the typographic quotation marks automatically inserted by `fumadocs-ui`'s prose styles around blockquotes, which are used as plain callout boxes throughout the docs.

- Adds `quotes: none` on `.prose blockquote` and `content: none` on the `::before`/`::after` pseudo-elements of the first and last paragraphs, overriding the upstream Tailwind Typography–style rules that inject `"` / `"` glyphs via `content: open-quote` / `content: close-quote`.
- The override is correctly scoped to `.prose` (matching the existing file convention) and has higher specificity `(0,2,3)` than the `:where()`-wrapped source rule `(0,1,1)`, so it wins reliably without needing `!important`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A single, isolated CSS addition with no risk of breaking existing styles.

The change is minimal and self-contained — two CSS rules appended at the end of an existing overrides file. The selectors are tightly scoped to `.prose blockquote`, the specificity correctly beats the upstream `:where()`-wrapped rule, and the `content: none` / `quotes: none` combination is the standard way to suppress CSS-generated quote characters. No other styles are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["fumadocs-ui dist/style.css"] --> B[".prose :where(blockquote p:first-of-type)::before\ncontent: open-quote\nSpecificity: 0,1,1"]
    A --> C[".prose :where(blockquote p:last-of-type)::after\ncontent: close-quote\nSpecificity: 0,1,1"]
    D["src/overrides.css (this PR)"] --> E[".prose blockquote\nquotes: none\nSpecificity: 0,1,1"]
    D --> F[".prose blockquote p:first-of-type::before,\n.prose blockquote p:last-of-type::after\ncontent: none\nSpecificity: 0,2,3"]
    B -->|"overridden by higher specificity"| F
    C -->|"overridden by higher specificity"| F
    E -->|"belt-and-suspenders guard"| G["No quote glyphs rendered\naround blockquote callouts"]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["fumadocs-ui dist/style.css"] --> B[".prose :where(blockquote p:first-of-type)::before\ncontent: open-quote\nSpecificity: 0,1,1"]
    A --> C[".prose :where(blockquote p:last-of-type)::after\ncontent: close-quote\nSpecificity: 0,1,1"]
    D["src/overrides.css (this PR)"] --> E[".prose blockquote\nquotes: none\nSpecificity: 0,1,1"]
    D --> F[".prose blockquote p:first-of-type::before,\n.prose blockquote p:last-of-type::after\ncontent: none\nSpecificity: 0,2,3"]
    B -->|"overridden by higher specificity"| F
    C -->|"overridden by higher specificity"| F
    E -->|"belt-and-suspenders guard"| G["No quote glyphs rendered\naround blockquote callouts"]
    F --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): remove auto quotation marks f..."](https://github.com/langfuse/langfuse-docs/commit/1b63ba4e7540c2bcf55e440f6ddd25bed6ee273f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38382593)</sub>

<!-- /greptile_comment -->