### PR TITLE
docs: clarify v4 evaluator context

### DIFF
--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -126,6 +126,12 @@ Evaluate live production traffic to monitor your LLM application performance in 
 
 Run evaluators on individual observations within your traces—such as LLM calls, retrieval operations, embedding generations, or tool calls.
 
+#### Context available to observation-level evaluators [#observation-evaluator-context]
+
+Observation-level evaluators map variables from the matched observation. They can use fields on that observation, such as `input`, `output`, `metadata`, and propagated attributes like `traceName`, `userId`, `sessionId`, and `tags`.
+
+They do not load sibling or child observations from the same trace. If your evaluator needs the overall request and response of an application or agent invocation, target a root observation that records that overall input and output. The evaluator still only sees data on that root observation; it will not automatically include data from child observations unless your application writes the required summary or context onto the root observation.
+
 **Why target Observations**
 
 - **Dramatically faster execution**: Evaluations complete in seconds, not minutes. Eliminates evaluation delays and backlogs. Asynchronous architecture processes thousands of evaluations per minute.
@@ -148,6 +154,10 @@ At ingest time, each observation is evaluated against your filter criteria. Matc
 <Tab>
 
 Run evaluators on complete traces, evaluating entire workflow executions from start to finish.
+
+<Callout type="warning">
+Trace-level LLM-as-a-Judge evaluators are legacy. They are available for classic deployments, but they are not supported in events-table-only Langfuse v4 preview deployments because they depend on lookups against the legacy traces and observations tables. For v4 preview deployments, migrate to observation-level evaluators and put the data the judge needs on the target observation.
+</Callout>
 
 <Callout type="info">
 **Consider targeting Observations instead**: Observation-level evaluators complete in seconds (vs minutes for trace-level), eliminating evaluation delays. They also offer better precision for production monitoring. See [upgrade guide](/faq/all/llm-as-a-judge-migration).

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -128,7 +128,7 @@ Run evaluators on individual observations within your traces—such as LLM calls
 
 #### Context available to observation-level evaluators [#observation-evaluator-context]
 
-Observation-level evaluators map variables from the matched observation. They can use fields on that observation, such as `input`, `output`, `metadata`, and propagated attributes like `traceName`, `userId`, `sessionId`, and `tags`.
+Observation-level evaluators map variables from the matched observation. They can use fields on that observation, such as `input`, `output`, and `metadata`.
 
 They do not load sibling or child observations from the same trace. If your evaluator needs the overall request and response of an application or agent invocation, target a root observation that records that overall input and output. The evaluator still only sees data on that root observation; it will not automatically include data from child observations unless your application writes the required summary or context onto the root observation.
 
@@ -156,7 +156,7 @@ At ingest time, each observation is evaluated against your filter criteria. Matc
 Run evaluators on complete traces, evaluating entire workflow executions from start to finish.
 
 <Callout type="warning">
-Trace-level LLM-as-a-Judge evaluators are legacy. They are available for classic deployments, but they are not supported in events-table-only Langfuse v4 preview deployments because they depend on lookups against the legacy traces and observations tables. For v4 preview deployments, migrate to observation-level evaluators and put the data the judge needs on the target observation.
+Trace-level LLM-as-a-Judge evaluators are legacy. Migrate to observation-level evaluators and put the data the judge needs on the target observation.
 </Callout>
 
 <Callout type="info">

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -25,7 +25,7 @@ Langfuse is now observations-first. Queries that used to require expensive joins
 - **SDK:** Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
 - **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
 - **UI:** If your organization was created before April 14, 2026, 14:00 UTC (15:00 CET), enable the **Preview** toggle (bottom-left) to opt in. Organizations created on/after this cutoff are already on "Fast Preview" and do not see the toggle. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
-- **Evals:** Migrate LLM-as-a-Judge evals to the observation level. Trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are not supported in events-table-only v4 preview deployments because they depend on legacy traces/observations table lookups. [See evals migration guide](/faq/all/llm-as-a-judge-migration)
+- **Evals:** Migrate LLM-as-a-Judge evals to the observation level. [See evals migration guide](/faq/all/llm-as-a-judge-migration)
 
 ---
 

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -25,7 +25,7 @@ Langfuse is now observations-first. Queries that used to require expensive joins
 - **SDK:** Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
 - **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
 - **UI:** If your organization was created before April 14, 2026, 14:00 UTC (15:00 CET), enable the **Preview** toggle (bottom-left) to opt in. Organizations created on/after this cutoff are already on "Fast Preview" and do not see the toggle. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
