### PR TITLE
docs(blob-storage): add Running status badge

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -151,7 +151,7 @@ The status card on the same page also surfaces:
 - **Export mode** — `Full history`, `From setup date`, or `From custom date` (plus the start date where applicable).
 - A **Last export failed** alert with the error message and time when in the Error state.
 
-While an export is running, the UI polls for updates every few seconds so the badge refreshes automatically. If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed.
+If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed. Reload the page to see the latest status.
 
 A failed export is retried automatically on the next run; repeated failures trigger a notification.
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -138,6 +138,7 @@ The integration settings page shows a status badge:
 | Badge        | Meaning                                                                                |
 | ------------ | -------------------------------------------------------------------------------------- |
 | **Active**   | Enabled and synced; the next export is scheduled for the future.                       |
+| **Running**  | An export job is currently in progress (shown with a spinner).                         |
 | **Queued**   | An export is due and waiting to run.                                                   |
 | **Pending**  | Enabled but has not run an export yet (`Data exported up to` shows `Never (pending)`). |
 | **Disabled** | The integration is turned off.                                                         |
@@ -149,6 +150,8 @@ The status card on the same page also surfaces:
 - **Next export scheduled** — when the next run will happen.
 - **Export mode** — `Full history`, `From setup date`, or `From custom date` (plus the start date where applicable).
 - A **Last export failed** alert with the error message and time when in the Error state.
+
+While an export is running, the UI polls for updates every few seconds so the badge refreshes automatically. If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed.
 
 A failed export is retried automatically on the next run; repeated failures trigger a notification.
 


### PR DESCRIPTION
## Summary
- Add **Running** status badge to the export status table — shown with a spinner while an export job is in progress
- Document the UI auto-polling behavior and the 2-hour safety-valve TTL that prevents stale Running badges if a worker crashes

Ref: langfuse/langfuse#14282

## Test plan
- [ ] Verify the status table renders correctly on `/docs/api-and-data-platform/features/export-to-blob-storage`
- [ ] Confirm no heading-level or formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the blob storage export documentation to include the **Running** status badge, which was previously undocumented. It also adds a prose paragraph explaining the UI's auto-polling behavior during active exports and the 2-hour TTL safety valve that resets a stale Running badge if a worker crashes.

- A new `Running` row is inserted between `Active` and `Queued` in the status badge table, which matches the logical job-lifecycle order.
- A new paragraph clarifies the polling cadence and the 2-hour TTL fallback, providing operators with enough context to understand why a stuck badge eventually self-corrects.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no code is modified.

The change adds one table row and one paragraph to an MDX doc page. The new Running row is placed in a sensible position (between Active and Queued), the prose accurately describes the polling and TTL behavior referenced in the linked issue, and formatting is consistent with the surrounding table.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Pending["**Pending**\nEnabled, no export run yet"]
    Queued["**Queued**\nExport due, waiting to run"]
    Running["**Running** _(new)_\nExport job in progress\n(UI polls every few seconds)"]
    Active["**Active**\nSynced; next export scheduled"]
    Error["**Error**\nMost recent export failed"]
    Disabled["**Disabled**\nIntegration turned off"]

    Pending --> Queued
    Queued --> Running
    Running -->|"Success"| Active
    Running -->|"Failure"| Error
    Running -->|"Worker crash\n(2-hour TTL)"| Queued
    Active --> Queued
    Error -->|"Auto-retry on next run"| Queued
    Active -->|"User disables"| Disabled
    Disabled -->|"User re-enables"| Pending
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Pending["**Pending**\nEnabled, no export run yet"]
    Queued["**Queued**\nExport due, waiting to run"]
    Running["**Running** _(new)_\nExport job in progress\n(UI polls every few seconds)"]
    Active["**Active**\nSynced; next export scheduled"]
    Error["**Error**\nMost recent export failed"]
    Disabled["**Disabled**\nIntegration turned off"]

    Pending --> Queued
    Queued --> Running
    Running -->|"Success"| Active
    Running -->|"Failure"| Error
    Running -->|"Worker crash\n(2-hour TTL)"| Queued
    Active --> Queued
    Error -->|"Auto-retry on next run"| Queued
    Active -->|"User disables"| Disabled
    Disabled -->|"User re-enables"| Pending
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(blob-storage): add Running status b..."](https://github.com/langfuse/langfuse-docs/commit/15146ad6e704f9cf91f9bbabe0b46991779bb4d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39554975)</sub>

<!-- /greptile_comment -->