### PR TITLE
docs(faq): add FAQ entry for GCS Rapid Storage blob export incompatibility (LFE-10465)

### DIFF
--- a/components-mdx/blob-storage-gcs-rapid.mdx
+++ b/components-mdx/blob-storage-gcs-rapid.mdx
@@ -1,0 +1,20 @@
+Langfuse's blob exporter uses S3-compatible XML API multipart uploads (`CreateMultipartUpload` → `UploadPart` → `CompleteMultipartUpload`). GCS **Rapid Storage** (Zonal Buckets) does not support the XML API — it only accepts gRPC `BidiWriteObject` writes — so multipart uploads, and therefore blob export, will fail.
+
+### Which storage classes work
+
+| Provider                | Compatible classes                                              | Notes                                       |
+| ----------------------- | --------------------------------------------------------------- | ------------------------------------------- |
+| **GCS**                 | Standard, Nearline, Coldline, Archive                           | Rapid (Zonal Buckets) is **not** compatible |
+| **AWS S3**              | All classes including Glacier tiers                             | No restrictions                             |
+| **Azure Blob**          | Hot, Cool, Cold, Archive                                        | No restrictions                             |
+| **Other S3-compatible** | MinIO, Backblaze B2, Cloudflare R2, DigitalOcean Spaces, Wasabi | All support multipart uploads               |
+
+GCS Rapid is the only known incompatible storage class across all supported providers.
+
+### How to tell you have a Rapid bucket
+
+The storage class metadata shows as `RAPID`. Some tooling may display it as `None` or empty because `RAPID` is not a valid S3 storage class.
+
+### Fix
+
+Create a regular (non-zonal) GCS bucket with the **Standard** storage class (or Nearline / Coldline / Archive) and point your blob storage integration at it instead.

--- a/components-mdx/blob-storage-gcs-rapid.mdx
+++ b/components-mdx/blob-storage-gcs-rapid.mdx
@@ -1,15 +1,4 @@
-Langfuse's blob exporter uses S3-compatible XML API multipart uploads (`CreateMultipartUpload` → `UploadPart` → `CompleteMultipartUpload`). GCS **Rapid Storage** (Zonal Buckets) does not support the XML API — it only accepts gRPC `BidiWriteObject` writes — so multipart uploads, and therefore blob export, will fail.
-
-### Which storage classes work
-
-| Provider                | Compatible classes                                              | Notes                                       |
-| ----------------------- | --------------------------------------------------------------- | ------------------------------------------- |
-| **GCS**                 | Standard, Nearline, Coldline, Archive                           | Rapid (Zonal Buckets) is **not** compatible |
-| **AWS S3**              | All classes including Glacier tiers                             | No restrictions                             |
-| **Azure Blob**          | Hot, Cool, Cold, Archive                                        | No restrictions                             |
-| **Other S3-compatible** | MinIO, Backblaze B2, Cloudflare R2, DigitalOcean Spaces, Wasabi | All support multipart uploads               |
-
-GCS Rapid is the only known incompatible storage class across all supported providers.
+Langfuse's blob exporter uses S3-compatible XML API multipart uploads (`CreateMultipartUpload` → `UploadPart` → `CompleteMultipartUpload`). GCS **Rapid Storage** (Zonal Buckets) does not support the XML API — it only accepts gRPC `BidiWriteObject` writes — so multipart uploads, and therefore blob export, will fail. All other GCS storage classes (Standard, Nearline, Coldline, Archive) and all storage classes on AWS S3, Azure Blob, and other S3-compatible providers work without restrictions. GCS Rapid is the only known incompatible storage class.
 
 ### How to tell you have a Rapid bucket
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -6,6 +6,7 @@ sidebarTitle: Export to Blob Storage
 
 import BlobStorageReExporting from "@/components-mdx/blob-storage-re-exporting.mdx";
 import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx";
+import BlobStorageGcsRapid from "@/components-mdx/blob-storage-gcs-rapid.mdx";
 
 # Export via Blob Storage Integration
 
@@ -159,6 +160,10 @@ A failed export is retried automatically on the next run; repeated failures trig
 ## Empty files in your bucket [#empty-files]
 
 <BlobStorageEmptyFiles />
+
+## GCS Rapid Storage (Zonal Buckets) incompatibility [#gcs-rapid]
+
+<BlobStorageGcsRapid />
 
 ## Alternatives
 

--- a/content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx
+++ b/content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx
@@ -10,6 +10,8 @@ import BlobStorageGcsRapid from "@/components-mdx/blob-storage-gcs-rapid.mdx";
 
 The [blob storage integration](/docs/api-and-data-platform/features/export-to-blob-storage) requires an S3-compatible endpoint with multipart upload support. GCS Rapid Storage (Zonal Buckets) disables the XML API entirely, making it incompatible with the exporter.
 
+## Details [#details]
+
 <BlobStorageGcsRapid />
 
 For the full integration setup guide, see [Export to Blob Storage](/docs/api-and-data-platform/features/export-to-blob-storage).

--- a/content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx
+++ b/content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx
@@ -1,0 +1,15 @@
+---
+title: Why does blob export fail with a GCS Rapid Storage (Zonal) bucket?
+description: GCS Rapid Storage (Zonal Buckets) does not support the XML API multipart uploads that Langfuse blob export requires — use a Standard, Nearline, Coldline, or Archive bucket instead.
+tags: [platform, integration]
+---
+
+import BlobStorageGcsRapid from "@/components-mdx/blob-storage-gcs-rapid.mdx";
+
+# Why does blob export fail with a GCS Rapid Storage (Zonal) bucket?
+
+The [blob storage integration](/docs/api-and-data-platform/features/export-to-blob-storage) requires an S3-compatible endpoint with multipart upload support. GCS Rapid Storage (Zonal Buckets) disables the XML API entirely, making it incompatible with the exporter.
+
+<BlobStorageGcsRapid />
+
+For the full integration setup guide, see [Export to Blob Storage](/docs/api-and-data-platform/features/export-to-blob-storage).


