### PR TITLE
Add sales CTA for high-volume pricing estimates

### DIFF
--- a/components/home/pricing/PricingCalculator.tsx
+++ b/components/home/pricing/PricingCalculator.tsx
@@ -22,8 +22,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import Link from "next/link";
-import { InfoIcon } from "lucide-react";
-import { Text } from "@/components/ui";
+import { InfoIcon, MessageCircle } from "lucide-react";
+import { Button, Text } from "@/components/ui";
+
+const SALES_ASSISTED_UNITS_THRESHOLD = 50_000_000;
 
 // Graduated pricing tiers
 const pricingTiers = [
@@ -118,12 +120,16 @@ export function PricingCalculator({
   const [currentBaseFee, setCurrentBaseFee] = useState<number>(
     PLAN_CONFIGS.find((p) => p.name === initialPlan)?.baseFee || 0,
   );
+  const monthlyUnits = useMemo(
+    () => parseInt(monthlyEvents.replace(/,/g, "")) || 0,
+    [monthlyEvents],
+  );
+  const shouldSuggestSales = monthlyUnits >= SALES_ASSISTED_UNITS_THRESHOLD;
 
   // Calculate pricing breakdown (single source of truth)
   const pricingBreakdown = useMemo(() => {
-    const events = parseInt(monthlyEvents.replace(/,/g, "")) || 0;
-    return calculatePricingBreakdown(events);
-  }, [monthlyEvents]);
+    return calculatePricingBreakdown(monthlyUnits);
+  }, [monthlyUnits]);
 
   // Derive total cost from breakdown
   const calculatedPrice = useMemo(() => {
@@ -244,6 +250,30 @@ export function PricingCalculator({
             </CornerBox>
           </div>
 
+          {shouldSuggestSales && (
+            <div className="flex flex-col gap-3 rounded-sm border border-line-structure bg-surface-1 p-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-1">
+                <div className="text-sm font-medium text-text-primary">
+                  High-volume workload
+                </div>
+                <Text size="s" className="text-left text-text-secondary">
+                  At {formatNumber(SALES_ASSISTED_UNITS_THRESHOLD)}+ billable
+                  units per month, talk to sales for help sizing the workload
+                  and a custom quote.
+                </Text>
+              </div>
+              <Button
+                href="/talk-to-us?deployment=cloud"
+                variant="secondary"
+                icon={<MessageCircle className="size-3.5" />}
+                wrapperClassName="w-full shrink-0 md:w-auto"
+                aria-label="Talk to sales"
+              >
+                Talk to sales
+              </Button>
+            </div>
+          )}
+
           {/* Breakdown */}
           <div className="space-y-3">
             <div className="font-medium">Pricing tiers breakdown:</div>
@@ -292,10 +322,8 @@ export function PricingCalculator({
                   <TableCell className="font-semibold">Total</TableCell>
                   <TableCell className="font-semibold text-right">
                     {(() => {
-                      const totalUnits =
-                        parseInt(monthlyEvents.replace(/,/g, "")) || 0;
-                      if (totalUnits === 0) return "—";
-                      const avgRate = (calculatedPrice / totalUnits) * 100000;
+                      if (monthlyUnits === 0) return "—";
+                      const avgRate = (calculatedPrice / monthlyUnits) * 100000;
                       return formatCurrency(avgRate) + "/100k";
                     })()}
                   </TableCell>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a conditional sales CTA banner to the `PricingCalculator` component that appears when a user enters 50M or more billable units per month, directing high-volume prospects to a "Talk to sales" flow. It also refactors the `monthlyUnits` computation into a dedicated `useMemo`, eliminating two redundant `parseInt` calls.

- A new constant `SALES_ASSISTED_UNITS_THRESHOLD` (50 million) drives both the display condition and the banner copy, making future threshold changes a one-line edit.
- The `Button` component is used with `href="/talk-to-us?deployment=cloud"` and renders correctly as a `NextLink` since the component supports the `href` prop natively.
- The `aria-label` on the Button is necessary (not redundant) because the component's children are wrapped in an `aria-hidden` span by design.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, only rendering a new banner at a well-defined threshold, with no impact on the price calculation itself.

The refactoring correctly consolidates a duplicated parseInt call into a single memoized value that feeds both the breakdown and the total row. The threshold constant and banner are straightforward additions with no side effects on existing calculator logic.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User enters monthly units] --> B[monthlyUnits useMemo\nparseInt + strip commas]
    B --> C{monthlyUnits >= 50M?}
    C -- Yes --> D[shouldSuggestSales = true]
    C -- No --> E[shouldSuggestSales = false]
    B --> F[pricingBreakdown useMemo\ncalculatePricingBreakdown]
    F --> G[calculatedPrice useMemo\nsum tier costs]
    D --> H[Render Sales CTA banner\n'High-volume workload'\nLink to /talk-to-us?deployment=cloud]
    E --> I[CTA hidden]
    G --> J[Render pricing table\n+ total row avg rate]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User enters monthly units] --> B[monthlyUnits useMemo\nparseInt + strip commas]
    B --> C{monthlyUnits >= 50M?}
    C -- Yes --> D[shouldSuggestSales = true]
    C -- No --> E[shouldSuggestSales = false]
    B --> F[pricingBreakdown useMemo\ncalculatePricingBreakdown]
    F --> G[calculatedPrice useMemo\nsum tier costs]
    D --> H[Render Sales CTA banner\n'High-volume workload'\nLink to /talk-to-us?deployment=cloud]
    E --> I[CTA hidden]
    G --> J[Render pricing table\n+ total row avg rate]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add sales CTA for high-volume pricing es..."](https://github.com/langfuse/langfuse-docs/commit/2d4e7e5964b6535308e8b5989aea9978c55b99d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38402994)</sub>

<!-- /greptile_comment -->