### PR TITLE
docs: add homepage hero slogan A/B test with PostHog tracking.

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,5 +1,20 @@
+import { cookies, headers } from "next/headers";
 import { Home } from "@/components/home";
+import {
+  HERO_SLOGAN_VARIANT_HEADER,
+  HERO_SLOGAN_VARIANT_KEY,
+  getHeroSloganVariantFromCookieValue,
+} from "@/lib/hero-slogan-variant";
 
-export default function HomePage() {
-  return <Home />;
+export default async function HomePage() {
+  const [cookieStore, headerStore] = await Promise.all([
+    cookies(),
+    headers(),
+  ]);
+  const heroSloganVariant = getHeroSloganVariantFromCookieValue(
+    headerStore.get(HERO_SLOGAN_VARIANT_HEADER) ??
+      cookieStore.get(HERO_SLOGAN_VARIANT_KEY)?.value,
+  );
+
+  return <Home heroSloganVariant={heroSloganVariant} />;
 }

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -5,15 +5,20 @@ import { HomeSection } from "@/components/home/HomeSection";
 import { EnterpriseLogoGrid } from "@/components/shared/EnterpriseLogoGrid";
 import { HeroStatsStrip } from "@/components/home/HeroStatsStrip";
 import { HeroSlogan } from "@/components/home/HeroSlogan";
+import type { HeroSloganVariant } from "@/lib/hero-slogan-variant";
 
-export function Hero() {
+export function Hero({
+  heroSloganVariant,
+}: {
+  heroSloganVariant: HeroSloganVariant;
+}) {
   return (
     <HomeSection className="pt-5 sm:pt-8 md:pt-[60px]">
       <CornerBox className="-mb-px -mt-px">
         <HeroStatsStrip />
       </CornerBox>
       <CornerBox className="flex flex-col gap-4 sm:gap-8 md:gap-10 items-center px-4 py-8 sm:px-8 sm:py-10">
-        <HeroSlogan />
+        <HeroSlogan initialVariant={heroSloganVariant} />
         <div className="flex flex-col gap-6">
           <Text className="max-w-xl">
             Trace and evaluate AI Agents. Collaborate with your team to

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -1,12 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { CornerBox } from "@/components/ui/corner-box";
-import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
-import { TextHighlight } from "@/components/ui";
 import { HomeSection } from "@/components/home/HomeSection";
 import { EnterpriseLogoGrid } from "@/components/shared/EnterpriseLogoGrid";
-import { cn } from "@/lib/utils";
 import { HeroStatsStrip } from "@/components/home/HeroStatsStrip";
+import { HeroSlogan } from "@/components/home/HeroSlogan";
 
 export function Hero() {
   return (
@@ -15,46 +13,7 @@ export function Hero() {
         <HeroStatsStrip />
       </CornerBox>
       <CornerBox className="flex flex-col gap-4 sm:gap-8 md:gap-10 items-center px-4 py-8 sm:px-8 sm:py-10">
-        <Heading
-          as="h1"
-          size="big"
-          className={cn(
-            "flex-col items-center gap-0.5 sm:gap-1 md:gap-1.5 text-center font-medium leading-[105%] max-md:max-w-[500px]",
-            "[leading-trim:both] [text-edge:cap]",
-          )}
-        >
-          <TextHighlight
-            highlightClassName="mix-blend-multiply"
-            className="whitespace-nowrap"
-          >
-            Open Source<span className="inline max-[499px]:hidden">&nbsp;</span>
-          </TextHighlight>
-          <span className="flex min-[500px]:inline">
-            <TextHighlight
-              highlightClassName="mix-blend-multiply"
-              className="max-[499px]:pr-1.75"
-            >
-              AI
-            </TextHighlight>
-            <TextHighlight
-              highlightClassName="mix-blend-multiply"
-              className="min-[500px]:pr-2"
-            >
-              Engineering
-            </TextHighlight>
-          </span>
-          <TextHighlight highlightClassName="mix-blend-multiply">
-            Platform
-          </TextHighlight>
-        </Heading>
-        <Heading
-          as="h1"
-          size="big"
-          className={cn(
-            "flex sm:hidden flex-col items-center gap-1.5 text-center font-medium leading-[105%]",
-            "[leading-trim:both] [text-edge:cap]",
-          )}
-        ></Heading>
+        <HeroSlogan />
         <div className="flex flex-col gap-6">
           <Text className="max-w-xl">
             Trace and evaluate AI Agents. Collaborate with your team to

--- a/components/home/HeroSlogan.tsx
+++ b/components/home/HeroSlogan.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePostHog } from "posthog-js/react";
+import { Heading } from "@/components/ui/heading";
+import { TextHighlight } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
+
+const STORAGE_KEY = "langfuse-hero-slogan-variant";
+
+type HeroSloganVariant = "ai-engineering" | "agent-evals";
+
+function pickVariant(): HeroSloganVariant {
+  return Math.random() < 0.5 ? "ai-engineering" : "agent-evals";
+}
+
+function readStoredVariant(): HeroSloganVariant | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "ai-engineering" || stored === "agent-evals") {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable (e.g. private browsing restrictions)
+  }
+  return null;
+}
+
+function persistVariant(variant: HeroSloganVariant) {
+  try {
+    localStorage.setItem(STORAGE_KEY, variant);
+  } catch {
+    // ignore write failures
+  }
+}
+
+const headingClassName = cn(
+  "flex-col items-center gap-0.5 sm:gap-1 md:gap-1.5 text-center font-medium leading-[105%] max-md:max-w-[500px]",
+  "[leading-trim:both] [text-edge:cap]",
+);
+
+function AiEngineeringSlogan() {
+  return (
+    <>
+      <TextHighlight
+        highlightClassName="mix-blend-multiply"
+        className="whitespace-nowrap"
+      >
+        Open Source<span className="inline max-[499px]:hidden">&nbsp;</span>
+      </TextHighlight>
+      <span className="flex min-[500px]:inline">
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className="max-[499px]:pr-1.75"
+        >
+          AI
+        </TextHighlight>
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className="min-[500px]:pr-2"
+        >
+          Engineering
+        </TextHighlight>
+      </span>
+      <TextHighlight highlightClassName="mix-blend-multiply">
+        Platform
+      </TextHighlight>
+    </>
+  );
+}
+
+function AgentEvalsSlogan() {
+  return (
+    <>
+      <TextHighlight
+        highlightClassName="mix-blend-multiply"
+        className="whitespace-nowrap"
+      >
+        Open Source<span className="inline max-[499px]:hidden">&nbsp;</span>
+      </TextHighlight>
+      <span className="flex min-[500px]:inline">
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className="max-[499px]:pr-1.75"
+        >
+          Agent
+        </TextHighlight>
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className="max-[499px]:pr-1.75"
+        >
+          Evals
+        </TextHighlight>
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className="max-[499px]:pr-1.75"
+        >
+          and
+        </TextHighlight>
+        <TextHighlight highlightClassName="mix-blend-multiply">
+          Tracing
+        </TextHighlight>
+      </span>
+    </>
+  );
+}
+
+export function HeroSlogan() {
+  const posthog = usePostHog();
+  const capture = usePostHogClientCapture();
+  const [variant, setVariant] = useState<HeroSloganVariant>("ai-engineering");
+
+  useEffect(() => {
+    const stored = readStoredVariant();
+    const nextVariant = stored ?? pickVariant();
+    const isNewAssignment = !stored;
+
+    if (!stored) {
+      persistVariant(nextVariant);
+    }
+
+    setVariant(nextVariant);
+
+    posthog.register({ hero_slogan_variant: nextVariant });
+    capture("hero_slogan_exposure", {
+      variant: nextVariant,
+      is_new_assignment: isNewAssignment,
+    });
+    // Track once when the hero mounts on the homepage.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Heading as="h1" size="big" className={headingClassName}>
+      {variant === "ai-engineering" ? (
+        <AiEngineeringSlogan />
+      ) : (
+        <AgentEvalsSlogan />
+      )}
+    </Heading>
+  );
+}

--- a/components/home/HeroSlogan.tsx
+++ b/components/home/HeroSlogan.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import { usePostHog } from "posthog-js/react";
 import { Heading } from "@/components/ui/heading";
 import { TextHighlight } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
-
-const STORAGE_KEY = "langfuse-hero-slogan-variant";
-
-type HeroSloganVariant = "ai-engineering" | "agent-evals";
-
-function pickVariant(): HeroSloganVariant {
-  return Math.random() < 0.5 ? "ai-engineering" : "agent-evals";
-}
+import {
+  HERO_SLOGAN_VARIANT_KEY,
+  type HeroSloganVariant,
+} from "@/lib/hero-slogan-variant";
 
 function readStoredVariant(): HeroSloganVariant | null {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(HERO_SLOGAN_VARIANT_KEY);
     if (stored === "ai-engineering" || stored === "agent-evals") {
       return stored;
     }
@@ -29,7 +25,7 @@ function readStoredVariant(): HeroSloganVariant | null {
 
 function persistVariant(variant: HeroSloganVariant) {
   try {
-    localStorage.setItem(STORAGE_KEY, variant);
+    localStorage.setItem(HERO_SLOGAN_VARIANT_KEY, variant);
   } catch {
     // ignore write failures
   }
@@ -40,6 +36,8 @@ const headingClassName = cn(
   "[leading-trim:both] [text-edge:cap]",
 );
 
+const desktopWordSpacing = "max-[499px]:pr-1.75 min-[500px]:pr-2";
+
 function AiEngineeringSlogan() {
   return (
     <>
@@ -49,10 +47,10 @@ function AiEngineeringSlogan() {
       >
         Open Source<span className="inline max-[499px]:hidden">&nbsp;</span>
       </TextHighlight>
-      <span className="flex min-[500px]:inline">
+      <span className="flex flex-wrap justify-center min-[500px]:inline">
         <TextHighlight
           highlightClassName="mix-blend-multiply"
-          className="max-[499px]:pr-1.75"
+          className={desktopWordSpacing}
         >
           AI
         </TextHighlight>
@@ -71,9 +69,6 @@ function AiEngineeringSlogan() {
 }
 
 function AgentEvalsSlogan() {
-  const wordGap = "gap-x-1.5 sm:gap-x-2";
-  const phraseGap = "gap-x-3 sm:gap-x-4";
-
   return (
     <>
       <TextHighlight
@@ -82,61 +77,87 @@ function AgentEvalsSlogan() {
       >
         Open Source
       </TextHighlight>
-      <span
-        className={cn(
-          "flex flex-wrap justify-center items-center",
-          phraseGap,
-        )}
-      >
-        <span className={cn("inline-flex items-center", wordGap)}>
-          <TextHighlight highlightClassName="mix-blend-multiply">
-            Agent
-          </TextHighlight>
-          <TextHighlight highlightClassName="mix-blend-multiply">
-            Evals
-          </TextHighlight>
-        </span>
-        <span className={cn("inline-flex items-center", wordGap)}>
-          <TextHighlight highlightClassName="mix-blend-multiply">
-            and
-          </TextHighlight>
-          <TextHighlight highlightClassName="mix-blend-multiply">
-            Tracing
-          </TextHighlight>
-        </span>
+      <span className="flex flex-wrap justify-center min-[500px]:inline">
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className={desktopWordSpacing}
+        >
+          Agent
+        </TextHighlight>
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className={desktopWordSpacing}
+        >
+          Evals
+        </TextHighlight>
+        <TextHighlight
+          highlightClassName="mix-blend-multiply"
+          className={desktopWordSpacing}
+        >
+          and
+        </TextHighlight>
+        <TextHighlight highlightClassName="mix-blend-multiply">
+          Tracing
+        </TextHighlight>
       </span>
     </>
   );
 }
 
-export function HeroSlogan() {
+function trackHeroSloganExposure(
+  posthog: ReturnType<typeof usePostHog>,
+  capture: ReturnType<typeof usePostHogClientCapture>,
+  variant: HeroSloganVariant,
+  isNewAssignment: boolean,
+) {
+  posthog.register({ hero_slogan_variant: variant });
+  capture("hero_slogan_exposure", {
+    variant,
+    is_new_assignment: isNewAssignment,
+  });
+}
+
+export function HeroSlogan({
+  initialVariant,
+}: {
+  initialVariant: HeroSloganVariant;
+}) {
   const posthog = usePostHog();
   const capture = usePostHogClientCapture();
-  const [variant, setVariant] = useState<HeroSloganVariant>("ai-engineering");
+  const trackedRef = useRef(false);
 
   useEffect(() => {
-    const stored = readStoredVariant();
-    const nextVariant = stored ?? pickVariant();
-    const isNewAssignment = !stored;
+    const hadLocalStorage = readStoredVariant() !== null;
+    persistVariant(initialVariant);
 
-    if (!stored) {
-      persistVariant(nextVariant);
+    if (trackedRef.current) {
+      return;
     }
 
-    setVariant(nextVariant);
+    const runTracking = () => {
+      if (trackedRef.current) {
+        return;
+      }
+      trackedRef.current = true;
+      trackHeroSloganExposure(
+        posthog,
+        capture,
+        initialVariant,
+        !hadLocalStorage,
+      );
+    };
 
-    posthog.register({ hero_slogan_variant: nextVariant });
-    capture("hero_slogan_exposure", {
-      variant: nextVariant,
-      is_new_assignment: isNewAssignment,
-    });
-    // Track once when the hero mounts on the homepage.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if ((posthog as { __loaded?: boolean }).__loaded) {
+      runTracking();
+      return;
+    }
+
+    posthog.onSessionId(runTracking);
+  }, [capture, initialVariant, posthog]);
 
   return (
     <Heading as="h1" size="big" className={headingClassName}>
-      {variant === "ai-engineering" ? (
+      {initialVariant === "ai-engineering" ? (
         <AiEngineeringSlogan />
       ) : (
         <AgentEvalsSlogan />

--- a/components/home/HeroSlogan.tsx
+++ b/components/home/HeroSlogan.tsx
@@ -71,36 +71,39 @@ function AiEngineeringSlogan() {
 }
 
 function AgentEvalsSlogan() {
+  const wordGap = "gap-x-1.5 sm:gap-x-2";
+  const phraseGap = "gap-x-3 sm:gap-x-4";
+
   return (
     <>
       <TextHighlight
         highlightClassName="mix-blend-multiply"
         className="whitespace-nowrap"
       >
-        Open Source<span className="inline max-[499px]:hidden">&nbsp;</span>
+        Open Source
       </TextHighlight>
-      <span className="flex min-[500px]:inline">
-        <TextHighlight
-          highlightClassName="mix-blend-multiply"
-          className="max-[499px]:pr-1.75"
-        >
-          Agent
-        </TextHighlight>
-        <TextHighlight
-          highlightClassName="mix-blend-multiply"
-          className="max-[499px]:pr-1.75"
-        >
-          Evals
-        </TextHighlight>
-        <TextHighlight
-          highlightClassName="mix-blend-multiply"
-          className="max-[499px]:pr-1.75"
-        >
-          and
-        </TextHighlight>
-        <TextHighlight highlightClassName="mix-blend-multiply">
-          Tracing
-        </TextHighlight>
+      <span
+        className={cn(
+          "flex flex-wrap justify-center items-center",
+          phraseGap,
+        )}
+      >
+        <span className={cn("inline-flex items-center", wordGap)}>
+          <TextHighlight highlightClassName="mix-blend-multiply">
+            Agent
+          </TextHighlight>
+          <TextHighlight highlightClassName="mix-blend-multiply">
+            Evals
+          </TextHighlight>
+        </span>
+        <span className={cn("inline-flex items-center", wordGap)}>
+          <TextHighlight highlightClassName="mix-blend-multiply">
+            and
+          </TextHighlight>
+          <TextHighlight highlightClassName="mix-blend-multiply">
+            Tracing
+          </TextHighlight>
+        </span>
       </span>
     </>
   );

--- a/components/home/index.tsx
+++ b/components/home/index.tsx
@@ -9,11 +9,16 @@ import { Enterprise } from "./Enterprise";
 import { WhyLangfuse } from "./WhyLangfuse";
 import { GetStartedSection } from "./GetStartedSection";
 import { FAQ } from "./FAQ";
+import type { HeroSloganVariant } from "@/lib/hero-slogan-variant";
 
-export const Home = () => (
+export const Home = ({
+  heroSloganVariant,
+}: {
+  heroSloganVariant: HeroSloganVariant;
+}) => (
   <>
     <main className="overflow-hidden relative w-full hero-bg xl:px-5 2xl:px-10">
-      <Hero />
+      <Hero heroSloganVariant={heroSloganVariant} />
       <FeatureTabsSection />
       <RiveSection />
       <AllTheTools />

--- a/lib/hero-slogan-variant.ts
+++ b/lib/hero-slogan-variant.ts
@@ -1,0 +1,22 @@
+export const HERO_SLOGAN_VARIANT_HEADER = "x-hero-slogan-variant";
+
+export const HERO_SLOGAN_VARIANT_KEY = "langfuse-hero-slogan-variant";
+
+export type HeroSloganVariant = "ai-engineering" | "agent-evals";
+
+export function isHeroSloganVariant(value: string): value is HeroSloganVariant {
+  return value === "ai-engineering" || value === "agent-evals";
+}
+
+export function pickHeroSloganVariant(): HeroSloganVariant {
+  return Math.random() < 0.5 ? "ai-engineering" : "agent-evals";
+}
+
+export function getHeroSloganVariantFromCookieValue(
+  value: string | undefined,
+): HeroSloganVariant {
+  if (value && isHeroSloganVariant(value)) {
+    return value;
+  }
+  return pickHeroSloganVariant();
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import {
+  HERO_SLOGAN_VARIANT_KEY,
+  isHeroSloganVariant,
+  pickHeroSloganVariant,
+} from "@/lib/hero-slogan-variant";
+
+const HERO_SLOGAN_VARIANT_HEADER = "x-hero-slogan-variant";
+
+export function middleware(request: NextRequest) {
+  const existing = request.cookies.get(HERO_SLOGAN_VARIANT_KEY)?.value;
+  const variant =
+    existing && isHeroSloganVariant(existing)
+      ? existing
+      : pickHeroSloganVariant();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(HERO_SLOGAN_VARIANT_HEADER, variant);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  if (!existing || !isHeroSloganVariant(existing)) {
+    response.cookies.set(HERO_SLOGAN_VARIANT_KEY, variant, {
+      maxAge: 60 * 60 * 24 * 365,
+      path: "/",
+      sameSite: "lax",
+    });
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: "/",
+};

--- a/src/usePostHogClientCapture.ts
+++ b/src/usePostHogClientCapture.ts
@@ -5,6 +5,10 @@ import { usePostHog } from "posthog-js/react";
 // This preserves existing PostHog event structure while adding type safety
 interface EventDefinitions {
   copy_page: { type: "copy" | "chatgpt" | "claude" | "mcp" };
+  hero_slogan_exposure: {
+    variant: "ai-engineering" | "agent-evals";
+    is_new_assignment: boolean;
+  };
 }
 
 type EventName = keyof EventDefinitions;


### PR DESCRIPTION
Rotate the main headline between the existing platform positioning and an agent evals/tracing variant, update the hero subheading, and track exposures in PostHog for conversion analysis.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an A/B test for the homepage hero heading, rotating between "Open Source AI Engineering Platform" (control) and an "Agent Evals and Tracing" variant, persisting the assignment in `localStorage` and firing a `hero_slogan_exposure` event to PostHog on each mount.

- A new `HeroSlogan` client component encapsulates variant selection, localStorage persistence, and PostHog tracking, replacing the inline heading JSX in `Hero.tsx`.
- The `usePostHogClientCapture` hook is extended with typed definitions for the new `hero_slogan_exposure` event.
- Variant assignment uses `Math.random()` and localStorage rather than PostHog's native Experiments feature flags, which limits the available analysis tooling in the PostHog UI.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change introduces a visible heading flash for ~50% of first-time visitors and uses a custom random assignment approach that bypasses PostHog's experiment analysis infrastructure, both of which should be addressed before merging.

The hard-coded initial state causes a flash of the wrong heading variant for every user assigned to 'agent-evals', which is half of new visitors on every first visit. Separately, the core objective — conversion analysis in PostHog — won't benefit from PostHog's built-in statistical tooling because variant assignment is done with Math.random() rather than a PostHog feature flag, meaning proper exposure events tied to an experiment won't be recorded.

components/home/HeroSlogan.tsx needs the most attention: the variant initialisation strategy (lazy state vs. effect-driven), and the decision to use custom random assignment vs. PostHog's Experiments feature flags.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant HeroSlogan
    participant localStorage
    participant PostHog

    Browser->>HeroSlogan: "SSR / first paint (variant = "ai-engineering" default)"
    Note over HeroSlogan: All users see control variant initially

    Browser->>HeroSlogan: Hydration complete → useEffect fires
    HeroSlogan->>localStorage: readStoredVariant()
    alt Stored variant found
        localStorage-->>HeroSlogan: "ai-engineering" | "agent-evals"
    else No stored variant
        HeroSlogan->>HeroSlogan: "pickVariant() → Math.random() < 0.5"
        HeroSlogan->>localStorage: persistVariant(nextVariant)
    end

    HeroSlogan->>HeroSlogan: setVariant(nextVariant)
    Note over Browser,HeroSlogan: ⚠️ If nextVariant = "agent-evals",<br/>visible flash occurs here

    HeroSlogan->>PostHog: "posthog.register({ hero_slogan_variant })"
    HeroSlogan->>PostHog: "capture("hero_slogan_exposure", { variant, is_new_assignment })"
    PostHog-->>HeroSlogan: void
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant HeroSlogan
    participant localStorage
    participant PostHog

    Browser->>HeroSlogan: "SSR / first paint (variant = "ai-engineering" default)"
    Note over HeroSlogan: All users see control variant initially

    Browser->>HeroSlogan: Hydration complete → useEffect fires
    HeroSlogan->>localStorage: readStoredVariant()
    alt Stored variant found
        localStorage-->>HeroSlogan: "ai-engineering" | "agent-evals"
    else No stored variant
        HeroSlogan->>HeroSlogan: "pickVariant() → Math.random() < 0.5"
        HeroSlogan->>localStorage: persistVariant(nextVariant)
    end

    HeroSlogan->>HeroSlogan: setVariant(nextVariant)
    Note over Browser,HeroSlogan: ⚠️ If nextVariant = "agent-evals",<br/>visible flash occurs here

    HeroSlogan->>PostHog: "posthog.register({ hero_slogan_variant })"
    HeroSlogan->>PostHog: "capture("hero_slogan_exposure", { variant, is_new_assignment })"
    PostHog-->>HeroSlogan: void
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
components/home/HeroSlogan.tsx:112-132
**Visible heading flash for `agent-evals` users**

The component hard-codes `"ai-engineering"` as the initial state, so every server render and first client paint shows the control variant. The `useEffect` then reads localStorage and may switch to `"agent-evals"`, causing a visible flash of the wrong heading for roughly half of new visitors. For returning users assigned to `"agent-evals"` the flash happens on every page load.

A lazy state initialiser avoids the re-render on the client side (localStorage access is already guard-wrapped for SSR): `useState<HeroSloganVariant>(() => readStoredVariant() ?? pickVariant())`. You'd also want to move `persistVariant` into the same initialiser block so the variant is stored before any render.

### Issue 2 of 3
components/home/HeroSlogan.tsx:14-15
**Custom random assignment bypasses PostHog Experiments**

PostHog's experiments best practices require using `getFeatureFlag()` or the React equivalent `useFeatureFlagVariantKey()` for experiment assignment. Without this, PostHog does not record the built-in exposure event tied to an experiment flag, so those users are excluded from PostHog's experiment results and statistical significance calculations. The `hero_slogan_exposure` custom event captures the exposure for raw analysis, but the stated goal of "conversion analysis" in PostHog's Experiments UI won't work with this approach.

Consider migrating variant assignment to a PostHog feature flag with two variants — this provides cohort consistency, proper exposure tracking, and the Experiments results dashboard out of the box. See [PostHog Experiments best practices](https://posthog.com/docs/experiments/best-practices).

### Issue 3 of 3
components/home/HeroSlogan.tsx:125
**`posthog.register` may fire before PostHog has finished initialising**

`usePostHog()` returns the PostHog instance synchronously, but the underlying SDK's async bootstrap (feature-flag fetch, session init) may not have completed when this effect runs immediately after mount. Calling `posthog.register()` at this point can silently succeed but the super-property may not propagate to events captured in the same tick. A safer approach is to gate the registration on `posthog.isFeatureEnabled` or listen to the `onFeatureFlags` callback, ensuring the SDK is ready before registering super-properties.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix agent evals hero slogan layout and w..."](https://github.com/langfuse/langfuse-docs/commit/3cfca6ce9adc736ea7f3e59b3d06b2264f428bb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38665845)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->