### PR TITLE
Add Z.ai integration cookbook guide

### DIFF
--- a/content/integrations/model-providers/meta.json
+++ b/content/integrations/model-providers/meta.json
@@ -27,6 +27,7 @@
     "qwen",
     "togetherai",
     "vllm",
-    "xai-grok"
+    "xai-grok",
+    "z-ai"
   ]
 }

--- a/content/integrations/model-providers/z-ai.mdx
+++ b/content/integrations/model-providers/z-ai.mdx
@@ -70,10 +70,6 @@ print(response.choices[0].message.content)
 
 After running the example, open [Langfuse Cloud](https://langfuse.com/cloud) to see the full trace including prompts, completions, tool calls, token usage, and latency.
 
-![Example Z.ai trace in Langfuse](https://langfuse.com/images/cookbook/integration-z-ai/z-ai-example-trace.png)
-
-[Example trace in Langfuse](https://cloud.langfuse.com/project/~/traces)
-
 </Steps>
 
 import LearnMore from "@/components-mdx/integration-learn-more.mdx";

--- a/content/integrations/model-providers/z-ai.mdx
+++ b/content/integrations/model-providers/z-ai.mdx
@@ -1,0 +1,81 @@
+---
+source: ⚠️ Jupyter Notebook
+title: Observability for Z.ai with Langfuse
+sidebarTitle: Z.ai
+logo: /images/integrations/z-ai_icon.svg
+description: Guide on using Z.ai's GLM models with Langfuse via the OpenAI SDK to trace, debug, and evaluate your LLM applications.
+category: Integrations
+---
+
+# Observability for Z.ai with Langfuse
+
+This guide shows you how to integrate Langfuse with Z.ai. Z.ai's API endpoints are fully compatible with the OpenAI SDK, allowing you to trace and monitor your AI applications seamlessly.
+
+> **What is Z.ai?** [Z.ai](https://z.ai/) provides API access to the GLM family of large language models (such as GLM-4.6) through OpenAI-compatible endpoints.
+
+> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source LLM engineering platform that helps teams trace API calls, monitor performance, and debug issues in their AI applications.
+
+<Steps>
+## Step 1: Install Dependencies
+
+```python
+%pip install openai langfuse
+```
+
+## Step 2: Set Up Environment Variables
+
+Get your Langfuse keys from the project settings in [Langfuse Cloud](https://langfuse.com/cloud) or set up [self-hosting](https://langfuse.com/self-hosting).
+
+```python
+import os
+
+# Get keys for your project from the project settings page: https://langfuse.com/cloud
+os.environ.setdefault("LANGFUSE_PUBLIC_KEY", "pk-lf-...")
+os.environ.setdefault("LANGFUSE_SECRET_KEY", "sk-lf-...")
+os.environ.setdefault("LANGFUSE_BASE_URL", "https://cloud.langfuse.com") # 🇪🇺 EU region (API host)
+# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
+
+os.environ.setdefault("ZAI_API_BASE", "https://api.z.ai/api/paas/v4/")
+os.environ.setdefault("ZAI_API_KEY", "...")
+```
+
+## Step 3: Use Langfuse OpenAI Drop-in Replacement
+
+Instead of importing `openai` directly, import it from `langfuse.openai`. Requests made through this client are automatically traced in Langfuse. Point the client at the Z.ai base URL and authenticate with your Z.ai API key.
+
+```python
+from langfuse.openai import openai
+
+client = openai.OpenAI(
+  api_key=os.environ.get("ZAI_API_KEY"),
+  base_url=os.environ.get("ZAI_API_BASE")
+)
+```
+
+## Step 4: Run an Example
+
+```python
+response = client.chat.completions.create(
+  model="glm-4.6",
+  messages=[
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Why is open source important?"},
+  ],
+  name="Z-ai-Trace" # name of the trace
+)
+print(response.choices[0].message.content)
+```
+
+## Step 5: View Traces in Langfuse
+
+After running the example, open [Langfuse Cloud](https://langfuse.com/cloud) to see the full trace including prompts, completions, tool calls, token usage, and latency.
+
+![Example Z.ai trace in Langfuse](https://langfuse.com/images/cookbook/integration-z-ai/z-ai-example-trace.png)
+
+[Example trace in Langfuse](https://cloud.langfuse.com/project/~/traces)
+
+</Steps>
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />

--- a/cookbook/_routes.json
+++ b/cookbook/_routes.json
@@ -498,5 +498,10 @@
     "notebook": "js_integration_flue.ipynb",
     "docsPath": "integrations/frameworks/flue",
     "isGuide": false
+  },
+  {
+    "notebook": "integration_z-ai.ipynb",
+    "docsPath": "integrations/model-providers/z-ai",
+    "isGuide": false
   }
 ]

--- a/cookbook/integration_z-ai.ipynb
+++ b/cookbook/integration_z-ai.ipynb
@@ -140,7 +140,7 @@
         "\n",
         "![Example Z.ai trace in Langfuse](https://langfuse.com/images/cookbook/integration-z-ai/z-ai-example-trace.png)\n",
         "\n",
-        "[Example trace in Langfuse](TODO: replace with your own public example trace URL from your Langfuse Cloud project)\n",
+        "[Example trace in Langfuse](https://cloud.langfuse.com/project/~/traces)\n",
         "\n",
         "<!-- STEPS_END -->"
       ]

--- a/cookbook/integration_z-ai.ipynb
+++ b/cookbook/integration_z-ai.ipynb
@@ -138,10 +138,6 @@
         "\n",
         "After running the example, open [Langfuse Cloud](https://langfuse.com/cloud) to see the full trace including prompts, completions, tool calls, token usage, and latency.\n",
         "\n",
-        "![Example Z.ai trace in Langfuse](https://langfuse.com/images/cookbook/integration-z-ai/z-ai-example-trace.png)\n",
-        "\n",
-        "[Example trace in Langfuse](https://cloud.langfuse.com/project/~/traces)\n",
-        "\n",
         "<!-- STEPS_END -->"
       ]
     },

--- a/cookbook/integration_z-ai.ipynb
+++ b/cookbook/integration_z-ai.ipynb
@@ -1,0 +1,172 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "<!-- NOTEBOOK_METADATA source: \"⚠️ Jupyter Notebook\" title: \"Observability for Z.ai with Langfuse\" sidebarTitle: \"Z.ai\" logo: \"/images/integrations/z-ai_icon.svg\" description: \"Guide on using Z.ai's GLM models with Langfuse via the OpenAI SDK to trace, debug, and evaluate your LLM applications.\" category: \"Integrations\" -->\n",
+        "\n",
+        "# Observability for Z.ai with Langfuse\n",
+        "\n",
+        "This guide shows you how to integrate Langfuse with Z.ai. Z.ai's API endpoints are fully compatible with the OpenAI SDK, allowing you to trace and monitor your AI applications seamlessly.\n",
+        "\n",
+        "> **What is Z.ai?** [Z.ai](https://z.ai/) provides API access to the GLM family of large language models (such as GLM-4.6) through OpenAI-compatible endpoints.\n",
+        "\n",
+        "> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source LLM engineering platform that helps teams trace API calls, monitor performance, and debug issues in their AI applications."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "<!-- STEPS_START -->\n",
+        "## Step 1: Install Dependencies"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install openai langfuse"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "## Step 2: Set Up Environment Variables\n",
+        "\n",
+        "Get your Langfuse keys from the project settings in [Langfuse Cloud](https://langfuse.com/cloud) or set up [self-hosting](https://langfuse.com/self-hosting)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Get keys for your project from the project settings page: https://langfuse.com/cloud\n",
+        "os.environ.setdefault(\"LANGFUSE_PUBLIC_KEY\", \"pk-lf-...\")\n",
+        "os.environ.setdefault(\"LANGFUSE_SECRET_KEY\", \"sk-lf-...\")\n",
+        "os.environ.setdefault(\"LANGFUSE_BASE_URL\", \"https://cloud.langfuse.com\") # 🇪🇺 EU region (API host)\n",
+        "# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com\n",
+        "\n",
+        "os.environ.setdefault(\"ZAI_API_BASE\", \"https://api.z.ai/api/paas/v4/\")\n",
+        "os.environ.setdefault(\"ZAI_API_KEY\", \"...\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "## Step 3: Use Langfuse OpenAI Drop-in Replacement\n",
+        "\n",
+        "Instead of importing `openai` directly, import it from `langfuse.openai`. Requests made through this client are automatically traced in Langfuse. Point the client at the Z.ai base URL and authenticate with your Z.ai API key."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langfuse.openai import openai\n",
+        "\n",
+        "client = openai.OpenAI(\n",
+        "  api_key=os.environ.get(\"ZAI_API_KEY\"),\n",
+        "  base_url=os.environ.get(\"ZAI_API_BASE\")\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "## Step 4: Run an Example"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "response = client.chat.completions.create(\n",
+        "  model=\"glm-4.6\",\n",
+        "  messages=[\n",
+        "    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+        "    {\"role\": \"user\", \"content\": \"Why is open source important?\"},\n",
+        "  ],\n",
+        "  name=\"Z-ai-Trace\" # name of the trace\n",
+        ")\n",
+        "print(response.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "## Step 5: View Traces in Langfuse\n",
+        "\n",
+        "After running the example, open [Langfuse Cloud](https://langfuse.com/cloud) to see the full trace including prompts, completions, tool calls, token usage, and latency.\n",
+        "\n",
+        "![Example Z.ai trace in Langfuse](https://langfuse.com/images/cookbook/integration-z-ai/z-ai-example-trace.png)\n",
+        "\n",
+        "[Example trace in Langfuse](TODO: replace with your own public example trace URL from your Langfuse Cloud project)\n",
+        "\n",
+        "<!-- STEPS_END -->"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "<!-- MARKDOWN_COMPONENT name: \"LearnMore\" path: \"@/components-mdx/integration-learn-more.mdx\" -->"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/public/images/integrations/z-ai_icon.svg
+++ b/public/images/integrations/z-ai_icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000" fill="none">
+  <rect x="60" y="60" width="880" height="880" rx="180" fill="#2B2B2B"/>
+  <g transform="translate(93,0) skewX(-11)" fill="#FFFFFF">
+    <!-- continuous Z: top bar + diagonal + bottom bar -->
+    <path d="M310 235 L795 235 L795 330 L440 635 L690 635 L690 730 L205 730 L205 635 L560 330 L310 330 Z"/>
+    <!-- detached top-left segment -->
+    <path d="M205 235 L280 235 L280 330 L205 330 Z"/>
+    <!-- detached bottom-right segment -->
+    <path d="M720 635 L795 635 L795 730 L720 730 Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds a new cookbook guide demonstrating how to integrate Langfuse with Z.ai's GLM models using the OpenAI SDK for tracing and monitoring AI applications.

## Changes

- **New notebook**: `cookbook/integration_z-ai.ipynb`
  - Step-by-step guide for setting up Langfuse with Z.ai
  - Covers environment configuration, client initialization, and example usage
  - Includes instructions for viewing traces in Langfuse Cloud
  - Uses Langfuse's OpenAI drop-in replacement for automatic tracing

- **Updated routing**: `cookbook/_routes.json`
  - Added entry mapping the new notebook to `integrations/model-providers/z-ai` docs path

## Implementation Details

The guide demonstrates:
- Installing required dependencies (`openai`, `langfuse`)
- Configuring Langfuse credentials and Z.ai API endpoints
- Using `langfuse.openai.openai.OpenAI` client with Z.ai's base URL and API key
- Making a chat completion request to the GLM-4.6 model with automatic tracing
- Viewing the resulting trace in Langfuse Cloud

The notebook follows the standard cookbook format with metadata for documentation generation and will be converted to markdown docs via the `update_cookbook_docs.sh` script.

https://claude.ai/code/session_01XapmrKz35o1Rmcou6c2P9c

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new cookbook notebook (`integration_z-ai.ipynb`) demonstrating how to integrate Langfuse with Z.ai's GLM models via the OpenAI-compatible SDK drop-in replacement, along with its routing entry in `_routes.json`.

- The notebook follows the standard 5-step cookbook format (install, env vars, drop-in client, example call, view traces) and is consistent with other provider integration guides.
- Step 5 contains an unfilled `TODO` placeholder for the example public trace link, which will be rendered verbatim as a broken link once the notebook is converted to docs markdown — this needs a real Langfuse Cloud trace URL before merging.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The code logic and routing are correct, but the notebook has an unfilled placeholder link that will appear broken in the published documentation.

The integration code itself is straightforward and mirrors other well-established cookbook guides. The one concrete problem is the TODO string left in place of a real public example trace URL in Step 5 — when update_cookbook_docs.sh converts this notebook, it will render as a malformed hyperlink on the live docs page. Everything else (env setup, client initialization, model call, route entry) looks correct.

cookbook/integration_z-ai.ipynb — Step 5 needs a real public Langfuse Cloud trace URL to replace the TODO placeholder before this is published.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User / Notebook
    participant LF as langfuse.openai (drop-in)
    participant ZAI as Z.ai API (GLM-4.6)
    participant LFC as Langfuse Cloud

    User->>LF: "openai.OpenAI(api_key, base_url=Z.ai)"
    User->>LF: "chat.completions.create(model=glm-4.6, messages, name=Z-ai-Trace)"
    LF->>ZAI: Proxied OpenAI-compatible request
    ZAI-->>LF: Chat completion response
    LF-->>User: response.choices[0].message.content
    LF->>LFC: Async trace (prompt, completion, token usage, latency)
    User->>LFC: View trace in Langfuse Cloud UI
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User / Notebook
    participant LF as langfuse.openai (drop-in)
    participant ZAI as Z.ai API (GLM-4.6)
    participant LFC as Langfuse Cloud

    User->>LF: "openai.OpenAI(api_key, base_url=Z.ai)"
    User->>LF: "chat.completions.create(model=glm-4.6, messages, name=Z-ai-Trace)"
    LF->>ZAI: Proxied OpenAI-compatible request
    ZAI-->>LF: Chat completion response
    LF-->>User: response.choices[0].message.content
    LF->>LFC: Async trace (prompt, completion, token usage, latency)
    User->>LFC: View trace in Langfuse Cloud UI
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
cookbook/integration_z-ai.ipynb:148-150
**Unfilled TODO placeholder will publish to docs**

The example trace link is still a raw `TODO` string: `[Example trace in Langfuse](TODO: replace with your own public example trace URL from your Langfuse Cloud project)`. When the notebook is converted to markdown via `update_cookbook_docs.sh`, this will render verbatim as a broken link on the docs page. Other integration notebooks (e.g., `integration_byteplus.ipynb`) include a real public Langfuse Cloud trace URL here — this one needs the same before it ships.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Z.ai integration page (OpenAI SDK dr..."](https://github.com/langfuse/langfuse-docs/commit/d5d7838bc58241984ba795a79d36f9a98fe17576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38623412)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->