### PR TITLE
add cloud credit faq question to pricing page

### DIFF
--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -33,6 +33,11 @@ const faqs: FAQItem[] = [
       "You get one bill each month. We charge your Core, Pro, or Team plan at the start of the month. We charge for your usage at the end of the month. The bill you get at the start of the month shows two things: the plan cost for the new month and the usage from last month.",
   },
   {
+    question: "What are Langfuse Cloud Credits, and how do they affect me?",
+    answer:
+      "A Langfuse Cloud Credit is a prepaid unit of credit, equal to one (1) US dollar, to be applied to a customer's use of Langfuse Cloud. Credits are drawn down according to the then-current pricing at [langfuse.com/pricing](/pricing). Langfuse Cloud Credits only apply to customers with a committed spend contract for Langfuse Cloud. If you have questions about your credit balance, drawdown schedule, or committed spend contract, please contact your account team. If you use Langfuse Cloud on a Pay-as-you-Go basis, Langfuse Cloud Credits do not apply to you.",
+  },
+  {
     question: "Can I set up alerts on the usage fees?",
     answer:
       "Yes, you can configure spend alerts to receive email notifications when your organization's spending exceeds predefined monetary thresholds. This helps you monitor costs and take action before unexpected charges occur. Navigate to your organization settings and the Billing tab to configure spend alerts. Learn more in our [spend alerts documentation](/docs/administration/spend-alerts).",

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -254,6 +254,13 @@ The primary way is to reduce the number of billable units you ingest. See [tips 
 **When do I get billed?**
 You get one bill each month. The plan fee is charged at the start of the month, and usage is charged at the end of the month.
 
+**What are Langfuse Cloud Credits, and how do they affect me?**
+A Langfuse Cloud Credit is a prepaid unit of credit, equal to one (1) US dollar, to be applied to a customer's use of Langfuse Cloud. Credits are drawn down according to the then-current pricing at [langfuse.com/pricing](/pricing).
+
+Langfuse Cloud Credits only apply to customers with a committed spend contract for Langfuse Cloud. If you have questions about your credit balance, drawdown schedule, or committed spend contract, please contact your account team.
+
+If you use Langfuse Cloud on a Pay-as-you-Go basis, Langfuse Cloud Credits do not apply to you.
+
 **Can I set up alerts on usage fees?**
 Yes, you can configure [spend alerts](/docs/administration/spend-alerts) to receive email notifications when spending exceeds predefined thresholds.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new FAQ entry explaining Langfuse Cloud Credits to the pricing page, covering what they are, how drawdown works, and clarifying they only apply to committed spend contracts (not Pay-as-you-Go users).

- The same content is added to two surfaces: `PricingFAQ.tsx` (the React accordion component) and `md-override/pricing.md` (the markdown fallback), with appropriate formatting for each.
- The `[langfuse.com/pricing](/pricing)` link in the React answer is parsed correctly by the existing `renderAnswerWithLinks` utility, which handles markdown-style link syntax.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — content-only addition with no logic or API changes.

Both changed files receive a straightforward new FAQ entry. The link syntax used in the React answer (`[langfuse.com/pricing](/pricing)`) is handled by the existing `renderAnswerWithLinks` utility, so it will render as a proper clickable link. The markdown file uses the same content split into paragraphs, which is consistent with the rendering surface. No component logic, routing, or data-fetching is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[faqs array in PricingFAQ.tsx] --> B[FAQAccordion component]
    B --> C[renderAnswerWithLinks utility]
    C --> D{Token type}
    D -->|Markdown link| E[Link component]
    D -->|Bold text| F[strong element]
    D -->|Plain text| G[Text node]
    E --> H[Rendered FAQ Accordion on pricing page]
    F --> H
    G --> H
    I[md-override/pricing.md] --> J[Markdown renderer]
    J --> K[Pricing page markdown section]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[faqs array in PricingFAQ.tsx] --> B[FAQAccordion component]
    B --> C[renderAnswerWithLinks utility]
    C --> D{Token type}
    D -->|Markdown link| E[Link component]
    D -->|Bold text| F[strong element]
    D -->|Plain text| G[Text node]
    E --> H[Rendered FAQ Accordion on pricing page]
    F --> H
    G --> H
    I[md-override/pricing.md] --> J[Markdown renderer]
    J --> K[Pricing page markdown section]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["add ud credit to faq"](https://github.com/langfuse/langfuse-docs/commit/636a4f8e3253c78b6227c2306ed7065d46a085de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39072577)</sub>

<!-- /greptile_comment -->