### PR TITLE
feat: add Ahrefs Web Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,7 @@ import { TwitterPixel } from "@/components/analytics/twitter-ads";
 import { ConversionTracker } from "@/components/analytics/ConversionTracker";
 import { ScarfPixel } from "@/components/analytics/scarf";
 import { CommonRoom } from "@/components/analytics/common-room";
+import { AhrefsAnalytics } from "@/components/analytics/ahrefs";
 import "../style.css";
 import "@vidstack/react/player/styles/base.css";
 import "../src/overrides.css";
@@ -105,6 +106,7 @@ export default function RootLayout({
             <ScarfPixel />
             <Hubspot />
             <CommonRoom />
+            <AhrefsAnalytics />
             <Script
               id="cookieyes"
               type="text/javascript"

--- a/components/analytics/ahrefs.tsx
+++ b/components/analytics/ahrefs.tsx
@@ -1,0 +1,18 @@
+import Script from "next/script";
+
+// Ahrefs Web Analytics — privacy-friendly, cookieless traffic analytics used
+// for SEO reporting. Loaded site-wide in production via next/script (the
+// idiomatic equivalent of dropping the async <script> into <head>). The
+// `data-key` identifies the Langfuse property in Ahrefs.
+const AHREFS_ANALYTICS_KEY = "Mex/bWanRRREdWiopW2rdA";
+
+export function AhrefsAnalytics() {
+  return (
+    <Script
+      id="ahrefs-analytics"
+      src="https://analytics.ahrefs.com/analytics.js"
+      data-key={AHREFS_ANALYTICS_KEY}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/content/security/subprocessors.mdx
+++ b/content/security/subprocessors.mdx
@@ -22,6 +22,7 @@ Langfuse (Langfuse GmbH) uses the following subprocessors to provide our service
 | Clickhouse Inc.                        | Application Hosting                                       | Client Data  | Affected individuals of the client | EU                          |
 | Google LLC                             | Product Metrics                                           | Client Data  | Affected individuals of the client | EU                          |
 | Posthog, Inc.                          | Product metrics                                           | Client Data  | Affected individuals of the client | EU                          |
+| Ahrefs Pte. Ltd.                       | Web Analytics                                             | Client Data  | Affected individuals of the client | Global                      |
 | Datadog, Inc.                          | Application logs                                          | Client Data  | Affected individuals of the client | EU                          |
 | Cloudflare, Inc.                       | Web Application Security (e.g. Firewall, DDOS protection) | Client Data  | Affected individuals of the client | Global Edge                 |
 | Functional Software, Inc. d/b/a Sentry | Application logs                                          | Client Data  | Affected individuals of the client | EU                          |
@@ -36,6 +37,7 @@ Langfuse (Langfuse GmbH) uses the following subprocessors to provide our service
 | Clickhouse Inc.                        | Application Hosting                                       | Client Data  | Affected individuals of the client | US                          |
 | Google LLC                             | Product Metrics                                           | Client Data  | Affected individuals of the client | EU                          |
 | Posthog, Inc.                          | Product metrics                                           | Client Data  | Affected individuals of the client | EU                          |
+| Ahrefs Pte. Ltd.                       | Web Analytics                                             | Client Data  | Affected individuals of the client | Global                      |
 | Datadog, Inc.                          | Application logs                                          | Client Data  | Affected individuals of the client | US                          |
 | Cloudflare, Inc.                       | Web Application Security (e.g. Firewall, DDOS protection) | Client Data  | Affected individuals of the client | Global Edge                 |
 | Functional Software, Inc. d/b/a Sentry | Application logs                                          | Client Data  | Affected individuals of the client | US                          |
@@ -52,6 +54,7 @@ The Japan region uses the same subprocessors as the EU region. Amazon Web Servic
 | Clickhouse Inc.                        | Application Hosting                                       | Client Data  | Affected individuals of the client | Japan                       |
 | Google LLC                             | Product Metrics                                           | Client Data  | Affected individuals of the client | EU                          |
 | Posthog, Inc.                          | Product metrics                                           | Client Data  | Affected individuals of the client | EU                          |
+| Ahrefs Pte. Ltd.                       | Web Analytics                                             | Client Data  | Affected individuals of the client | Global                      |
 | Datadog, Inc.                          | Application logs                                          | Client Data  | Affected individuals of the client | EU                          |
 | Cloudflare, Inc.                       | Web Application Security (e.g. Firewall, DDOS protection) | Client Data  | Affected individuals of the client | Global Edge                 |
 | Functional Software, Inc. d/b/a Sentry | Application logs                                          | Client Data  | Affected individuals of the client | EU                          |


### PR DESCRIPTION
## What

Adds [Ahrefs Web Analytics](https://ahrefs.com/web-analytics) (cookieless, privacy-friendly traffic analytics for SEO reporting) to the site.

- **New component** `components/analytics/ahrefs.tsx` — loads `https://analytics.ahrefs.com/analytics.js` via `next/script` (`afterInteractive`), passing the `data-key`. This is the idiomatic Next.js equivalent of dropping the async `<script>` into `<head>`; Ahrefs also officially supports this kind of client-side injection (their GTM Custom-HTML install method).
- **Wired into** `app/layout.tsx` inside the existing `process.env.NODE_ENV === "production"` block, alongside the other analytics integrations (GTM, PostHog, Scarf, Common Room, …).

## Notes for reviewers

- **Production-gated**, matching the other analytics — it won't load in `pnpm dev`. Once merged and deployed, verify via Ahrefs' "Recheck installation" against `langfuse.com` (or the Vercel preview, which also builds in production mode).
- No CSP change needed: `script-src` already allows `https:` (`next.config.mjs`).
- Ahrefs Web Analytics is cookieless and stores no PII, so no consent gating is required.
- Script endpoint verified reachable (`GET analytics.ahrefs.com/analytics.js → 200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Ahrefs Web Analytics to the docs site by introducing a small `AhrefsAnalytics` component (`components/analytics/ahrefs.tsx`) and mounting it inside the existing `NODE_ENV === "production"` analytics block in `app/layout.tsx`.

- New component wraps `next/script` with `strategy="afterInteractive"` and passes the site-identifying `data-key` — matching Ahrefs' supported client-side injection approach and consistent with how `CommonRoom` and other analytics scripts are loaded throughout the layout.
- The key is hardcoded as a module-level constant (not in an env var), which is the established pattern for non-secret, public analytics identifiers across this codebase (e.g., `COMMON_ROOM_SITE_ID`, GTM container IDs).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal, production-gated analytics integration with no functional changes to the site itself.

The change is a two-file addition: a new component that wraps `next/script` for Ahrefs analytics and a single mount point inside the existing production-only analytics block. It follows the established patterns for every other analytics integration in the codebase, the public tracking key is handled the same way as `COMMON_ROOM_SITE_ID` and GTM IDs, and there are no logic branches, data mutations, or auth paths involved.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Runtime
    participant AhrefsScript as analytics.ahrefs.com/analytics.js

    Browser->>NextJS: Request page (production)
    NextJS-->>Browser: "HTML + hydration (NODE_ENV === "production" block active)"
    Note over Browser,NextJS: afterInteractive fires post-hydration
    Browser->>AhrefsScript: GET analytics.js (with data-key attr on script tag)
    AhrefsScript-->>Browser: 200 OK — script executed
    Note over Browser: Cookieless pageview recorded in Ahrefs dashboard
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Runtime
    participant AhrefsScript as analytics.ahrefs.com/analytics.js

    Browser->>NextJS: Request page (production)
    NextJS-->>Browser: "HTML + hydration (NODE_ENV === "production" block active)"
    Note over Browser,NextJS: afterInteractive fires post-hydration
    Browser->>AhrefsScript: GET analytics.js (with data-key attr on script tag)
    AhrefsScript-->>Browser: 200 OK — script executed
    Note over Browser: Cookieless pageview recorded in Ahrefs dashboard
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Ahrefs Web Analytics"](https://github.com/langfuse/langfuse-docs/commit/3ccbea5734a44512e355b0ee71048cb810f14f5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41379287)</sub>

<!-- /greptile_comment -->