### PR TITLE
Update billable units documentation for clarity

### DIFF
--- a/content/docs/administration/billable-units.mdx
+++ b/content/docs/administration/billable-units.mdx
@@ -9,11 +9,15 @@ Langfuse [pricing](/pricing) is based on the number of ingested units per billin
 
 `Units` = `Count of Traces` + `Count of Observations` + `Count of Scores`
 
+## Langfuse Cloud
+
 For Langfuse Cloud, you can use our [pricing calculator](/pricing?calculatorOpen=true) to estimate your monthly costs based on your expected usage.
 
-## Self-hosted (OSS)
+## Self-hosted (OSS/Enterprise)
 
-Self-hosted Langfuse (OSS) is free under the MIT license, so there is no usage-based bill. The unit definition above is still useful when you want to quantify your data volume, for example to estimate the cost of moving to [Langfuse Cloud](/pricing) or to size a [self-hosted](/self-hosting) deployment.
+Self-hosted Langfuse (OSS) is free under the MIT license, so there is no usage-based bill. For self-hosted Langfuse Enterprise, billable units are one component of the pricing.
+
+The unit definition above is still useful when you want to quantify your data volume, for example to estimate the cost of moving to [Langfuse Cloud](/pricing) or to size a [self-hosted](/self-hosting) deployment.
 
 You can read your unit counts directly from the built-in **Langfuse Usage Management** dashboard, one of Langfuse's curated dashboards (see [Custom Dashboards](/docs/metrics/features/custom-dashboards)).
 


### PR DESCRIPTION
Clarified pricing information for self-hosted Langfuse, distinguishing between OSS and Enterprise versions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the billable units documentation to distinguish between self-hosted OSS (free) and self-hosted Enterprise (usage-based billing) versions of Langfuse, and adds an explicit "Langfuse Cloud" section heading.

- The "Self-hosted" section is renamed to "Self-hosted (OSS/Enterprise)" and now clarifies that OSS is free under MIT while Enterprise includes usage-based billing as a pricing component.
- A standalone "Langfuse Cloud" heading is added to match the new section structure, and the OSS-only paragraph is split to accommodate the Enterprise caveat.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with accurate content; safe to merge.

The change is limited to a single documentation file and accurately describes the distinction between OSS (free) and Enterprise self-hosted billing. No code, configuration, or schema is touched. The one note is that a sentence written for the OSS-only context ("still useful") slightly undersells the relevance of billable units for Enterprise self-hosted users, but this does not introduce incorrect information.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Langfuse User] --> B{Deployment Type?}
    B --> C[Langfuse Cloud]
    B --> D[Self-hosted OSS]
    B --> E[Self-hosted Enterprise]
    C --> F[Billable units apply\nUse pricing calculator]
    D --> G[Free – MIT license\nNo usage-based bill]
    E --> H[Billable units are one\ncomponent of pricing]
    F --> I[Units = Traces + Observations + Scores]
    H --> I
    G --> J[Units still useful for\ndata volume estimation]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Langfuse User] --> B{Deployment Type?}
    B --> C[Langfuse Cloud]
    B --> D[Self-hosted OSS]
    B --> E[Self-hosted Enterprise]
    C --> F[Billable units apply\nUse pricing calculator]
    D --> G[Free – MIT license\nNo usage-based bill]
    E --> H[Billable units are one\ncomponent of pricing]
    F --> I[Units = Traces + Observations + Scores]
    H --> I
    G --> J[Units still useful for\ndata volume estimation]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/administration/billable-units.mdx:20
The sentence "The unit definition above is still useful…" uses "still" in a way that made sense when the section was OSS-only (where no billing exists), but is now slightly misleading for Enterprise self-hosted users for whom billable units are the actual basis of their bill — not just a secondary estimation tool. Splitting the sentence by audience avoids the ambiguity.

```suggestion
For self-hosted OSS users, the unit definition above is useful when you want to quantify your data volume, for example to estimate the cost of moving to [Langfuse Cloud](/pricing) or to size a [self-hosted](/self-hosting) deployment. For Enterprise self-hosted users, units are directly used in billing and can also help with capacity planning.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update billable units documentation for ..."](https://github.com/langfuse/langfuse-docs/commit/b2c128ae84c21fa893ab89dd66e4c095a307c87a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39681801)</sub>

<!-- /greptile_comment -->