### PR TITLE
docs: add Filter Search Bar changelog and docs page

### DIFF
--- a/components-mdx/team-members.mdx
+++ b/components-mdx/team-members.mdx
@@ -21,4 +21,4 @@
 | **Mark Salpeter**      | Product Engineer           | [Twitter](https://x.com/marksalpeter), [LinkedIn](https://www.linkedin.com/in/marksalpeter/), [GitHub](https://github.com/marksalpeter)         |
 | **Caleb Seeling**      | Support Engineer           | [LinkedIn](https://www.linkedin.com/in/calebloveseeling/), [GitHub](https://github.com/CodeCLS)                                                 |
 | **Niklas Semmler**     | Backend Engineer           | [LinkedIn](https://www.linkedin.com/in/nsemmler/), [GitHub](https://github.com/niklassemmler)                                                   |
-| **Nikita Kabardin**    | Frontend Engineer          | [LinkedIn](https://www.linkedin.com/in/nkabardin/), [GitHub](https://github.com/nkabardin)                                                      |
+| **Nikita Kabardin**    | Frontend Engineer          | [Twitter](https://x.com/nkabardin), [LinkedIn](https://www.linkedin.com/in/nkabardin/), [GitHub](https://github.com/nkabardin)                  |

--- a/content/changelog/2026-06-19-filter-search-bar.mdx
+++ b/content/changelog/2026-06-19-filter-search-bar.mdx
@@ -33,7 +33,7 @@ The **Filter Search Bar** turns one line of text into the same filters you would
 - **Operators:** `latency:>2`, `cost:>=0.01`, `startTime:>2026-06-01`
 - **Full-text search:** a bare word or phrase like `refund failed` matches across ids, names, input and output; scope it with `input:` or `output:`
 - **Wildcards:** `name:*checkout*` (contains), `name:checkout*` (starts with)
-- **Negation:** `-environment:prod`
+- **Negation:** `-environment:production`
 - **Metadata and scores:** `metadata.region:eu`, `scores.accuracy:>0.8`
 - **Any-of for one field:** `level:(ERROR OR WARNING)`
 
@@ -53,4 +53,4 @@ This one took a while: a custom grammar with a hand-written parser, a text input
 
 This is the foundation for one query language across Langfuse, including nested boolean expressions and broader coverage. We would love to hear which queries you reach for most.
 
-See the [Filter Search Bar docs](/docs/observability/features/filter-search-bar) to learn how to use it in the UI and the API.
+See the [Filter Search Bar docs](/docs/observability/features/filter-search-bar) to learn how to use it.

--- a/content/changelog/2026-06-19-filter-search-bar.mdx
+++ b/content/changelog/2026-06-19-filter-search-bar.mdx
@@ -43,7 +43,7 @@ Type a field name and autocomplete suggests operators and observed values; press
 
 The bar parses your text into an AST and compiles it down to the same filter representation the sidebar and the filters API already use. Two consequences: your existing **Saved Views keep working unchanged**, and the full query is **serialized into the URL**, so sending someone the link reproduces the exact filtered view (a frequently requested workflow).
 
-Free-text terms are matched with [ClickHouse full-text search](/changelog/2026-05-27-clickhouse-full-text-search-fast-mode) over input, output and metadata, so search stays fast on projects with millions of traces. A bare term searches ids, names, input and output; `input:` and `output:` scope it to one payload.
+Free-text terms are matched with [ClickHouse full-text search](/changelog/2026-05-27-clickhouse-full-text-search-fast-mode), so search stays fast on projects with millions of traces. A bare term searches ids, names, input and output; `input:` and `output:` scope it to one payload.
 
 ## The story behind it
 

--- a/content/changelog/2026-06-19-filter-search-bar.mdx
+++ b/content/changelog/2026-06-19-filter-search-bar.mdx
@@ -1,0 +1,56 @@
+---
+date: 2026-06-19
+title: "Filter Search Bar"
+description: "Filter traces and observations by typing. A fast query bar with operators, full-text search, wildcards, and autocomplete."
+author: Nikita Kabardin
+ogVideo: /images/changelog/2026-06-19-filter-search-bar.mp4
+canonical: https://langfuse.com/docs/observability/features/filter-search-bar
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Say you are debugging an agent and you want the ERROR-level tool calls from the last hour, in production, slower than two seconds, on your checkout flow. Until now that meant clicking through a stack of sidebar dropdowns. Now you can just type it — the bar suggests fields and values as you go, so there's nothing to memorize:
+
+```
+level:ERROR type:TOOL environment:production latency:>2 name:*checkout*
+```
+
+The **Filter Search Bar** turns one line of text into the same filters you would otherwise assemble in the sidebar, with autocomplete the whole way.
+
+<Callout type="info">
+  The Filter Search Bar runs on the Langfuse v4 data model. It is currently
+  available on Langfuse Cloud only; turn on **Fast** on the Observations or
+  Traces table to use it. Open-source support follows once the v4 schema
+  migration is ready for self-hosted deployments.
+</Callout>
+
+## What you can type
+
+- **Fields and values:** `level:ERROR`, `environment:production`, `user:alice`
+- **Short aliases:** type less with `env` (environment), `user` (user id), `session` (session id), `model` (model name), `cost` (total cost), `tokens` (total tokens), `tags` (trace tags), plus `ttft` and `tps`
+- **Operators:** `latency:>2`, `cost:>=0.01`, `startTime:>2026-06-01`
+- **Full-text search:** a bare word or phrase like `refund failed` matches across ids, names, input and output; scope it with `input:` or `output:`
+- **Wildcards:** `name:*checkout*` (contains), `name:checkout*` (starts with)
+- **Negation:** `-environment:prod`
+- **Metadata and scores:** `metadata.region:eu`, `scores.accuracy:>0.8`
+- **Any-of for one field:** `level:(ERROR OR WARNING)`
+
+Type a field name and autocomplete suggests operators and observed values; press Enter to apply. The bar runs next to the existing filter sidebar and time-range selector.
+
+## How it works
+
+The bar parses your text into an AST and compiles it down to the same filter representation the sidebar and the filters API already use. Two consequences: your existing **Saved Views keep working unchanged**, and the full query is **serialized into the URL**, so sending someone the link reproduces the exact filtered view (a frequently requested workflow).
+
+Free-text terms are matched with [ClickHouse full-text search](/changelog/2026-05-27-clickhouse-full-text-search-fast-mode) over input, output and metadata, so search stays fast on projects with millions of traces. A bare term searches ids, names, input and output; `input:` and `output:` scope it to one payload.
+
+## The story behind it
+
+This one took a while: a custom grammar with a hand-written parser, a text input rebuilt from scratch on a single contenteditable, and a lot of edge cases. We wrote up the whole path, dead ends included, in a thread: [how we built the Filter Search Bar](https://x.com/nkabardin/status/2067931939235926186).
+
+## What is next
+
+This is the foundation for one query language across Langfuse, including nested boolean expressions and broader coverage. We would love to hear which queries you reach for most.
+
+See the [Filter Search Bar docs](/docs/observability/features/filter-search-bar) to learn how to use it in the UI and the API.

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -74,7 +74,7 @@ A bare word or phrase searches across ids, names, input, and output:
 refund failed
 ```
 
-Scope it to a single payload with `input:` or `output:` (for example `output:"refund failed"`). Free-text terms match a contiguous, case-insensitive substring. See [Full-Text Search](/docs/observability/features/full-text-search) for details on how matching works and how to search via the API.
+Scope it to a single payload with `input:` or `output:` (for example `output:"refund failed"`). Free-text matching is case-insensitive — see [Full-Text Search](/docs/observability/features/full-text-search) for how it works and how to search via the API.
 
 ## Field aliases [#aliases]
 

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -108,4 +108,4 @@ Some operator-like tokens are not supported yet and are flagged instead of being
 
 import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
 
-<GhDiscussionsPreview labels={["feat-search"]} />
+<GhDiscussionsPreview labels={["feat-filter-search-bar"]} />

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -1,0 +1,111 @@
+---
+title: Filter Search Bar
+description: Filter and search traces and observations by typing — fields, operators, wildcards, aliases, and full-text search in one query bar with autocomplete.
+sidebarTitle: Filter Search Bar
+---
+
+# Filter Search Bar
+
+The Filter Search Bar lets you filter and search the Observations and Traces tables by typing a single line of text instead of assembling filters in the sidebar. It parses your query into the same filters the sidebar produces, autocompletes fields and values as you type, and serializes the full query into the URL so you can share an exact view with a link.
+
+```
+level:ERROR type:TOOL environment:production latency:>2 name:*checkout*
+```
+
+<Callout type="info">
+  The Filter Search Bar runs on the Langfuse v4 data model and is currently
+  available on Langfuse Cloud. Turn on **Fast** on the Observations or Traces
+  table to use it. Open-source support follows once the v4 schema migration is
+  ready for self-hosted deployments.
+</Callout>
+
+The bar runs next to the existing filter sidebar and time-range selector. Because the bar and the sidebar are two editors over the same filter state, anything you type appears as sidebar filters and vice versa. Type a field name and autocomplete suggests operators and observed values; press Enter to apply.
+
+## Query syntax [#syntax]
+
+A query is a list of `field:value` filters, combined with implicit AND.
+
+### Fields and values
+
+`level:ERROR`, `environment:production`, `user:alice`. Type a field name and the bar suggests the values it has observed for that field, so you don't have to memorize them.
+
+### Operators
+
+`latency:>2`, `cost:>=0.01`, `startTime:>2026-06-01` — `>`, `>=`, `<`, and `<=` work on numeric and datetime fields.
+
+### Wildcards and exact match
+
+On text fields, use `*` as a wildcard:
+
+- `name:*checkout*` — contains
+- `name:checkout*` — starts with
+- `name:*checkout` — ends with
+- `name:checkout` — bare term, defaults to contains
+- `name:=checkout` — exact match
+
+### Negation
+
+Prefix a filter with `-` to exclude: `-environment:production`.
+
+### Any-of and all-of
+
+- `level:(ERROR OR WARNING)` — match either value for one field
+- `tags:(billing AND urgent)` — match all values (array fields)
+
+### Metadata and scores
+
+Use dot paths for nested fields:
+
+- `metadata.region:eu`
+- `scores.accuracy:>0.8`
+- `traceScores.helpfulness:positive`
+
+Quote keys that contain spaces or special characters after the prefix: `scores."Answer Relevance":>=0.9`, `metadata."my key":eu`.
+
+### Null checks
+
+`has:endTime` matches rows where the field is set; `-has:endTime` matches rows where it is null.
+
+### Full-text search
+
+A bare word or phrase searches across ids, names, input, and output:
+
+```
+refund failed
+```
+
+Scope it to a single payload with `input:` or `output:` (for example `output:"refund failed"`). Free-text terms match a contiguous, case-insensitive substring. See [Full-Text Search](/docs/observability/features/full-text-search) for details on how matching works and how to search via the API.
+
+## Field aliases [#aliases]
+
+Most fields accept a short alias so you can type less. The canonical field name always works too.
+
+| Alias        | Field               |
+| ------------ | ------------------- |
+| `env`        | environment         |
+| `user`       | user id             |
+| `session`    | session id          |
+| `model`      | model name          |
+| `prompt`     | prompt name         |
+| `cost`       | total cost          |
+| `tokens`     | total tokens        |
+| `tags`       | trace tags          |
+| `status`     | status message      |
+| `ttft`       | time to first token |
+| `tps`        | tokens per second   |
+| `dataset`    | experiment dataset  |
+| `experiment` | experiment name     |
+
+## Share and save queries [#share]
+
+The full query is serialized into the URL, so sending someone the link reproduces the exact filtered view. Because the bar compiles to the same filter representation as the sidebar, your existing Saved Views keep working unchanged.
+
+## Reserved tokens
+
+Some operator-like tokens are not supported yet and are flagged instead of being treated as text: `!`, and the lowercase words `and`, `or`, and `not`. Use `-field:value` to exclude and `field:(A OR B)` to match several values of one field. To search for a reserved word as literal text, quote it (`"or"`).
+
+## GitHub Discussions
+
+import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
+
+<GhDiscussionsPreview labels={["feat-search"]} />

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -74,7 +74,7 @@ A bare word or phrase searches across ids, names, input, and output:
 refund failed
 ```
 
-Scope it to a single payload with `input:` or `output:` (for example `output:"refund failed"`). Free-text matching is case-insensitive — see [Full-Text Search](/docs/observability/features/full-text-search) for how it works and how to search via the API.
+Scope it to a single payload with `input:` or `output:` (for example `output:"refund failed"`). Matching is case-insensitive and word-based: a term matches whole words — `error` matches `error` but not `errors` — and a multi-word term matches as a contiguous phrase. The bar searches with the same v4 ClickHouse full-text search documented in [Full-Text Search](/docs/observability/features/full-text-search).
 
 ## Field aliases [#aliases]
 

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -23,6 +23,8 @@ On the v4 Observations and Traces tables, full-text search is also available inl
 
 Search uses [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes). Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).
 
+Because these indexes are token-based, a query matches whole words rather than substrings within them — `error` matches `error` but not `errors` — and a multi-word query matches as a contiguous phrase.
+
 ## Search via the API [#api]
 
 The [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) supports a `matches` operator for token-based full-text search on `input`, `output`, and string `metadata` filters.

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -17,6 +17,8 @@ Full-text search lets you find all occurrences of a specific keyword or phrase a
 
 Use the search bar above the traces and observations tables to search across `input` and `output` content. Matching traces and observations are returned so you can quickly locate the run you are looking for and combine search with the existing filters and time range selectors.
 
+On the v4 Observations and Traces tables, full-text search is also available inline in the [Filter Search Bar](/docs/observability/features/filter-search-bar), alongside structured filters like `level:ERROR` and `latency:>2`.
+
 ## Performance [#performance]
 
 Search uses [ClickHouse full-text search](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes). Text indexes let Langfuse skip over data that cannot match a query before reading full observation payloads, which keeps search fast even for large projects with high-volume traces. You can read more in the [ClickHouse GA announcement](https://clickhouse.com/blog/full-text-search-ga-release).

--- a/content/docs/observability/features/meta.json
+++ b/content/docs/observability/features/meta.json
@@ -14,6 +14,7 @@
     "user-feedback",
     "log-levels",
     "agent-graphs",
+    "filter-search-bar",
     "full-text-search",
     "masking",
     "mcp-tracing",

--- a/data/authors.json
+++ b/data/authors.json
@@ -215,6 +215,7 @@
     "name": "Nikita Kabardin",
     "title": "Frontend Engineer",
     "image": "/images/people/nikitakabardin.jpg",
+    "twitter": "nkabardin",
     "github": "nkabardin",
     "linkedin": "nkabardin"
   }


### PR DESCRIPTION
Announce the Filter Search Bar in the changelog and document it on a new observability/features page covering the query syntax (fields, operators, wildcards, negation, any-of/all-of, metadata/scores, null checks, full-text search) and field aliases. Cross-link with the full-text-search page and add the page to the features sidebar.

Also add Nikita's Twitter to the team table and authors data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a changelog entry and a new docs page for the Filter Search Bar feature — a query bar that lets users filter and search Traces and Observations tables by typing `field:value` expressions instead of assembling sidebar dropdowns. It also cross-links the existing Full-Text Search page to the new page, adds the page to the features sidebar, and adds Nikita's Twitter to the team table and authors data.

- **New docs page** (`filter-search-bar.mdx`) covers the full query syntax: fields, operators, wildcards, negation, any-of/all-of, metadata/scores, null checks, full-text search, field aliases, URL sharing, and reserved tokens.
- **Changelog entry** (`2026-06-19-filter-search-bar.mdx`) announces the feature with examples and a link to the implementation write-up thread.
- **Supporting changes**: cross-link added to `full-text-search.mdx`, sidebar updated in `meta.json`, Twitter handle added for Nikita in `authors.json` and `team-members.mdx`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only PR with no code changes; cannot cause runtime regressions and is safe to merge.

The new docs and changelog are well-written. There is a small factual inconsistency in the changelog — one sentence describes free-text as matching 'input, output and metadata' while the next sentence (and the docs page) say 'ids, names, input and output' with no mention of metadata. The filter-search-bar page also reuses the feat-search GitHub Discussions label already owned by the full-text-search page, diverging from the one-label-per-feature pattern used everywhere else in the repo.

content/changelog/2026-06-19-filter-search-bar.mdx (bare-term metadata scope claim) and content/docs/observability/features/filter-search-bar.mdx (shared GhDiscussionsPreview label)
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User types in Filter Search Bar"] --> B["Query parsed into AST"]
    B --> C["Compiled to filter representation"]
    C --> D["Same filter state as sidebar"]
    D --> E["Sidebar filters updated"]
    D --> F["URL serialized with query"]
    C --> G{"Filter type?"}
    G -->|"field:value"| H["Structured filter\n(level, env, latency, etc.)"]
    G -->|"bare term"| I["Full-text search\n(ClickHouse FTS)"]
    G -->|"metadata.key:val"| J["Dot-path filter\n(metadata / scores)"]
    G -->|"has:field"| K["Null check filter"]
    H --> L["Traces / Observations API"]
    I --> L
    J --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User types in Filter Search Bar"] --> B["Query parsed into AST"]
    B --> C["Compiled to filter representation"]
    C --> D["Same filter state as sidebar"]
    D --> E["Sidebar filters updated"]
    D --> F["URL serialized with query"]
    C --> G{"Filter type?"}
    G -->|"field:value"| H["Structured filter\n(level, env, latency, etc.)"]
    G -->|"bare term"| I["Full-text search\n(ClickHouse FTS)"]
    G -->|"metadata.key:val"| J["Dot-path filter\n(metadata / scores)"]
    G -->|"has:field"| K["Null check filter"]
    H --> L["Traces / Observations API"]
    I --> L
    J --> L
    K --> L
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/observability/features/filter-search-bar.mdx:109-111
**Shared GitHub Discussions label with full-text-search**

`filter-search-bar.mdx` uses `labels={["feat-search"]}`, which is the same label already used by `full-text-search.mdx`. Every other feature page in this repo uses a distinct label (e.g. `feat-playground`, `feat-users`, `feat-cost-tracking`). With both pages sharing `feat-search`, the GitHub Discussions section on the filter-search-bar page will surface identical threads as the full-text-search page, making it impossible to distinguish feature-specific feedback. Consider a dedicated label such as `feat-filter-search-bar`.

### Issue 2 of 2
content/changelog/2026-06-19-filter-search-bar.mdx:46
**Inconsistent bare-term search scope between changelog and docs**

The changelog states free-text terms are matched "over input, output and **metadata**", but two lines later in the same paragraph it says "A bare term searches ids, names, input and output" — omitting metadata. The filter-search-bar docs page (line 71) also says "ids, names, input, and output" with no mention of metadata. If bare terms actually search metadata, the docs page needs to reflect that; if they don't, the earlier sentence in the changelog is misleading.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Filter Search Bar changelog an..."](https://github.com/langfuse/langfuse-docs/commit/deaae8f2ebd4d48011dd0377444d7fa57614ae72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38663109)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->