### PR TITLE
feat: Add Langfuse Assistant docs page

### DIFF
--- a/content/docs/langfuse-assistant.mdx
+++ b/content/docs/langfuse-assistant.mdx
@@ -1,0 +1,76 @@
+---
+title: Langfuse Assistant
+description: Ask questions about your Langfuse project data in plain language from inside the Langfuse Cloud UI.
+sidebarTitle: Assistant
+---
+
+# Langfuse Assistant
+
+The Langfuse Assistant is an in-product assistant for exploring your Langfuse project data. Ask questions about traces, observations, sessions, metrics, and Langfuse workflows in plain language.
+
+<Callout type="info">
+
+The Langfuse Assistant is currently in beta and only available on Langfuse Cloud.
+
+</Callout>
+
+<Video src="https://static.langfuse.com/docs-videos/in-app-agent.mp4" />
+
+## What you can ask [#what-you-can-ask]
+
+Ask the Assistant questions such as:
+
+- "Which traces had the highest latency yesterday?"
+- "Show me failed generations in the last hour."
+- "What's my token spend this week, broken down by model?"
+- "How do I set up an evaluator?"
+- "Open the traces table filtered to errors from today."
+
+## How it works [#how-it-works]
+
+The Assistant uses the Langfuse MCP server and additional tools to answer questions, inspect project data, and propose navigation actions.
+
+The Assistant can:
+
+- Query traces, observations, sessions, and metrics through Langfuse tools
+- Search Langfuse documentation
+- Propose links to Langfuse pages such as traces, sessions, dashboards, prompts, datasets, experiments, evals, monitors, and project settings
+
+The Assistant does not automatically navigate or modify project data. When a destination is useful, it proposes an action that you confirm.
+
+The Assistant is also aware of your current context in the Langfuse UI, such as the current trace, observation, session, or dashboard, as well as user metadata such as your name, browser language, and timezone. This context is used to provide more relevant answers and propose actions.
+
+## Access and availability [#access-and-availability]
+
+It is currently available on Langfuse Cloud and not yet available for self-hosted deployments.
+
+## Data privacy and security [#data-privacy-and-security]
+
+The Assistant follows the same data handling model as other Langfuse AI features. See [AI Features](/security/ai-features) for the canonical security and privacy details.
+
+Key points:
+
+- Model requests are handled in the same AWS region as your [Langfuse data region](/security/data-regions).
+- Assistant access is scoped to the authenticated user and current project.
+- AI feature tracing for product and service improvement can be enabled or disabled separately by organization admins and owners.
+
+## Conversation history [#conversation-history]
+
+Assistant conversations are saved per user and project so you can return to previous conversations.
+
+## Feedback [#feedback]
+
+You can submit thumbs-up or thumbs-down feedback on Assistant responses. If AI feature tracing is enabled, feedback may be used for product and service improvement.
+
+You can also share your thoughts in our [feedback discussion](https://github.com/orgs/langfuse/discussions/14196).
+
+## Limitations [#limitations]
+
+The Assistant is a beta feature. It may misunderstand a question or return incomplete results. Verify important answers before acting on them.
+
+## Related resources [#related-resources]
+
+- [AI Feature Security](/security/ai-features)
+- [Langfuse MCP Server](/docs/api-and-data-platform/features/mcp-server)
+- [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill)
+- [Langfuse Assistant announcement](/changelog/2026-06-19-langfuse-assistant-public-beta)

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -15,6 +15,7 @@
     "---Platform---",
     "metrics",
     "api-and-data-platform",
+    "langfuse-assistant",
     "administration",
     "security-and-guardrails",
     "---More---",

--- a/content/security/ai-features.mdx
+++ b/content/security/ai-features.mdx
@@ -18,7 +18,7 @@ The setting applies to all users and projects within the organization.
 
 Non-exhaustive list of available AI features in Langfuse:
 
-- Langfuse Assistant for asking questions about traces, observations, and metrics in plain language
+- [Langfuse Assistant](/docs/langfuse-assistant) for asking questions about traces, observations, and metrics in plain language
 - Natural language-based filter builder for tables
 
 ## Data Privacy


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new documentation page for the Langfuse Assistant feature and links it from the existing AI Features security page. The sidebar navigation in `meta.json` is updated to surface the page under the "Platform" section.

- New `langfuse-assistant.mdx` doc covers usage, how it works, data privacy, conversation history, feedback, and limitations. All internal links (`/security/ai-features`, `/security/data-regions`, `/docs/api-and-data-platform/features/mcp-server`, `/docs/api-and-data-platform/features/agent-skill`, and the changelog entry) resolve to existing files.
- `content/security/ai-features.mdx` is updated to make the Langfuse Assistant list item a hyperlink, pointing to the new page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only changes; all internal links resolve to existing files and no application logic is affected.

The PR adds a new docs page and one hyperlink update. Every cross-referenced path was verified to exist in the repo. The only observation is a minor cosmetic redundancy between the callout and the 'Access and availability' section.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User["User (Langfuse Cloud UI)"] -->|"asks a question in plain language"| Assistant["Langfuse Assistant"]
    Assistant -->|"queries via Langfuse tools"| Data["Traces / Observations / Sessions / Metrics"]
    Assistant -->|"searches"| Docs["Langfuse Documentation"]
    Assistant -->|"proposes navigation action"| Nav["Links to Langfuse Pages\n(traces, dashboards, prompts, etc.)"]
    User -->|"confirms"| Nav
    Assistant -->|"model requests (same AWS region)"| Bedrock["AWS Bedrock"]
    Bedrock -->|"response"| Assistant
    Assistant -->|"context-aware answers"| User
    User -->|"thumbs up / down"| Feedback["Feedback (optional AI tracing)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    User["User (Langfuse Cloud UI)"] -->|"asks a question in plain language"| Assistant["Langfuse Assistant"]
    Assistant -->|"queries via Langfuse tools"| Data["Traces / Observations / Sessions / Metrics"]
    Assistant -->|"searches"| Docs["Langfuse Documentation"]
    Assistant -->|"proposes navigation action"| Nav["Links to Langfuse Pages\n(traces, dashboards, prompts, etc.)"]
    User -->|"confirms"| Nav
    Assistant -->|"model requests (same AWS region)"| Bedrock["AWS Bedrock"]
    Bedrock -->|"response"| Assistant
    Assistant -->|"context-aware answers"| User
    User -->|"thumbs up / down"| Feedback["Feedback (optional AI tracing)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/langfuse-assistant.mdx:43-45
The "Access and availability" section repeats information already stated in the callout directly above the video (`"currently in beta and only available on Langfuse Cloud"`). The standalone section adds no new detail and may confuse readers who wonder if there's a distinction. Consider either removing it and folding any unique content into the callout, or expanding it with genuinely additive information (e.g., a roadmap note for self-hosted).

```suggestion
## Access and availability [#access-and-availability]

The Langfuse Assistant is currently in **beta** and available on **Langfuse Cloud** only. Self-hosted support is not yet available.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Add Langfuse Assistant docs page"](https://github.com/langfuse/langfuse-docs/commit/9d7f69ad975d67cdaed619a0b8843e0f586a8c53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39860243)</sub>

<!-- /greptile_comment -->