### PR TITLE
docs: add Python span masking changelog

### DIFF
--- a/content/changelog/2026-06-16-python-sdk-export-stage-masking.mdx
+++ b/content/changelog/2026-06-16-python-sdk-export-stage-masking.mdx
@@ -1,0 +1,68 @@
+---
+date: 2026-06-16
+title: Mask exported spans in Python
+description: Run media detection and configured masking on every span accepted by the Python SDK span processor, including third-party OpenTelemetry spans.
+author: Hassieb
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { BookOpen, ShieldCheck } from "lucide-react";
+
+<ChangelogHeader />
+
+The Langfuse Python SDK now runs media detection for every span accepted by the Langfuse span processor, and can apply configured export-stage masking to those same spans. This includes spans created by Langfuse SDK APIs and spans emitted by third-party OpenTelemetry instrumentations.
+
+Use this to keep redaction and media handling consistent across your full trace export path. For example, you can redact prompt or completion attributes from OpenAI instrumentation spans, replace inline base64 media payloads with Langfuse media references, or apply the same masking rule to custom OpenTelemetry spans and Langfuse SDK observations.
+
+Previously, Python SDK masking happened when Langfuse SDK attributes were created via APIs such as `start_observation()`, `update()`, and `set_trace_io()`. That legacy `mask` hook does not see final raw OpenTelemetry span attributes from other instrumentations. The new `mask_otel_spans` hook runs at export stage, after export filtering and after Langfuse media detection, so it can patch the attributes that the Langfuse exporter is about to send.
+
+```python
+from typing import Optional
+
+from langfuse import Langfuse
+from langfuse.types import (
+    MaskOtelSpansParams,
+    MaskOtelSpansResult,
+    OtelSpanPatch,
+)
+
+
+def mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    patches = {}
+
+    for identifier, span in params.spans.items():
+        if span.instrumentation_scope_name == "openai":
+            patches[identifier] = OtelSpanPatch(
+                delete_attributes=(
+                    "gen_ai.prompt.0.content",
+                    "gen_ai.completion.0.content",
+                ),
+                set_attributes={"masking.applied": True},
+            )
+
+    return MaskOtelSpansResult(span_patches=patches)
+
+
+langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
+```
+
+The hook receives one OpenTelemetry export batch at a time, not necessarily a complete trace. It is synchronous and usually runs on the OpenTelemetry batch span processor worker thread, so it should not block the main application thread. Keep it fast: slow network calls or expensive masking logic can back up the export queue.
+
+## Get started
+
+<Cards num={2}>
+  <Card
+    title="Masking documentation"
+    href="/docs/observability/features/masking"
+    icon={<ShieldCheck />}
+    arrow
+  />
+  <Card
+    title="Python SDK overview"
+    href="/docs/observability/sdk/overview"
+    icon={<BookOpen />}
+    arrow
+  />
+</Cards>


### PR DESCRIPTION
## Summary

- Add a changelog entry dated `2026-06-16`, the merge date of `langfuse/langfuse-python#1646`.
- Announce export-stage media detection and configured masking for all spans accepted by the Python SDK span processor.
- Link readers to the masking docs and Python SDK overview.

## Validation

- `bun x prettier@3.8.4 --experimental-cli --check content/changelog/2026-06-16-python-sdk-export-stage-masking.mdx`
- `git diff --check`

Note: `pnpm` in this local shell is routed through an nvm Node 22 target that is not installed, so I used the repo's Prettier version range via `bun x` for the targeted formatting check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single changelog entry announcing export-stage span masking for the Langfuse Python SDK, introducing the `mask_otel_spans` hook that runs after export filtering and media detection so it can patch raw OpenTelemetry attributes from any instrumentation before they are sent.

- The new `mask_otel_spans` hook is described with a complete, runnable Python code example that matches the corresponding entry in the masking docs exactly.
- Both linked pages (`/docs/observability/features/masking` and `/docs/observability/sdk/overview`) resolve to existing content files.
- Frontmatter, imports, and `Cards`/`Card` usage are all consistent with other recent changelog entries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only changelog addition with no runtime code changes; safe to merge.

The change is a single MDX changelog file. The code example is a verbatim copy of the snippet already published in the masking docs, both linked destination pages exist, and the frontmatter and component usage are consistent with every other recent changelog entry.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenTelemetry Span emitted\nLangfuse SDK or 3rd-party] --> B[Langfuse Span Processor\naccepts span]
    B --> C{Export filter\npasses?}
    C -- No --> X[Span dropped]
    C -- Yes --> D[Langfuse media detection\nreplace inline base64 with media refs]
    D --> E[mask_otel_spans hook\nreceives export batch]
    E --> F{Hook returns\nOtelSpanPatch?}
    F -- No patch --> G[Span exported as-is]
    F -- delete_attributes / set_attributes --> H[Attributes patched]
    H --> G
    G --> I[Langfuse backend]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OpenTelemetry Span emitted\nLangfuse SDK or 3rd-party] --> B[Langfuse Span Processor\naccepts span]
    B --> C{Export filter\npasses?}
    C -- No --> X[Span dropped]
    C -- Yes --> D[Langfuse media detection\nreplace inline base64 with media refs]
    D --> E[mask_otel_spans hook\nreceives export batch]
    E --> F{Hook returns\nOtelSpanPatch?}
    F -- No patch --> G[Span exported as-is]
    F -- delete_attributes / set_attributes --> H[Attributes patched]
    H --> G
    G --> I[Langfuse backend]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Python span masking changelog"](https://github.com/langfuse/langfuse-docs/commit/382eb4dd0048b1542625e790d76cab87b5322577) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38438502)</sub>

<!-- /greptile_comment -->