### PR TITLE
docs: host filter search bar changelog video on static.langfuse.com

### DIFF
--- a/content/changelog/2026-06-19-filter-search-bar.mdx
+++ b/content/changelog/2026-06-19-filter-search-bar.mdx
@@ -3,7 +3,7 @@ date: 2026-06-19
 title: "Filter Search Bar"
 description: "Filter traces and observations by typing. A fast query bar with operators, full-text search, wildcards, and autocomplete."
 author: Nikita Kabardin
-ogVideo: /images/changelog/2026-06-19-filter-search-bar.mp4
+ogVideo: https://static.langfuse.com/docs-videos/2026-06-19-filter-search-bar.mp4
 canonical: https://langfuse.com/docs/observability/features/filter-search-bar
 ---
 


### PR DESCRIPTION
Follow-up to #3160.

Updates the Filter Search Bar changelog to reference the hosted video at
`https://static.langfuse.com/docs-videos/2026-06-19-filter-search-bar.mp4`
instead of the local `/images/changelog/...` path, and removes the committed
7 MB mp4. This matches the repo convention that changelog/docs videos are
hosted on `static.langfuse.com/docs-videos` rather than committed to the repo.

The hosted URL is live (verified `200`, `video/mp4`).

Opened as a draft via the langfuse-feature-launch skill — review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)