### PR TITLE
docs: clarify spend limits

### DIFF
--- a/content/docs/administration/spend-alerts.mdx
+++ b/content/docs/administration/spend-alerts.mdx
@@ -16,7 +16,7 @@ description: Get notified when your organization's spend exceeds predefined mone
   }}
 />
 
-Configure spend alerts to receive email notifications when your organization's spending exceeds a predefined monetary threshold. This helps you monitor costs and take action before unexpected charges occur.
+Configure spend alerts to receive email notifications when your **Langfuse Cloud** bill exceeds a predefined monetary threshold. These alerts cover what you pay Langfuse for using Langfuse Cloud — not LLM or model costs you track in Langfuse observability. This helps you monitor your Langfuse bill and take action before unexpected charges occur.
 
 Navigate to your organization settings and the **Billing** tab to configure spend alerts.
 
@@ -26,7 +26,7 @@ Navigate to your organization settings and the **Billing** tab to configure spen
 
 ## How it works
 
-Spend alerts monitor your organization's total spending on Langfuse Cloud. You can set custom thresholds in your organization's billing currency and receive email notifications when spending crosses these limits.
+Spend alerts monitor your organization's total Langfuse Cloud subscription spend. You can set custom thresholds in your organization's billing currency and receive email notifications when spending crosses these limits.
 
 **Threshold calculation:** Spend is evaluated against the total expected invoice, including base fees, usage-based fees, discounts, and taxes.
 


### PR DESCRIPTION
Make it explicit that spend alerts monitor Langfuse subscription costs, not LLM or model spend tracked in observability.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the spend alerts documentation to explicitly state that the alerts cover Langfuse Cloud subscription costs (base fees, usage-based fees, discounts, taxes) and are **not** related to LLM or model spend tracked through Langfuse observability — a distinction users commonly confuse.

- The opening paragraph now names "Langfuse Cloud" directly and adds an explanatory clause ruling out observability-tracked LLM costs.
- The "How it works" section is updated from "total spending on Langfuse Cloud" to "total Langfuse Cloud subscription spend" for consistency with the clearer framing above.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no code, configuration, or schema is affected.

Both modified sentences accurately describe the feature and are consistent with the unchanged sections of the page (frontmatter description, threshold-calculation bullet). No factual errors or contradictions were found.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Langfuse Cloud Usage] --> B[Invoice Calculation]
    B --> C{Spend threshold\nexceeded?}
    C -- Yes --> D[Email alert sent\nto Owners & Admins]
    C -- No --> E[Continue monitoring\nevery 60-90 min]
    D --> F[Alert marked as sent\nfor billing cycle]

    G[LLM / Model Costs\ntracked in Observability] -. not monitored .-> C

    style G fill:#f5f5f5,stroke:#aaa,color:#888
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Langfuse Cloud Usage] --> B[Invoice Calculation]
    B --> C{Spend threshold\nexceeded?}
    C -- Yes --> D[Email alert sent\nto Owners & Admins]
    C -- No --> E[Continue monitoring\nevery 60-90 min]
    D --> F[Alert marked as sent\nfor billing cycle]

    G[LLM / Model Costs\ntracked in Observability] -. not monitored .-> C

    style G fill:#f5f5f5,stroke:#aaa,color:#888
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify spend alerts apply to Langfuse C..."](https://github.com/langfuse/langfuse-docs/commit/aeb82046b34e5d4a52d6064c6168bf87e3127864) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38682477)</sub>

<!-- /greptile_comment -->