### PR TITLE
docs: add OpenClaw x Langfuse demo video

### DIFF
--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -8,6 +8,17 @@ category: Integrations
 
 # Trace OpenClaw with Langfuse
 
+<iframe
+  width="100%"
+  className="aspect-[16/9] rounded border w-full"
+  src="https://www.youtube-nocookie.com/embed/lT8XsHg3uZA"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
+></iframe>
+
 > **What is OpenClaw?** [OpenClaw](https://github.com/openclaw/openclaw) is a free and open-source autonomous AI agent created by Peter Steinberger. It is model-agnostic, supporting Claude, GPT, DeepSeek, and other LLMs. It runs locally and is accessed through messaging platforms like Signal, Telegram, Discord, and WhatsApp. OpenClaw can execute tasks, write its own skills, and maintain long-term memory of user preferences.
 
 > **What is Langfuse?** [Langfuse](/) is an open-source AI engineering platform that helps teams trace LLM calls, monitor performance, and debug issues in their AI applications.


### PR DESCRIPTION
Adds the OpenClaw x Langfuse demo video to the OpenClaw integration page, placed right after the H1 — the same spot and iframe pattern used for the Claude Code and Vercel AI SDK integration pages.

Video: https://www.youtube.com/watch?v=lT8XsHg3uZA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a YouTube demo video embed to the OpenClaw integration page, placed immediately after the H1 heading — matching the exact pattern used on the Claude Code and Goose integration pages.

- A privacy-enhanced (`youtube-nocookie.com`) iframe is inserted using the same JSX-style attributes (`frameBorder`, `referrerPolicy`, `allowFullScreen`) and `className` used on `claude-code.mdx` and `goose.mdx`.
- No functional code, routing, or configuration is changed; the diff is a single 11-line MDX block.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single YouTube embed added to a docs page, with no effect on application logic.

The addition mirrors the exact same iframe pattern used on several other integration pages in the repo. Privacy-enhanced embed domain, correct JSX attribute casing, and placement are all consistent with the established convention.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DocsSite as Langfuse Docs
    participant YouTube as youtube-nocookie.com

    User->>DocsSite: Visit /integrations/other/openclaw
    DocsSite-->>User: Render openclaw.mdx (H1 + iframe)
    User->>YouTube: Browser loads embed src (privacy-enhanced)
    YouTube-->>User: Serve video player
    User->>DocsSite: Continue reading integration guide
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DocsSite as Langfuse Docs
    participant YouTube as youtube-nocookie.com

    User->>DocsSite: Visit /integrations/other/openclaw
    DocsSite-->>User: Render openclaw.mdx (H1 + iframe)
    User->>YouTube: Browser loads embed src (privacy-enhanced)
    YouTube-->>User: Serve video player
    User->>DocsSite: Continue reading integration guide
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add OpenClaw x Langfuse demo video..."](https://github.com/langfuse/langfuse-docs/commit/2f19090844b7a9fb25179afca432362ba0152c34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41073489)</sub>

<!-- /greptile_comment -->