### PR TITLE
Fix Pro pricing table regions

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -1000,7 +1000,7 @@ const sections: Section[] = [
           cloud: {
             Hobby: "US, EU, or JP",
             Core: "US, EU, or JP",
-            Pro: "US, EU, or JP",
+            Pro: "US, EU, JP, or HIPAA",
             Enterprise: "US, EU, JP, or HIPAA",
           },
         },


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the "Data region" row in the Pro pricing tier to include HIPAA as an available region, matching it with the Enterprise tier which already listed "US, EU, JP, or HIPAA".

- Updates the Pro tier's `Data region` value from `"US, EU, or JP"` to `"US, EU, JP, or HIPAA"` in `PricingTable.tsx`, ensuring the pricing table accurately reflects what regions are available to Pro customers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A one-line copy fix in a static pricing table data object — nothing executable changes and no logic is touched.

The change is purely cosmetic: it updates a display string in the Pro tier's Data region row to add HIPAA, matching the existing Enterprise entry. There is no code logic, conditional, or API call involved.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Pro pricing table regions"](https://github.com/langfuse/langfuse-docs/commit/ea840f98702ebca4f562368c08c6226dfbd3fb11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39209841)</sub>

<!-- /greptile_comment -->