### PR TITLE
fix(promptfolders): add details

### DIFF
--- a/content/docs/prompt-management/features/folders.mdx
+++ b/content/docs/prompt-management/features/folders.mdx
@@ -8,7 +8,8 @@ description: "Organize prompts into virtual folders to group prompts with simila
 
 Prompt folders help you organize your prompts into logical groups. As your prompt library grows, folders keep related prompts together — by feature, team, environment, or any structure that makes sense for your workflow.
 
-To create a folder, add slashes (`/`) to a prompt name. The UI shows every segment ending with a `/` as a folder automatically.
+To create a folder, add slashes (`/`) to a prompt name. 
+The UI shows every segment ending with a `/` as a folder automatically.
 
 <Callout type="info">
 

--- a/content/docs/prompt-management/features/folders.mdx
+++ b/content/docs/prompt-management/features/folders.mdx
@@ -8,8 +8,7 @@ description: "Organize prompts into virtual folders to group prompts with simila
 
 Prompt folders help you organize your prompts into logical groups. As your prompt library grows, folders keep related prompts together — by feature, team, environment, or any structure that makes sense for your workflow.
 
-To create a folder, add slashes (`/`) to a prompt name. 
-The UI shows every segment ending with a `/` as a folder automatically.
+To create a folder, add slashes (`/`) to a prompt name. The UI shows every segment ending with a `/` as a folder automatically. Like this you can structure into folders.
 
 <Callout type="info">
 


### PR DESCRIPTION
force docs redeploy

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR splits one prose sentence across two source lines in the prompt folders documentation page, with no changes to rendered content or logic.

- A single sentence in `folders.mdx` is split at a period onto two lines; in MDX/Markdown this remains one paragraph in the rendered output.
- The PR description notes this is intended to force a docs redeploy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change touches only a documentation source file and has no effect on rendered output or application logic.

The only change is splitting one sentence across two lines in an MDX file. In Markdown/MDX a single line break within a paragraph does not produce a new paragraph, so the rendered page is identical before and after. There is no logic, config, or SDK code involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User names prompt with slash e.g. team/my-prompt] --> B[Langfuse UI detects slash delimiter]
    B --> C[Each segment ending with / displayed as folder]
    C --> D[Prompts grouped under virtual folder hierarchy]
    D --> E[Access via SDK using langfuse >= 3.0.2]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User names prompt with slash e.g. team/my-prompt] --> B[Langfuse UI detects slash delimiter]
    B --> C[Each segment ending with / displayed as folder]
    C --> D[Prompts grouped under virtual folder hierarchy]
    D --> E[Access via SDK using langfuse >= 3.0.2]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add formatting"](https://github.com/langfuse/langfuse-docs/commit/316c517e807cf3763e874aa27a8364f6adb22aed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40624612)</sub>

<!-- /greptile_comment -->