### PR TITLE
job-matcher

### DIFF
--- a/components/role-finder/RoleFinderQuiz.tsx
+++ b/components/role-finder/RoleFinderQuiz.tsx
@@ -122,12 +122,10 @@ export function RoleFinderQuiz({
       setHistory((h) => h.slice(0, -1));
       return;
     }
-    setHistory((h) => {
-      if (h.length === 0) return h;
-      const previous = h[h.length - 1];
-      setView({ type: "question", id: previous });
-      return h.slice(0, -1);
-    });
+    if (history.length === 0) return;
+    const previous = history[history.length - 1];
+    setView({ type: "question", id: previous });
+    setHistory((h) => h.slice(0, -1));
   };
 
   const startOver = () => {

--- a/components/role-finder/RoleFinderQuiz.tsx
+++ b/components/role-finder/RoleFinderQuiz.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import * as React from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ExternalLink,
+  RotateCcw,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { Option, Question, QuizResult } from "./role-finder-data";
+
+/** A role with live job-board data merged in (resolved by the server component). */
+export type ResolvedRole = {
+  key: string;
+  /** False when the role is no longer listed on the live Ashby board. */
+  available: boolean;
+  title: string;
+  url: string;
+  pitch: string;
+  youll: string[];
+};
+
+type RoleFinderQuizProps = {
+  roles: Record<string, ResolvedRole>;
+  tree: Record<string, Question>;
+  rootId: string;
+  careersFallbackUrl: string;
+};
+
+type View =
+  | { type: "question"; id: string }
+  | { type: "result"; res: QuizResult };
+
+export function RoleFinderQuiz({
+  roles,
+  tree,
+  rootId,
+  careersFallbackUrl,
+}: RoleFinderQuizProps) {
+  const [history, setHistory] = React.useState<string[]>([]);
+  const [view, setView] = React.useState<View>({
+    type: "question",
+    id: rootId,
+  });
+
+  // Memoize, per question, whether any reachable result is for an available
+  // role. Used to hide answer options that only lead to closed roles.
+  const optionLeadsToAvailable = React.useMemo(() => {
+    const questionCache = new Map<string, boolean>();
+
+    const questionHasAvailable = (
+      id: string,
+      visited: Set<string>,
+    ): boolean => {
+      if (questionCache.has(id)) return questionCache.get(id)!;
+      if (visited.has(id)) return false;
+      visited.add(id);
+      const question = tree[id];
+      if (!question) return false;
+      const result = question.options.some((opt) =>
+        leadsToAvailable(opt, visited),
+      );
+      questionCache.set(id, result);
+      return result;
+    };
+
+    const leadsToAvailable = (
+      option: Option,
+      visited: Set<string>,
+    ): boolean => {
+      if (typeof option.next === "string") {
+        return questionHasAvailable(option.next, visited);
+      }
+      return Boolean(roles[option.next.result]?.available);
+    };
+
+    return (option: Option) => leadsToAvailable(option, new Set<string>());
+  }, [roles, tree]);
+
+  // Longest path (number of questions) from the root to any result. Used as the
+  // progress-bar denominator so it stays correct if the tree changes.
+  const maxDepth = React.useMemo(() => {
+    const depthOf = (id: string, visited: Set<string>): number => {
+      const question = tree[id];
+      if (!question || visited.has(id)) return 0;
+      visited.add(id);
+      let deepest = 1;
+      for (const option of question.options) {
+        if (typeof option.next === "string") {
+          deepest = Math.max(deepest, 1 + depthOf(option.next, visited));
+        }
+      }
+      visited.delete(id);
+      return deepest;
+    };
+    return Math.max(1, depthOf(rootId, new Set<string>()));
+  }, [tree, rootId]);
+
+  // The result screen is the final step beyond the last question.
+  const totalSteps = maxDepth + 1;
+  const currentStep = view.type === "result" ? totalSteps : history.length + 1;
+  const progress = Math.min(1, currentStep / totalSteps);
+
+  const answer = (option: Option) => {
+    if (view.type !== "question") return;
+    setHistory((h) => [...h, view.id]);
+    if (typeof option.next === "string") {
+      setView({ type: "question", id: option.next });
+    } else {
+      setView({ type: "result", res: option.next });
+    }
+  };
+
+  const back = () => {
+    if (view.type === "result") {
+      // Return to the question that produced this result.
+      const previous = history[history.length - 1];
+      if (previous) setView({ type: "question", id: previous });
+      setHistory((h) => h.slice(0, -1));
+      return;
+    }
+    setHistory((h) => {
+      if (h.length === 0) return h;
+      const previous = h[h.length - 1];
+      setView({ type: "question", id: previous });
+      return h.slice(0, -1);
+    });
+  };
+
+  const startOver = () => {
+    setHistory([]);
+    setView({ type: "question", id: rootId });
+  };
+
+  const canGoBack = history.length > 0 || view.type === "result";
+
+  return (
+    <div className="not-prose mx-auto w-full max-w-2xl">
+      <div
+        className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress * 100)}
+        aria-label="Quiz progress"
+      >
+        <div
+          className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+
+      {view.type === "question" ? (
+        <QuestionScreen
+          question={tree[view.id]}
+          questionNumber={history.length + 1}
+          onAnswer={answer}
+          isOptionVisible={optionLeadsToAvailable}
+          careersFallbackUrl={careersFallbackUrl}
+        />
+      ) : (
+        <ResultScreen
+          res={view.res}
+          roles={roles}
+          careersFallbackUrl={careersFallbackUrl}
+        />
+      )}
+
+      <div className="mt-6 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={back}
+          disabled={!canGoBack}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={startOver}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+          Start over
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function QuestionScreen({
+  question,
+  questionNumber,
+  onAnswer,
+  isOptionVisible,
+  careersFallbackUrl,
+}: {
+  question: Question | undefined;
+  questionNumber: number;
+  onAnswer: (option: Option) => void;
+  isOptionVisible: (option: Option) => boolean;
+  careersFallbackUrl: string;
+}) {
+  if (!question) {
+    return <ClosedFallback careersFallbackUrl={careersFallbackUrl} />;
+  }
+
+  const visibleOptions = question.options.filter(isOptionVisible);
+
+  if (visibleOptions.length === 0) {
+    return <ClosedFallback careersFallbackUrl={careersFallbackUrl} />;
+  }
+
+  return (
+    <div>
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Question {questionNumber}
+      </p>
+      <h2 className="mt-1.5 text-balance text-xl font-semibold tracking-tight md:text-2xl">
+        {question.q}
+      </h2>
+      <div className="mt-5 flex flex-col gap-3">
+        {visibleOptions.map((option) => (
+          <button
+            key={option.label}
+            type="button"
+            onClick={() => onAnswer(option)}
+            className={cn(
+              "group flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-card p-4 text-left",
+              "transition-colors hover:border-foreground/30 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            )}
+          >
+            <span className="text-sm font-medium md:text-base">
+              {option.label}
+            </span>
+            <ArrowRight
+              className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+              aria-hidden
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ResultScreen({
+  res,
+  roles,
+  careersFallbackUrl,
+}: {
+  res: QuizResult;
+  roles: Record<string, ResolvedRole>;
+  careersFallbackUrl: string;
+}) {
+  const role = roles[res.result];
+
+  // Defensive: if the matched role has closed since the tree was authored,
+  // fall back to the general careers board.
+  if (!role || !role.available) {
+    return <ClosedFallback careersFallbackUrl={careersFallbackUrl} />;
+  }
+
+  const alsoRoles = (res.also ?? [])
+    .map((key) => roles[key])
+    .filter((r): r is ResolvedRole => Boolean(r?.available));
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 md:p-8">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Your best match
+      </p>
+      <h2 className="mt-1.5 text-2xl font-semibold tracking-tight md:text-3xl">
+        {role.title}
+      </h2>
+      <p className="mt-3 text-muted-foreground">{role.pitch}</p>
+
+      <ul className="mt-5 flex flex-col gap-2.5">
+        {role.youll.map((item) => (
+          <li key={item} className="flex items-start gap-2.5">
+            <Check
+              className="mt-0.5 h-4 w-4 shrink-0 text-foreground"
+              aria-hidden
+            />
+            <span className="text-sm">{item}</span>
+          </li>
+        ))}
+      </ul>
+
+      {res.note ? (
+        <p className="mt-5 rounded-md border-l-2 border-border bg-muted px-4 py-3 text-sm text-muted-foreground">
+          {res.note}
+        </p>
+      ) : null}
+
+      <div className="mt-6">
+        <a
+          href={role.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          View role &amp; apply
+          <ExternalLink className="h-4 w-4" aria-hidden />
+        </a>
+      </div>
+
+      {alsoRoles.length > 0 ? (
+        <div className="mt-7 border-t border-border pt-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Also worth a look
+          </p>
+          <ul className="mt-3 flex flex-col gap-2">
+            {alsoRoles.map((r) => (
+              <li key={r.key}>
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  {r.title}
+                  <ExternalLink
+                    className="h-3.5 w-3.5 text-muted-foreground"
+                    aria-hidden
+                  />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ClosedFallback({
+  careersFallbackUrl,
+}: {
+  careersFallbackUrl: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 md:p-8">
+      <h2 className="text-xl font-semibold tracking-tight md:text-2xl">
+        That role isn&apos;t open right now
+      </h2>
+      <p className="mt-3 text-muted-foreground">
+        The roles change as we grow. Browse all currently open positions to find
+        your fit.
+      </p>
+      <div className="mt-6">
+        <a
+          href={careersFallbackUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          See all open roles
+          <ExternalLink className="h-4 w-4" aria-hidden />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/role-finder/index.tsx
+++ b/components/role-finder/index.tsx
@@ -1,0 +1,54 @@
+import { getAshbyJobs } from "@/lib/ashby-jobs";
+import {
+  CAREERS_FALLBACK_URL,
+  ROLES,
+  ROOT_QUESTION_ID,
+  TREE,
+} from "./role-finder-data";
+import { RoleFinderQuiz, type ResolvedRole } from "./RoleFinderQuiz";
+
+/**
+ * Server component for the careers role-finder quiz.
+ *
+ * Fetches the live Ashby job board (cached via ISR in `getAshbyJobs`) and merges
+ * each role's live title, apply URL, and availability into the curated config
+ * before handing off to the client engine. If the board can't be fetched, roles
+ * fall back to the static config and stay available so the quiz keeps working.
+ */
+export async function RoleFinder() {
+  const jobs = await getAshbyJobs();
+
+  const resolvedRoles = Object.fromEntries(
+    (
+      Object.entries(ROLES) as [
+        keyof typeof ROLES,
+        (typeof ROLES)[keyof typeof ROLES],
+      ][]
+    ).map(([key, role]) => {
+      const job = jobs?.[role.ashbyId];
+      // When the board fetch succeeds, availability = the posting exists and
+      // is listed. When it fails (jobs === null) we can't know, so assume the
+      // role is open and use the static fallback data.
+      const available = jobs ? Boolean(job && job.isListed !== false) : true;
+
+      const resolved: ResolvedRole = {
+        key,
+        available,
+        title: job?.title ?? role.title,
+        url: job?.jobUrl ?? role.url,
+        pitch: role.pitch,
+        youll: role.youll,
+      };
+      return [key, resolved];
+    }),
+  ) as Record<string, ResolvedRole>;
+
+  return (
+    <RoleFinderQuiz
+      roles={resolvedRoles}
+      tree={TREE}
+      rootId={ROOT_QUESTION_ID}
+      careersFallbackUrl={CAREERS_FALLBACK_URL}
+    />
+  );
+}

--- a/components/role-finder/role-finder-data.ts
+++ b/components/role-finder/role-finder-data.ts
@@ -1,0 +1,323 @@
+/**
+ * Role-finder quiz configuration — edit this file to change questions, roles,
+ * branching, pitches, or bullets. No engine code needs to be touched.
+ *
+ * How live job-board sync works:
+ *   Each role has an `ashbyId` (its Ashby posting id). At build time the server
+ *   component (`./index.tsx`) fetches the live Ashby board and merges the live
+ *   `title` + apply URL into the role, and marks roles that are no longer listed
+ *   as unavailable. The `title` and `url` below are only fallbacks used if the
+ *   board can't be fetched. The `pitch`, `youll` bullets, questions, and tree
+ *   are curated content that lives only here.
+ *
+ * To add a role: add an entry to ROLES (with its Ashby posting id) and route to
+ * it from the TREE via `{ result: "<key>" }`. To remove one: delete it from
+ * ROLES and remove any options that point at it.
+ */
+
+export type RoleKey =
+  | "product"
+  | "growth"
+  | "integrations"
+  | "sdk"
+  | "data_infra"
+  | "iam_billing"
+  | "cloud"
+  | "devrel";
+
+export type Role = {
+  /** Ashby posting id — used to sync title/apply-URL/availability with the live board. */
+  ashbyId: string;
+  /** Fallback title (used only if the live board can't be fetched). */
+  title: string;
+  /** Fallback apply URL (used only if the live board can't be fetched). */
+  url: string;
+  /** One-line pitch for the role. */
+  pitch: string;
+  /** "What you'll do" bullets (3 recommended). */
+  youll: string[];
+};
+
+/** A result leaf in the tree: the recommended role + optional caveats/alternates. */
+export type QuizResult = {
+  result: RoleKey;
+  /** Honest caveat shown on the result screen. */
+  note?: string;
+  /** Secondary roles surfaced under "also worth a look". */
+  also?: RoleKey[];
+};
+
+/** An answer option: advances to another question id, or ends on a result. */
+export type Option = {
+  label: string;
+  next: string | QuizResult;
+};
+
+export type Question = {
+  q: string;
+  options: Option[];
+};
+
+export const ROOT_QUESTION_ID = "start";
+
+/** General careers board, used as a fallback when a specific role has closed. */
+export const CAREERS_FALLBACK_URL = "https://jobs.ashbyhq.com/langfuse";
+
+export const ROLES: Record<RoleKey, Role> = {
+  product: {
+    ashbyId: "a2c4e24c-21d1-4a9f-8d46-422d0592efd6",
+    title: "Senior Product Engineer",
+    url: "https://jobs.ashbyhq.com/langfuse/a2c4e24c-21d1-4a9f-8d46-422d0592efd6",
+    pitch:
+      "Build user-facing features end-to-end in TypeScript/React, with taste for UI detail, API design, and clear docs.",
+    youll: [
+      "Ship products from scratch end-to-end",
+      "Own projects with strong conviction",
+      "Care deeply about developer experience & UI craft",
+    ],
+  },
+  growth: {
+    ashbyId: "71a67633-5770-481b-9fb3-22e4f27cbca1",
+    title: "Senior Product Engineer (Growth)",
+    url: "https://jobs.ashbyhq.com/langfuse/71a67633-5770-481b-9fb3-22e4f27cbca1",
+    pitch:
+      "Full-stack product work aimed at product-led growth — experiments, activation, conversion, backed by SQL analytics.",
+    youll: [
+      "Run experiments across many topics",
+      "Think like a user and like the business",
+      "Ship FE+BE changes and query the data yourself",
+    ],
+  },
+  integrations: {
+    ashbyId: "f17768f8-525b-4caa-a8ee-5553a4ff4979",
+    title: "Senior Product Engineer (Integrations)",
+    url: "https://jobs.ashbyhq.com/langfuse/f17768f8-525b-4caa-a8ee-5553a4ff4979",
+    pitch:
+      "Own the first impression across 40+ framework integrations (LangChain, Vercel AI SDK, LlamaIndex, Pydantic AI…).",
+    youll: [
+      "Build real apps with LLM frameworks",
+      "Obsess over the getting-started experience",
+      "Write clean Python and/or TypeScript",
+    ],
+  },
+  sdk: {
+    ashbyId: "891eda0a-a9f6-45e6-8750-71874db8cc11",
+    title: "Senior Software Engineer (SDK)",
+    url: "https://jobs.ashbyhq.com/langfuse/891eda0a-a9f6-45e6-8750-71874db8cc11",
+    pitch:
+      "Build SDKs downloaded 26M+ times/month. Performance, versioning, and DX in code that runs in other people's production.",
+    youll: [
+      "Profile & minimize overhead in hot paths",
+      "Think about versioning & backwards compatibility",
+      "Python + TypeScript, ideally OpenTelemetry",
+    ],
+  },
+  data_infra: {
+    ashbyId: "1225fa3d-d590-41d2-b798-ef927320fb2e",
+    title: "Senior Backend Engineer (Data Infrastructure)",
+    url: "https://jobs.ashbyhq.com/langfuse/1225fa3d-d590-41d2-b798-ef927320fb2e",
+    pitch:
+      "Make Langfuse fast and affordable at scale — own the ingestion pipeline and optimize ClickHouse data models & queries.",
+    youll: [
+      "Get excited about database internals & query optimization",
+      "Work with a ton of data",
+      "TypeScript + SQL; ClickHouse/OLAP a plus",
+    ],
+  },
+  iam_billing: {
+    ashbyId: "69bc6e7a-0304-4d81-ae72-7ccf5652a053",
+    title: "Senior Backend Engineer (IAM & Billing)",
+    url: "https://jobs.ashbyhq.com/langfuse/69bc6e7a-0304-4d81-ae72-7ccf5652a053",
+    pitch:
+      "Own the platform every team depends on: authentication, authorization, and usage-based billing.",
+    youll: [
+      "Build SSO/SAML, OAuth, RBAC, API keys",
+      "Integrate billing/metering (Stripe or similar)",
+      "Reason about security & multi-tenant edge cases",
+    ],
+  },
+  cloud: {
+    ashbyId: "1745b263-e25e-4037-a3a8-d0460fbba165",
+    title: "Senior Cloud Infrastructure Engineer",
+    url: "https://jobs.ashbyhq.com/langfuse/1745b263-e25e-4037-a3a8-d0460fbba165",
+    pitch:
+      "Operate Langfuse Cloud on AWS ECS Fargate + ClickHouse Cloud, and own the self-hosted Helm/Docker story.",
+    youll: [
+      "Run production workloads on AWS",
+      "Container orchestration + infra-as-code (Terraform/Pulumi)",
+      "Build monitoring/alerts that actually catch problems",
+    ],
+  },
+  devrel: {
+    ashbyId: "60231438-f158-4e7b-b08d-12e5222fcc16",
+    title: "DevRel Engineer",
+    url: "https://jobs.ashbyhq.com/langfuse/60231438-f158-4e7b-b08d-12e5222fcc16",
+    pitch:
+      "An engineer who educates through content — powering developer relations and thought leadership in LLM ops.",
+    youll: [
+      "Create content & documentation",
+      "Engage the global user base",
+      "Have taste in good content; OSS & AI-eng a big plus",
+    ],
+  },
+};
+
+export const TREE: Record<string, Question> = {
+  start: {
+    q: "When you imagine your ideal week at Langfuse, what are you doing most?",
+    options: [
+      {
+        label: "Shipping features users see and touch",
+        next: "product_focus",
+      },
+      {
+        label: "Going deep on backend systems, data, and reliability",
+        next: "systems_focus",
+      },
+      {
+        label: "Making it effortless for other devs to use our tools",
+        next: "devtools_focus",
+      },
+      {
+        label: "Teaching, writing, and growing a developer community",
+        next: "content_focus",
+      },
+    ],
+  },
+
+  product_focus: {
+    q: "Within product work, what pulls you most?",
+    options: [
+      {
+        label: "Owning a feature end-to-end, with real craft in the UI",
+        next: { result: "product" },
+      },
+      {
+        label: "Moving growth metrics — activation, conversion, experiments",
+        next: "growth_sql",
+      },
+      {
+        label: "The AI/LLM framework ecosystem and great first-run experiences",
+        next: { result: "integrations" },
+      },
+    ],
+  },
+  growth_sql: {
+    q: "How hands-on are you with SQL and product analytics?",
+    options: [
+      {
+        label: "Very — I dig into funnels and write the queries myself",
+        next: { result: "growth" },
+      },
+      {
+        label: "Comfortable, but I'd rather spend my time building features",
+        next: {
+          result: "product",
+          note: "Growth needs heavy SQL/analytics ownership — Product Engineer is the cleaner fit.",
+        },
+      },
+    ],
+  },
+
+  systems_focus: {
+    q: "Which systems problem excites you most?",
+    options: [
+      {
+        label: "Massive data, query optimization, making dashboards instant",
+        next: "data_depth",
+      },
+      {
+        label:
+          "Auth, billing & multi-tenant security — the platform others build on",
+        next: { result: "iam_billing" },
+      },
+      {
+        label: "Running production reliably — cloud, containers, IaC, on-call",
+        next: { result: "cloud" },
+      },
+    ],
+  },
+  data_depth: {
+    q: "How close is your experience to analytical data at scale (ClickHouse, BigQuery, Kafka, Spark, OLAP…)?",
+    options: [
+      {
+        label: "That's my wheelhouse",
+        next: { result: "data_infra" },
+      },
+      {
+        label: "Not there yet, but database internals genuinely excite me",
+        next: {
+          result: "data_infra",
+          note: "Strong interest counts — ClickHouse experience is a plus, not a hard requirement.",
+        },
+      },
+      {
+        label: "More general/platform backend than data-at-scale",
+        next: {
+          result: "iam_billing",
+          note: "Sounds more like platform backend than the data-infra shape.",
+        },
+      },
+    ],
+  },
+
+  devtools_focus: {
+    q: "What's your sweet spot when building for other developers?",
+    options: [
+      {
+        label:
+          "Rock-solid SDKs / client libraries — performance, versioning, DX",
+        next: "sdk_lang",
+      },
+      {
+        label: "Wiring up framework integrations across the LLM ecosystem",
+        next: { result: "integrations" },
+      },
+      {
+        label:
+          "I love building them, but most enjoy talking/writing about them publicly",
+        next: "content_focus",
+      },
+    ],
+  },
+  sdk_lang: {
+    q: "Where are you strongest?",
+    options: [
+      {
+        label:
+          "Python and/or TypeScript, with real performance-profiling chops",
+        next: { result: "sdk" },
+      },
+      {
+        label:
+          "I know the LLM frameworks deeply and love the integration surface",
+        next: {
+          result: "integrations",
+          note: "Framework breadth points to Integrations over core SDK.",
+        },
+      },
+    ],
+  },
+
+  content_focus: {
+    q: "How central is creating technical content to the job you want?",
+    options: [
+      {
+        label: "It's the main thing — content & community is what energizes me",
+        next: { result: "devrel" },
+      },
+      {
+        label: "I create some, but I'd rather build product day-to-day",
+        next: {
+          result: "product",
+          note: "If content is a side-effect rather than the job, Product Engineer fits better.",
+          also: ["devrel"],
+        },
+      },
+      {
+        label: "I'm strongest on OSS and integrations specifically",
+        next: { result: "integrations", also: ["devrel"] },
+      },
+    ],
+  },
+};

--- a/content/marketing/careers.mdx
+++ b/content/marketing/careers.mdx
@@ -24,9 +24,12 @@ import Image from "next/image";
     <TextHighlight>Building Langfuse</TextHighlight>
   </Heading>
   <Text>Join the team building the leading open-source AI engineering platform</Text>
-  <div className="mt-2 inline-flex">
+  <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
     <Button href="https://jobs.ashbyhq.com/langfuse" target="_blank" rel="noopener">
       View Open Positions →
+    </Button>
+    <Button href="/role-finder" variant="secondary">
+      AI Job Matcher
     </Button>
   </div>
 </div>

--- a/content/marketing/meta.json
+++ b/content/marketing/meta.json
@@ -16,6 +16,7 @@
     "oss-friends",
     "press",
     "privacy",
+    "role-finder",
     "non-profit",
     "research",
     "startups",

--- a/content/marketing/role-finder.mdx
+++ b/content/marketing/role-finder.mdx
@@ -1,0 +1,57 @@
+---
+title: Find your role at Langfuse
+description: "Answer a few quick questions and we'll point you to the Langfuse role that fits you best."
+contentWidth: docs
+---
+
+import { Heading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import { TextHighlight } from "@/components/ui/text-highlight";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/components/ui/link";
+import IconLinkedin from "@/components/icons/linkedin";
+import { RoleFinder } from "@/components/role-finder";
+
+<div className="not-prose flex flex-col gap-4 mb-10 items-center text-center">
+  <Heading as="h1" size="large">
+    <TextHighlight>Which role fits you?</TextHighlight>
+  </Heading>
+  <Text>
+    Answer 2–3 quick questions and we'll point you to the open role that fits
+    you best.
+  </Text>
+</div>
+
+<RoleFinder />
+
+<div className="not-prose mt-10 flex flex-wrap items-center justify-center gap-3">
+  <Button
+    href="https://jobs.ashbyhq.com/langfuse"
+    target="_blank"
+    rel="noopener noreferrer"
+    variant="secondary"
+  >
+    See all open roles
+  </Button>
+  <Button href="/careers" variant="secondary">
+    Read more on the careers page
+  </Button>
+</div>
+
+<div className="not-prose mt-8 flex flex-col items-center gap-3 text-center">
+  <div className="flex flex-wrap items-center justify-center gap-2">
+    <Text>
+      Didn't find a role that fits? Follow us on LinkedIn to not miss any
+      openings.
+    </Text>
+    <Link
+      href="https://www.linkedin.com/company/langfuse/"
+      aria-label="LinkedIn"
+      className="text-text-tertiary transition-colors hover:text-text-primary"
+      target="_blank"
+      rel="nofollow noreferrer"
+    >
+      <IconLinkedin className="size-5" />
+    </Link>
+  </div>
+</div>

--- a/lib/ashby-jobs.ts
+++ b/lib/ashby-jobs.ts
@@ -1,0 +1,55 @@
+/**
+ * Fetches the live Langfuse job board from Ashby's public posting API.
+ *
+ * Used by the careers role-finder quiz so role titles, apply URLs, and
+ * availability always reflect the current job board. Results are cached with
+ * ISR (revalidated hourly) so the page stays static and cheap while staying
+ * accurate without manual updates.
+ */
+
+const ASHBY_JOB_BOARD_API_URL =
+  "https://api.ashbyhq.com/posting-api/job-board/langfuse";
+
+export type AshbyJob = {
+  id: string;
+  title: string;
+  jobUrl: string;
+  applyUrl?: string;
+  isListed?: boolean;
+};
+
+/** Map of Ashby posting id -> job, for O(1) lookup by id. */
+export type AshbyJobMap = Record<string, AshbyJob>;
+
+/**
+ * Returns a map of live Ashby jobs keyed by posting id, or `null` if the board
+ * could not be fetched. Callers should treat `null` as "unknown" and fall back
+ * to their static config rather than hiding everything.
+ */
+export async function getAshbyJobs(): Promise<AshbyJobMap | null> {
+  try {
+    const response = await fetch(ASHBY_JOB_BOARD_API_URL, {
+      headers: { Accept: "application/json" },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch Ashby job board: ${response.status} ${response.statusText}`,
+      );
+      return null;
+    }
+
+    const data = (await response.json()) as { jobs?: AshbyJob[] };
+    if (!Array.isArray(data.jobs)) return null;
+
+    const map: AshbyJobMap = {};
+    for (const job of data.jobs) {
+      if (job?.id) map[job.id] = job;
+    }
+    return map;
+  } catch (error) {
+    console.error("Failed to fetch Ashby job board", error);
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "AI Job Matcher" role-finder quiz to the Langfuse careers marketing section. Visitors answer 2–3 branching questions and receive a personalized role recommendation pulled live from the Ashby job board (ISR-cached hourly).

- `lib/ashby-jobs.ts` fetches and caches the live Ashby posting list; on failure it returns `null` so all roles stay visible rather than disappearing.
- `components/role-finder/` introduces a server component that merges live availability/title/URL data into the static quiz config, and a client quiz component with progress tracking, cycle-safe tree traversal for availability pre-computation, and a graceful "role is closed" fallback.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for a docs/marketing page; the one code issue is isolated to the Back button's question-path branch and doesn't affect data or navigation correctness in production mode.

The `back()` function calls `setView` inside a `setHistory` functional updater. React's Strict Mode double-invokes updater functions to surface this pattern, so in development the Back button will trigger two `setView` calls per click. In production builds the double-invocation doesn't happen, so end-users aren't affected — but the pattern should be corrected to match the existing result-branch code immediately above it.

components/role-finder/RoleFinderQuiz.tsx — the `back()` function's question-path branch (lines 125–130)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant RoleFinder as RoleFinder (Server)
    participant Ashby as Ashby API
    participant Quiz as RoleFinderQuiz (Client)

    Browser->>RoleFinder: Page request
    RoleFinder->>Ashby: GET /posting-api/job-board/langfuse (ISR 1h)
    alt fetch succeeds
        Ashby-->>RoleFinder: "{ jobs: [...] }"
        Note over RoleFinder: Merge live title, URL, availability
    else fetch fails
        Ashby-->>RoleFinder: error / non-2xx
        Note over RoleFinder: Fall back to static config, all roles available
    end
    RoleFinder->>Quiz: resolvedRoles, tree, rootId, careersFallbackUrl
    Quiz-->>Browser: Render question screen

    loop User navigates quiz
        Browser->>Quiz: Click answer option
        Quiz->>Quiz: answer() — push history, advance view
        alt option.next is string
            Quiz-->>Browser: Show next question
        else option.next is QuizResult
            Quiz-->>Browser: Show result screen
        end
    end

    Browser->>Quiz: Click Back
    Quiz->>Quiz: back() — pop history, restore previous question
    Browser->>Quiz: Click Start over
    Quiz->>Quiz: startOver() — reset history + view to rootId
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant RoleFinder as RoleFinder (Server)
    participant Ashby as Ashby API
    participant Quiz as RoleFinderQuiz (Client)

    Browser->>RoleFinder: Page request
    RoleFinder->>Ashby: GET /posting-api/job-board/langfuse (ISR 1h)
    alt fetch succeeds
        Ashby-->>RoleFinder: "{ jobs: [...] }"
        Note over RoleFinder: Merge live title, URL, availability
    else fetch fails
        Ashby-->>RoleFinder: error / non-2xx
        Note over RoleFinder: Fall back to static config, all roles available
    end
    RoleFinder->>Quiz: resolvedRoles, tree, rootId, careersFallbackUrl
    Quiz-->>Browser: Render question screen

    loop User navigates quiz
        Browser->>Quiz: Click answer option
        Quiz->>Quiz: answer() — push history, advance view
        alt option.next is string
            Quiz-->>Browser: Show next question
        else option.next is QuizResult
            Quiz-->>Browser: Show result screen
        end
    end

    Browser->>Quiz: Click Back
    Quiz->>Quiz: back() — pop history, restore previous question
    Browser->>Quiz: Click Start over
    Quiz->>Quiz: startOver() — reset history + view to rootId
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/role-finder/RoleFinderQuiz.tsx:125-130
Calling `setView` inside the `setHistory` functional updater is a side effect inside a pure function, which violates React's rules. React Strict Mode (on by default in Next.js dev builds) deliberately double-invokes functional updaters to catch exactly this kind of issue, so `setView` fires twice per click. The result-branch of the same function already uses the correct pattern — read from the closure and call both setters separately — and the same approach applies here since this runs in a synchronous event handler where `history` is always current.

```suggestion
    if (history.length === 0) return;
    const previous = history[history.length - 1];
    setView({ type: "question", id: previous });
    setHistory((h) => h.slice(0, -1));
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["job-matcher"](https://github.com/langfuse/langfuse-docs/commit/84c48d69166816d59f2e9c588bd80b430437950a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39881391)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->