### PR TITLE
docs(claude-code): fix plugin install command

### DIFF
--- a/content/integrations/developer-tools/claude-code.mdx
+++ b/content/integrations/developer-tools/claude-code.mdx
@@ -30,7 +30,7 @@ The easiest way to set this up is now the [Langfuse Observability Plugin](https:
 
 ```bash
 claude plugin marketplace add langfuse/Claude-Observability-Plugin
-claude plugin install langfuse@langfuse-observability
+claude plugin install langfuse-observability@langfuse-observability
 ```
 
 On enable, you'll be prompted for your `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`. Your secret key is stored in your OS keychain. Requires Python 3.9+ and `pip install "langfuse>=4.0,<5"`.


### PR DESCRIPTION
## What

The Claude Code integration page ([`/integrations/developer-tools/claude-code`](https://langfuse.com/integrations/developer-tools/claude-code)) listed an outdated plugin install command:

```bash
claude plugin install langfuse@langfuse-observability   # ❌ fails
```

This fails with:

> Plugin "langfuse" not found in marketplace "langfuse-observability".

The marketplace plugin is named `langfuse-observability`, so the correct command is:

```bash
claude plugin install langfuse-observability@langfuse-observability   # ✅ works
```

This matches the [Claude-Observability-Plugin README](https://github.com/langfuse/Claude-Observability-Plugin).

## Change

One-line fix to the install snippet in `content/integrations/developer-tools/claude-code.mdx` (the marketplace `add` line was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects a broken install command in the Claude Code integration docs: the plugin name was `langfuse` but the marketplace expects `langfuse-observability`, causing a clear "Plugin not found" error.

- Fixes line 33 of `content/integrations/developer-tools/claude-code.mdx` by changing `claude plugin install langfuse@langfuse-observability` to `claude plugin install langfuse-observability@langfuse-observability`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line docs correction that fixes a broken install command for end users.

The change is a one-line fix in a documentation file with no logic or runtime implications. The old command provably fails with an explicit "plugin not found" error, and the new command aligns with the plugin's actual name (`langfuse-observability`) in the marketplace.

No files require special attention. One minor observation: the upstream `Claude-Observability-Plugin` README (as cached by search) still shows the old command — a follow-up PR to that repo may be warranted, but it does not block merging this docs fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant ClaudeCode as Claude Code CLI
    participant Marketplace as langfuse-observability marketplace

    User->>ClaudeCode: claude plugin marketplace add langfuse/Claude-Observability-Plugin
    ClaudeCode->>Marketplace: Register marketplace

    Note over User,Marketplace: Before fix (broken)
    User->>ClaudeCode: "claude plugin install langfuse@langfuse-observability"
    ClaudeCode->>Marketplace: Look up plugin langfuse
    Marketplace-->>ClaudeCode: Plugin langfuse not found

    Note over User,Marketplace: After fix (correct)
    User->>ClaudeCode: "claude plugin install langfuse-observability@langfuse-observability"
    ClaudeCode->>Marketplace: Look up plugin langfuse-observability
    Marketplace-->>ClaudeCode: Plugin found
    ClaudeCode-->>User: Plugin installed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant ClaudeCode as Claude Code CLI
    participant Marketplace as langfuse-observability marketplace

    User->>ClaudeCode: claude plugin marketplace add langfuse/Claude-Observability-Plugin
    ClaudeCode->>Marketplace: Register marketplace

    Note over User,Marketplace: Before fix (broken)
    User->>ClaudeCode: "claude plugin install langfuse@langfuse-observability"
    ClaudeCode->>Marketplace: Look up plugin langfuse
    Marketplace-->>ClaudeCode: Plugin langfuse not found

    Note over User,Marketplace: After fix (correct)
    User->>ClaudeCode: "claude plugin install langfuse-observability@langfuse-observability"
    ClaudeCode->>Marketplace: Look up plugin langfuse-observability
    Marketplace-->>ClaudeCode: Plugin found
    ClaudeCode-->>User: Plugin installed
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(claude-code): fix plugin install co..."](https://github.com/langfuse/langfuse-docs/commit/d6612d517387ced28b3eaaaa6f84e936a78a4329) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38993915)</sub>

<!-- /greptile_comment -->