### PR TITLE
docs(agent): Update Assistant docs around write actions + HITL

### DIFF
--- a/content/docs/langfuse-assistant.mdx
+++ b/content/docs/langfuse-assistant.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Assistant
 
 # Langfuse Assistant
 
-The Langfuse Assistant is an in-product assistant for exploring your Langfuse project data. Ask questions about traces, observations, sessions, metrics, and Langfuse workflows in plain language.
+The Langfuse Assistant is an in-product assistant for exploring your Langfuse project data and taking selected actions in Langfuse with your approval. You can ask questions about traces, observations, sessions, metrics, and Langfuse workflows in plain language.
 
 <Callout type="info">
 
@@ -25,18 +25,25 @@ Ask the Assistant questions such as:
 - "What's my token spend this week, broken down by model?"
 - "How do I set up an evaluator?"
 - "Open the traces table filtered to errors from today."
+- "Create a dataset for regression examples."
+- "Set up a numeric score config for friendliness."
 
 ## How it works [#how-it-works]
 
-The Assistant uses the Langfuse MCP server and additional tools to answer questions, inspect project data, and propose navigation actions.
+The Assistant uses the Langfuse MCP server and additional tools to answer questions, inspect project data, and help you take actions in Langfuse.
 
 The Assistant can:
 
 - Query traces, observations, sessions, and metrics through Langfuse tools
 - Search Langfuse documentation
 - Propose links to Langfuse pages such as traces, sessions, dashboards, prompts, datasets, experiments, evals, monitors, and project settings
+- Help with selected actions such as creating or updating Langfuse resources
 
-The Assistant does not automatically navigate or modify project data. When a destination is useful, it proposes an action that you confirm.
+The Assistant is designed to be safe by default:
+
+- If a request would change data or configuration, the Assistant pauses and asks you to explicitly approve that specific action first.
+
+The Assistant can only use actions that your account already has access to in the current project. Approval adds a second safety check, but it does not grant any extra permissions.
 
 The Assistant is also aware of your current context in the Langfuse UI, such as the current trace, observation, session, or dashboard, as well as user metadata such as your name, browser language, and timezone. This context is used to provide more relevant answers and propose actions.
 
@@ -52,6 +59,7 @@ Key points:
 
 - Model requests are handled in the same AWS region as your [Langfuse data region](/security/data-regions).
 - Assistant access is scoped to the authenticated user and current project.
+- Actions that can change data require explicit approval and remain limited to the permissions of the signed-in user.
 - AI feature tracing for product and service improvement can be enabled or disabled separately by organization admins and owners.
 
 ## Conversation history [#conversation-history]
@@ -66,7 +74,7 @@ You can also share your thoughts in our [feedback discussion](https://github.com
 
 ## Limitations [#limitations]
 
-The Assistant is a beta feature. It may misunderstand a question or return incomplete results. Verify important answers before acting on them.
+The Assistant is a beta feature. It may misunderstand a question or return incomplete results. Verify important answers and review action details carefully before acting on them.
 
 ## Related resources [#related-resources]
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Langfuse Assistant documentation to reflect the addition of write actions and a Human-in-the-Loop (HITL) approval mechanism, where the assistant pauses and requests explicit user approval before any data-modifying operation.

- Example queries for write actions (`Create a dataset…`, `Set up a numeric score config…`) are added to the "What you can ask" section.
- The "How it works" and "Data privacy and security" sections are expanded to explain that write actions require explicit approval and are bounded by the signed-in user's existing permissions.
- The limitations disclaimer is updated to remind users to review action details before proceeding.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; content is internally consistent and the safety model is clearly described, with only a stale frontmatter description as the gap.

All body content, examples, and security bullet points are updated to reflect the new write-action and approval flow. The single outstanding issue is the `description` frontmatter, which still describes a read-only assistant and will produce misleading search snippets and social previews until fixed.

content/docs/langfuse-assistant.mdx — the frontmatter `description` field needs updating to match the expanded feature scope.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Assistant
    participant LangfuseTools as Langfuse Tools / MCP
    participant LangfuseAPI as Langfuse API

    User->>Assistant: "Create a dataset for regression examples"
    Assistant->>LangfuseTools: Query current project context
    LangfuseTools-->>Assistant: Context (project, user, permissions)
    Assistant-->>User: Propose action + request explicit approval
    User->>Assistant: Approve action
    Assistant->>LangfuseAPI: Execute write action (within user permissions)
    LangfuseAPI-->>Assistant: Success / result
    Assistant-->>User: Confirmation
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Assistant
    participant LangfuseTools as Langfuse Tools / MCP
    participant LangfuseAPI as Langfuse API

    User->>Assistant: "Create a dataset for regression examples"
    Assistant->>LangfuseTools: Query current project context
    LangfuseTools-->>Assistant: Context (project, user, permissions)
    Assistant-->>User: Propose action + request explicit approval
    User->>Assistant: Approve action
    Assistant->>LangfuseAPI: Execute write action (within user permissions)
    LangfuseAPI-->>Assistant: Success / result
    Assistant-->>User: Confirmation
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/langfuse-assistant.mdx:3
The `description` frontmatter is now stale — it only mentions querying data, but the PR's main purpose is to document write actions and the HITL approval flow. Search engines and social previews will surface this outdated description, potentially misleading users who discover the page via search.

```suggestion
description: Ask questions about your Langfuse project data and take selected actions in Langfuse with your approval, all in plain language from inside the Langfuse Cloud UI.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agent): Update Assistant docs aroun..."](https://github.com/langfuse/langfuse-docs/commit/1dae62add44f514919380f6d6484f28bf5f2f9f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41128578)</sub>

<!-- /greptile_comment -->