### PR TITLE
fix(cookbook): use structured output in JS LangChain prompt example

### DIFF
--- a/content/guides/cookbook/js_prompt_management_langchain.mdx
+++ b/content/guides/cookbook/js_prompt_management_langchain.mdx
@@ -200,7 +200,7 @@ As we passed the langfuse callback handler, we can explore the execution trace i
 
 [Public trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/4c35a5f52ca0588d022d2ac55d7322e7?timestamp=2025-08-25T13%3A59%3A30.900Z&display=details&observation=40be66bf70a82583)
 
-## Example 1: OpenAI functions with structured output
+## Example 2: OpenAI functions with structured output
 
 ### Add prompt to Langfuse
 

--- a/content/guides/cookbook/js_prompt_management_langchain.mdx
+++ b/content/guides/cookbook/js_prompt_management_langchain.mdx
@@ -176,10 +176,10 @@ import { ChatOpenAI } from "npm:@langchain/openai"
 import { RunnableSequence } from "npm:@langchain/core/runnables";
 
 const model = new ChatOpenAI({
-    model: prompt.config.model,
+    modelName: prompt.config.model,
     temperature: prompt.config.temperature
 });
-const chain = RunnableSequence.from([langchainTextPrompt, model]);
+const chain = RunnableSequence.from([promptTemplate, model]);
 ```
 
 #### Invoke chain
@@ -200,7 +200,7 @@ As we passed the langfuse callback handler, we can explore the execution trace i
 
 [Public trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/4c35a5f52ca0588d022d2ac55d7322e7?timestamp=2025-08-25T13%3A59%3A30.900Z&display=details&observation=40be66bf70a82583)
 
-## Example 2: OpenAI tool calling and structured output
+## Example 1: OpenAI functions and JsonOutputFunctionsParser
 
 ### Add prompt to Langfuse
 
@@ -251,10 +251,10 @@ Transform into schema
 
 
 ```typescript
