### PR TITLE
fix(ci): github discussions cache generation 

### DIFF
--- a/scripts/load_github_discussions.py
+++ b/scripts/load_github_discussions.py
@@ -87,8 +87,8 @@ def load_github_discussions():
                 "resolved": discussion['answer'] is not None,
                 "labels": [label['name'] for label in discussion['labels']['nodes']],
                 "author": {
-                    "login": discussion['author']['login'],
-                    "html_url": discussion['author']['url']
+                    "login": discussion['author']['login'] if discussion['author'] else "ghost",
+                    "html_url": discussion['author']['url'] if discussion['author'] else ""
                 },
                 "category": discussion['category']['name']
             })

--- a/scripts/load_github_discussions.py
+++ b/scripts/load_github_discussions.py
@@ -87,7 +87,7 @@ def load_github_discussions():
                 "resolved": discussion['answer'] is not None,
                 "labels": [label['name'] for label in discussion['labels']['nodes']],
                 "author": {
-                    "login": discussion['author']['login'] if discussion['author'] else "ghost",
+                    "login": discussion['author']['login'] if discussion['author'] else "[deleted]",
                     "html_url": discussion['author']['url'] if discussion['author'] else ""
                 },
                 "category": discussion['category']['name']

--- a/scripts/load_github_discussions.py
+++ b/scripts/load_github_discussions.py
@@ -212,13 +212,17 @@ def generate_sitemap(discussions, filename="public/github-discussions-sitemap.xm
     print(f"Sitemap generated at {file_path}")
 
 if __name__ == "__main__":
+    import sys
     try:
         discussions = load_github_discussions()
         save_discussions_to_json(discussions)
         generate_sitemap(discussions)
     except ValueError as e:
         print(f"Error: {e}")
+        sys.exit(1)
     except requests.exceptions.RequestException as e:
         print(f"Network error occurred: {e}")
+        sys.exit(1)
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
+        sys.exit(1)

--- a/scripts/load_github_discussions.py
+++ b/scripts/load_github_discussions.py
@@ -90,7 +90,7 @@ def load_github_discussions():
                     "login": discussion['author']['login'] if discussion['author'] else "[deleted]",
                     "html_url": discussion['author']['url'] if discussion['author'] else ""
                 },
-                "category": discussion['category']['name'] if discussion['category'] else ""
+                "category": discussion['category']['name'] if discussion['category'] else "Uncategorized"
             })
         
         if not discussions['pageInfo']['hasNextPage']:

--- a/scripts/load_github_discussions.py
+++ b/scripts/load_github_discussions.py
@@ -90,7 +90,7 @@ def load_github_discussions():
                     "login": discussion['author']['login'] if discussion['author'] else "[deleted]",
                     "html_url": discussion['author']['url'] if discussion['author'] else ""
                 },
-                "category": discussion['category']['name']
+                "category": discussion['category']['name'] if discussion['category'] else ""
             })
         
         if not discussions['pageInfo']['hasNextPage']:


### PR DESCRIPTION
## Summary
The `update-github-discussions` workflow crashed on discussions with deleted authors or null categories, and failures passed as green because the script always exited 0.

To achieve this we:
- Handled deleted authors by falling back to a `[deleted]` login label and an empty URL when a discussion's author no longer exists.
- Guarded against null categories by falling back to an `Uncategorized` sentinel so the JSON output gets an explicit bucket name instead of a blank key.
- Made the script exit with code 1 on any error so failures surface in CI instead of passing silently.

## Verification

- [x] `uv run --with requests --python 3.12 -- python scripts/load_github_discussions.py`

## Test plan

- [ ] Run the `update-github-discussions` workflow and confirm it completes against live data.
- [ ] Confirm a discussion with a deleted author renders with `[deleted]` and no broken link.
- [ ] Confirm a discussion with a null category lands in the `Uncategorized` bucket without crashing.
- [ ] Confirm an induced error (e.g. bad token) fails the workflow instead of passing.
