### PR TITLE
docs: add community hour links across docs and FAQ

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -145,6 +145,7 @@ We actively develop Langfuse in [open source](/open-source) together with our co
 - Ask questions on [GitHub Discussions](/gh-support) or private [support channels](/support).
 - Report bugs via [GitHub Issues](/issue).
 - Chat with the community on [Discord](/discord).
+- Join a [community hour](/events) to talk to the team and ask questions live.
 - [Why people choose Langfuse?](/why)
 
 Langfuse evolves quickly, check out the [changelog](/changelog) for the latest updates. Subscribe to the **mailing list** to get notified about new major features:

--- a/content/docs/roadmap.mdx
+++ b/content/docs/roadmap.mdx
@@ -188,7 +188,7 @@ Subscribe to our mailing list to get occasional email updates about new features
 
 ## 🙏 Feature requests and bug reports
 
-The best way to support Langfuse is to share your feedback, report bugs, and upvote on ideas suggested by others.
+The best way to support Langfuse is to share your feedback, report bugs, and upvote on ideas suggested by others. You can also discuss the roadmap with the team at our next [community hour](/events).
 
 ### Feature requests
 

--- a/content/faq/all/langfuse-support.mdx
+++ b/content/faq/all/langfuse-support.mdx
@@ -7,4 +7,6 @@ tags: [platform, administration]
 
 We recommend raising support requests through our [GitHub Discussions](https://github.com/orgs/langfuse/discussions). Please allow for 24-48 hours for a response.
 
+You can also join a [community hour](/events) to ask your questions live with the Langfuse team and community.
+
 Find more information on our support page [Support](/support).

--- a/content/faq/index.mdx
+++ b/content/faq/index.mdx
@@ -26,6 +26,8 @@ import { FaqIndex } from "@/components/faq/FaqIndex";
 
 We use GitHub Discussions to answer technical questions while making them easy to find. Feel free to open a new thread to get help by the community and Langfuse team.
 
+Prefer to talk it through? Join a [community hour](/events) to ask your questions live with the Langfuse team and community.
+
 import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
 
 <GhDiscussionsPreview filterCategory="Support" itemsPerPage={10} />

--- a/content/marketing/community.mdx
+++ b/content/marketing/community.mdx
@@ -24,11 +24,17 @@ Connect with the Langfuse community on:
 - [X.com](https://x.com/langfuse)
 - [LinkedIn](https://www.linkedin.com/company/langfuse)
 
-## Langfuse Community Sessions
+## Langfuse Community Hour
 
-We host **Langfuse Community Sessions** every week on Google Meet where we hang out together, talk AI, and answer any questions you might have. We also host regular Langfuse Town Hall meetings where we share larger updates on our latest releases and future roadmap.
+We host a **Langfuse Community Hour** every week on Google Meet where we hang out together, talk AI, answer any questions you might have, and discuss the roadmap with the team. We also host regular Langfuse Town Hall meetings where we share larger updates on our latest releases and future roadmap.
 
-Check out the [Langfuse Lu.ma calendar](https://lu.ma/langfuse) for all event dates.
+Subscribe to the [Langfuse Lu.ma calendar](/events) to see when the next community hour takes place.
+
+import { Calendar } from "lucide-react";
+
+<Cards num={1}>
+  <Card title="Luma Calendar" href="/events" icon={<Calendar />} arrow />
+</Cards>
 
 ## 🖼️ Get Langfuse Stickers
 


### PR DESCRIPTION
## What

Adds links to the [Langfuse Community Hour](/events) across the natural on-ramps where users explore the product or are about to ask a question. Today community hours are only surfaced on the `/support` and `/community` marketing pages, so they're effectively only discovered by people who already attend.

Each link points to the existing `/events` short link (→ Luma calendar), so there's nothing new to maintain.

## Changes

- **`docs/roadmap.mdx`** — note under "Feature requests and bug reports" inviting users to discuss the roadmap with the team at the next community hour.
- **`docs/index.mdx`** — bullet in the "Community & Contact" list.
- **`faq/index.mdx`** — live-help on-ramp under the GitHub Discussions section.
- **`faq/all/langfuse-support.mdx`** — community hours listed alongside GitHub Discussions on the "How can I receive support?" page.
- **`marketing/community.mdx`** — renamed "Community Sessions" → "Langfuse Community Hour" for naming consistency and added a Luma calendar CTA card.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds links to the Langfuse Community Hour across high-traffic docs pages (index, roadmap, FAQ index, FAQ support page) and renames the "Community Sessions" section on the community marketing page to "Langfuse Community Hour" with a new Luma Calendar card.

- Five documentation files updated with `/events` links; the `Cards`/`Card` components are globally registered in `mdx-components.tsx` so no additional imports are needed for those.
- The `import { Calendar }` in `community.mdx` follows the existing inline-import pattern already established in other marketing pages (e.g., `support.mdx`).
- The frontmatter `description` in `community.mdx` still says "community sessions" while the heading now reads "Community Hour" — a minor copy inconsistency worth correcting.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are documentation copy and links with no runtime logic involved.

All five files contain only markdown/MDX prose and link additions. The only noteworthy item is the stale "community sessions" wording in the community.mdx frontmatter description, which is a minor copy inconsistency that won't break anything but may surface in SEO meta tags and social previews.

content/marketing/community.mdx — the frontmatter description should be updated to match the new "Community Hour" naming.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User lands on docs page] --> B{Which page?}
    B --> |docs index| C[Community and Contact list]
    B --> |docs roadmap| D[Feature requests section]
    B --> |faq index| E[GitHub Discussions section]
    B --> |faq support| F[Support FAQ]
    B --> |marketing community| G[Community Hour section]
    C --> H[events link]
    D --> H
    E --> H
    F --> H
    G --> H
    H --> I[Luma calendar lu.ma/langfuse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User lands on docs page] --> B{Which page?}
    B --> |docs index| C[Community and Contact list]
    B --> |docs roadmap| D[Feature requests section]
    B --> |faq index| E[GitHub Discussions section]
    B --> |faq support| F[Support FAQ]
    B --> |marketing community| G[Community Hour section]
    C --> H[events link]
    D --> H
    E --> H
    F --> H
    G --> H
    H --> I[Luma calendar lu.ma/langfuse]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/marketing/community.mdx:3
The page `description` frontmatter still says "attend community sessions" while the section heading was renamed to "Langfuse Community Hour". This inconsistency affects SEO meta tags and social-preview cards shown when the page is shared.

```suggestion
description: Join the Langfuse Community to connect with developers, contribute to our open-source LLM observability platform, join a community hour, and collaborate worldwide.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add community hour links across do..."](https://github.com/langfuse/langfuse-docs/commit/d4a6248b2542d62dd33e9d47a45fcec7aa037447) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39431499)</sub>

<!-- /greptile_comment -->