-const extractionSchema = {
-    title: "extractor",
+const extractionFunctionSchema = {
+    name: "extractor",
     description: extractorPrompt.prompt,
-    ...extractorPrompt.config.schema,
+    parameters: extractorPrompt.config.schema,
 }
 ```
 
@@ -263,18 +263,24 @@ const extractionSchema = {
 
 ```typescript
 import { ChatOpenAI } from "npm:@langchain/openai";
+import { JsonOutputFunctionsParser } from "npm:langchain/output_parsers";
+
+// Instantiate the parser
+const parser = new JsonOutputFunctionsParser();
 
 // Instantiate the ChatOpenAI class
 const model = new ChatOpenAI({ 
-    model: extractorPrompt.config.modelName,
+    modelName: extractorPrompt.config.modelName,
     temperature: extractorPrompt.config.temperature
 });
 
-// Create a runnable that uses OpenAI tool calling and returns parsed JSON
-const runnable = model.withStructuredOutput(extractionSchema, {
-  name: "extractor",
-  method: "functionCalling",
-});
+// Create a new runnable, bind the function to the model, and pipe the output through the parser
+const runnable = model
+  .bind({
+    functions: [extractionFunctionSchema],
+    function_call: { name: "extractor" },
+  })
+  .pipe(parser);
 ```
 
 ### Invoke chain

--- a/content/guides/cookbook/js_prompt_management_langchain.mdx
+++ b/content/guides/cookbook/js_prompt_management_langchain.mdx
@@ -200,7 +200,7 @@ As we passed the langfuse callback handler, we can explore the execution trace i
 
 [Public trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/4c35a5f52ca0588d022d2ac55d7322e7?timestamp=2025-08-25T13%3A59%3A30.900Z&display=details&observation=40be66bf70a82583)
 
-## Example 1: OpenAI functions and JsonOutputFunctionsParser
+## Example 1: OpenAI functions with structured output
 
 ### Add prompt to Langfuse
 
@@ -263,10 +263,6 @@ const extractionFunctionSchema = {
 
 ```typescript
 import { ChatOpenAI } from "npm:@langchain/openai";
-import { JsonOutputFunctionsParser } from "npm:langchain/output_parsers";
-
-// Instantiate the parser
-const parser = new JsonOutputFunctionsParser();
 
 // Instantiate the ChatOpenAI class
 const model = new ChatOpenAI({ 
@@ -274,13 +270,10 @@ const model = new ChatOpenAI({
     temperature: extractorPrompt.config.temperature
 });
 
-// Create a new runnable, bind the function to the model, and pipe the output through the parser
-const runnable = model
-  .bind({
-    functions: [extractionFunctionSchema],
-    function_call: { name: "extractor" },
-  })
-  .pipe(parser);
+// Create a runnable that uses OpenAI function calling and returns parsed JSON
+const runnable = model.withStructuredOutput(extractionFunctionSchema, {
+  method: "functionCalling",
+});
 ```
 
 ### Invoke chain

--- a/content/guides/cookbook/js_prompt_management_langchain.mdx
+++ b/content/guides/cookbook/js_prompt_management_langchain.mdx
@@ -176,10 +176,10 @@ import { ChatOpenAI } from "npm:@langchain/openai"
 import { RunnableSequence } from "npm:@langchain/core/runnables";
 
 const model = new ChatOpenAI({
-    modelName: prompt.config.model,
+    model: prompt.config.model,
     temperature: prompt.config.temperature
 });
-const chain = RunnableSequence.from([promptTemplate, model]);
+const chain = RunnableSequence.from([langchainTextPrompt, model]);
 ```
 
 #### Invoke chain
@@ -200,7 +200,7 @@ As we passed the langfuse callback handler, we can explore the execution trace i
 
 [Public trace in the Langfuse UI](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/4c35a5f52ca0588d022d2ac55d7322e7?timestamp=2025-08-25T13%3A59%3A30.900Z&display=details&observation=40be66bf70a82583)
 
-## Example 1: OpenAI functions and JsonOutputFunctionsParser
+## Example 2: OpenAI tool calling and structured output
 
 ### Add prompt to Langfuse
 
@@ -251,10 +251,10 @@ Transform into schema
 
 
 ```typescript
-const extractionFunctionSchema = {
-    name: "extractor",
+const extractionSchema = {
+    title: "extractor",
     description: extractorPrompt.prompt,
-    parameters: extractorPrompt.config.schema,
+    ...extractorPrompt.config.schema,
 }
 ```
 
@@ -263,24 +263,18 @@ const extractionFunctionSchema = {
 
 ```typescript
 import { ChatOpenAI } from "npm:@langchain/openai";
-import { JsonOutputFunctionsParser } from "npm:langchain/output_parsers";
-
-// Instantiate the parser
-const parser = new JsonOutputFunctionsParser();
 
 // Instantiate the ChatOpenAI class
 const model = new ChatOpenAI({ 
-    modelName: extractorPrompt.config.modelName,
+    model: extractorPrompt.config.modelName,
     temperature: extractorPrompt.config.temperature
 });
 
-// Create a new runnable, bind the function to the model, and pipe the output through the parser
-const runnable = model
-  .bind({
-    functions: [extractionFunctionSchema],
-    function_call: { name: "extractor" },
-  })
-  .pipe(parser);
+// Create a runnable that uses OpenAI tool calling and returns parsed JSON
+const runnable = model.withStructuredOutput(extractionSchema, {
+  name: "extractor",
+  method: "functionCalling",
+});
 ```
 
 ### Invoke chain

--- a/cookbook/js_prompt_management_langchain.ipynb
+++ b/cookbook/js_prompt_management_langchain.ipynb
@@ -265,10 +265,10 @@
     "import { RunnableSequence } from \"npm:@langchain/core/runnables\";\n",
     "\n",
     "const model = new ChatOpenAI({\n",
-    "    model: prompt.config.model,\n",
+    "    modelName: prompt.config.model,\n",
     "    temperature: prompt.config.temperature\n",
     "});\n",
-    "const chain = RunnableSequence.from([langchainTextPrompt, model]);"
+    "const chain = RunnableSequence.from([promptTemplate, model]);"
    ],
    "execution_count": 32,
    "outputs": []
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2: OpenAI tool calling and structured output"
+    "## Example 1: OpenAI functions and JsonOutputFunctionsParser"
    ]
   },
   {
@@ -391,10 +391,10 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "const extractionSchema = {\n",
-    "    title: \"extractor\",\n",
+    "const extractionFunctionSchema = {\n",
+    "    name: \"extractor\",\n",
     "    description: extractorPrompt.prompt,\n",
-    "    ...extractorPrompt.config.schema,\n",
+    "    parameters: extractorPrompt.config.schema,\n",
     "}"
    ],
    "execution_count": 39,
@@ -412,18 +412,24 @@
    "metadata": {},
    "source": [
     "import { ChatOpenAI } from \"npm:@langchain/openai\";\n",
+    "import { JsonOutputFunctionsParser } from \"npm:langchain/output_parsers\";\n",
+    "\n",
+    "// Instantiate the parser\n",
+    "const parser = new JsonOutputFunctionsParser();\n",
     "\n",
     "// Instantiate the ChatOpenAI class\n",
     "const model = new ChatOpenAI({ \n",
-    "    model: extractorPrompt.config.modelName,\n",
+    "    modelName: extractorPrompt.config.modelName,\n",
     "    temperature: extractorPrompt.config.temperature\n",
     "});\n",
     "\n",
-    "// Create a runnable that uses OpenAI tool calling and returns parsed JSON\n",
-    "const runnable = model.withStructuredOutput(extractionSchema, {\n",
-    "  name: \"extractor\",\n",
-    "  method: \"functionCalling\",\n",
-    "});"
+    "// Create a new runnable, bind the function to the model, and pipe the output through the parser\n",
+    "const runnable = model\n",
+    "  .bind({\n",
+    "    functions: [extractionFunctionSchema],\n",
+    "    function_call: { name: \"extractor\" },\n",
+    "  })\n",
+    "  .pipe(parser);"
    ],
    "execution_count": 41,
    "outputs": []

--- a/cookbook/js_prompt_management_langchain.ipynb
+++ b/cookbook/js_prompt_management_langchain.ipynb
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: OpenAI functions and JsonOutputFunctionsParser"
+    "## Example 1: OpenAI functions with structured output"
    ]
   },
   {
@@ -412,10 +412,6 @@
    "metadata": {},
    "source": [
     "import { ChatOpenAI } from \"npm:@langchain/openai\";\n",
-    "import { JsonOutputFunctionsParser } from \"npm:langchain/output_parsers\";\n",
-    "\n",
-    "// Instantiate the parser\n",
-    "const parser = new JsonOutputFunctionsParser();\n",
     "\n",
     "// Instantiate the ChatOpenAI class\n",
     "const model = new ChatOpenAI({ \n",
@@ -423,13 +419,10 @@
     "    temperature: extractorPrompt.config.temperature\n",
     "});\n",
     "\n",
-    "// Create a new runnable, bind the function to the model, and pipe the output through the parser\n",
-    "const runnable = model\n",
-    "  .bind({\n",
-    "    functions: [extractionFunctionSchema],\n",
-    "    function_call: { name: \"extractor\" },\n",
-    "  })\n",
-    "  .pipe(parser);"
+    "// Create a runnable that uses OpenAI function calling and returns parsed JSON\n",
+    "const runnable = model.withStructuredOutput(extractionFunctionSchema, {\n",
+    "  method: \"functionCalling\",\n",
+    "});"
    ],
    "execution_count": 41,
    "outputs": []

--- a/cookbook/js_prompt_management_langchain.ipynb
+++ b/cookbook/js_prompt_management_langchain.ipynb
@@ -265,10 +265,10 @@
     "import { RunnableSequence } from \"npm:@langchain/core/runnables\";\n",
     "\n",
     "const model = new ChatOpenAI({\n",
-    "    modelName: prompt.config.model,\n",
+    "    model: prompt.config.model,\n",
     "    temperature: prompt.config.temperature\n",
     "});\n",
-    "const chain = RunnableSequence.from([promptTemplate, model]);"
+    "const chain = RunnableSequence.from([langchainTextPrompt, model]);"
    ],
    "execution_count": 32,
    "outputs": []
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: OpenAI functions and JsonOutputFunctionsParser"
+    "## Example 2: OpenAI tool calling and structured output"
    ]
   },
   {
@@ -391,10 +391,10 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "const extractionFunctionSchema = {\n",
-    "    name: \"extractor\",\n",
+    "const extractionSchema = {\n",
+    "    title: \"extractor\",\n",
     "    description: extractorPrompt.prompt,\n",
-    "    parameters: extractorPrompt.config.schema,\n",
+    "    ...extractorPrompt.config.schema,\n",
     "}"
    ],
    "execution_count": 39,
