### PR TITLE
chore: update Scarf pixel ID to new org

### DIFF
--- a/components/analytics/scarf.tsx
+++ b/components/analytics/scarf.tsx
@@ -23,7 +23,7 @@ import { usePathname } from "next/navigation";
 // — the same approach `PostHogProvider` uses for `$pageview` — so client-side
 // navigations are counted too. Scarf responds with `no-store`, so each new
 // request reaches Scarf without a cache-busting query param.
-const SCARF_PIXEL_ID = "a083b1ee-8b4b-4903-88e8-ecbf7f22e7fe";
+const SCARF_PIXEL_ID = "e976646f-b5b2-4877-83ea-6d52444533ea";
 
 export function ScarfPixel() {
   const pathname = usePathname();


### PR DESCRIPTION
## What

Points the website's Scarf web traffic pixel at our **new Scarf organization's** pixel ID. We moved orgs, so the previously merged pixel ID needs to be swapped.

```diff
- const SCARF_PIXEL_ID = "a083b1ee-8b4b-4903-88e8-ecbf7f22e7fe";
+ const SCARF_PIXEL_ID = "e976646f-b5b2-4877-83ea-6d52444533ea";
```

Single-line change in `components/analytics/scarf.tsx`. No behavior change — the component, referrer-policy handling, and route re-fire logic are untouched.

## Context

The Scarf pixel itself was added in #3152 (merged). This just updates the ID after the org move. The new pixel resolves (`GET …?x-pxid=e976646f… → 200 image/png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Scarf analytics pixel ID in `components/analytics/scarf.tsx` following a Langfuse org migration on Scarf's platform. No logic, behavior, or structure is changed.

- Updates `SCARF_PIXEL_ID` from `a083b1ee-8b4b-4903-88e8-ecbf7f22e7fe` to `e976646f-b5b2-4877-83ea-6d52444533ea` to point to the new Scarf org.
- All other aspects of the component — `referrerPolicy` handling, `usePathname`-driven re-fire logic, and the pixel endpoint URL — remain identical.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single constant swap with no effect on component logic or application behavior.

Only the pixel ID string is updated; the component's referrer-policy handling, route-change re-fire logic, and pixel endpoint URL are untouched. The PR description confirms the new ID returns a 200 response from Scarf, and there are no other touched files.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant ScarfPixel as ScarfPixel (Next.js)
    participant Scarf as static.scarf.sh

    Browser->>ScarfPixel: Page load / route change (usePathname)
    ScarfPixel->>ScarfPixel: useEffect fires
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=e976646f-b5b2-4877-83ea-6d52444533ea (referrerPolicy: no-referrer-when-downgrade)"
    Scarf-->>Browser: 200 image/png (Cache-Control: no-store)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant ScarfPixel as ScarfPixel (Next.js)
    participant Scarf as static.scarf.sh

    Browser->>ScarfPixel: Page load / route change (usePathname)
    ScarfPixel->>ScarfPixel: useEffect fires
    ScarfPixel->>Scarf: "GET /a.png?x-pxid=e976646f-b5b2-4877-83ea-6d52444533ea (referrerPolicy: no-referrer-when-downgrade)"
    Scarf-->>Browser: 200 image/png (Cache-Control: no-store)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update Scarf pixel ID to new org"](https://github.com/langfuse/langfuse-docs/commit/b5e8138f91b2813863d5cdce318d3fc9a7b4325d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39057889)</sub>

<!-- /greptile_comment -->