### PR TITLE
Add remark plugin to migrate legacy filename= meta to title=

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .pnpm-store
 .vercel
+node-compile-cache
 
 .env.local
 .env

--- a/lib/remark-code-filename.mjs
+++ b/lib/remark-code-filename.mjs
@@ -1,0 +1,29 @@
+/**
+ * Remark plugin that renders the file-path header above fenced code blocks.
+ *
+ * The previous docs stack (Nextra) showed the file path from the
+ * `filename="..."` code-fence meta, e.g.:
+ *
+ *     ```ts filename="instrumentation.ts"
+ *
+ * Fumadocs instead reads the `title="..."` meta to render that header, so the
+ * large amount of existing content using `filename=` lost its file-path label.
+ *
+ * This plugin rewrites the legacy `filename=` meta to `title=` so both
+ * spellings render the header. It runs on the mdast `code` node before
+ * remark-rehype/rehypeCode, and only rewrites when no explicit `title=` is
+ * already present so an author-provided title always wins.
+ */
+import { visit } from "unist-util-visit";
+
+export function remarkCodeFilename() {
+  return (tree) => {
+    visit(tree, "code", (node) => {
+      if (typeof node.meta !== "string" || !/\bfilename=/.test(node.meta)) {
+        return;
+      }
+      if (/\btitle=/.test(node.meta)) return;
+      node.meta = node.meta.replace(/\bfilename=/g, "title=");
+    });
+  };
+}

--- a/source.config.ts
+++ b/source.config.ts
@@ -11,6 +11,7 @@ import monokaiProLightRaw from "./lib/themes/monokai-pro-light.json";
 const monokaiProLight = monokaiProLightRaw as unknown as any;
 import remarkGfm from "remark-gfm";
 import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
+import { remarkCodeFilename } from "./lib/remark-code-filename.mjs";
 import { mdxJsxToMarkdown } from "mdast-util-mdx-jsx";
 import { z } from "zod";
 
@@ -198,7 +199,7 @@ export const marketing = defineDocs({
 export default defineConfig({
   plugins: [lastModified()],
   mdxOptions: {
-    remarkPlugins: [remarkGfm, remarkMdxMermaid],
+    remarkPlugins: [remarkGfm, remarkMdxMermaid, remarkCodeFilename],
     providerImportSource: "@/mdx-components",
     // Disable remark-image: many content files reference remote images via https://
     // and the plugin tries to fetch dimensions at compile time, causing build failures


### PR DESCRIPTION
## Summary

Adds a new remark plugin to support the legacy `filename="..."` code-fence meta syntax from the previous Nextra documentation stack. The plugin automatically rewrites `filename=` to `title=` so existing content continues to render file-path headers in Fumadocs.

## Changes

- **New plugin**: `lib/remark-code-filename.mjs` — Remark plugin that:
  - Visits all `code` nodes in the mdast tree
  - Detects `filename=` in the code-fence meta string
  - Rewrites it to `title=` (the Fumadocs convention)
  - Respects explicit `title=` attributes (author-provided titles always win)
  - Runs before remark-rehype/rehypeCode processing

- **Integration**: Added `remarkCodeFilename` to the remark plugins list in `source.config.ts`

- **Maintenance**: Updated `.gitignore` to exclude `node-compile-cache`

## Implementation details

The plugin uses `unist-util-visit` to traverse the mdast tree and only modifies nodes where:
1. `node.meta` is a string containing `\bfilename=` (word boundary ensures we don't match partial strings)
2. No existing `\btitle=` is present (preserves author intent)

This approach ensures backward compatibility with existing Nextra-style documentation while supporting the Fumadocs `title=` convention going forward.

https://claude.ai/code/session_01DCWnCBUZvVZeQ2AB1EyAXP

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a remark plugin (`lib/remark-code-filename.mjs`) to rewrite legacy Nextra `filename=` code-fence meta to the Fumadocs `title=` convention, restoring file-path headers for all existing content without requiring manual updates.

- **New plugin**: visits every mdast `code` node, detects `filename=` via a word-boundary regex, and replaces it with `title=` — only when no explicit `title=` already exists, so author-provided titles always win.
- **Integration**: `remarkCodeFilename` is appended to the global `remarkPlugins` list in `source.config.ts`, so it runs across all collections before rehype processing.
- **Housekeeping**: `node-compile-cache` added to `.gitignore`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, scoped only to code-fence meta strings, and cannot affect any node that doesn't already carry a filename= attribute.

The plugin is minimal and correctly guarded: the word-boundary regex prevents false matches on identifiers like myfilename=, the title= pre-check preserves explicit author overrides, and the global replace flag is harmless because the same guard already ensures title= is absent before any write happens. All imports are at the top level of the module. The integration in source.config.ts follows the exact same pattern as the two existing remark plugins.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MDX Build Process] --> B[remark pipeline]
    B --> C[remarkGfm]
    C --> D[remarkMdxMermaid]
    D --> E[remarkCodeFilename]
    E --> F{Visit each 'code' node}
    F --> G{"node.meta is string AND contains \bfilename=?"}
    G -- No --> H[Skip node unchanged]
    G -- Yes --> I{"\btitle= already present?"}
    I -- Yes --> H
    I -- No --> J["Replace filename= to title= (global, word-boundary safe)"]
    J --> K[Continue to rehype pipeline]
    H --> K
    K --> L[rehypeCode renders title= as file-path header]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MDX Build Process] --> B[remark pipeline]
    B --> C[remarkGfm]
    C --> D[remarkMdxMermaid]
    D --> E[remarkCodeFilename]
    E --> F{Visit each 'code' node}
    F --> G{"node.meta is string AND contains \bfilename=?"}
    G -- No --> H[Skip node unchanged]
    G -- Yes --> I{"\btitle= already present?"}
    I -- Yes --> H
    I -- No --> J["Replace filename= to title= (global, word-boundary safe)"]
    J --> K[Continue to rehype pipeline]
    H --> K
    K --> L[rehypeCode renders title= as file-path header]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: gitignore node-compile-cache buil..."](https://github.com/langfuse/langfuse-docs/commit/7216e68e559e1749c8ca66bc081ba8e84499eb1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38409775)</sub>

<!-- /greptile_comment -->