### PR TITLE
docs: add changelog post for Langfuse Assistant (Public Beta)

### DIFF
--- a/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
+++ b/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
@@ -1,13 +1,12 @@
 ---
 date: 2026-06-19
-title: Chat with your data using the Langfuse Assistant
+title: Langfuse Assistant
 description: The Langfuse Assistant is now in public beta for everyone on Langfuse Cloud. Ask questions about your traces, observations, and metrics in plain language.
 author: Ben Bachem
 ogVideo: https://static.langfuse.com/docs-videos/in-app-agent.mp4
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
-import { Book } from "lucide-react";
 
 <ChangelogHeader />
 
@@ -26,14 +25,3 @@ The Assistant runs on the [Langfuse MCP server](/docs/api-and-data-platform/feat
 This is the initial release. More capabilities will follow.
 
 The Assistant is Langfuse Cloud only and still labeled Beta. It is free during the Beta, though pricing may change later.
-
-## Get started [#get-started]
-
-<Cards num={1}>
-  <Card
-    title="MCP server documentation"
-    href="/docs/api-and-data-platform/features/mcp-server"
-    icon={<Book />}
-    arrow
-  />
-</Cards>

--- a/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
+++ b/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
@@ -3,6 +3,7 @@ date: 2026-06-19
 title: Chat with your data using the Langfuse Assistant
 description: The Langfuse Assistant is now in public beta for everyone on Langfuse Cloud. Ask questions about your traces, observations, and metrics in plain language.
 author: Ben Bachem
+ogVideo: https://static.langfuse.com/docs-videos/in-app-agent.mp4
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
@@ -17,12 +18,6 @@ Ask in plain language. For example:
 - "Which traces had the highest latency yesterday?"
 - "Show me failed generations in the last hour."
 - "What's my token spend this week, broken down by model?"
-
-{/* TODO: add screenshot or short screen recording of the Assistant answering a question over real trace data */}
-
-<Frame fullWidth>
-  ![Langfuse Assistant answering a question about trace data](/images/changelog/2026-06-19-langfuse-assistant-public-beta.png)
-</Frame>
 
 ## How it works
 

--- a/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
+++ b/content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx
@@ -1,0 +1,44 @@
+---
+date: 2026-06-19
+title: Chat with your data using the Langfuse Assistant
+description: The Langfuse Assistant is now in public beta for everyone on Langfuse Cloud. Ask questions about your traces, observations, and metrics in plain language.
+author: Ben Bachem
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book } from "lucide-react";
+
+<ChangelogHeader />
+
+The Langfuse Assistant is now available to everyone on Langfuse Cloud. No opt-in, no Feature Preview modal. Open it and start asking questions about your data.
+
+Ask in plain language. For example:
+
+- "Which traces had the highest latency yesterday?"
+- "Show me failed generations in the last hour."
+- "What's my token spend this week, broken down by model?"
+
+{/* TODO: add screenshot or short screen recording of the Assistant answering a question over real trace data */}
+
+<Frame fullWidth>
+  ![Langfuse Assistant answering a question about trace data](/images/changelog/2026-06-19-langfuse-assistant-public-beta.png)
+</Frame>
+
+## How it works
+
+The Assistant runs on the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server), the same MCP server you can connect to your own tools. It uses those tools to query your traces, observations, and metrics, then answers in context.
+
+This is the initial release. More capabilities will follow.
+
+The Assistant is Langfuse Cloud only and still labeled Beta. It is free during the Beta, though pricing may change later.
+
+## Get started [#get-started]
+
+<Cards num={1}>
+  <Card
+    title="MCP server documentation"
+    href="/docs/api-and-data-platform/features/mcp-server"
+    icon={<Book />}
+    arrow
+  />
+</Cards>


### PR DESCRIPTION
Adds a changelog post announcing the **Langfuse Assistant (Public Beta)** — now available to everyone on Langfuse Cloud without opt-in, removed from the Feature Preview modal.

The post covers: chatting with your Langfuse data in plain language (with example questions), that it runs on the Langfuse MCP server under the hood, and the beta status (Cloud only, Beta label, free during Beta with pricing subject to change).

- Slug: `2026-06-19-langfuse-assistant-public-beta`
- File: `content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx`
- #lf-launches submission by @Ben Bachem
- This changelog post IS the canonical link (no separate docs page).

**Before merge:**
- [ ] Add hero asset: screenshot/short screen recording of the Assistant answering a question over real trace data, at `public/images/changelog/2026-06-19-langfuse-assistant-public-beta.png` (the `<Frame>` placeholder + TODO comment mark the spot). Consider adding `ogImage` frontmatter once captured.
- [ ] Run `pnpm run format` (file was hand-formatted outside the repo workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single changelog post announcing the Langfuse Assistant moving from Feature Preview to public beta on Langfuse Cloud. The frontmatter, prose, and MCP-server link are all well-formed and consistent with surrounding changelog entries.

- The `ogVideo` field is correctly populated, but the file has no inline `<Video>` or `<Frame>` component in the body, so readers see a text-only post with no visual demonstration of the feature.
- The PR checklist states \"the `<Frame>` placeholder + TODO comment mark the spot\" for the hero asset, but neither element exists in the file, removing the in-file anchor for the pre-merge follow-up work.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a documentation-only change; the text, frontmatter, and MCP-server link are all correct.

The change is a single new MDX file with no logic. The prose and frontmatter are accurate. The one gap — the checklist references a `<Frame>` placeholder that was never added to the file — means the post will go live without an inline visual, and whoever handles the hero-asset TODO afterward has no in-file marker to guide placement.

content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx — missing inline `<Frame>` / `<Video>` placeholder and TODO comment referenced by the pre-merge checklist.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Langfuse Cloud] --> B[Langfuse Assistant UI]
    B --> C{Ask question in plain language}
    C --> D[Langfuse MCP Server]
    D --> E[Query traces / observations / metrics]
    E --> F[Return results to Assistant]
    F --> G[Assistant answers in context]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens Langfuse Cloud] --> B[Langfuse Assistant UI]
    B --> C{Ask question in plain language}
    C --> D[Langfuse MCP Server]
    D --> E[Query traces / observations / metrics]
    E --> F[Return results to Assistant]
    F --> G[Assistant answers in context]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/changelog/2026-06-19-langfuse-assistant-public-beta.mdx:13
**Missing `<Frame>` placeholder contradicts PR checklist**

The PR description says "the `<Frame>` placeholder + TODO comment mark the spot" for the hero asset, but there is no `<Frame>` placeholder or TODO comment anywhere in the file. Other feature changelog entries (e.g. `2026-05-26-langfuse-agent-skill.mdx`) place a `<Video>` or `<Frame>` inline immediately after `<ChangelogHeader />`. Without a placeholder here, the "Before merge" checklist item has no anchor in the file, making it easy to merge with an entirely text-only post and no clear insertion point for the screenshot/recording later.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): shorten title, drop get..."](https://github.com/langfuse/langfuse-docs/commit/264a27173d2b4c0de1f674d17fc1c776a61f62cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38656135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->