### PR TITLE
docs(sso): document how to prevent lockout when enforcing SSO

### DIFF
--- a/content/docs/administration/authentication-and-sso.mdx
+++ b/content/docs/administration/authentication-and-sso.mdx
@@ -122,11 +122,9 @@ GitHub and GitHub Enterprise do not expose a standard OIDC discovery endpoint. L
 
 Enforcing SSO does not end sessions that are already active. Your current browser session stays signed in, even after enforcement is enabled. Use this to verify the setup safely: enable enforcement, then test the SSO login in a separate browser or a private/incognito window. If sign-in does not work as expected, revert the configuration from your still-active session before it affects other users.
 
-<Callout type="warning">
+#### Break-Glass Users
 
-Langfuse does not support exceptions on enforced domains. There are no "break glass" accounts that can keep using email/password sign-in once SSO enforcement is enabled for a domain.
-
-</Callout>
+Langfuse does not support exceptions on enforced domains. There are no "break glass" accounts that can keep using email/password sign-in once SSO enforcement is enabled for a domain. If you are interested in this functionality, please upvote this [GitHub discussion](https://github.com/orgs/langfuse/discussions/14532).
 
 ### Vendor Guides
 

--- a/content/docs/administration/authentication-and-sso.mdx
+++ b/content/docs/administration/authentication-and-sso.mdx
@@ -118,6 +118,16 @@ GitHub and GitHub Enterprise do not expose a standard OIDC discovery endpoint. L
 
 </Callout>
 
+#### Prevent lockout when enforcing SSO [#prevent-lockout]
+
+Enforcing SSO does not end sessions that are already active. Your current browser session stays signed in, even after enforcement is enabled. Use this to verify the setup safely: enable enforcement, then test the SSO login in a separate browser or a private/incognito window. If sign-in does not work as expected, revert the configuration from your still-active session before it affects other users.
+
+<Callout type="warning">
+
+Langfuse does not support exceptions on enforced domains. There are no "break glass" accounts that can keep using email/password sign-in once SSO enforcement is enabled for a domain.
+
+</Callout>
+
 ### Vendor Guides
 
 #### Okta [#okta]


### PR DESCRIPTION
Add a subsection to the self-service Enterprise SSO setup explaining that the current session stays active after enforcement, so admins can test SSO in a separate/private browser and revert if needed. Also note that enforced domains do not support break-glass email/password accounts.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a short advisory subsection under the Enterprise SSO configuration guide explaining how to safely enable SSO enforcement without locking yourself out: existing sessions remain active, allowing admins to test in a separate browser and revert if needed. It also adds a warning that break-glass email/password accounts are not supported once enforcement is active.

- Adds `#### Prevent lockout when enforcing SSO [#prevent-lockout]` between the "Configure SSO" step and the Vendor Guides section.
- Includes a `<Callout type="warning">` noting that enforced domains have no email/password exceptions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; safe to merge.

The change adds a single advisory subsection and a warning callout to an existing MDX doc. Content is accurate and the guidance (test in a private browser before committing) is sound. The only gap is that the prose refers to enabling enforcement without pointing to the specific UI control, which may leave readers searching for the right toggle, but this does not affect application behavior.

content/docs/administration/authentication-and-sso.mdx — the new paragraph could benefit from a concrete UI reference for the enforcement toggle.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin active session
    participant Langfuse as Langfuse Cloud
    participant PrivBrowser as Private Browser
    participant IdP as Identity Provider

    Admin->>Langfuse: Enable SSO enforcement for domain
    Langfuse-->>Admin: Enforcement active, existing session preserved
    Admin->>PrivBrowser: Open private window, navigate to login
    PrivBrowser->>Langfuse: Sign-in with SSO domain email
    Langfuse->>IdP: Redirect to IdP for authentication
    alt SSO works correctly
        IdP-->>PrivBrowser: Authentication success
        PrivBrowser-->>Admin: Login confirmed, enforcement safe
    else SSO fails
        IdP-->>PrivBrowser: Authentication failure
        Admin->>Langfuse: Revert SSO config via still-active session
        Langfuse-->>Admin: Enforcement disabled, email/password restored
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin active session
    participant Langfuse as Langfuse Cloud
    participant PrivBrowser as Private Browser
    participant IdP as Identity Provider

    Admin->>Langfuse: Enable SSO enforcement for domain
    Langfuse-->>Admin: Enforcement active, existing session preserved
    Admin->>PrivBrowser: Open private window, navigate to login
    PrivBrowser->>Langfuse: Sign-in with SSO domain email
    Langfuse->>IdP: Redirect to IdP for authentication
    alt SSO works correctly
        IdP-->>PrivBrowser: Authentication success
        PrivBrowser-->>Admin: Login confirmed, enforcement safe
    else SSO fails
        IdP-->>PrivBrowser: Authentication failure
        Admin->>Langfuse: Revert SSO config via still-active session
        Langfuse-->>Admin: Enforcement disabled, email/password restored
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/administration/authentication-and-sso.mdx:123
**Missing UI reference for "enable enforcement"**

The paragraph tells admins to "enable enforcement" and to "revert the configuration", but neither the preceding steps nor this section explain *where* in the UI the enforcement toggle lives. A reader who has just followed steps 1 and 2 (Verify Domain → Configure SSO) has no anchor to find this control. Consider adding a brief pointer such as "click the **Enforce SSO** toggle in Organization Settings > SSO" to make the guidance self-contained and actionable without requiring the reader to discover the UI on their own.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sso): document how to prevent locko..."](https://github.com/langfuse/langfuse-docs/commit/efa94ea2c6209be5bec21b5a2467fd392a9c8710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41045349)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->