### PR TITLE
docs: clarify cloud security model

### DIFF
--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -21,6 +21,16 @@ import { CredibilitySentence } from "@/components/CredibilitySentence";
 
 <CredibilitySentence />
 
+## Langfuse Cloud security model
+
+Langfuse Cloud is a fully managed, multi-tenant SaaS deployment. The security model combines three layers:
+
+- **Security posture:** The production service is based on the same open-source Langfuse codebase, is covered by SOC 2 Type II and ISO 27001 audits, and undergoes annual third-party penetration tests. You can request the latest reports [here](/request-security-docs).
+- **Tenant isolation:** All product data is scoped to a project. Every record is associated with a `projectId`, API keys are project-scoped, and authenticated requests are authorized through RBAC before queries are made. See the [Security FAQ](/security/security-faq) and [RBAC docs](/docs/administration/rbac).
+- **Customer controls:** Teams can reduce what reaches Langfuse and how long it stays there with [masking](/docs/observability/features/masking), [data retention](/docs/administration/data-retention), [data deletion](/docs/administration/data-deletion), region selection, SSO/SCIM, and audit logs.
+
+Langfuse Cloud runs on AWS and ClickHouse Cloud in isolated regional environments. Supporting services such as Postgres, ClickHouse, Redis, and S3 are covered by the same cloud security program: private network placement, least-privilege service access, encryption at rest and in transit, monitoring, and vendor/compliance review. If your requirements mandate infrastructure-level isolation in your own account or VPC, use [self-hosted Langfuse](/self-hosting) or contact us about Enterprise options.
+
 ## Compliance
 
 We maintain [internal policies](/security/policies) and adhere to several industry-standard compliance frameworks. Please check [Security FAQs](/security/security-faq) for more details.
@@ -67,13 +77,13 @@ Langfuse is an **open‑source AI engineering platform** that provides tracing, 
 
 ### What deployment models are available?
 
-- **Langfuse Cloud** – fully‑managed SaaS (multi‑tenant) with US, EU and HIPAA data regions
+- **Langfuse Cloud** – fully‑managed SaaS (multi‑tenant) with US, EU, Japan, and HIPAA data regions
 - **Self‑hosted OSS** – MIT‑licensed software that you can deploy on your own infrastructure
 - **Self‑hosted Enterprise Edition** – commercial license with additional security/compliance features and vendor support.
 
 ### Which cloud provider and regions do you use?
 
-Langfuse Cloud mainly runs on **AWS and Clickhouse via AWS**:
+Langfuse Cloud mainly runs on **AWS and ClickHouse Cloud**:
 
 - **US & HIPAA region**: us-west-2 (Oregon)
 - **EU region**: eu-west-1 (Ireland)

--- a/content/security/security-faq.mdx
+++ b/content/security/security-faq.mdx
@@ -21,19 +21,31 @@ Customer‑managed keys are not supported. Langfuse Cloud uses AWS‑managed enc
 
 > **What retention, deletion and export controls exist?**
 
-Each project can set its own retention window; data older than that is purged nightly, and users/API can trigger immediate deletion or export. See [data retention](/docs/data-retention) and [data deletion](/docs/data-deletion) documentation.
+Each project can set its own retention window; data older than that is purged nightly, and users/API can trigger immediate deletion or export. See [data retention](/docs/administration/data-retention) and [data deletion](/docs/administration/data-deletion) documentation.
+
+> **How should I evaluate Langfuse Cloud's multi-tenant security model?**
+
+Multi-tenancy is the standard operating model for modern SaaS products. The relevant security question is whether tenant isolation is explicit, consistently enforced, and independently tested. Langfuse Cloud combines project-scoped data isolation, project-scoped API keys, RBAC authorization, encrypted infrastructure, continuous monitoring, and annual third-party penetration tests. For most teams, this provides a strong balance of security, time to value, product experience, and operational reliability because Langfuse operates the full application and infrastructure stack.
+
+If your internal policy requires infrastructure-level isolation, customer-operated networking, or a customer-controlled database boundary, use [self-hosted Langfuse](/self-hosting) or discuss Enterprise Cloud options with us.
 
 > **Can I deploy Langfuse in a single-tenant environment?**
 
