### PR TITLE
docs(handbook): add feature request handling to support playbook

### DIFF
--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -1171,7 +1171,31 @@ Best,
 
 ---
 
-### 13. Not-actually-support inbox (filter these fast)
+### 13. Feature requests
+
+<details>
+
+<summary>"Can you add X?" / "It would be great if Langfuse could…"</summary>
+
+Feature requests are not something to resolve on the thread, they're something to route so the product team sees the demand. How you handle it depends on where the request comes from.
+
+**Paying customers (Pylon):**
+
+1. Acknowledge the request and log the +1. For example: "Agree that this would make sense! I'll add your +1 to this feature request."
+2. Create a new Linear ticket for the request, or connect an existing Linear issue to the Pylon issue so the demand is tracked against a concrete piece of work.
+
+**Community / GitHub ideas board:**
+
+1. Acknowledge the request. For example: "Thanks for adding this here!"
+2. @-mention the Langfuse product engineer who owns that product area (see [ownership](/handbook/how-we-work/ownership)) so it lands with the right person. For example: "`@nimar` FYI - feature request for faster evals."
+
+**Escalate when:** the request is tied to a deal or renewal (route to the enterprise team), or when several customers ask for the same thing in a short window, flag it to the owning product engineer directly rather than only logging +1s.
+
+</details>
+
+---
+
+### 14. Not-actually-support inbox (filter these fast)
 
 <details>
 


### PR DESCRIPTION
## What

Adds a **Feature requests** section (new category #13) to the support playbook in `content/handbook/support/how-to-answer-support-questions.mdx`, covering how to handle "Can you add X?" style requests depending on their source. The former "Not-actually-support inbox" category is renumbered to #14.

## Guidance added

- **Paying customers (Pylon):** acknowledge and log a +1 (e.g. "Agree that this would make sense! I'll add your +1 to this feature request"), then create a new Linear ticket or connect an existing Linear issue to the Pylon issue.
- **Community / GitHub ideas board:** acknowledge (e.g. "Thanks for adding this here!"), then @-mention the product engineer who owns that area (links to the [ownership](/handbook/how-we-work/ownership) page), e.g. "`@nimar` FYI - feature request for faster evals."
- An "Escalate when" note for deal/renewal-tied requests and repeated demand, matching the pattern used across the rest of the tree.

Follows the existing `<details>` decision-tree style. Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Feature requests" section (category #13) to the support playbook, describing how to handle "Can you add X?" style requests from paying customers (via Pylon) versus the community/GitHub ideas board. The former category #13 is renumbered to #14.

- **Paying customer path**: Acknowledge, log a +1 in Pylon, and create or link a Linear ticket to track demand against concrete work.
- **Community path**: Acknowledge, then `` `@` ``-mention the owning product engineer (linked to the ownership page) to route the request to the right person.
- An "Escalate when" note covers deal/renewal-tied requests and repeated demand, matching the pattern used throughout the rest of the playbook.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only addition; no code is changed and no existing guidance is removed or contradicted.

The change adds one new markdown section and renumbers one existing section. The internal link to the ownership page resolves correctly, the section structure mirrors every other branch in the playbook, and the escalation criteria are clearly scoped. Nothing here can break a running system or mislead a reader in a harmful way.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Feature request received] --> B{Source?}
    B -->|Paying customer via Pylon| C[Acknowledge and log +1]
    B -->|Community or GitHub ideas| D[Acknowledge request]
    C --> E{Linear ticket exists?}
    E -->|No| F[Create new Linear ticket]
    E -->|Yes| G[Connect existing Linear issue to Pylon issue]
    D --> H[Check ownership page]
    H --> I[Mention owning product engineer]
    F --> J{Escalate?}
    G --> J
    I --> J
    J -->|Tied to deal or renewal| K[Route to enterprise team]
    J -->|High repeated demand| L[Flag directly to owning product engineer]
    J -->|Otherwise| M[Done - demand tracked]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Feature request received] --> B{Source?}
    B -->|Paying customer via Pylon| C[Acknowledge and log +1]
    B -->|Community or GitHub ideas| D[Acknowledge request]
    C --> E{Linear ticket exists?}
    E -->|No| F[Create new Linear ticket]
    E -->|Yes| G[Connect existing Linear issue to Pylon issue]
    D --> H[Check ownership page]
    H --> I[Mention owning product engineer]
    F --> J{Escalate?}
    G --> J
    I --> J
    J -->|Tied to deal or renewal| K[Route to enterprise team]
    J -->|High repeated demand| L[Flag directly to owning product engineer]
    J -->|Otherwise| M[Done - demand tracked]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): add feature request hand..."](https://github.com/langfuse/langfuse-docs/commit/504c4437937119227ff95959d70ef381b664bfe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41110132)</sub>

<!-- /greptile_comment -->