### PR TITLE
docs: explain how to load the .env file in Python get-started

### DIFF
--- a/components-mdx/env-python.mdx
+++ b/components-mdx/env-python.mdx
@@ -4,3 +4,21 @@ LANGFUSE_PUBLIC_KEY = "pk-lf-..."
 LANGFUSE_BASE_URL = "https://cloud.langfuse.com" # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 ```
+
+<Callout type="info">
+
+A `.env` file is not loaded automatically. Load it before initializing Langfuse, for example with [python-dotenv](https://pypi.org/project/python-dotenv/):
+
+```bash
+pip install python-dotenv
+```
+
+```python
+from dotenv import load_dotenv
+
+load_dotenv()  # load variables from .env
+```
+
+Alternatively, set the variables directly in your shell (e.g. `export LANGFUSE_SECRET_KEY=...`).
+
+</Callout>


### PR DESCRIPTION
## Problem

The Python get-started env block shows a `.env` file with the Langfuse credentials, but nothing on the page explains that Python doesn't load `.env` automatically. A first-time user who follows the guide verbatim (`python script.py`) hits missing-credential errors on their very first run, because the variables were never actually loaded into the environment.

## Fix

Add a short `<Callout>` right after the `.env` block that points to [python-dotenv](https://pypi.org/project/python-dotenv/) (`load_dotenv()`), with a shell `export` alternative for anyone who prefers that.

This edit is in the shared `components-mdx/env-python.mdx` component, which is imported by the **OpenAI SDK**, **Python SDK**, and **LangChain (Python)** get-started tabs (plus the OpenAI-py integration page), so the note shows up everywhere the `.env` block appears — one small change, consistent everywhere.

## Notes

- No existing lines changed; the diff is purely additive (one Callout block).
- `<Callout>` is already used elsewhere in `components-mdx` (e.g. `github-cta.mdx`), so no new import is needed.
- Found while following the get-started guide end-to-end as a new user.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds guidance for loading Python `.env` files in the shared docs snippet. The main changes are:

- Adds an info callout after the Python environment block.
- Shows `python-dotenv` installation and `load_dotenv()` usage.
- Mentions shell `export` as an alternative.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: explain how to load the .env file ..."](https://github.com/langfuse/langfuse-docs/commit/ec1265f14f8bd0247627ca9bff91e84306402e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41180267)</sub>

<!-- /greptile_comment -->