-Langfuse Cloud is multi-tenant only. For strict infrastructure-level isolation, we recommend Self-hosting Langfuse.
+Langfuse Cloud is multi-tenant. For strict infrastructure-level isolation, we recommend self-hosting Langfuse. Self-hosted Enterprise deployments can be paired with your preferred ClickHouse deployment, including ClickHouse Cloud, but your team owns the networking, scaling, upgrades, backups, and operational controls.
 
 > **How is tenant isolation enforced?**
 
-Logical data isolation is technically achieved by associating every piece of data with a specific projectId and pen-tested yearly. This unique identifier acts as a key to partition data within the database, ensuring that all information, from traces and observations to scores and datasets, is explicitly linked to a single project. Access to other projects' data is prevented through a role-based access control (RBAC) system built on ProjectMembership. Users are granted access to projects through these memberships, each of which defines their role and permissions within that specific project. See [RBAC documentation](/docs/rbac) for more details. The application logic then uses the user's authenticated session to filter all database queries by their authorized projectIds, effectively creating a secure wall between different projects' data.
+Logical data isolation is technically achieved by associating every piece of data with a specific `projectId`. This unique identifier acts as a key to partition data within the database, ensuring that all information, from traces and observations to scores and datasets, is explicitly linked to a single project. Access to other projects' data is prevented through a role-based access control (RBAC) system built on project memberships. Users are granted access to projects through these memberships, each of which defines their role and permissions within that specific project. See [RBAC documentation](/docs/administration/rbac) for more details. The application logic then uses the user's authenticated session to filter all database queries by their authorized project IDs. The tenant boundary is included in Langfuse's annual third-party penetration tests.
+
+> **How does Langfuse Cloud compare with running Langfuse yourself on ClickHouse Cloud?**
+
+Langfuse Cloud uses ClickHouse Cloud as part of the managed backend, so customers benefit from ClickHouse Cloud's infrastructure security while Langfuse operates the application, control plane, queues/cache, object storage, database integrations, upgrades, backups, and incident response. This is the recommended path when you want the fastest setup and the least operational overhead.
+
+Running self-hosted Langfuse with your own ClickHouse Cloud environment gives your team direct ownership of network topology, database configuration, and infrastructure policies. This can be the right model when a customer policy requires a customer-controlled VPC, private connectivity managed by the customer, or a dedicated database boundary, but it comes with higher cost and operational responsibility.
 
 > **Can customers pin data to specific regions?**
 
-Yes. EU, US and HIPAA‑ready US zones are available, and self‑hosted deployments let you choose any region and infrastructure.
+Yes. EU, US, Japan, and HIPAA-ready US regions are available. Langfuse Cloud regions are separated from each other, and self-hosted deployments let you choose any region and infrastructure.
 
 ## Identity & Access Management
 
@@ -51,7 +63,7 @@ Session tokens are valid for 86,400 seconds (24 hours). We use JWT tokens which 
 
 > **How is least‑privilege enforced?**
 
-RBAC lets you scope roles to organisation or project. See [RBAC documentation](/docs/rbac) for more details.
+RBAC lets you scope roles to organization or project. See [RBAC documentation](/docs/administration/rbac) for more details.
 
 ## Infrastructure & Network Security
 
