### PR TITLE
feat(analytics): add Common Room website visitor tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,7 @@ import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
 import { RedditPixel } from "@/components/analytics/reddit-ads";
 import { TwitterPixel } from "@/components/analytics/twitter-ads";
 import { ConversionTracker } from "@/components/analytics/ConversionTracker";
+import { CommonRoom } from "@/components/analytics/common-room";
 import "../style.css";
 import "@vidstack/react/player/styles/base.css";
 import "../src/overrides.css";
@@ -101,6 +102,7 @@ export default function RootLayout({
             <TwitterPixel />
             <ConversionTracker />
             <Hubspot />
+            <CommonRoom />
             <Script
               id="cookieyes"
               type="text/javascript"

--- a/components/analytics/PostHogProvider.tsx
+++ b/components/analytics/PostHogProvider.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { hsPageView } from "@/components/analytics/hubspot";
+import { crPageView } from "@/components/analytics/common-room";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const isInitialPageView = useRef(true);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -36,6 +38,13 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     if (pathname) {
       posthog.capture("$pageview");
       hsPageView(pathname);
+      // Common Room's snippet auto-tracks the first page load, so only report
+      // subsequent client-side navigations to avoid double counting.
+      if (isInitialPageView.current) {
+        isInitialPageView.current = false;
+      } else {
+        crPageView();
+      }
     }
   }, [pathname]);
 

--- a/components/analytics/common-room.tsx
+++ b/components/analytics/common-room.tsx
@@ -1,0 +1,43 @@
+import Script from "next/script";
+
+// Common Room website visitor tracking ("Signals"). Loads the signals.js
+// snippet, which auto-tracks the initial page view and form submissions that
+// contain an email field. Because the docs site is a single-page app, the
+// snippet only sees the first page load — subsequent client-side navigations
+// are reported manually via `crPageView` (see PostHogProvider).
+// https://www.commonroom.io/docs/signals/website-visitor-tracking/
+const COMMON_ROOM_SITE_ID = "56cd5a2c-528f-44aa-8175-7aad9d06854a";
+
+export function CommonRoom() {
+  return (
+    <Script id="common-room" strategy="afterInteractive">
+      {`(function() {
+  if (typeof window === 'undefined') return;
+  if (typeof window.signals !== 'undefined') return;
+  var script = document.createElement('script');
+  script.src = 'https://cdn.cr-relay.com/v1/site/${COMMON_ROOM_SITE_ID}/signals.js';
+  script.async = true;
+  window.signals = Object.assign(
+    [],
+    { _opts: { apiHost: 'https://api.cr-relay.com' } },
+    ['page', 'identify', 'form'].reduce(function (acc, method){
+      acc[method] = function () {
+        signals.push([method, arguments]);
+        return signals;
+      };
+     return acc;
+    }, {})
+  );
+  document.head.appendChild(script);
+})();`}
+    </Script>
+  );
+}
+
+// Report a page view to Common Room. The snippet auto-tracks the initial page
+// load, so this is only needed for SPA route changes.
+export const crPageView = () => {
+  if (typeof window !== "undefined" && window.signals) {
+    window.signals.page();
+  }
+};