@@ -412,24 +412,18 @@
    "metadata": {},
    "source": [
     "import { ChatOpenAI } from \"npm:@langchain/openai\";\n",
-    "import { JsonOutputFunctionsParser } from \"npm:langchain/output_parsers\";\n",
-    "\n",
-    "// Instantiate the parser\n",
-    "const parser = new JsonOutputFunctionsParser();\n",
     "\n",
     "// Instantiate the ChatOpenAI class\n",
     "const model = new ChatOpenAI({ \n",
-    "    modelName: extractorPrompt.config.modelName,\n",
+    "    model: extractorPrompt.config.modelName,\n",
     "    temperature: extractorPrompt.config.temperature\n",
     "});\n",
     "\n",
-    "// Create a new runnable, bind the function to the model, and pipe the output through the parser\n",
-    "const runnable = model\n",
-    "  .bind({\n",
-    "    functions: [extractionFunctionSchema],\n",
-    "    function_call: { name: \"extractor\" },\n",
-    "  })\n",
-    "  .pipe(parser);"
+    "// Create a runnable that uses OpenAI tool calling and returns parsed JSON\n",
+    "const runnable = model.withStructuredOutput(extractionSchema, {\n",
+    "  name: \"extractor\",\n",
+    "  method: \"functionCalling\",\n",
+    "});"
    ],
    "execution_count": 41,
    "outputs": []

