### PR TITLE
docs(jp): add jp region IPs

### DIFF
--- a/content/security/networking.mdx
+++ b/content/security/networking.mdx
@@ -16,6 +16,7 @@ Langfuse Cloud makes outbound API calls from our infrastructure on behalf of use
 | US-HIPAA | 35.82.248.193<br/>34.211.191.155<br/>52.43.164.18 |
 | US       | 35.81.129.167<br/>44.232.137.35<br/>52.34.39.144  |
 | EU       | 54.77.243.21<br/>52.30.45.150<br/>54.216.18.112   |
+| JP       | 18.177.111.223<br/>13.114.208.109<br/>35.78.16.46 |
 
 ## Contact
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds egress IP addresses for the Japan (JP) region to the Langfuse Cloud networking documentation, matching the existing pattern used for US-HIPAA, US, and EU regions.

- Appends a new `JP` row with three IP addresses (`18.177.111.223`, `13.114.208.109`, `35.78.16.46`) to the egress IP table in `content/security/networking.mdx`.
- Formatting and `<br/>` separators are consistent with all existing region rows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single-line documentation addition with no logic changes.

The change adds three Japan-region AWS IP addresses to a static documentation table, following the exact same format as existing US-HIPAA, US, and EU rows. There is nothing that could introduce a regression.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Langfuse Cloud JP Region] -->|Egress| B[18.177.111.223]
    A -->|Egress| C[13.114.208.109]
    A -->|Egress| D[35.78.16.46]
    B --> E[User Infrastructure / Firewall]
    C --> E
    D --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Langfuse Cloud JP Region] -->|Egress| B[18.177.111.223]
    A -->|Egress| C[13.114.208.109]
    A -->|Egress| D[35.78.16.46]
    B --> E[User Infrastructure / Firewall]
    C --> E
    D --> E
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(jp): add jp region IPs"](https://github.com/langfuse/langfuse-docs/commit/69af906361022f1d130ff6959838101e14accded) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40078792)</sub>

<!-- /greptile_comment -->