### PR TITLE
fix(cookbook): update LangChain integration imports

### DIFF
--- a/content/guides/cookbook/integration_langchain.md
+++ b/content/guides/cookbook/integration_langchain.md
@@ -18,7 +18,7 @@ Follow the [integration guide](https://langfuse.com/integrations/frameworks/lang
 
 
 ```python
-%pip install langfuse langchain langchain_openai langchain_community --upgrade
+%pip install langfuse langchain langchain-classic langchain_openai langchain_community --upgrade
 ```
 
 Initialize the Langfuse client with your API keys from the project settings in the Langfuse UI and add them to your environment.
@@ -57,8 +57,8 @@ langfuse_handler = CallbackHandler()
 ```python
 from operator import itemgetter
 from langchain_openai import ChatOpenAI
-from langchain.prompts import ChatPromptTemplate
-from langchain.schema import StrOutputParser
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
 
 langfuse_handler = CallbackHandler()
 
@@ -138,8 +138,8 @@ os.environ.setdefault("SERPAPI_API_KEY", "...")
 from langchain_community.document_loaders import SeleniumURLLoader
 from langchain_chroma import Chroma
 from langchain_text_splitters import CharacterTextSplitter
-from langchain_openai import OpenAIEmbeddings
-from langchain.chains import RetrievalQA
+from langchain_openai import OpenAI, OpenAIEmbeddings
+from langchain_classic.chains import RetrievalQA
 
 langfuse_handler = CallbackHandler()
 
@@ -183,7 +183,7 @@ os.environ.setdefault("OPENAI_API_VERSION", "2023-09-01-preview")
 
 ```python
 from langchain_openai import AzureChatOpenAI
-from langchain.prompts import ChatPromptTemplate
+from langchain_core.prompts import ChatPromptTemplate
 from langfuse.langchain import CallbackHandler
  
 # Initialize Langfuse CallbackHandler for Langchain (tracing)

--- a/cookbook/integration_langchain.ipynb
+++ b/cookbook/integration_langchain.ipynb
@@ -57,7 +57,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install langfuse langchain langchain_openai langchain_community --upgrade"
+    "%pip install langfuse langchain langchain-classic langchain_openai langchain_community --upgrade"
    ]
   },
   {
@@ -151,8 +151,8 @@
    "source": [
     "from operator import itemgetter\n",
     "from langchain_openai import ChatOpenAI\n",
-    "from langchain.prompts import ChatPromptTemplate\n",
-    "from langchain.schema import StrOutputParser\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
     "\n",
     "langfuse_handler = CallbackHandler()\n",
     "\n",
@@ -287,8 +287,8 @@
     "from langchain_community.document_loaders import SeleniumURLLoader\n",
     "from langchain_chroma import Chroma\n",
     "from langchain_text_splitters import CharacterTextSplitter\n",
-    "from langchain_openai import OpenAIEmbeddings\n",
-    "from langchain.chains import RetrievalQA\n",
+    "from langchain_openai import OpenAI, OpenAIEmbeddings\n",
+    "from langchain_classic.chains import RetrievalQA\n",
     "\n",
     "langfuse_handler = CallbackHandler()\n",
     "\n",
@@ -343,7 +343,7 @@
    "outputs": [],
    "source": [
     "from langchain_openai import AzureChatOpenAI\n",
-    "from langchain.prompts import ChatPromptTemplate\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
     "from langfuse.langchain import CallbackHandler\n",
     " \n",
     "# Initialize Langfuse CallbackHandler for Langchain (tracing)\n",


### PR DESCRIPTION
## What changed

Updates the LangChain integration cookbook to work with current LangChain Python packages.

LangChain v1 no longer exposes several legacy import paths from the main `langchain` package. This PR keeps the existing cookbook logic unchanged and only updates the install command and import paths needed for the examples to run.

## Why

Without this change, the cookbook fails with import errors for current LangChain packages, including:

```text
ModuleNotFoundError: No module named 'langchain.prompts'
ModuleNotFoundError: No module named 'langchain.schema'
ModuleNotFoundError: No module named 'langchain.chains'

## Related: 
Fixes LF-2217

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the LangChain integration cookbook to fix `ModuleNotFoundError` failures caused by LangChain v1 removing several legacy import paths from the main `langchain` package.

- Moves `ChatPromptTemplate` and `StrOutputParser` to `langchain_core`, and `RetrievalQA` to `langchain_classic.chains`, matching LangChain v1's official package layout.
- Adds the `langchain-classic` package to the pip install command, and adds the previously-missing `OpenAI` import alongside `OpenAIEmbeddings` so the RetrievalQA example can actually instantiate the LLM.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are purely import path updates with no logic alterations, and all target packages have been verified as legitimate on PyPI.

The `langchain-classic` package is an official LangChain package published on PyPI (v1.0.8) that houses the legacy chains removed from the core `langchain` package in v1. All three new import paths (`langchain_core.prompts`, `langchain_core.output_parsers`, `langchain_classic.chains`) are correct per LangChain v1 migration documentation. The added `OpenAI` import on the `langchain_openai` line fixes a pre-existing gap where `llm = OpenAI()` was used in the RetrievalQA cell without being imported. No business logic was changed.

No files require special attention. Both `integration_langchain.md` and `integration_langchain.ipynb` are kept in sync and contain identical import fixes.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User installs packages] --> B["langfuse, langchain, langchain-classic\nlangchain_openai, langchain_community"]
    B --> C{Import path}
    C -->|ChatPromptTemplate| D["langchain_core.prompts ✅\n(was: langchain.prompts)"]
    C -->|StrOutputParser| E["langchain_core.output_parsers ✅\n(was: langchain.schema)"]
    C -->|RetrievalQA| F["langchain_classic.chains ✅\n(was: langchain.chains)"]
    C -->|OpenAI + OpenAIEmbeddings| G["langchain_openai ✅\n(OpenAI was previously missing)"]
    D --> H[Cookbook runs without ModuleNotFoundError]
    E --> H
    F --> H
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User installs packages] --> B["langfuse, langchain, langchain-classic\nlangchain_openai, langchain_community"]
    B --> C{Import path}
    C -->|ChatPromptTemplate| D["langchain_core.prompts ✅\n(was: langchain.prompts)"]
    C -->|StrOutputParser| E["langchain_core.output_parsers ✅\n(was: langchain.schema)"]
    C -->|RetrievalQA| F["langchain_classic.chains ✅\n(was: langchain.chains)"]
    C -->|OpenAI + OpenAIEmbeddings| G["langchain_openai ✅\n(OpenAI was previously missing)"]
    D --> H[Cookbook runs without ModuleNotFoundError]
    E --> H
    F --> H
    G --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cookbook): update LangChain integrat..."](https://github.com/langfuse/langfuse-docs/commit/65cd4a23c383114bbf152732d96056909fa0a714) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40475581)</sub>

<!-- /greptile_comment -->