### PR TITLE
docs(glossary): add Langfuse Assistant and Filter Search Bar

### DIFF
--- a/lib/glossary-data.js
+++ b/lib/glossary-data.js
@@ -203,6 +203,15 @@ const TERMS = [
     synonyms: ["Observation Type"],
   },
   {
+    term: "Filter Search Bar",
+    id: "filter-search-bar",
+    definition:
+      "A single-line query bar for filtering and searching the Observations and Traces tables by typing field:value expressions instead of assembling filters in the sidebar. Supports operators, wildcards, negation, and an Ask AI button that drafts filters from a plain-language description.",
+    link: "/docs/observability/features/filter-search-bar",
+    categories: ["OBSERVABILITY"],
+    relatedTerms: ["Trace", "Observation", "Tags", "Environment"],
+  },
+  {
     term: "Flush",
     id: "flush",
     definition:
@@ -248,6 +257,15 @@ const TERMS = [
     link: "/docs/administration/llm-connection",
     categories: ["PLATFORM"],
     relatedTerms: ["Playground", "LLM-as-a-Judge"],
+  },
+  {
+    term: "Langfuse Assistant",
+    id: "langfuse-assistant",
+    definition:
+      "An in-product AI assistant, available in beta on Langfuse Cloud, for exploring project data and Langfuse workflows in plain language. It queries traces, observations, sessions, and metrics through the Langfuse MCP server, searches documentation, and proposes navigation actions that you confirm.",
+    link: "/docs/langfuse-assistant",
+    categories: ["PLATFORM"],
+    relatedTerms: ["MCP Server", "Trace", "Observation", "Session"],
   },
   {
     term: "LLM-as-a-Judge",


### PR DESCRIPTION
## Summary

Monthly glossary audit (commits from 2026-06-01 to 2026-07-01). Two major features shipped in the last month were missing glossary entries:

- **Langfuse Assistant** — in-product AI assistant for querying project data in plain language (`content/docs/langfuse-assistant.mdx`, added in #3188). Naming is consistent across `content/security/ai-features.mdx` and the announcement changelog.
- **Filter Search Bar** — single-line query bar for the Observations/Traces tables (`content/docs/observability/features/filter-search-bar.mdx`, changelog `2026-06-19-filter-search-bar`). Naming is consistent across the feature doc, the `full-text-search.mdx` cross-link, and both related changelog entries.

Both entries were added to `lib/glossary-data.js` following the existing schema (`term`, `id`, `definition`, `link`, `categories`, `relatedTerms`).

## Terminology inconsistency flagged (not fixed here — needs a product/docs decision)

**"Ask AI" now names two unrelated features:**
- The long-standing Inkeep-powered documentation chatbot (`content/docs/ask-ai.mdx`, `components/inkeep/ask-ai-button.tsx`) — answers questions about Langfuse docs/GitHub discussions.
- The new (2026-06-26) button inside the Filter Search Bar that drafts trace/observation filters from a plain-language description (`content/changelog/2026-06-26-ask-ai-filter-search-bar.mdx`, `content/docs/observability/features/filter-search-bar.mdx#ask-ai`).

Both are labeled "Ask AI" in their respective UIs and docs, but one searches documentation and the other builds ClickHouse query filters inside the app — a reader encountering "Ask AI" in a changelog or support thread can't tell which feature is meant without context. Did not add "Ask AI" as its own glossary term because of this ambiguity; flagging for the docs/product team to consider disambiguating (e.g., "Ask AI" for the docs chatbot vs. a distinct name for the filter-builder, such as its predecessor "magic filter").

## Other observations (no action taken)

- `content/changelog/2026-06-30-media-previews-json-views.mdx` introduces "media preview tags" (clickable chips in JSON/table views) — a minor enhancement to the existing multi-modality feature, not a standalone concept warranting its own glossary entry. Worth noting it's an unrelated use of the word "tag" from the existing glossary **Tags** term (trace/observation labels), though context makes each usage clear.
- Recent LLM-as-a-Judge/v4 evaluator clarifications (#3184) use the existing glossary terminology (**Evaluator**, **LLM-as-a-Judge**) consistently — no inconsistency found.
- "Prompt Folders" and "Dataset Folders" predate the last month (original changelogs from 2025) and already have doc coverage; out of scope for this pass.

## Test plan

- [x] `node -e "require('./lib/glossary-data.js')"` loads without error; new entries verified present via console output
- [x] `npx prettier --write lib/glossary-data.js` — no formatting changes needed
- [ ] Visually confirm the two new entries render correctly on `/docs/glossary` (not run — no dev server check performed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011efnnZqj9HriwXkv1LL1jh)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds two missing glossary entries — **Filter Search Bar** and **Langfuse Assistant** — to `lib/glossary-data.js` to cover features shipped in the last month.

- **Filter Search Bar** (OBSERVABILITY): describes the single-line `field:value` query bar for Observations/Traces tables, with correct related terms (`Trace`, `Observation`, `Tags`, `Environment`) and a valid feature-doc link.
- **Langfuse Assistant** (PLATFORM): describes the beta in-product AI assistant backed by the MCP server, with correct related terms (`MCP Server`, `Trace`, `Observation`, `Session`) and a valid doc link. The entry is inserted between \"LLM Connection\" and \"LLM-as-a-Judge\" rather than before both, which is a minor alphabetical ordering issue.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is purely additive glossary data with no functional side effects.

Both new entries are well-formed: all relatedTerms resolve to existing glossary entries, the schema matches every other term in the file, and the linked doc paths match the feature docs described in the PR. The one thing worth a second look is the insertion point of Langfuse Assistant — it sits between LLM Connection and LLM-as-a-Judge when it alphabetically belongs before both. This does not affect runtime behavior but would leave the L-section slightly inconsistent for anyone maintaining the list.

No files require special attention beyond the minor ordering note on lib/glossary-data.js.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    FSB["Filter Search Bar\n(new)"]
    LA["Langfuse Assistant\n(new)"]

    Trace["Trace"]
    Obs["Observation"]
    Tags["Tags"]
    Env["Environment"]
    MCP["MCP Server"]
    Session["Session"]

    FSB -->|relatedTerms| Trace
    FSB -->|relatedTerms| Obs
    FSB -->|relatedTerms| Tags
    FSB -->|relatedTerms| Env

    LA -->|relatedTerms| MCP
    LA -->|relatedTerms| Trace
    LA -->|relatedTerms| Obs
    LA -->|relatedTerms| Session
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    FSB["Filter Search Bar\n(new)"]
    LA["Langfuse Assistant\n(new)"]

    Trace["Trace"]
    Obs["Observation"]
    Tags["Tags"]
    Env["Environment"]
    MCP["MCP Server"]
    Session["Session"]

    FSB -->|relatedTerms| Trace
    FSB -->|relatedTerms| Obs
    FSB -->|relatedTerms| Tags
    FSB -->|relatedTerms| Env

    LA -->|relatedTerms| MCP
    LA -->|relatedTerms| Trace
    LA -->|relatedTerms| Obs
    LA -->|relatedTerms| Session
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/glossary-data.js:252-269
The "Langfuse Assistant" entry is inserted between "LLM Connection" and "LLM-as-a-Judge", but alphabetically "La…" sorts before "LL…", so the entry belongs just before "LLM Connection". The rest of the L-block stays in order. (Note: "API Key" after "Billable Unit" is a pre-existing ordering issue, but within the L-group the sequence was clean until this insertion.)

```suggestion
  {
    term: "Langfuse Assistant",
    id: "langfuse-assistant",
    definition:
      "An in-product AI assistant, available in beta on Langfuse Cloud, for exploring project data and Langfuse workflows in plain language. It queries traces, observations, sessions, and metrics through the Langfuse MCP server, searches documentation, and proposes navigation actions that you confirm.",
    link: "/docs/langfuse-assistant",
    categories: ["PLATFORM"],
    relatedTerms: ["MCP Server", "Trace", "Observation", "Session"],
  },
  {
    term: "LLM Connection",
    id: "llm-connection",
    definition:
      "An API key configuration that allows Langfuse to call LLM models in the Playground or for LLM-as-a-Judge evaluations. Supports providers like OpenAI, Anthropic, and Google.",
    link: "/docs/administration/llm-connection",
    categories: ["PLATFORM"],
    relatedTerms: ["Playground", "LLM-as-a-Judge"],
  },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(glossary): add Langfuse Assistant a..."](https://github.com/langfuse/langfuse-docs/commit/abfdb10bb30c9e07643eca5711e2cd705432b779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41051777)</sub>

<!-- /greptile_comment -->