### PR TITLE
docs: document legacy read API rate limits

### DIFF
--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -34,7 +34,10 @@ Rate limits are applied per-organization.
 | **Prompts**. GET APIs used to fetch prompts for use in applications.                                                 | No limit           | No limit           | No limit            |
 | **Metrics**. GET APIs used to fetch analytics data, e.g. [metrics api](/docs/analytics/metrics-api).                 | 100&nbsp;req/day   | 200&nbsp;req/day   | 2000&nbsp;req/day   |
 | **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                     | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Legacy read APIs**. Older trace, observation, and session read endpoints, listed below.                            | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
 | **API**. All other APIs.                                                                                             | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+
+The legacy read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 
 On the Enterprise plan, you can request custom rate limits by contacting [support](/support).
 

--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -248,6 +248,7 @@ If something here still doesn't add up, let me know and I'll investigate further
 Best,
 {you}
 ```
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- Add a separate legacy read API rate-limit row to the API limits FAQ.
- Document the 15/30/100 req/min limits for older trace, observation, and session read endpoints.
- Explicitly list the legacy read API routes: `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
- Keep pricing pages and pricing table data unchanged.
- Format `content/handbook/support/how-to-answer-support-questions.mdx` to satisfy the repo-wide Prettier check.

## Impacted packages / areas

- `content/faq/all/api-limits.mdx`
- `content/handbook/support/how-to-answer-support-questions.mdx` (formatting only)

## Validation

- `pnpm run format:check`: passed locally.
- `git diff --check origin/main...HEAD`: passed locally.
- Cross-checked legacy route list against `rateLimitResource: "public-api-legacy"` route declarations in `web/src/pages/api/public`.
