### PR TITLE
Update link for prompt version control

### DIFF
--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -136,6 +136,6 @@ This guide helps you get started with Langfuse Prompt Management manually.
 Now that you've used your first prompt, there are a couple of things we recommend you do next to make the most of Langfuse Prompt Management:
 
 - [Link prompts to traces](/docs/prompt-management/features/link-to-traces) to analyze performance by prompt version
-- [Use version control and labels](/docs/prompt-management/features/prompt-version-control) to manage deployments across environments
+- [Use version control and labels](/docs/prompt-management/features/prompt-version-control#protected-prompt-labels) to manage deployments across environments
 
 Looking for something specific? Take a look under _Features_ for guides on specific topics.


### PR DESCRIPTION
Updated link to prompt version control section with protected prompt labels.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a section anchor to an existing internal link in the prompt management get-started guide, pointing readers directly to the "Protected prompt labels" subsection of the version control page.

- The link destination changes from `/docs/prompt-management/features/prompt-version-control` to `/docs/prompt-management/features/prompt-version-control#protected-prompt-labels`, which maps to the confirmed heading `## Protected prompt labels` at line 158 of the target file.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line docs change adding a valid anchor to an existing internal link — no logic or configuration affected.

The anchor #protected-prompt-labels resolves correctly to the ## Protected prompt labels heading at line 158 of the target file. No other files are touched, and nothing structural changes.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get-started.mdx\n'Use version control and labels'"] -->|"Before: /docs/.../prompt-version-control"| B["prompt-version-control.mdx\n(top of page)"]
    A -->|"After: /docs/.../prompt-version-control#protected-prompt-labels"| C["prompt-version-control.mdx\n§ Protected prompt labels (line 158)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["get-started.mdx\n'Use version control and labels'"] -->|"Before: /docs/.../prompt-version-control"| B["prompt-version-control.mdx\n(top of page)"]
    A -->|"After: /docs/.../prompt-version-control#protected-prompt-labels"| C["prompt-version-control.mdx\n§ Protected prompt labels (line 158)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update link for prompt version control"](https://github.com/langfuse/langfuse-docs/commit/c3fbfa156805cfc3da67ccf45bae12c269484a23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40173160)</sub>

<!-- /greptile_comment -->