### PR TITLE
docs: move refund approval thresholds to private handbook

### DIFF
--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -229,7 +229,7 @@ This is the most sensitive billing question. Lead with empathy and _facts_, neve
 3. Cross-check the org in Impersonation View → Usage tab → confirm trace/observation volume in the billing period.
 4. **Specifically check for OTEL-related overcounting.** A common case: customers had a pre-existing OTEL setup, and after wiring it to Langfuse it ingested unrelated HTTP/DB/framework spans that drove up volume. See [/faq/all/existing-otel-setup#unwanted-spans-in-langfuse](/faq/all/existing-otel-setup#unwanted-spans-in-langfuse), the fix is `blocked_instrumentation_scopes` on the SDK.
 5. Reply with the specific reason, link the invoice or usage view.
-6. If a refund is warranted under USD 500 you can approve it directly via Stripe (small POs / proration corrections / clear-cut errors). **For refunds above USD 500 loop in the team.**
+6. If a refund is warranted, follow the internal refund handling guidelines in the private handbook for approval limits and when to loop in the team.
 
 **Reply template:**
 
@@ -252,7 +252,7 @@ Best,
 {you}
 ```
 
-**Escalate when:** the charge is genuinely wrong on our side, refund is over USD 2,000, or the customer is on an enterprise contract with bespoke billing terms (loop in the enterprise team).
+**Escalate when:** the charge is genuinely wrong on our side, the refund exceeds the approval limit in the private handbook, or the customer is on an enterprise contract with bespoke billing terms (loop in the enterprise team).
 
 </details>
 
@@ -293,7 +293,7 @@ Best,
 {you}
 ```
 
-**Escalate when:** EE contracts above standard tier, route to the enterprise team. Refunds above USD 2,000, loop in the team.
+**Escalate when:** EE contracts above standard tier, route to the enterprise team. For refunds, follow the approval limits in the private handbook.
 
 </details>
 
@@ -307,7 +307,7 @@ Best,
 2. Determine if the charge was correct (customer's mistake / they didn't downgrade in time) or our error (billing bug / contract misalignment / EE-license-removal-doesn't-cancel confusion above).
 3. Customer error and they're on a small plan: explain politely, offer goodwill credit if appropriate.
 4. Our error or genuine misunderstanding: refund.
-5. For refunds **above USD 2,000, loop in the team.** Do not approve unilaterally.
+5. For approval limits and when to loop in the team, follow the internal refund handling guidelines in the private handbook. Do not approve refunds beyond your limit unilaterally.
 
 **Reply template:**
 


### PR DESCRIPTION
## What

Removes the exact refund-handling details from the public support playbook (`content/handbook/support/how-to-answer-support-questions.mdx`, published at `langfuse.com/handbook/...`) and replaces them with a reference to the internal refund handling guidelines in the private handbook.

Specifically, the following internal-policy specifics were removed from four places in the **Billing, pricing, and contracts** section:

- "If a refund is warranted under USD 500 you can approve it directly via Stripe… For refunds above USD 500 loop in the team."
- "Escalate when: … refund is over USD 2,000 …" (two occurrences)
- Refund-request step: "For refunds above USD 2,000, loop in the team. Do not approve unilaterally."

The general triage flow (check Stripe, determine whether the charge was correct, goodwill credit, customer-facing reply templates) is unchanged — only the dollar thresholds and approval authority were moved out.

## Why

The specific approval limits and escalation thresholds are internal policy and shouldn't live on a publicly indexed page. They now belong in the private handbook; the public page points there generically without exposing the internal document URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes specific dollar-threshold values for refund approvals from the public support handbook and replaces them with references to the private handbook, preventing internal policy limits from appearing on a publicly indexed page.

- Four instances of hard-coded USD thresholds (USD 500 direct-approval limit, USD 2,000 escalation limits) are redacted from `how-to-answer-support-questions.mdx` and replaced with prose directing agents to the private handbook.
- The surrounding triage flow, reply templates, and all other billing guidance are unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that removes internal policy details from a public page — no functional code is touched.

All four threshold references are consistently redacted and replaced with equivalent prose pointing to the private handbook. The triage flow, reply templates, and escalation conditions are preserved verbatim. There is nothing here that could break behavior or introduce a regression.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Refund request received] --> B[Check Stripe / usage]
    B --> C{Charge correct?}
    C -- Yes, customer error --> D[Explain politely, offer goodwill credit if appropriate]
    C -- No, our error --> E[Refund warranted]
    E --> F{Approval limit check\n⟶ see private handbook}
    F -- Within limit --> G[Approve directly in Stripe]
    F -- Exceeds limit --> H[Loop in team / escalate]
    C -- Enterprise contract --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Refund request received] --> B[Check Stripe / usage]
    B --> C{Charge correct?}
    C -- Yes, customer error --> D[Explain politely, offer goodwill credit if appropriate]
    C -- No, our error --> E[Refund warranted]
    E --> F{Approval limit check\n⟶ see private handbook}
    F -- Within limit --> G[Approve directly in Stripe]
    F -- Exceeds limit --> H[Loop in team / escalate]
    C -- Enterprise contract --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/langfuse/langfuse-docs/commit/7e55ea60bcebe0b70e5a4531b24493c55763a247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38455986)</sub>

<!-- /greptile_comment -->