### PR TITLE
docs(legal): add Scarf and Common Room vendors, update company address

### DIFF
--- a/content/handbook/tools-and-processes/travel-and-expense-policy.mdx
+++ b/content/handbook/tools-and-processes/travel-and-expense-policy.mdx
@@ -54,4 +54,4 @@ You are not required to book these specific properties, but they are tried and t
 
 ### Booking and invoices
 
-Please book your travel and accommodation via Pleo cards and upload the correct invoices addressed to our commercial Langfuse GmbH address ([Gethsemanestraße 4, 10437 Berlin](/imprint)). Include our VAT ID (DE358330767) if it is a cross-border transaction. More info in [Spending money](/handbook/tools-and-processes/spending-money).
+Please book your travel and accommodation via Pleo cards and upload the correct invoices addressed to our commercial Langfuse GmbH address ([Oranienburgerstraße 91, 10178 Berlin](/imprint)). Include our VAT ID (DE358330767) if it is a cross-border transaction. More info in [Spending money](/handbook/tools-and-processes/spending-money).

--- a/content/marketing/cookie-policy.mdx
+++ b/content/marketing/cookie-policy.mdx
@@ -75,7 +75,7 @@ The date at the top of this Cookie Policy indicates when it was last updated.
 If you have any questions about our use of cookies or other technologies, please email us at legal@langfuse.com or by post to:
 
 Langfuse GmbH<br />
-Gethsemanestraße 4 c/o Deichmann<br />
-10437 Berlin<br />
+Oranienburgerstraße 91<br />
+10178 Berlin<br />
 Germany<br />
 Phone: (+49)015208459573

--- a/content/marketing/cookie-policy.mdx
+++ b/content/marketing/cookie-policy.mdx
@@ -4,7 +4,7 @@ title: Cookie Policy
 
 # Cookie Policy
 
-**Last updated: May 06, 2024 | <a href="/api/md-to-pdf?url=/cookie-policy.md" target="_blank">download as PDF</a>**
+**Last updated: June 19, 2026 | <a href="/api/md-to-pdf?url=/cookie-policy.md" target="_blank">download as PDF</a>**
 
 This Cookie Policy explains how **Langfuse GmbH** ("Company," "we," "us," and "our") uses cookies and similar technologies to recognize you when you visit our website at https://www.langfuse.com ("Website"). It explains what these technologies are and why we use them, as well as your rights to control our use of them.
 

--- a/content/marketing/privacy.mdx
+++ b/content/marketing/privacy.mdx
@@ -183,6 +183,7 @@ We may share your data with third-party vendors, service providers, contractors,
   - Resend
   - cal.com
   - Google Workspace
+  - Common Room
 - **Allow Users to Connect to Their Third-Party Accounts**
   - Google Authentication, GitHub, AzureAD
 - **Cloud Computing Services**
@@ -201,6 +202,7 @@ We may share your data with third-party vendors, service providers, contractors,
   - Stripe
 - **Product metrics**
   - Posthog, Inc.
+  - Scarf
 - **Recruiting**
   - Ashby
 - **Internal Use**
@@ -385,16 +387,15 @@ to be informed of how we are protecting your information.
 If you have questions or comments about this notice, you may email us at **legal@langfuse.com** or contact us by post at:
 
 Langfuse GmbH\
