### PR TITLE
docs: fix two review nits on the Ask AI / annotation changelog docs

### DIFF
--- a/content/changelog/2026-06-26-ask-ai-filter-search-bar.mdx
+++ b/content/changelog/2026-06-26-ask-ai-filter-search-bar.mdx
@@ -11,11 +11,11 @@ import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
 
 <ChangelogHeader />
 
-The [Filter Search Bar](/changelog/2026-06-19-filter-search-bar) is fast once you know your field names. On a project you have not touched in a while, you often don't. What was the metadata key for the routing queue again? Is it `name` or `traceName`? **Ask AI** is for exactly that moment: click it, describe what you are after, and it drafts a query for you to edit.
+The [Filter Search Bar](/changelog/2026-06-19-filter-search-bar) is fast once you know your field names. On a project you have not touched in a while, you often don't. What was the metadata key for the routing queue again? Is it `name` or `traceName`? **Ask AI** is for exactly that moment: click it and describe what you are after in plain language. Type something like:
 
 > enterprise plan customers stuck in the membership-support queue
 
-comes back as a set of `metadata.*` filters, dropped into the bar as editable pills you can adjust or throw away.
+and it drafts a set of editable `metadata.*` filter pills, dropped into the bar for you to adjust or throw away.
 
 <Callout type="info">
   Ask AI is in beta and available on **Langfuse Cloud only**. It is **off by

--- a/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
+++ b/content/docs/evaluation/evaluation-methods/annotation-queues.mdx
@@ -78,17 +78,17 @@ You will see an annotation task for each item in the queue.
 
 Processing a queue is fully keyboard-driven, so you can score items without reaching for the mouse. The shortcuts follow a navigate-then-edit model and are suppressed while you are typing in a text field or while a dialog or dropdown is open. Press `?` in the queue to open the in-app cheatsheet.
 
-| Key                  | Action                                                  |
-| -------------------- | ------------------------------------------------------- |
-| `→` / `←`            | Next / previous item in the queue                       |
-| `↑` / `↓`            | Move between score fields (wraps at the ends)           |
-| `1`–`9`              | Select the Nth option on a categorical or boolean field |
-| `Enter`              | Commit the current value, or open a dropdown            |
-| `Esc`                | Leave a text field and return to field navigation       |
-| `Cmd`/`Ctrl + Enter` | Complete the item and advance to the next               |
-| `?`                  | Open the keyboard shortcuts cheatsheet                  |
+| Key                    | Action                                                  |
+| ---------------------- | ------------------------------------------------------- |
+| `→` / `←`              | Next / previous item in the queue                       |
+| `↑` / `↓`              | Move between score fields (wraps at the ends)           |
+| `1`–`9`                | Select the Nth option on a categorical or boolean field |
+| `Enter`                | Commit the current value, or open a dropdown            |
+| `Esc`                  | Leave a text field and return to field navigation       |
+| `Cmd`/`Ctrl` + `Enter` | Complete the item and advance to the next               |
+| `?`                    | Open the keyboard shortcuts cheatsheet                  |
 
-Number badges appear on categorical options when a field is focused, and the `⌘↵` / `Ctrl↵` hint is shown on the **Mark Completed** button. The score-field shortcuts (`↑`/`↓`, `1`–`9`, `Enter`, `Esc`) also work in the inline **Annotate** drawer on trace, observation, and session pages; the queue navigation keys (`→`/`←`, `Cmd`/`Ctrl + Enter`) apply when processing a queue.
+Number badges appear on categorical options when a field is focused, and the `⌘↵` / `Ctrl↵` hint is shown on the **Mark Completed** button. The score-field shortcuts (`↑`/`↓`, `1`–`9`, `Enter`, `Esc`) also work in the inline **Annotate** drawer on trace, observation, and session pages; the queue navigation keys (`→`/`←`, `Cmd`/`Ctrl` + `Enter`) apply when processing a queue.
 
 ## Manage Annotation Queues via API
 

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -109,7 +109,7 @@ If you don't know a project's field names yet, click **Ask AI**, describe the fi
 
 Ask AI is **project-aware**: the request carries a compact, client-side snapshot of the columns, values, and metadata keys already loaded in the table, so natural language maps to your project's real schema rather than a generic guess. "enterprise customers in the membership-support queue", for example, resolves to the actual `metadata.*` keys your traces use.
 
-- It is a button next to the bar; **Tab is not affected** and stays autocomplete and focus navigation.
+- It is a button next to the bar, always available.
 - With an empty bar it builds a query from scratch; with existing filters it **refines** them (add, change, or remove) based on your request.
 - It can only emit filters the [syntax](#syntax) supports, and any column it invents is dropped before the query is applied.
 - Results apply through the same path as the sidebar, so they are lossless and you can undo with the browser back button.


### PR DESCRIPTION
## TL;DR
Two small nits the Claude review flagged on #3192, which merged via the queue before the fixes could land.

- **annotation-queues docs:** `Cmd`/`Ctrl + Enter` rendered as "Cmd OR Ctrl+Enter"; split to `Cmd`/`Ctrl` + `Enter` (matching the changelog) so it reads "Cmd+Enter or Ctrl+Enter".
- **filter-search-bar docs:** dropped the ungrammatical, low-value "Tab is not affected and stays autocomplete…" clause from the Ask AI section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two minor documentation copy fixes following a review on the merged PR #3192.

- **`annotation-queues.mdx`**: Splits `` `Cmd`/`Ctrl + Enter` `` into `` `Cmd`/`Ctrl` + `Enter` `` (both in the table and the accompanying prose) so the rendered output reads "Cmd+Enter or Ctrl+Enter" rather than "Cmd OR Ctrl+Enter".
- **`filter-search-bar.mdx`**: Replaces the ungrammatical "Tab is not affected and stays autocomplete…" clause with the cleaner "always available."
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Two isolated documentation copy edits with no functional, API, or logic changes — safe to merge immediately.

Both changes are pure prose/formatting fixes in MDX content files. The keyboard-shortcut table correction and the clause removal are accurate, self-contained, and consistent with the referenced changelog. No code paths, schemas, or user-facing behaviour are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open Annotation Queue] --> B{Keyboard navigation active?}
    B -- "typing in text field or dialog/dropdown open" --> C[Shortcuts suppressed]
    B -- idle --> D["Navigate items: → / ←"]
    D --> E["Move between score fields: ↑ / ↓"]
    E --> F["Select option: 1–9 or Enter"]
    F --> G{Done scoring item?}
    G -- No --> E
    G -- Yes --> H["Complete & advance: Cmd+Enter / Ctrl+Enter"]
    H --> D
    C --> B
    D --> I["Open cheatsheet: ?"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Open Annotation Queue] --> B{Keyboard navigation active?}
    B -- "typing in text field or dialog/dropdown open" --> C[Shortcuts suppressed]
    B -- idle --> D["Navigate items: → / ←"]
    D --> E["Move between score fields: ↑ / ↓"]
    E --> F["Select option: 1–9 or Enter"]
    F --> G{Done scoring item?}
    G -- No --> E
    G -- Yes --> H["Complete & advance: Cmd+Enter / Ctrl+Enter"]
    H --> D
    C --> B
    D --> I["Open cheatsheet: ?"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: address review nits (Cmd/Ctrl+Ente..."](https://github.com/langfuse/langfuse-docs/commit/e6de4139e58c4058124d7d0d94053022ad6eb966) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40086519)</sub>

<!-- /greptile_comment -->