### PR TITLE
fix(seo): address critical Ahrefs site-audit issues

### DIFF
--- a/app/(pricing)/pricing/page.tsx
+++ b/app/(pricing)/pricing/page.tsx
@@ -5,6 +5,10 @@ export const metadata: Metadata = {
   title: "Pricing",
   description:
     "Simple pricing for projects of all sizes. Get started on our Hobby plan without a credit card.",
+  // Self-referencing canonical so query-param variants (e.g. ?calculatorOpen=true) consolidate to /pricing
+  alternates: {
+    canonical: "/pricing",
+  },
 };
 
 export default function Pricing() {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getBlogIndexPages } from "@/lib/blog-index";
 import { ContentColumns } from "@/components/layout";
 import { BlogPageClient } from "@/components/blog/BlogPageClient";
@@ -9,6 +10,16 @@ import { TextHighlight } from "@/components/ui/text-highlight";
 import { Link } from "@/components/ui/link";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "The latest updates from Langfuse: product announcements, engineering deep dives, and guides for building LLM applications.",
+  // Self-referencing canonical so filtered views (e.g. /blog?tag=...) consolidate to /blog
+  alternates: {
+    canonical: "/blog",
+  },
+};
 
 export default function BlogIndexPage() {
   const pages = getBlogIndexPages();

--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -51,7 +51,6 @@ References:
 
 - API Reference: https://api.reference.langfuse.com
 - OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
-- Postman collection: https://cloud.langfuse.com/generated/postman/collection.json
 
 <Callout type="info">
 

--- a/content/handbook/product-engineering/how-we-work/roadmapping.mdx
+++ b/content/handbook/product-engineering/how-we-work/roadmapping.mdx
@@ -25,5 +25,5 @@ title: Roadmapping
 3. Comments: everyone reviews draft and adds comments/questions
 4. Discussion: teams meet to go through questions and agree on prioritization
 5. Share
-   - Update [langfuse.com/roadmap](http://langfuse.com/roadmap)
+   - Update [langfuse.com/roadmap](https://langfuse.com/roadmap)
    - Organize community townhall and publish recording on YouTube ([playlist](https://www.youtube.com/playlist?list=PL4v4zZF1rGG6ICfvehJcDWAnAigSpEcxc))

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1434,6 +1434,11 @@ const errorAnalysisAcademyMove202605 = [
     "/blog/2025-08-29-error-analysis-to-evaluate-llm-applications",
     "/academy/monitoring/error-analysis",
   ],
+  // Also redirect the .md variant so the markdown URL does not 404
+  [
+    "/blog/2025-08-29-error-analysis-to-evaluate-llm-applications.md",
+    "/academy/monitoring/error-analysis.md",
+  ],
 ];
 
 // Developer-tool integrations moved from "Other" into the new "Developer Tools" section - June 2026
@@ -1464,6 +1469,39 @@ const howWeShipRename202606 = [
   [
     "/handbook/product-engineering/how-we-work/workflow",
     "/handbook/product-engineering/how-we-work/how-we-ship",
+  ],
+];
+
+// JS SDK cookbook example images moved into the example-js-sdk/ subfolder.
+// Redirect the old top-level paths so existing references no longer 404 - June 2026
+const cookbookJsImagesMove202606 = [
+  [
+    "/images/cookbook/js_integration_openai_simple.png",
+    "/images/cookbook/example-js-sdk/js_integration_openai_simple.png",
+  ],
+  [
+    "/images/cookbook/js_integration_openai_grouped.png",
+    "/images/cookbook/example-js-sdk/js_integration_openai_grouped.png",
+  ],
+  [
+    "/images/cookbook/js_integration_langchain_trace.png",
+    "/images/cookbook/example-js-sdk/js_integration_langchain_trace.png",
+  ],
+  [
+    "/images/cookbook/js_prompt_management_langchain_simple_prompt.png",
+    "/images/cookbook/example-js-sdk/js_prompt_management_langchain_simple_prompt.png",
+  ],
+  [
+    "/images/cookbook/js_prompt_management_langchain_simple_trace.png",
+    "/images/cookbook/example-js-sdk/js_prompt_management_langchain_simple_trace.png",
+  ],
+  [
+    "/images/cookbook/js_prompt_management_langchain_json_extraction_prompt.png",
+    "/images/cookbook/example-js-sdk/js_prompt_management_langchain_json_extraction_prompt.png",
+  ],
+  [
+    "/images/cookbook/js_prompt_management_langchain_json_extraction_trace.png",
+    "/images/cookbook/example-js-sdk/js_prompt_management_langchain_json_extraction_trace.png",
   ],
 ];
 
@@ -1501,6 +1539,7 @@ const permanentRedirects = [
   ...integrationsDeveloperToolsMove202606,
   ...integrationsAgenticDataStackMove202606,
   ...howWeShipRename202606,
+  ...cookbookJsImagesMove202606,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };


### PR DESCRIPTION
## Summary

Addresses the **critical (Error-severity)** issues from the langfuse.com Ahrefs Site Audit (project `9945827`, crawl 2026-06-17) that are fixable in this repository. The audit runs in *subdomains* mode, so the bulk of the 878 reported URL errors come from subdomains this repo does not control (`*.docs-snapshot.langfuse.com`, `js.reference`, `python.reference`, `cloud`, `static`, `chat`). This PR fixes the findings whose root cause lives in `langfuse-docs`.

## Changes

| Audit issue (Error) | Fix |
|---|---|
| **Page has links to broken page** — Public API page linked to the dead `cloud.langfuse.com/generated/postman/collection.json` (404, no working alternative) | Removed the dead Postman bullet; the working OpenAPI spec + API reference links remain ([public-api.mdx](content/docs/api-and-data-platform/features/public-api.mdx)) |
| **404 page** — `…/2025-08-29-error-analysis-to-evaluate-llm-applications.md` 404s (the HTML page already 308-redirects to `/academy/monitoring/error-analysis`, but the `.md` variant was not covered) | Added the `.md` redirect ([lib/redirects.js](lib/redirects.js)) |
| **Image broken** / **Page has broken image** — 7 JS-SDK cookbook images at `/images/cookbook/js_*.png` 404 (they were moved into the `example-js-sdk/` subfolder) | Added permanent redirects to the new paths ([lib/redirects.js](lib/redirects.js)) |
| **HTTPS page has internal links to HTTP** — roadmapping handbook page linked to `http://langfuse.com/roadmap` | Switched to `https://` ([roadmapping.mdx](content/handbook/product-engineering/how-we-work/roadmapping.mdx)) |
| **Duplicate pages without canonical** — `/blog`, `/blog?tag=…`, `/pricing`, `/pricing?calculatorOpen=true` emitted no canonical | Added self-referencing canonicals so query-param variants consolidate ([blog](app/blog/page.tsx), [pricing](app/(pricing)/pricing/page.tsx)) |

## Verification

- `lib/redirects.js` loads cleanly; all 8 new entries resolve to live `200` targets; no new duplicate sources introduced.
- Redirect tuples follow the existing `[source, destination]` pattern (mapped to `permanent: true` in `next.config.mjs`); redirects run before rewrites, so the `.png` and `.md` sources fire correctly.
- `prettier --check` passes on all touched files.
- Full `build` + `link-check` / `sitemap-check` run in CI.

## Intentionally out of scope

These Error-severity findings are **not** fixable in this repo and are left for follow-up:

- **~482 "404 page" + most "missing title"/"broken-link" findings** originate on separate deployments: `*.docs-snapshot.langfuse.com` (versioned SDK doc snapshots), `js.reference` / `python.reference` (TypeDoc/pdoc generated in the SDK repos), and `cloud` / `static` / `chat`. `cdn-cgi/l/email-protection` links are Cloudflare artifacts.
- **Image file size too large (240)** — mostly large `.gif`s and PNGs, many hosted on `static.langfuse.com` / snapshot subdomains. Converting GIFs to `.mp4` (per repo policy) and uploading to `static.langfuse.com` is a separate, larger asset-optimization effort.
- **Hreflang / HTML-lang mismatch (9)** — the `/japan` and `/academy/japan/*` pages serve `<html lang="en">` while declaring `ja-JP` hreflang. The `<html lang>` is hardcoded in the single root `app/layout.tsx`; making it locale-aware is a global change with site-wide regression risk, so it is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes five categories of Error-severity issues surfaced by the Ahrefs site audit: a dead Postman link, a missing `.md`-variant redirect for a moved blog post, seven broken image paths for relocated JS-SDK cookbook screenshots, an HTTP internal link, and missing self-referencing canonicals on `/blog` and `/pricing`.

- **Redirects** (`lib/redirects.js`): adds a `.md` redirect for the moved error-analysis blog post (destination validated — `copy_md_sources.js` generates `public/md-src/academy/monitoring/error-analysis.md` at build time) and seven permanent image redirects pointing at the correct `example-js-sdk/` subfolder, all of which exist in `public/images/cookbook/example-js-sdk/`.
- **Canonicals** (`app/blog/page.tsx`, `app/(pricing)/pricing/page.tsx`): adds `alternates.canonical` using a relative path; because `metadataBase: new URL("https://langfuse.com")` is set in the root layout, Next.js resolves these to absolute URLs as required by Google.
- **Content fixes**: removes the 404 Postman link and upgrades the handbook `http://` link to `https://`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all five fix categories are independently verified: destination images exist on disk, the `.md` redirect destination is produced by `copy_md_sources.js` at build time, and the canonical path resolution is backed by the root layout's `metadataBase`.

Every changed file makes a narrow, targeted fix. The redirect destinations were cross-checked against the filesystem and the build pipeline. The canonical URLs follow the existing Next.js metadata pattern and inherit the correct `metadataBase`. No logic regressions or side-effects were found.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Browser / Crawler Request"] --> B{Path type?}

    B -->|"/blog/2025-08-29-...error-analysis.md"| C["308 Permanent Redirect\n→ /academy/monitoring/error-analysis.md"]
    C --> D["Next.js afterFiles rewrite\n→ /md-src/academy/monitoring/error-analysis.md"]
    D --> E["Static file served\n(generated by copy_md_sources.js at build)"]

    B -->|"/blog/2025-08-29-...error-analysis"| F["308 Permanent Redirect\n→ /academy/monitoring/error-analysis"]
    F --> G["Academy page (HTML)"]

    B -->|"/images/cookbook/js_*.png"| H["308 Permanent Redirect\n→ /images/cookbook/example-js-sdk/js_*.png"]
    H --> I["Static image served\n(exists in public/images/cookbook/example-js-sdk/)"]

    B -->|"/blog?tag=..."| J["Page renders\n<link rel='canonical' href='https://langfuse.com/blog'>"]
    B -->|"/pricing?calculatorOpen=true"| K["Page renders\n<link rel='canonical' href='https://langfuse.com/pricing'>"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Browser / Crawler Request"] --> B{Path type?}

    B -->|"/blog/2025-08-29-...error-analysis.md"| C["308 Permanent Redirect\n→ /academy/monitoring/error-analysis.md"]
    C --> D["Next.js afterFiles rewrite\n→ /md-src/academy/monitoring/error-analysis.md"]
    D --> E["Static file served\n(generated by copy_md_sources.js at build)"]

    B -->|"/blog/2025-08-29-...error-analysis"| F["308 Permanent Redirect\n→ /academy/monitoring/error-analysis"]
    F --> G["Academy page (HTML)"]

    B -->|"/images/cookbook/js_*.png"| H["308 Permanent Redirect\n→ /images/cookbook/example-js-sdk/js_*.png"]
    H --> I["Static image served\n(exists in public/images/cookbook/example-js-sdk/)"]

    B -->|"/blog?tag=..."| J["Page renders\n<link rel='canonical' href='https://langfuse.com/blog'>"]
    B -->|"/pricing?calculatorOpen=true"| K["Page renders\n<link rel='canonical' href='https://langfuse.com/pricing'>"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seo): address critical Ahrefs site-a..."](https://github.com/langfuse/langfuse-docs/commit/428a1ecf22f805d08348767b1775e93e87dfe024) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39244526)</sub>

<!-- /greptile_comment -->