--- a/global.d.ts
+++ b/global.d.ts
@@ -6,6 +6,11 @@ interface Window {
   _linkedin_data_partner_ids?: any[];
   rdt?: (...args: any[]) => void;
   twq?: (...args: any[]) => void;
+  signals?: any[] & {
+    page: (...args: any[]) => void;
+    identify: (...args: any[]) => void;
+    form: (...args: any[]) => void;
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds [Common Room](https://www.commonroom.io/docs/signals/website-visitor-tracking/) website visitor tracking ("Signals") to the docs site.

## How (mirrors the ClickHouse docs approach, adapted to our stack)

I analyzed how the ClickHouse docs site loads Common Room. Their docs are Docusaurus and they inject the Common Room snippet **through their Google Tag Manager container** (`GTM-WTNTDT7W`) rather than committing it to the repo — the GTM bootstrap is the only tracking reference in their static HTML, and the Common Room snippet is configured as a custom HTML tag inside GTM.

We already use GTM (`GTM-NGLK4TZX`) too, so injecting via GTM would be the most literal copy. **But** our convention is to keep each tracker in the repo as a small `next/script` component under `components/analytics/*` (HubSpot, LinkedIn, Twitter, Reddit) rather than hiding them in GTM. This PR follows that convention — it's version-controlled, reviewable, and consistent. (Injecting via GTM instead remains an option if the marketing team prefers; this can then be dropped.)

### Changes
- **`components/analytics/common-room.tsx`** (new) — `<CommonRoom />` renders the official snippet verbatim via `<Script strategy="afterInteractive">`. The site ID (`56cd5a2c-…`) is factored into a constant. Also exports `crPageView()`.
- **`app/layout.tsx`** — renders `<CommonRoom />` inside the existing `process.env.NODE_ENV === "production"` analytics block, so it only loads in production (same as the other pixels).
- **`components/analytics/PostHogProvider.tsx`** — Common Room's snippet only tracks the **first** page load. Since the docs are a Next.js App Router SPA, subsequent navigations are reported with `signals.page()` from the existing `pathname` effect (right next to the PostHog and HubSpot pageview calls). The initial load is skipped via a ref to avoid double counting, since the snippet already tracks it.
- **`global.d.ts`** — declares `window.signals` alongside the other tracker globals.

## Assumptions verified against Common Room docs
- Snippet is loaded site-wide (their docs say place it in `<body>`; in Next.js the `<Script>` component is the equivalent and handles ordering). ✅
- For SPAs, route changes need a manual `page()` call — Common Room's docs explicitly note SPAs "may need additional setup to track route changes." ✅
- The snippet auto-tracks form submissions containing an email field, so no extra wiring is needed for forms. ✅
- `identify()` is intentionally not wired: the docs site has no authenticated user/email to pass.

## Verification
- `tsc --noEmit`: 0 errors.
- `prettier --check` on all changed files: passes.

## Note for reviewer / before merge
Confirm the Common Room **site ID** (`56cd5a2c-528f-44aa-8175-7aad9d06854a`) is the correct production Langfuse Signals site. It ships behind the production-only gate, so it won't run in dev/preview.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Common Room "Signals" website visitor tracking to the Langfuse docs site, following the existing pattern of per-tracker `next/script` components. The double-count prevention logic using `isInitialPageView` ref is correctly designed. One minor P2 suggestion: remove an unreachable `typeof window === 'undefined'` guard inside the inline IIFE since `strategy="afterInteractive"` guarantees client-only execution.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after confirming the Common Room site ID is the correct production Langfuse Signals site (as noted in the PR description).

The change is well-scoped: analytics-only, production-gated, and follows existing patterns. The double-count avoidance logic for the initial page view is sound. The one minor point is a single dead-code guard inside the inline script that can't be reached at runtime.

No files require special attention beyond the site ID confirmation noted in the PR description.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js (layout.tsx)
    participant CommonRoom as CommonRoom Script
    participant CRRelay as cdn.cr-relay.com
    participant PHProvider as PostHogProvider (useEffect)
    participant CRApi as api.cr-relay.com

    Browser->>NextJS: Initial page load
    NextJS->>Browser: Renders HTML (Script[afterInteractive])
    Browser->>Browser: Hydration complete
    Browser->>CommonRoom: Executes inline IIFE (sets window.signals stub)
    CommonRoom->>CRRelay: Fetches signals.js
    CRRelay-->>Browser: signals.js loaded
    Browser->>CRApi: Auto-fires initial page view (from signals.js)

    Browser->>PHProvider: "useEffect fires (pathname = initial URL)"
    PHProvider->>PHProvider: "isInitialPageView.current = true → set false, skip crPageView()"

    Note over Browser,CRApi: User navigates (SPA route change)
    Browser->>PHProvider: "useEffect fires (pathname = new URL)"
    PHProvider->>PHProvider: "isInitialPageView.current = false → call crPageView()"
    PHProvider->>Browser: window.signals.page()
    Browser->>CRApi: Reports SPA page view
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js (layout.tsx)
    participant CommonRoom as CommonRoom Script
    participant CRRelay as cdn.cr-relay.com
    participant PHProvider as PostHogProvider (useEffect)
    participant CRApi as api.cr-relay.com

    Browser->>NextJS: Initial page load
    NextJS->>Browser: Renders HTML (Script[afterInteractive])
    Browser->>Browser: Hydration complete
    Browser->>CommonRoom: Executes inline IIFE (sets window.signals stub)
    CommonRoom->>CRRelay: Fetches signals.js
    CRRelay-->>Browser: signals.js loaded
    Browser->>CRApi: Auto-fires initial page view (from signals.js)

    Browser->>PHProvider: "useEffect fires (pathname = initial URL)"
    PHProvider->>PHProvider: "isInitialPageView.current = true → set false, skip crPageView()"

    Note over Browser,CRApi: User navigates (SPA route change)
    Browser->>PHProvider: "useEffect fires (pathname = new URL)"
    PHProvider->>PHProvider: "isInitialPageView.current = false → call crPageView()"
    PHProvider->>Browser: window.signals.page()
    Browser->>CRApi: Reports SPA page view
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/analytics/common-room.tsx:15-16
The `typeof window === 'undefined'` check on line 15 is unreachable dead code. `strategy="afterInteractive"` guarantees this inline script only executes in the browser after hydration — `window` is always defined at that point.

```suggestion
  if (typeof window.signals !== 'undefined') return;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): add Common Room website..."](https://github.com/langfuse/langfuse-docs/commit/ac996d011c7c7c926107235b273cad566a217da7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38618860)</sub>

<!-- /greptile_comment -->