--- a/cookbook/js_prompt_management_langchain.ipynb
+++ b/cookbook/js_prompt_management_langchain.ipynb
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: OpenAI functions with structured output"
+    "## Example 2: OpenAI functions with structured output"
    ]
   },
   {


### PR DESCRIPTION
## What changed

Updates the JS LangChain prompt management cookbook to use the current LangChain structured output API.

The previous example used `JsonOutputFunctionsParser` from `langchain/output_parsers` together with `model.bind(...).pipe(parser)`. With the current LangChain JS packages, that path is stale: `model.bind` is no longer available on `ChatOpenAI`, while `withStructuredOutput(...)` is the supported path for function-calling based structured output.

## Why

This keeps the cookbook runnable with current LangChain JS versions and avoids a stale output parser import.

## Related

Fixes Linear: LF-2221

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces a stale LangChain JS structured-output pattern (`JsonOutputFunctionsParser` + `model.bind().pipe(parser)`) with the current `model.withStructuredOutput()` API in both the MDX cookbook and its paired Jupyter notebook. The section heading is also updated to match the new approach.

- Removes the `JsonOutputFunctionsParser` import and its instantiation, eliminating a dependency on the now-unsupported `langchain/output_parsers` path.
- Introduces `model.withStructuredOutput(extractionFunctionSchema, { method: \"functionCalling\" })`, which is the recommended API for function-calling-based structured output in current `@langchain/openai` versions — the `\"functionCalling\"` method value is confirmed by the official LangChain JS reference docs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changed files are updated consistently and the new API call is correct per official LangChain JS docs.

The migration replaces two removed APIs (model.bind and JsonOutputFunctionsParser) with withStructuredOutput, which is the current recommended path. The method: "functionCalling" camelCase value is confirmed correct by the LangChain JS reference. Both the MDX file and the paired notebook are updated in sync, so no version drift between the two formats.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User Code
    participant Langfuse
    participant Model as ChatOpenAI
    participant OpenAI as OpenAI API

    Note over User,OpenAI: Before (stale)
    User->>Langfuse: langfuse.prompt.get("extractor")
    Langfuse-->>User: extractorPrompt
    User->>Model: "model.bind({ functions, function_call }).pipe(JsonOutputFunctionsParser)"
    Model->>OpenAI: function_call request
    OpenAI-->>Model: raw function call response
    Model-->>User: parsed JSON via parser

    Note over User,OpenAI: After (current API)
    User->>Langfuse: langfuse.prompt.get("extractor")
    Langfuse-->>User: extractorPrompt
    User->>Model: "model.withStructuredOutput(schema, { method: "functionCalling" })"
    Model->>OpenAI: function calling request
    OpenAI-->>Model: structured response
    Model-->>User: parsed JSON (built-in)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User Code
    participant Langfuse
    participant Model as ChatOpenAI
    participant OpenAI as OpenAI API

    Note over User,OpenAI: Before (stale)
    User->>Langfuse: langfuse.prompt.get("extractor")
    Langfuse-->>User: extractorPrompt
    User->>Model: "model.bind({ functions, function_call }).pipe(JsonOutputFunctionsParser)"
    Model->>OpenAI: function_call request
    OpenAI-->>Model: raw function call response
    Model-->>User: parsed JSON via parser

    Note over User,OpenAI: After (current API)
    User->>Langfuse: langfuse.prompt.get("extractor")
    Langfuse-->>User: extractorPrompt
    User->>Model: "model.withStructuredOutput(schema, { method: "functionCalling" })"
    Model->>OpenAI: function calling request
    OpenAI-->>Model: structured response
    Model-->>User: parsed JSON (built-in)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix js langchain prompt cookbook structu..."](https://github.com/langfuse/langfuse-docs/commit/f6c492d433bcd16ecab1facc54881fe0a3e8ce37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40467699)</sub>

<!-- /greptile_comment -->