### PR TITLE
feat: add Scarf web traffic pixel to analytics layer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,7 @@ import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
 import { RedditPixel } from "@/components/analytics/reddit-ads";
 import { TwitterPixel } from "@/components/analytics/twitter-ads";
 import { ConversionTracker } from "@/components/analytics/ConversionTracker";
+import { ScarfPixel } from "@/components/analytics/scarf";
 import "../style.css";
 import "@vidstack/react/player/styles/base.css";
 import "../src/overrides.css";
@@ -100,6 +101,7 @@ export default function RootLayout({
             <RedditPixel />
             <TwitterPixel />
             <ConversionTracker />
+            <ScarfPixel />
             <Hubspot />
             <Script
               id="cookieyes"

--- a/components/analytics/scarf.tsx
+++ b/components/analytics/scarf.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+// Scarf web traffic pixel (https://docs.scarf.sh/web-traffic/).
+//
+// Scarf is a cookie-free, privacy-preserving analytics pixel — it sets no
+// cookies and stores no IP/PII — so it needs no consent banner and can fire on
+// every page.
+//
+// Scarf infers which page was viewed from the request's `Referer` header, so
+// the pixel MUST be loaded with `referrerPolicy="no-referrer-when-downgrade"`.
+// This site sends `Referrer-Policy: strict-origin-when-cross-origin` by default
+// (see next.config.mjs), which would strip the path on the cross-origin request
+// to static.scarf.sh and leave Scarf unable to segment traffic by route
+// (self-hosting, Docker Compose, Kubernetes/Helm, Terraform, pricing, SDK docs,
+// …). Setting the policy on the element overrides the document default for this
+// one request, so the full URL is sent and Scarf can segment by path.
+//
+// Because this is a client-side-routed Next.js app, a static pixel would only
+// fire on the initial load. We re-fire it on every route change (`usePathname`)
+// — the same approach `PostHogProvider` uses for `$pageview` — so client-side
+// navigations are counted too. Scarf responds with `no-store`, so each new
+// request reaches Scarf without a cache-busting query param.
+const SCARF_PIXEL_ID = "a083b1ee-8b4b-4903-88e8-ecbf7f22e7fe";
+
+export function ScarfPixel() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !pathname) return;
+
+    const pixel = new Image();
+    pixel.referrerPolicy = "no-referrer-when-downgrade";
+    pixel.src = `https://static.scarf.sh/a.png?x-pxid=${SCARF_PIXEL_ID}`;
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What

Adds a cookie-free [Scarf](https://docs.scarf.sh/web-traffic/) web traffic pixel to the site, fired through the existing production analytics layer in `app/layout.tsx`.

- **New component** `components/analytics/scarf.tsx` — a client component that fires the Scarf pixel and re-fires it on every client-side route change via `usePathname()` (same pattern as `PostHogProvider`).
- **Wired into** `app/layout.tsx` inside the existing `process.env.NODE_ENV === "production"` block, alongside the other analytics pixels.

## Why this shape

- **Route segmentation is automatic.** A single site-wide pixel is enough: Scarf reads the viewed page from the request's `Referer` header, so it segments self-hosting / Docker Compose / Kubernetes-Helm / Terraform / pricing / SDK docs automatically in its dashboard — no per-route pixel IDs needed.
- **Element-level `referrerPolicy` is load-bearing.** The site sends `Referrer-Policy: strict-origin-when-cross-origin` by default (`next.config.mjs`), which would strip the path on the cross-origin request to `static.scarf.sh`. Setting `no-referrer-when-downgrade` on the element overrides that for this one request so Scarf gets the full path. This is exactly what Scarf's snippet specifies.
- **SPA re-fire.** Scarf's docs note that in client-routed apps a static pixel only fires on initial load. ClickHouse (Docusaurus) uses a static `<img>`; LibreChat (App Router, like us) injects `new Image()` and re-fires on navigation. This PR uses `usePathname()` — the idiomatic App Router equivalent — so client-side navigations are counted too.
- **Cookie-free / no PII**, so it needs no consent gating and fires regardless of CookieYes. Production-gated, matching the other pixels.

## Validation

- Pixel endpoint is live: `GET https://static.scarf.sh/a.png?x-pxid=…` → `200 image/png`; responds `no-cache, no-store`, so each route re-fire reaches Scarf without a cache-buster.
- CSP already allows it (`img-src 'self' https: …`).
- `prettier --check` passes on both changed files.

## Note

The Scarf README pixel for the `langfuse/langfuse` repo is a separate change in that repo and is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a cookie-free Scarf web traffic pixel to the documentation site's analytics layer, wired into the existing production-only block in `app/layout.tsx`. The implementation correctly re-fires the pixel on client-side navigations using `usePathname()` and overrides the document-level `Referrer-Policy` at the element level so Scarf receives the full URL path for route segmentation.

- **`components/analytics/scarf.tsx`** — New client component that fires `new Image()` against the Scarf endpoint on mount and on every `pathname` change; `referrerPolicy="no-referrer-when-downgrade"` is set directly on the image element to override the site's default `strict-origin-when-cross-origin` policy for this one cross-origin request.
- **`app/layout.tsx`** — `ScarfPixel` is imported at the top of the module and rendered inside the `process.env.NODE_ENV === "production"` guard, consistent with all other analytics pixels on the page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, production-gated, and follows the same pattern as every other analytics pixel in the layout.

The new component is small, well-commented, and consistent with existing analytics integrations. The only note is a dead-code window guard inside useEffect that has no runtime impact.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextRouter as Next.js Router
    participant ScarfPixel as ScarfPixel (client component)
    participant Scarf as static.scarf.sh

    Browser->>NextRouter: Initial page load
    NextRouter->>ScarfPixel: "Mount, pathname = current path"
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=... (referrerPolicy: no-referrer-when-downgrade)"
    Note over Scarf: Reads Referer header → full URL with path

    Browser->>NextRouter: Client-side navigation
    NextRouter->>ScarfPixel: pathname changes (usePathname)
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=... (re-fired, no-store → not cached)"
    Note over Scarf: Segments traffic by route in dashboard
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextRouter as Next.js Router
    participant ScarfPixel as ScarfPixel (client component)
    participant Scarf as static.scarf.sh

    Browser->>NextRouter: Initial page load
    NextRouter->>ScarfPixel: "Mount, pathname = current path"
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=... (referrerPolicy: no-referrer-when-downgrade)"
    Note over Scarf: Reads Referer header → full URL with path

    Browser->>NextRouter: Client-side navigation
    NextRouter->>ScarfPixel: pathname changes (usePathname)
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=... (re-fired, no-store → not cached)"
    Note over Scarf: Segments traffic by route in dashboard
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/analytics/scarf.tsx:32
The `typeof window === "undefined"` guard is dead code inside `useEffect` — React never runs effects on the server, so `window` is always defined at this point. The `!pathname` guard is sufficient on its own. Removing the window check avoids misleading future readers into thinking SSR execution is possible here.

```suggestion
    if (!pathname) return;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Scarf web traffic pixel to ana..."](https://github.com/langfuse/langfuse-docs/commit/34687b3dbe08ecade4387e53f3008e9a686679fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38619049)</sub>

<!-- /greptile_comment -->