-Oranienburger Str. 91
-10178
-Berlin
+Oranienburgerstraße 91\
+10178 Berlin\
 Germany
 
 If you are a resident in the European Economic Area, we are the "data controller" of your personal information. We have appointed **Langfuse GmbH** to be our representative in the EEA. You can contact them directly regarding our processing of your information, by email at **legal@langfuse.com**, by visiting [https://langfuse.com](https://langfuse.com), by phone at **+49 0152 08459573**, or by post to:
 
-Langfuse GmbH
-Gethsemanestr. 4\
-Berlin, Berlin 10437\
+Langfuse GmbH\
+Oranienburgerstraße 91\
+10178 Berlin\
 Germany
 
 ## 15. How Can You Review, Update, or Delete the Data We Collect From You? [#review]

--- a/content/marketing/privacy.mdx
+++ b/content/marketing/privacy.mdx
@@ -4,7 +4,7 @@ title: Privacy Policy
 
 # Privacy Policy
 
-**Last updated March 26th, 2026 | <a href="/api/md-to-pdf?url=/privacy.md" target="_blank">download as PDF</a>**
+**Last updated June 19th, 2026 | <a href="/api/md-to-pdf?url=/privacy.md" target="_blank">download as PDF</a>**
 
 This privacy notice for **Langfuse GmbH** ("**we**," "**us**," or "**our**"), describes how and why we might collect, store, use, and/or share ("**process**") your information when you use our services ("**Services**"), such as when you:
 

--- a/content/marketing/privacy.mdx
+++ b/content/marketing/privacy.mdx
@@ -184,6 +184,9 @@ We may share your data with third-party vendors, service providers, contractors,
   - cal.com
   - Google Workspace
   - Common Room
+  - LinkedIn
+  - Reddit
+  - X (formerly Twitter)
 - **Allow Users to Connect to Their Third-Party Accounts**
   - Google Authentication, GitHub, AzureAD
 - **Cloud Computing Services**

--- a/content/security/dpa.mdx
+++ b/content/security/dpa.mdx
@@ -210,7 +210,7 @@ Please refer to Section 4 of this DPA for further information on subprocessing.
 
 - **Data exporter:** the Client as identified in the Main Contract, including its legal name, registered address and contact details as recorded therein; role: Controller (and/or Processor for onward transfers as applicable).
 
-- **Data importer:** Langfuse GmbH, Gethsemanestr. 4, 10437 Berlin, Germany; privacy@langfuse.com; legal@langfuse.com; role: Processor.
+- **Data importer:** Langfuse GmbH, Oranienburgerstraße 91, 10178 Berlin, Germany; privacy@langfuse.com; legal@langfuse.com; role: Processor.
 
 _(Additional Langfuse entities and/or sub‑processors may accede pursuant to Clause 7 by executing an accession; no further Client action is required.)_
 
@@ -246,7 +246,7 @@ The sub‑processors in Annex 3 are incorporated here by reference as Annex III 
 
 For restricted transfers under the UK GDPR, the Parties incorporate by reference the UK Information Commissioner's International Data Transfer Addendum to the EU SCCs (Version B1.0, in force 21 March 2022\) (the 'UK Addendum'). The UK Addendum varies the EU SCCs only as required by UK law.
 
-- **Table 1 (Parties):** Exporter \= the Client as identified in the Main Contract; Importer \= Langfuse GmbH, Gethsemanestr. 4, 10437 Berlin, Germany.
+- **Table 1 (Parties):** Exporter \= the Client as identified in the Main Contract; Importer \= Langfuse GmbH, Oranienburgerstraße 91, 10178 Berlin, Germany.
 
 - **Table 2 (Selected SCCs):** EU SCCs (Decision (EU) 2021/914), Module 2 and/or Module 3; Docking clause included; Clause 9 Option 2 with 30 days; Clause 17 \= German law; Clause 18 \= courts of Berlin, Germany.
 

--- a/content/security/nda.mdx
+++ b/content/security/nda.mdx
@@ -19,7 +19,7 @@ This Mutual Non-Disclosure Agreement (the "Agreement") is entered into by and be
 
 **Party 1:**\
 Langfuse GmbH\
-Gethsemanestr. 4, 10437 Berlin, Germany\
+Oranienburgerstraße 91, 10178 Berlin, Germany\
 Notices to: legal@langfuse.com
 
 **Party 2:**\


### PR DESCRIPTION
## What changed

**Privacy policy (`content/marketing/privacy.mdx`)**
- Added two third-party tracking vendors to section 4 ("When and With Whom Do We Share Your Personal Information?"):
  - **Common Room** → *Advertising, Direct Marketing, and Lead Generation* (customer/community-intelligence and lead-gen platform)
  - **Scarf** → *Product metrics*, alongside PostHog (website/usage analytics)
- Updated both postal-address blocks to the current imprint address (**Oranienburgerstraße 91, 10178 Berlin, Germany**):
  - The EEA-representative block still carried the **old** address (Gethsemanestr. 4, 10437 Berlin).
  - The "contact us by post" block had broken line breaks collapsing the street/zip/city onto one line and used an abbreviated street name — fixed and standardized.

**Cookie policy (`content/marketing/cookie-policy.mdx`)**
- Updated the postal address (was Gethsemanestraße 4 c/o Deichmann, 10437 Berlin) to **Oranienburgerstraße 91, 10178 Berlin**. Phone number unchanged.

## Why

Scarf and Common Room are now used to track website visitors, so they need to be disclosed as vendors. The company address was also outdated relative to the imprint.

## Reviewer notes
- **Cookie policy vendor table is not edited here.** The vendor/cookie list on the cookie policy page is the dynamic `cky-audit-table-element` rendered by the CookieYes consent manager, not static MDX. Scarf and Common Room still need to be added/categorized in the **CookieYes dashboard** to appear there.
- **Subprocessors page left untouched.** `content/security/subprocessors.mdx` is scoped to Client Data processed inside the Langfuse Cloud product, not marketing-site tracking, so the two vendors were not added there.
- Two judgment calls worth a sanity check: Common Room's category (marketing/lead-gen vs. product metrics) and keeping the existing phone number on the cookie policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates two marketing legal pages — the privacy policy and cookie policy — to disclose two newly-deployed tracking vendors and correct a stale company address. No code logic is changed.

- **Vendor additions**: Common Room is added under "Advertising, Direct Marketing, and Lead Generation" and Scarf is added under "Product metrics" in `privacy.mdx`.
- **Address updates**: Both `privacy.mdx` (two address blocks, including the EEA-representative block that still carried the old `Gethsemanestr. 4` address) and `cookie-policy.mdx` are updated to the current `Oranienburgerstraße 91, 10178 Berlin` address; line-break formatting is also fixed in `privacy.mdx`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are limited to legal disclosure text and postal addresses in two MDX pages, with no code or configuration touched.

All three address blocks across the two files are now consistently updated to the new address, and the two new tracking vendors are placed in plausible categories. The one open question is whether four other files elsewhere in the repo (nda.mdx, dpa.mdx ×2, travel-and-expense-policy.mdx) should also have their old address updated — some may intentionally retain it for signed-contract reasons, but this PR does not address them.

content/security/nda.mdx, content/security/dpa.mdx, and content/handbook/tools-and-processes/travel-and-expense-policy.mdx still reference the old Gethsemanestr. 4 address and may warrant a follow-up PR.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: docs/legal updates] --> B[privacy.mdx]
    A --> C[cookie-policy.mdx]

    B --> D[Vendor list — Section 4]
    D --> D1[Advertising/Lead-Gen: + Common Room]
    D --> D2[Product metrics: + Scarf]

    B --> E[Address blocks]
    E --> E1["Contact us by post\nOranienburgerstraße 91, 10178 Berlin ✔"]
    E --> E2["EEA representative block\nOranienburgerstraße 91, 10178 Berlin ✔\n(was Gethsemanestr. 4, 10437 Berlin)"]

    C --> F["Contact address\nOranienburgerstraße 91, 10178 Berlin ✔\n(was Gethsemanestraße 4 c/o Deichmann, 10437 Berlin)"]

    style D1 fill:#d4edda,stroke:#28a745
    style D2 fill:#d4edda,stroke:#28a745
    style E1 fill:#d4edda,stroke:#28a745
    style E2 fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR: docs/legal updates] --> B[privacy.mdx]
    A --> C[cookie-policy.mdx]

    B --> D[Vendor list — Section 4]
    D --> D1[Advertising/Lead-Gen: + Common Room]
    D --> D2[Product metrics: + Scarf]

    B --> E[Address blocks]
    E --> E1["Contact us by post\nOranienburgerstraße 91, 10178 Berlin ✔"]
    E --> E2["EEA representative block\nOranienburgerstraße 91, 10178 Berlin ✔\n(was Gethsemanestr. 4, 10437 Berlin)"]

    C --> F["Contact address\nOranienburgerstraße 91, 10178 Berlin ✔\n(was Gethsemanestraße 4 c/o Deichmann, 10437 Berlin)"]

    style D1 fill:#d4edda,stroke:#28a745
    style D2 fill:#d4edda,stroke:#28a745
    style E1 fill:#d4edda,stroke:#28a745
    style E2 fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/marketing/privacy.mdx:186
**Other files still reference the old address**

`content/security/nda.mdx` (line 22), `content/security/dpa.mdx` (lines 213 and 249), and `content/handbook/tools-and-processes/travel-and-expense-policy.mdx` (line 57) all still reference `Gethsemanestr. 4, 10437 Berlin`. If the move is complete and the old address is no longer valid for any purpose, those files may need matching updates. Some (especially `dpa.mdx` clauses) may intentionally retain the historical address for signed-contract continuity — worth confirming before changing them.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(legal): add Scarf and Common Room v..."](https://github.com/langfuse/langfuse-docs/commit/34ef2a6f9b4072133baa9ee3ae8a7e58515b78eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38619615)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->