@@ -59,13 +71,23 @@ RBAC lets you scope roles to organisation or project. See [RBAC documentation](/
 
 Langfuse runs on AWS in isolated VPCs with WAF and AWS Shield for DDoS mitigation.
 
+> **Do supporting services such as Redis introduce additional tenant-isolation concerns?**
+
+Langfuse Cloud uses several managed backing services, including Postgres, ClickHouse, Redis/ElastiCache, and S3. These services are not exposed directly to customers and are accessed by Langfuse services using least-privilege credentials inside isolated regional environments. Stored data is encrypted, activity is monitored, and the service providers are covered by vendor risk management and compliance review.
+
+The tenant boundary remains the Langfuse application and data model: product data is scoped by `projectId`, API keys are project-scoped, and every user request is authorized through RBAC. Supporting infrastructure is part of that controlled service architecture rather than a separate customer-operated surface.
+
+> **Does Langfuse Cloud support AWS PrivateLink or private connectivity?**
+
+Public regional endpoints are the default for Langfuse Cloud. AWS PrivateLink can be enabled for Enterprise customers on committed contracts; contact enterprise@langfuse.com or security@langfuse.com to discuss region availability and onboarding. If you need private connectivity in infrastructure fully controlled by your team, self-hosting gives you that control.
+
 > **What security headers are implemented on Langfuse endpoints?**
 
 We enforce CSP (Content Security Policy), HSTS (HTTP Strict Transport Security), and X-Frame-Options on all endpoints including [langfuse.com](https://domsignal.com/test/ea3amc5z08sh6fnovjek392ihxrb66q6) and [cloud.langfuse.com](https://domsignal.com/test/spdnv4cx0949ah3nvz5b5eapab8o2390).
 
 > **How does Langfuse Cloud monitor its environment?**
 
-Langfuse uses DataDog and Sentry to monitor its application and environments. All cloud audit logs are automatically written into a seperate, locked-down account. In addition, we have automated systems in place to alert us about anomalous usage.
+Langfuse uses DataDog and Sentry to monitor its application and environments. All cloud audit logs are automatically written into a separate, locked-down account. In addition, we have automated systems in place to alert us about anomalous usage.
 
 > **What anomaly detection and security alerting capabilities are in place?**
 
@@ -81,7 +103,7 @@ Yes. All services run in AWS cloud, which provides both NTP (Network Time Protoc
 
 > **How often does Langfuse rotate its API keys?**
 
-Langfuse uses short-lived api keys where possible. For long-lived API keys we rotate them every 90 days.
+Langfuse uses short-lived API keys where possible. For long-lived API keys we rotate them every 90 days.
 
 ## Software Development Lifecycle
 
@@ -141,7 +163,7 @@ Yes—please run penetration tests in self-hosted deployments.
 
 > **Which obligations stay with the customer when I am self-hosting?**
 
-Endpoint security, webhook endpoint hardening, backups, monitoring, and IAM hygiene on your side remain your responsibility. See [security overview](/docs/security/overview) for more details.
+Endpoint security, webhook endpoint hardening, backups, monitoring, and IAM hygiene on your side remain your responsibility. See the [self-hosted deployment strategies](/self-hosting/security/deployment-strategies) for more details.
 
 > **How should my backup strategy look like when I am self-hosting?**
 
@@ -159,12 +181,12 @@ Langfuse stores the data as-is. You can redact sensitive data via [data masking]
 
 > **Can long‑term retention be disabled?**
 
-Yes. While data is stored indefinitely by default, you can configure custom [data retention](/docs/data-retention) policies per project.
+Yes. While data is stored indefinitely by default, you can configure custom [data retention](/docs/administration/data-retention) policies per project.
 
 > **Is prompt/trace data ever used for benchmarking or training?**
 
-No. Langfuse does not repurpose customer data for external benchmarks or model training. See [security overview](/docs/security/overview) for more details.
+No. Langfuse does not repurpose customer data for external benchmarks or model training. See [AI features](/security/ai-features) for more details on how optional AI-powered features handle data.
 
 > **Do you ever use customer data to train models or analytics?**
 
-No. Customer traces and prompts are processed only to provide the Langfuse service and are never used to train internal or third‑party ML models. See [security overview](/docs/security/overview) for more details.
+No. Customer traces and prompts are processed only to provide the Langfuse service and are never used to train internal or third-party ML models. See [AI features](/security/ai-features) for more details on how optional AI-powered features handle data.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands the security documentation to clarify Langfuse Cloud's multi-tenant security model and add new FAQ entries covering topics like Redis/ElastiCache tenant isolation, AWS PrivateLink availability, and a side-by-side comparison of Langfuse Cloud vs. self-hosted on ClickHouse Cloud. It also updates several internal doc links (e.g., `/docs/rbac` → `/docs/administration/rbac`) and fixes minor copy issues (typo "seperate", capitalization of "API keys", "organisation" → "organization").

- **New content sections** add clarity on tenant isolation enforcement, the Japan region, PrivateLink availability for Enterprise customers, and how ClickHouse Cloud fits into the managed vs. self-hosted choice.
- **Link corrections** align references to new URL paths (`/docs/administration/data-retention`, `/docs/administration/rbac`, `/self-hosting/security/deployment-strategies`, `/security/ai-features`) across both files.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with clear, well-structured additions; safe to merge after addressing the minor content and formatting notes.

Both files contain only prose and MDX markup — no executable code paths are affected. The main items worth a second look are ClickHouse appearing both as a primary platform and as a supporting service in the same sentence (potentially confusing to security reviewers), and two newly added email addresses missing the backtick wrapping required to prevent platform mention interpretation. Neither blocks correctness of the security model being described.

content/security/index.mdx (ClickHouse listed twice in the cloud model paragraph) and content/security/security-faq.mdx (email addresses without backticks on the PrivateLink answer).
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer Request] --> B{Authentication}
    B -->|API Key| C[Project-scoped API Key Validation]
    B -->|Session| D[JWT / OIDC SSO Session]
    C --> E{RBAC Authorization}
    D --> E
    E -->|Authorized| F[Application Layer]
    E -->|Denied| G[403 Rejected]

    F --> H[Filter by projectId]
    H --> I[(Postgres)]
    H --> J[(ClickHouse Cloud)]
    H --> K[(S3 Object Storage)]
    H --> L[(Redis / ElastiCache)]

    subgraph Langfuse Cloud - AWS Region
        F
        H
        I
        J
        K
        L
    end

    subgraph Monitoring & Compliance
        M[DataDog / Sentry]
        N[AWS GuardDuty]
        O[SOC 2 Type II & ISO 27001]
    end

    F --> M
    F --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Customer Request] --> B{Authentication}
    B -->|API Key| C[Project-scoped API Key Validation]
    B -->|Session| D[JWT / OIDC SSO Session]
    C --> E{RBAC Authorization}
    D --> E
    E -->|Authorized| F[Application Layer]
    E -->|Denied| G[403 Rejected]

    F --> H[Filter by projectId]
    H --> I[(Postgres)]
    H --> J[(ClickHouse Cloud)]
    H --> K[(S3 Object Storage)]
    H --> L[(Redis / ElastiCache)]

    subgraph Langfuse Cloud - AWS Region
        F
        H
        I
        J
        K
        L
    end

    subgraph Monitoring & Compliance
        M[DataDog / Sentry]
        N[AWS GuardDuty]
        O[SOC 2 Type II & ISO 27001]
    end

    F --> M
    F --> N
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/security/security-faq.mdx:82
Email addresses containing `@` are not wrapped in backticks, which means the platform will attempt to interpret them as user mentions and the rendered output may be garbled or broken. Per the project's formatting guidance, all `@` symbols outside of code fences must be in backticks.

```suggestion
Public regional endpoints are the default for Langfuse Cloud. AWS PrivateLink can be enabled for Enterprise customers on committed contracts; contact `enterprise@langfuse.com` or `security@langfuse.com` to discuss region availability and onboarding. If you need private connectivity in infrastructure fully controlled by your team, self-hosting gives you that control.
```

### Issue 2 of 2
content/security/index.mdx:32
ClickHouse is listed twice in the same sentence — first as a primary platform ("AWS and ClickHouse Cloud") and then again in the "supporting services" enumeration ("Postgres, ClickHouse, Redis, and S3"). This is internally contradictory and may confuse readers about ClickHouse's role. Since ClickHouse Cloud is already highlighted as a primary platform component, it should be omitted from the supporting services list.

```suggestion
Langfuse Cloud runs on AWS and ClickHouse Cloud in isolated regional environments. Supporting services such as Postgres, Redis, and S3 are covered by the same cloud security program: private network placement, least-privilege service access, encryption at rest and in transit, monitoring, and vendor/compliance review. If your requirements mandate infrastructure-level isolation in your own account or VPC, use [self-hosted Langfuse](/self-hosting) or contact us about Enterprise options.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify cloud security model"](https://github.com/langfuse/langfuse-docs/commit/ceaa3a53c55b88242aea1b219e9319fe2cf918a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40237389)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->