### PR TITLE
fix(readme-embed): render raw HTML in fetched self-hosting READMEs

### DIFF
--- a/components/RenderedReadmeContent.tsx
+++ b/components/RenderedReadmeContent.tsx
@@ -2,7 +2,29 @@
 
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { cn } from "@/lib/utils";
+
+/**
+ * READMEs (e.g. langfuse-terraform-aws) embed raw HTML like <img width height>
+ * for hero images; rehype-raw parses that HTML instead of leaving it as literal
+ * escaped text, and rehype-sanitize keeps that safe since the HTML is fetched
+ * from an external source at runtime.
+ */
+const readmeSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    img: [
+      ...(defaultSchema.attributes?.img ?? []),
+      "width",
+      "height",
+      "alt",
+      "align",
+    ],
+  },
+};
 
 /**
  * Renders markdown content with doc-style typography (headings, lists, tables, code).
@@ -12,7 +34,11 @@ import { cn } from "@/lib/utils";
 export function RenderedReadmeContent({ content }: { content: string }) {
   return (
     <div className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={readmeComponents}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, readmeSanitizeSchema]]}
+        components={readmeComponents}
+      >
         {content}
       </ReactMarkdown>
     </div>
@@ -156,4 +182,12 @@ const readmeComponents: Components = {
     </td>
   ),
   hr: () => <hr className="my-4 border-border" />,
+  img: ({ alt, ...props }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      alt={alt ?? ""}
+      className="my-3 h-auto max-w-full rounded-md"
+      {...props}
+    />
+  ),
 };

--- a/package.json
+++ b/package.json
@@ -119,6 +119,8 @@
     "react-tweet": "^3.2.2",
     "recharts": "^3.6.0",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,12 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark:
         specifier: ^15.0.1
         version: 15.0.1
@@ -4554,6 +4560,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
@@ -5866,6 +5875,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -11422,6 +11434,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -13223,6 +13241,11 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Issue
Sample: Screenshot of the issue before this fix attached below.

The README hero image is rendered as literal ‎`<img ...>` text instead of an image.

<img width="1523" height="1291" alt="Screenshot 2026-07-01 at 17 47 28" src="https://github.com/user-attachments/assets/a851513c-5b3b-44aa-a9b2-f3a38e852dcf" />


## Summary
- The self-hosting AWS/Azure/GCP/Kubernetes-Helm pages (and the terraform-modules changelog entry) embed each module's README via `<GitHubReadme>`, which fetches the raw markdown at runtime and renders it with `react-markdown`.
- Each of those READMEs opens with a raw `<img width="2400" height="600" alt="hero-b" src="..." />` hero tag instead of markdown image syntax. `react-markdown` escapes raw HTML by default (no `rehype-raw`), so the tag rendered as literal visible text on the page instead of an image.
- Added `rehype-raw` to parse embedded HTML, paired with `rehype-sanitize` (schema extended to allow `width`/`height`/`align` on `<img>`) since the README content is fetched from an external source at runtime. Also added an `img` renderer to `RenderedReadmeContent` for consistent doc styling.

## Test plan
- [x] `pnpm install` picks up the two new deps (`rehype-raw`, `rehype-sanitize`) cleanly
- [x] `tsc --noEmit` passes with no errors
- [x] `pnpm run format` applied cleanly
- [x] Visually confirm on `/self-hosting/deployment/aws`, `azure`, `gcp`, `kubernetes-helm` that the hero image renders instead of literal `<img ...>` text
- [x] Confirm rest of README formatting (headings, tables, code blocks, links) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes hero images in self-hosting READMEs (AWS/Azure/GCP/Kubernetes-Helm) that were rendering as literal `<img ...>` text because `react-markdown` escapes raw HTML by default. It adds `rehype-raw` (to parse embedded HTML) and `rehype-sanitize` (to keep external content safe), extends the sanitize schema to allow `width`/`height`/`align` on `<img>`, and adds a styled `img` renderer to `readmeComponents`.

- `rehype-raw` and `rehype-sanitize` are applied in the correct order (parse first, then sanitize), and the custom schema properly extends `defaultSchema` so the `src` and other default-allowed attributes are preserved.
- The `img` renderer follows the existing pattern of spreading `{...props}` without explicitly destructuring `node`, which is consistent with how all other renderers in the file are written.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, correctly orders the rehype pipeline, and adds no new security surface beyond what GitHub CDN images already represent.

The fix is narrow and targets a clear rendering gap (raw HTML hero tags showing as literal text). The rehype plugin order and sanitize schema extension are both correct, the two new deps are well-maintained packages in the unified/rehype ecosystem, and the img renderer is consistent with the existing component map. No logic paths or data flows are broken.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["External GitHub README\n(fetched at runtime)"] --> B["ReactMarkdown"]
    B --> C["remark-gfm\n(GFM tables, strikethrough…)"]
    C --> D["rehype-raw\n(parse raw HTML tags\ne.g. &lt;img width height&gt;)"]
    D --> E["rehype-sanitize\n(apply readmeSanitizeSchema:\ndefaultSchema + width/height/alt/align on img)"]
    E --> F["Custom Components\n(readmeComponents)"]
    F --> G1["img renderer\n&lt;img className=...&gt;"]
    F --> G2["Other renderers\nh1/h2/a/code/table…"]
    G1 --> H["Rendered page\n/self-hosting/aws|azure|gcp|k8s"]
    G2 --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["External GitHub README\n(fetched at runtime)"] --> B["ReactMarkdown"]
    B --> C["remark-gfm\n(GFM tables, strikethrough…)"]
    C --> D["rehype-raw\n(parse raw HTML tags\ne.g. &lt;img width height&gt;)"]
    D --> E["rehype-sanitize\n(apply readmeSanitizeSchema:\ndefaultSchema + width/height/alt/align on img)"]
    E --> F["Custom Components\n(readmeComponents)"]
    F --> G1["img renderer\n&lt;img className=...&gt;"]
    F --> G2["Other renderers\nh1/h2/a/code/table…"]
    G1 --> H["Rendered page\n/self-hosting/aws|azure|gcp|k8s"]
    G2 --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(readme-embed): render raw HTML in fe..."](https://github.com/langfuse/langfuse-docs/commit/e27992291efbc98c4674f94e1ec3ee304e1bec33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41144022)</sub>

<!-- /greptile_comment -->