### PR TITLE
Clarify billing information for self-hosted Langfuse

### DIFF
--- a/content/docs/administration/billable-units.mdx
+++ b/content/docs/administration/billable-units.mdx
@@ -15,7 +15,7 @@ For Langfuse Cloud, you can use our [pricing calculator](/pricing?calculatorOpen
 
 ## Self-hosted (OSS/Enterprise)
 
-Self-hosted Langfuse (OSS) is free under the MIT license, so there is no usage-based bill. For self-hosted Langfuse Enterprise, billable units are one component of the pricing.
+Self-hosted Langfuse (OSS) is free under the MIT license, so there is no usage-based billing. For self-hosted Langfuse Enterprise, billable units are one component of the pricing.
 
 The unit definition above is still useful when you want to quantify your data volume, for example to estimate the cost of moving to [Langfuse Cloud](/pricing) or to size a [self-hosted](/self-hosting) deployment.
 


### PR DESCRIPTION
Updated wording for clarity regarding billing for self-hosted Langfuse.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes a single-word documentation fix in `content/docs/administration/billable-units.mdx`, changing "no usage-based bill" to "no usage-based billing" for grammatical correctness.

- The wording change clarifies the self-hosted OSS pricing section, making the sentence read more naturally without altering its meaning.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a one-word grammatical fix with no risk.

The change swaps "bill" for "billing" in a single documentation sentence. No logic, links, code, or factual content is modified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify billing information for self-hos..."](https://github.com/langfuse/langfuse-docs/commit/bbecf46cc0f52b50722264d4e64c52fd0460dc8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39720335)</sub>

<!-- /greptile_comment -->