### PR TITLE
docs: clarify Python masking export scope

### DIFF
--- a/content/docs/observability/features/masking.mdx
+++ b/content/docs/observability/features/masking.mdx
@@ -75,6 +75,12 @@ langfuse = Langfuse(mask_otel_spans=mask_otel_spans)
 - The hook can only change span attributes. It cannot change the span name, IDs, parent relationship, resource attributes, events, links, or instrumentation scope.
 - The hook affects only spans exported by this Langfuse client. If the same OpenTelemetry spans are sent to another exporter, that exporter receives its own unmodified copy.
 
+<Callout type="info">
+
+`mask_otel_spans` only affects spans that pass through the Langfuse Python SDK span processor and are exported by this Langfuse client. If you also send telemetry to another observability backend through a separate OpenTelemetry span processor or exporter, that backend receives its own unmodified copy of the spans. Configure masking separately for any non-Langfuse exporter.
+
+</Callout>
+
 <Callout type="warning">
 
 `mask_otel_spans` is synchronous. It usually runs on the OpenTelemetry batch span processor worker thread, so it should not block the main caller thread of your application. During `flush()` and shutdown it may run on the caller thread.


### PR DESCRIPTION
## Summary

- Add an info callout to the Python `mask_otel_spans` docs.
- Clarify that masking only applies to spans that pass through the Langfuse Python SDK span processor and are exported by that Langfuse client.
- Note that separate third-party observability exporters receive their own unmodified span copy and need separate masking.

## Validation

- `bun x prettier@3.8.4 --experimental-cli --check content/docs/observability/features/masking.mdx`
- `git diff --check`

Note: `gh` is not available on PATH in this sandboxed session, so I used the GitHub connector to open the PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an informational `<Callout type="info">` block to the Python `mask_otel_spans` documentation to more prominently clarify that masking only applies to spans exported through the Langfuse Python SDK span processor, and that separate third-party exporters receive their own unmodified span copies requiring separate masking configuration.

- Adds a new `<Callout type="info">` block directly after the existing bullet-point contract list and before the existing `<Callout type="warning">` in `masking.mdx`, making the export-scope limitation visually prominent.
- The callout adds an explicit actionable note ("Configure masking separately for any non-Langfuse exporter") that was not present in the existing bullet point on the same topic.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that adds a clarifying callout — no code, configuration, or behavior is modified.

The change is purely additive prose in a single `.mdx` file. The new callout is technically accurate (OTel processors/exporters each receive their own span copy), uses the correct existing `<Callout>` component convention already present in the file, and adds an actionable recommendation not present in the adjacent bullet point. There is a minor overlap with bullet point line 76, but the callout's added guidance ("Configure masking separately for any non-Langfuse exporter") makes it non-redundant.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenTelemetry Span Created] --> B[OTel SDK distributes span to registered processors]
    B --> C[Langfuse Python SDK Span Processor]
    B --> D[Third-party Span Processor / Exporter]
    C --> E["mask_otel_spans hook applied\n(modifies attributes)"]
    E --> F[Langfuse Backend\nreceives masked span]
    D --> G[Third-party Observability Backend\nreceives unmodified span copy]
    G --> H["⚠️ Requires separate masking config\n(not handled by mask_otel_spans)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OpenTelemetry Span Created] --> B[OTel SDK distributes span to registered processors]
    B --> C[Langfuse Python SDK Span Processor]
    B --> D[Third-party Span Processor / Exporter]
    C --> E["mask_otel_spans hook applied\n(modifies attributes)"]
    E --> F[Langfuse Backend\nreceives masked span]
    D --> G[Third-party Observability Backend\nreceives unmodified span copy]
    G --> H["⚠️ Requires separate masking config\n(not handled by mask_otel_spans)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify Python masking export scop..."](https://github.com/langfuse/langfuse-docs/commit/9f5b9b433167b000bc695f64551b23bfa89e51ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38621626)</sub>

<!-- /greptile_comment -->