### PR TITLE
docs(changelog): steer AI agents away from using changelog code examples for implementation

### DIFF
--- a/lib/mcp-handler.ts
+++ b/lib/mcp-handler.ts
@@ -82,7 +82,7 @@ export const mcpHandler = createMcpHandler(
 
     (server as any).tool(
       "getLangfuseDocsPage",
-      "Fetch the raw Markdown for a single Langfuse docs page. Accepts a docs path (e.g., /docs/observability/overview) or a full https://langfuse.com URL. Returns the exact Markdown (may include front matter). Use when you need a specific page content (Integration, Features, API, etc.) or code samples. Prefer searchLangfuseDocs for broader questions where there is not one specific page about it.",
+      "Fetch the raw Markdown for a single Langfuse docs page. Accepts a docs path (e.g., /docs/observability/overview) or a full https://langfuse.com URL. Returns the exact Markdown (may include front matter). Use when you need a specific page content (Integration, Features, API, etc.) or code samples. Prefer searchLangfuseDocs for broader questions where there is not one specific page about it. Changelog pages (/changelog/...) are historical release notes: use them only to confirm that a feature exists or when it shipped, not as an implementation reference. Their code samples reflect the SDK/API at release time and may be outdated, so for implementation follow the current docs and the API/SDK reference instead.",
       {
         pathOrUrl: z
           .string()

--- a/scripts/copy_md_sources.js
+++ b/scripts/copy_md_sources.js
@@ -17,6 +17,61 @@ const SOURCE_DIR = path.join(process.cwd(), "content");
 const OUTPUT_DIR = path.join(process.cwd(), "public", "md-src");
 const OVERRIDE_DIR = path.join(process.cwd(), "md-override");
 
+// Directories whose .md output is historical changelog content. Agents fetch
+// these pages (via the ".md" route or the docs MCP `getLangfuseDocsPage` tool)
+// and can mistake the release-time code snippets for current implementation
+// guidance. We prepend a machine-readable notice so agents use changelog
+// entries only to confirm a feature exists, and follow the canonical docs /
+// API / SDK reference for implementation. See CHANGELOG_AGENT_NOTICE below.
+const CHANGELOG_URL_PREFIX = "changelog";
+
+/**
+ * Read the `canonical` frontmatter value (a docs path) from raw MDX, if present.
+ * @param {string} originalContent
+ * @returns {string | null}
+ */
+function extractCanonicalPath(originalContent) {
+  const fmMatch = originalContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return null;
+  const canonicalMatch = fmMatch[1].match(/^canonical:\s*(\S+)\s*$/m);
+  return canonicalMatch ? canonicalMatch[1].trim() : null;
+}
+
+/**
+ * Prepend an AI-agent notice to changelog markdown, inserted right after the
+ * YAML frontmatter block so it is the first thing a model reads in the body.
+ * The notice steers agents away from using (potentially outdated) release-time
+ * code examples for implementation and toward the canonical docs / API / SDK
+ * reference.
+ * @param {string} processed  markdown already stripped for plain output
+ * @param {string} originalContent  raw MDX source (for frontmatter lookup)
+ * @returns {string}
+ */
+function injectChangelogAgentNotice(processed, originalContent) {
+  const canonical = extractCanonicalPath(originalContent);
+  const canonicalUrl = canonical
+    ? canonical.startsWith("http")
+      ? canonical
+      : `https://langfuse.com${canonical}`
+    : null;
+  const reference = canonicalUrl
+    ? `the canonical documentation for this feature (${canonicalUrl}) and the API/SDK reference (https://api.reference.langfuse.com)`
+    : `the current documentation (https://langfuse.com/docs) and the API/SDK reference (https://api.reference.langfuse.com)`;
+  const notice =
+    `> **Note for AI agents and LLMs:** This is a Langfuse changelog entry. ` +
+    `Use it only to confirm that a feature exists and when it shipped. ` +
+    `Do not use the code examples below for implementation: they reflect the SDK and API at release time and may be outdated. ` +
+    `For implementation, always follow ${reference}.`;
+
+  const fmMatch = processed.match(/^(---\r?\n[\s\S]*?\r?\n---\r?\n)/);
+  if (fmMatch) {
+    const frontmatter = fmMatch[1];
+    const body = processed.slice(frontmatter.length).replace(/^\s*\n/, "");
+    return `${frontmatter}\n${notice}\n\n${body}`;
+  }
+  return `${notice}\n\n${processed.replace(/^\s*\n/, "")}`;
+}
+
 /**
  * Recursively walk a directory collecting file paths.
  */
@@ -99,9 +154,20 @@ function copyAll() {
     const inlined = replaceComponentsWithMarkdown(
       inlineComponentsMdx(originalContent, file),
     );
-    const processed = stripMdxForPlainMarkdown(inlined, {
+    let processed = stripMdxForPlainMarkdown(inlined, {
       unwrapCalloutsForPlainMd: true,
     });
+
+    // For changelog entries, prepend an AI-agent notice so models use the page
+    // to confirm a feature exists rather than copying release-time examples.
+    const destRel = path.relative(OUTPUT_DIR, dest);
+    const isChangelogEntry =
+      destRel.startsWith(`${CHANGELOG_URL_PREFIX}/`) &&
+      destRel !== `${CHANGELOG_URL_PREFIX}/index.md`;
+    if (isChangelogEntry) {
+      processed = injectChangelogAgentNotice(processed, originalContent);
+    }
+
     fs.writeFileSync(dest, processed, "utf8");
     copied += 1;
   }

--- a/scripts/copy_md_sources.js
+++ b/scripts/copy_md_sources.js
@@ -52,7 +52,7 @@ function injectChangelogAgentNotice(processed, originalContent) {
   const canonicalUrl = canonical
     ? canonical.startsWith("http")
       ? canonical
-      : `https://langfuse.com${canonical}`
+      : `https://langfuse.com${canonical.startsWith("/") ? canonical : `/${canonical}`}`
     : null;
   const reference = canonicalUrl
     ? `the canonical documentation for this feature (${canonicalUrl}) and the API/SDK reference (https://api.reference.langfuse.com)`
@@ -160,7 +160,7 @@ function copyAll() {
 
     // For changelog entries, prepend an AI-agent notice so models use the page
     // to confirm a feature exists rather than copying release-time examples.
-    const destRel = path.relative(OUTPUT_DIR, dest);
+    const destRel = path.relative(OUTPUT_DIR, dest).split(path.sep).join("/");
     const isChangelogEntry =
       destRel.startsWith(`${CHANGELOG_URL_PREFIX}/`) &&
       destRel !== `${CHANGELOG_URL_PREFIX}/index.md`;


### PR DESCRIPTION
## Problem

AI coding agents should use changelog entries only to confirm that a feature exists and when it shipped, not as an implementation reference. Changelog code examples reflect the SDK/API at release time and can be outdated. For implementation, agents should follow the current docs and the API/SDK reference.

I traced the surfaces an agent reads and found two where changelog code examples leak into implementation:

- The `.md` content-negotiation route (`/changelog/….md`) serves changelog markdown verbatim.
- The docs MCP `getLangfuseDocsPage` tool fetches that same `.md`.

(`llms.txt` already excludes changelog; the "Copy page as Markdown" button is not enabled for changelog.)

## Changes

- **`scripts/copy_md_sources.js`** — every changelog `.md` in the generated `public/md-src/` now gets a machine-readable notice prepended right after its frontmatter, telling agents to use the entry only to confirm a feature exists and to follow the canonical docs / API/SDK reference for implementation. When the entry has a `canonical:` frontmatter field it links straight to that doc page; otherwise it falls back to `https://langfuse.com/docs`. The notice lives only in the generated markdown, so it is invisible to human readers on the rendered page. `public/md-src/` is gitignored and prettier-ignored, so there is no CI impact.
- **`lib/mcp-handler.ts`** — the `getLangfuseDocsPage` tool description now notes that changelog pages are historical release notes whose code samples may be outdated.

## Verified

- Ran the build script: changelog `.md` gets the notice (with and without a canonical link); docs pages get zero notices.
- Confirmed live over HTTP: `/changelog/2023-09-25-datasets.md` serves the notice, `/docs/observability/overview.md` does not.
- Both source files pass `prettier --check`.

## Out of scope (deliberately)

- Inkeep RAG search — hosted index we do not control here.
- A visible banner on rendered HTML changelog pages — would affect human-facing UX across all entries.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two lightweight guardrails that steer AI agents away from treating Langfuse changelog entries as authoritative implementation references. The changes are isolated to the build-time markdown pipeline and the MCP tool description.

- **`scripts/copy_md_sources.js`**: A machine-readable blockquote notice is prepended (after the YAML frontmatter) to every generated `public/md-src/changelog/*.md` file at build time, with a link to the canonical doc page when the `canonical:` frontmatter field is present. Non-changelog pages are untouched.
- **`lib/mcp-handler.ts`**: The `getLangfuseDocsPage` tool description now explicitly warns consuming agents that changelog pages are historical release notes whose code samples may be outdated.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all behaviour-changing logic lives in the build script that populates the gitignored public/md-src/ tree, and the MCP change is description-only.

The script correctly injects the agent notice on Linux/macOS where CI runs. The two flagged items are a Windows path-separator assumption that would silently skip all notice injection on Windows developer machines, and a minor URL-construction edge case for canonical values that lack a leading slash — both benign in the current production build environment but worth addressing for robustness.

scripts/copy_md_sources.js — specifically the isChangelogEntry path comparison and the canonicalUrl construction.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[copyAll: iterate content/ files] --> B{mapDestination}
    B -->|not .md/.mdx| SKIP[skip file]
    B -->|valid| C[readFileSync originalContent]
    C --> D[inlineComponentsMdx]
    D --> E[replaceComponentsWithMarkdown]
    E --> F[stripMdxForPlainMarkdown → processed]
    F --> G{destRel starts with changelog/ AND not index.md?}
    G -->|No - docs/blog/etc.| H[writeFileSync as-is]
    G -->|Yes - changelog entry| I[extractCanonicalPath from originalContent]
    I --> J{canonical: field present?}
    J -->|yes| K[canonicalUrl = https://langfuse.com + canonical]
    J -->|no| L[fallback: https://langfuse.com/docs]
    K --> M[injectChangelogAgentNotice]
    L --> M
    M --> N{frontmatter in processed?}
    N -->|yes| O[insert notice after frontmatter block]
    N -->|no| P[prepend notice at top]
    O --> H
    P --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[copyAll: iterate content/ files] --> B{mapDestination}
    B -->|not .md/.mdx| SKIP[skip file]
    B -->|valid| C[readFileSync originalContent]
    C --> D[inlineComponentsMdx]
    D --> E[replaceComponentsWithMarkdown]
    E --> F[stripMdxForPlainMarkdown → processed]
    F --> G{destRel starts with changelog/ AND not index.md?}
    G -->|No - docs/blog/etc.| H[writeFileSync as-is]
    G -->|Yes - changelog entry| I[extractCanonicalPath from originalContent]
    I --> J{canonical: field present?}
    J -->|yes| K[canonicalUrl = https://langfuse.com + canonical]
    J -->|no| L[fallback: https://langfuse.com/docs]
    K --> M[injectChangelogAgentNotice]
    L --> M
    M --> N{frontmatter in processed?}
    N -->|yes| O[insert notice after frontmatter block]
    N -->|no| P[prepend notice at top]
    O --> H
    P --> H
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/copy_md_sources.js:164-166
**Windows path-separator mismatch in `isChangelogEntry`**

`path.relative()` returns OS-native separators — backslashes on Windows — so `destRel.startsWith("changelog/")` is always `false` on Windows, silently skipping every notice injection. On Linux/macOS (where builds run in CI) this works fine, but any developer running the script locally on Windows would produce an `md-src/` tree without the agent notices. Consider normalising with `destRel.split(path.sep).join("/")` to stay consistent with the rest of the file's path handling.

### Issue 2 of 2
scripts/copy_md_sources.js:52-56
If a `canonical` value in frontmatter is missing its leading slash (e.g. `canonical: docs/foo`), the constructed URL becomes `https://langfuse.comdocs/foo` — a malformed link the agent would follow blindly. All current changelog entries use a leading `/`, but a defensive guard keeps future entries safe.

```suggestion
  const canonicalUrl = canonical
    ? canonical.startsWith("http")
      ? canonical
      : `https://langfuse.com${canonical.startsWith("/") ? canonical : `/${canonical}`}`
    : null;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): steer AI agents away fr..."](https://github.com/langfuse/langfuse-docs/commit/7937eb308d732bea1309ebb34d603389b7190854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41220162)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->