### PR DESCRIPTION
## Summary

Add FAQ entry documenting GCS Rapid Storage (Zonal Buckets) incompatibility with Langfuse blob export ([LFE-10465](https://linear.app/langfuse/issue/LFE-10465)).

- **Shared MDX component** (`components-mdx/blob-storage-gcs-rapid.mdx`) — explains why Rapid buckets are incompatible (no XML API), lists compatible storage classes across all providers, how to identify a Rapid bucket, and the fix.
- **FAQ entry** (`content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx`) — imports the shared component, following the same pattern as the existing blob storage FAQ entries.
- **Main docs page** (`export-to-blob-storage.mdx`) — adds a new section linking the shared component with an explicit `#gcs-rapid` anchor.

## Test plan

- [x] `pnpm run format` — no formatting issues
- [x] `node scripts/check-h1-headings.js` — all files pass
- [ ] Verify pages render correctly on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents GCS Rapid Storage (Zonal Buckets) incompatibility with Langfuse blob export, and adds broader blob storage documentation improvements alongside it.

- Three new shared MDX components (`blob-storage-gcs-rapid.mdx`, `blob-storage-empty-files.mdx`, `blob-storage-re-exporting.mdx`) are introduced and reused in both FAQ pages and the main export-to-blob-storage docs page, following the established pattern.
- `export-to-blob-storage.mdx` gains several new sections (Export modes, How exports run, Export status, Re-exporting, Empty files, GCS Rapid incompatibility) and updates the export frequency to include a 20-minute option, consistent with the matching change in `blob-storage-export-fields.mdx`.
- `blob-storage-gcs-rapid.mdx` uses `### ` (H3) headings, which are hierarchically correct when embedded under the H2 in the main docs page, but create an H1 → H3 skip on the FAQ page where no H2 exists.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are documentation only with no code paths affected.

The GCS Rapid incompatibility guidance is technically accurate and the shared-component reuse pattern is consistent with the rest of the repo. The only issue is that `blob-storage-gcs-rapid.mdx` embeds H3 headings directly under the FAQ page's H1, skipping H2, which is an accessibility concern for that single page.

The `components-mdx/blob-storage-gcs-rapid.mdx` shared component and `content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx` FAQ page together create the heading-level skip worth addressing before publish.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["components-mdx/blob-storage-re-exporting.mdx\n(shared component, no headings)"]
    B["components-mdx/blob-storage-empty-files.mdx\n(shared component, no headings)"]
    C["components-mdx/blob-storage-gcs-rapid.mdx\n(shared component, ### H3 headings)"]

    D["export-to-blob-storage.mdx\n(main docs page, uses ## H2 sections)"]
    E["faq: blob-storage-config-changes-and-errors.mdx\n(H1 page)"]
    F["faq: blob-storage-empty-files.mdx\n(H1 page)"]
    G["faq: blob-storage-gcs-rapid-incompatibility.mdx\n(H1 page)"]

    A --> D
    B --> D
    C --> D

    A --> E
    B --> F
    C --> G

    style G fill:#ffe0e0
    style C fill:#ffe0e0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["components-mdx/blob-storage-re-exporting.mdx\n(shared component, no headings)"]
    B["components-mdx/blob-storage-empty-files.mdx\n(shared component, no headings)"]
    C["components-mdx/blob-storage-gcs-rapid.mdx\n(shared component, ### H3 headings)"]

    D["export-to-blob-storage.mdx\n(main docs page, uses ## H2 sections)"]
    E["faq: blob-storage-config-changes-and-errors.mdx\n(H1 page)"]
    F["faq: blob-storage-empty-files.mdx\n(H1 page)"]
    G["faq: blob-storage-gcs-rapid-incompatibility.mdx\n(H1 page)"]

    A --> D
    B --> D
    C --> D

    A --> E
    B --> F
    C --> G

    style G fill:#ffe0e0
    style C fill:#ffe0e0
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/faq/all/blob-storage-gcs-rapid-incompatibility.mdx:9-15
**Heading hierarchy skip (H1 → H3) in FAQ page**

The `BlobStorageGcsRapid` component embeds `### Which storage classes work`, `### How to tell you have a Rapid bucket`, and `### Fix` (all H3) directly under the FAQ's single H1 heading, skipping H2 entirely. Screen readers and accessibility validators treat a heading level skip as a structural error. The same component is used in `export-to-blob-storage.mdx` under an H2, which is fine there; the problem is specific to the FAQ file's flat structure. The two other shared blob-storage components (`BlobStorageReExporting`, `BlobStorageEmptyFiles`) contain no headings at all, so they don't have this issue. Consider downgrading the `### ` headings in `blob-storage-gcs-rapid.mdx` to `## ` — this resolves the skip in the FAQ page and remains valid in `export-to-blob-storage.mdx` (H2 section → H2 subsection is acceptable) — or add an H2 bridge in the FAQ page itself before the component.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(faq): add FAQ entry for GCS Rapid S..."](https://github.com/langfuse/langfuse-docs/commit/af3fce0290bd27dbe4374948c607642d7620615a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39311645)</sub>

<!-- /greptile_comment -->