-- **Evals:** Migrate evals to the observation level. [See evals migration guide](/faq/all/llm-as-a-judge-migration))
+- **Evals:** Migrate LLM-as-a-Judge evals to the observation level. Trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are not supported in events-table-only v4 preview deployments because they depend on legacy traces/observations table lookups. [See evals migration guide](/faq/all/llm-as-a-judge-migration)
 
 ---
 
@@ -120,6 +120,8 @@ The new [Observations API v2](/docs/api-and-data-platform/features/observations-
 ### Faster evaluation workflows
 
 [Observation-level evaluations](/docs/evaluation/evaluation-methods/llm-as-a-judge) execute in seconds as we do not need to query ClickHouse for each evaluation anymore.
+
+Observation-level evaluators only use data on the observation they run against. They do not automatically read sibling or child observations from the same trace. If you need to judge an overall application or agent invocation, target a root observation that records the overall input and output, and write any additional context the judge needs onto that same observation.
 
 ## Under the hood [#under-the-hood]
 

--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -23,6 +23,10 @@ Observation-level evaluators offer:
 
 Trace-level evaluators will continue to work. This is an upgrade path, not a deprecation.
 
+<Callout type="warning">
+If you are running an events-table-only Langfuse v4 preview deployment, trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are not supported because they depend on lookups against the legacy traces and observations tables. Use observation-level evaluators and target an observation that contains the input, output, and context the judge needs.
+</Callout>
+
 ## When to Upgrade
 
 ### ✅ Upgrade Now If:
@@ -30,12 +34,14 @@ Trace-level evaluators will continue to work. This is an upgrade path, not a dep
 - **You're experiencing evaluation delays, backlogs, or slow evaluation processing** (observation-level evaluations complete in seconds)
 - You're using or planning to use OTel-based SDKs (Python v3+ or JS/TS v4+)
 - You're setting up new evaluators
+- You're using Langfuse Fast Preview or an events-table-only v4 preview deployment
 
 ### ⏸️ Stay with Trace-Level For Now If:
 
 - You're on legacy SDKs (Python v2 or JS/TS v3) and can't upgrade yet
 - Your trace evaluators work perfectly for your use case
 - You need to evaluate aggregate workflow data spanning multiple operations
+- You are not using an events-table-only v4 preview deployment
 
 ## Prerequisites
 
@@ -154,6 +160,8 @@ Variables:
 
 - Scores appear on the specific observation in the trace tree
 - You can have multiple scores per trace (one per evaluated observation)
+
+Observation-level evaluators can only map variables from the matched observation. They do not automatically read sibling or child observations from the same trace. If the judge needs an end-to-end request and response, target a root observation that records those values, and write any additional required context onto that root observation.
 
 <Frame fullWidth>
   ![Score output example](/images/docs/evaluator-score-output-example.png)

--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -23,10 +23,6 @@ Observation-level evaluators offer:
 
 Trace-level evaluators will continue to work. This is an upgrade path, not a deprecation.
 
-<Callout type="warning">
-If you are running an events-table-only Langfuse v4 preview deployment, trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are not supported because they depend on lookups against the legacy traces and observations tables. Use observation-level evaluators and target an observation that contains the input, output, and context the judge needs.
-</Callout>
-
 ## When to Upgrade
 
 ### ✅ Upgrade Now If:
@@ -34,14 +30,12 @@ If you are running an events-table-only Langfuse v4 preview deployment, trace-le
 - **You're experiencing evaluation delays, backlogs, or slow evaluation processing** (observation-level evaluations complete in seconds)
 - You're using or planning to use OTel-based SDKs (Python v3+ or JS/TS v4+)
 - You're setting up new evaluators
-- You're using Langfuse Fast Preview or an events-table-only v4 preview deployment
 
 ### ⏸️ Stay with Trace-Level For Now If:
 
 - You're on legacy SDKs (Python v2 or JS/TS v3) and can't upgrade yet
 - Your trace evaluators work perfectly for your use case
 - You need to evaluate aggregate workflow data spanning multiple operations
-- You are not using an events-table-only v4 preview deployment
 
 ## Prerequisites
 


### PR DESCRIPTION
## What changed

- Clarified that observation-level LLM-as-a-Judge evaluators only map variables from the matched observation.
- Added warnings that trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are not supported in events-table-only v4 preview deployments.
- Updated the Fast Preview/v4 page and migration FAQ to point users toward observation-level evaluators and root-observation instrumentation when they need end-to-end context.

## Why

Customers were confused by the v4 preview limitation around trace-based and legacy-dataset-based evaluators. The docs now explain the product behavior directly: v4 preview evaluation should target observations, and any context needed by the judge must be present on the target observation.

## Validation

- Focused Prettier check on the touched MDX files
- `node scripts/check-h1-headings.js`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the data context available to observation-level evaluators and adds warnings that trace-level and legacy-dataset-based LLM-as-a-Judge evaluators are unsupported in events-table-only Langfuse v4 preview deployments.

- **`llm-as-a-judge.mdx`**: Adds an \"observation-evaluator-context\" sub-section explaining variable scoping and a `<Callout type=\"warning\">` under the Traces tab.
- **`v4.mdx`**: Fixes a stray `))`, expands the Evals bullet with the v4 incompatibility note, and adds a clarifying paragraph in \"Faster evaluation workflows\".
- **`llm-as-a-judge-migration.mdx`**: Adds a warning callout, two new \"When to Upgrade\" bullets, and a scoping reminder after the upgrade example.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only changes that are internally consistent across three files; the only concern is a pre-existing "Optional" step label in v4.mdx that now conflicts with the newly added incompatibility warning.

The new warnings and context clarifications are accurate and consistent with each other. The one notable gap is that the migration Step 2 in v4.mdx is still labelled "Optional" while the "At a glance" section added by this PR declares trace-level evaluators unsupported for v4 preview users — a reader following the numbered steps could skip the migration and end up with broken evaluators.

content/docs/v4.mdx — the pre-existing "Optional: Migrate LLM-as-a-judge evaluations" step heading should be reviewed in light of the new incompatibility warning added in this PR.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM-as-a-Judge Evaluator Triggered] --> B{Deployment type?}
    B -- Classic / non-v4-preview --> C[Trace-level OR Observation-level]
    B -- Events-table-only v4 Preview --> D[Observation-level ONLY]
    C --> E{Evaluator target}
    E -- Trace-level --> F[Query legacy traces & observations tables\nLoad full trace context\nAttach score to trace]
    E -- Observation-level --> G[Read matched observation\nUse propagated attributes\nDo NOT load siblings/children]
    D --> G
    G --> H{Need end-to-end context?}
    H -- Yes --> I[Target root observation\nWrite full context onto it\nvia propagate_attributes]
    H -- No --> J[Score attached to observation]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[LLM-as-a-Judge Evaluator Triggered] --> B{Deployment type?}
    B -- Classic / non-v4-preview --> C[Trace-level OR Observation-level]
    B -- Events-table-only v4 Preview --> D[Observation-level ONLY]
    C --> E{Evaluator target}
    E -- Trace-level --> F[Query legacy traces & observations tables\nLoad full trace context\nAttach score to trace]
    E -- Observation-level --> G[Read matched observation\nUse propagated attributes\nDo NOT load siblings/children]
    D --> G
    G --> H{Need end-to-end context?}
    H -- Yes --> I[Target root observation\nWrite full context onto it\nvia propagate_attributes]
    H -- No --> J[Score attached to observation]
    I --> J
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/v4.mdx:94-96
**"Optional" step label now conflicts with the mandatory-for-v4 warning above**

The migration step heading `### Optional: Migrate LLM-as-a-judge evaluations` still says "Optional", but the PR adds a statement at line 28 that these evaluators are *not supported* in events-table-only v4 preview deployments. A v4 preview user following the numbered migration steps will see "Optional" and may skip it, only to discover their evaluators are broken. The step body also describes the change purely as a performance improvement ("significantly faster execution") with no mention of the compatibility requirement added elsewhere in the same file.

### Issue 2 of 2
content/faq/all/llm-as-a-judge-migration.mdx:44
The negative condition "You are not using an events-table-only v4 preview deployment" reads awkwardly in a "reasons to stay" list — it's a double-negative gate rather than a clear positive rationale for staying on trace-level. Reframing it as a positive condition makes the intent clearer.

```suggestion
- You are on a classic Langfuse deployment (not an events-table-only v4 preview deployment)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify v4 evaluator context"](https://github.com/langfuse/langfuse-docs/commit/f4209ed0344103e8fdd9de27fd2f6903e091e8c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39811535)</sub>

<!-- /greptile_comment -->