### PR TITLE
docs: link judge calibration guide from academy

### DIFF
--- a/content/academy/evaluate.mdx
+++ b/content/academy/evaluate.mdx
@@ -64,7 +64,7 @@ This is the right method for qualities that require understanding language: whet
 LLM judges are imperfect and easy to get wrong. This means:
 
 - A model does not automatically grade things as a human expert would as they do not have the context of the expert
-- They need calibration against human preferences to verify they are measuring what you think they are measuring
+- They need [calibration](/guides/llm-as-a-judge-calibration-skill) against human preferences to verify they are measuring what you think they are measuring
 - They can share blind spots with your application's LLM, especially when the same model family is used for both
 
 These limitations aren't reasons to avoid LLM judges. An LLM judge that has been calibrated against human labels and is backed by code evaluator checks is a reliable evaluator.


### PR DESCRIPTION
Links the [calibration guide](/guides/llm-as-a-judge-calibration-skill) from the academy evaluation page, in the LLM-as-a-judge section where the limitation "they need calibration against human preferences" is introduced. Gives readers a direct path from learning that judges must be calibrated to the guide that walks through doing it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a hyperlink on the word "calibration" in `content/academy/evaluate.mdx`, pointing readers to the existing `/guides/llm-as-a-judge-calibration-skill` guide at the exact moment the limitation is introduced.

- The target file `content/guides/llm-as-a-judge-calibration-skill.mdx` was confirmed to exist in the repository, so the link resolves correctly.
- No other content was changed; the prose and surrounding context remain identical.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A single-word hyperlink addition in a documentation file — the target guide already exists, nothing is broken or removed.

The only change is wrapping the word "calibration" in a Markdown link that points to an existing .mdx guide confirmed present in the repository. There is no logic, no code, and no broken reference.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Academy: Evaluate page\n(content/academy/evaluate.mdx)"] -->|"Reads about LLM-as-a-judge limitations"| B["Bullet: 'They need calibration\nagainst human preferences'"]
    B -->|"Clicks new link /guides/llm-as-a-judge-calibration-skill"| C["Calibration Guide\n(content/guides/llm-as-a-judge-calibration-skill.mdx)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Academy: Evaluate page\n(content/academy/evaluate.mdx)"] -->|"Reads about LLM-as-a-judge limitations"| B["Bullet: 'They need calibration\nagainst human preferences'"]
    B -->|"Clicks new link /guides/llm-as-a-judge-calibration-skill"| C["Calibration Guide\n(content/guides/llm-as-a-judge-calibration-skill.mdx)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link judge calibration guide from ..."](https://github.com/langfuse/langfuse-docs/commit/28178b0358bf63b95971555ac815d5f93ebcc7bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40585889)</sub>

<!-- /greptile_comment -->