### PR TITLE
Add engineering resources: Phoenix migration, LLM gateway explainer, coding-agent tracing

### DIFF
--- a/content/integrations/gateways/litellm.mdx
+++ b/content/integrations/gateways/litellm.mdx
@@ -3,11 +3,12 @@ title: LiteLLM Proxy Integration
 seoTitle: Open Source Observability for LiteLLM Proxy
 sidebarTitle: LiteLLM Proxy
 logo: /images/integrations/litellm_icon.png
+description: Open source observability and tracing for LiteLLM Proxy. Log every LLM call routed through LiteLLM to Langfuse for tracing, cost tracking, and debugging.
 ---
 
 # LiteLLM Proxy Integration
 
-In this guide, we will show you how to use the LiteLLM Proxy to capture LLM calls and log them to Langfuse.
+Langfuse provides observability for LiteLLM: every LLM call routed through the LiteLLM Proxy can be logged to Langfuse, with token usage, cost, and latency captured per request. In this guide, we will show you how to set it up.
 
 > **What is LiteLLM?** [LiteLLM](https://github.com/BerriAI/litellm) is an open-source proxy and SDK that provides a single unified API to call and manage hundreds of different LLM providers and models with OpenAI-compatible endpoints.
 

--- a/content/resources/engineering/coding-agent-tracing.mdx
+++ b/content/resources/engineering/coding-agent-tracing.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Tracing Coding Agents: Claude Code, Codex, Copilot & More"
+title: "Tracing coding agents: Claude Code, Codex, Copilot & more"
 description: "How to trace AI coding agents with Langfuse: Claude Code, OpenAI Codex, GitHub Copilot, Cursor, and five more. Setup patterns, cost tracking, and team governance."
 tags: [guide, agents]
 ---
 
-# Tracing Coding Agents with Langfuse
+# Tracing coding agents with Langfuse
 
 AI coding agents now do real engineering work: they edit files, run terminal commands, call
 MCP tools, and burn meaningful token budgets while doing it. Tracing them answers three

--- a/content/resources/engineering/coding-agent-tracing.mdx
+++ b/content/resources/engineering/coding-agent-tracing.mdx
@@ -1,0 +1,108 @@
+---
+title: "Tracing Coding Agents: Claude Code, Codex, Copilot & More"
+description: "How to trace AI coding agents with Langfuse: Claude Code, OpenAI Codex, GitHub Copilot, Cursor, and five more. Setup patterns, cost tracking, and team governance."
+tags: [guide, agents]
+---
+
+# Tracing Coding Agents with Langfuse
+
+AI coding agents now do real engineering work: they edit files, run terminal commands, call
+MCP tools, and burn meaningful token budgets while doing it. Tracing them answers three
+questions teams keep asking: **what did the agent actually do**, **what does it cost per
+developer or per session**, and **where does it fail or waste work**.
+
+**TL;DR:** Langfuse traces all major coding agents today. GitHub Copilot exports
+OpenTelemetry natively: point it at Langfuse's OTLP endpoint and you're done. Claude Code
+and OpenAI Codex use lifecycle hooks that ship each session to Langfuse. Cursor, Kiro,
+OpenCode, and Augment Code have dedicated integrations as well. Setup is per-developer,
+minutes each, and no proxy or gateway is required.
+
+## Three reasons teams trace coding agents
+
+Three drivers show up consistently:
+
+1. **Visibility into agent behavior.** A coding agent's session is a long chain of model
+   calls and tool executions. When it deletes the wrong file or loops on a failing test, the
+   trace shows the exact sequence: which tool ran, with what arguments, after which model
+   output. That is the same debugging value LLM tracing provides in production apps, applied
+   to your own development workflow.
+2. **Cost and usage accounting.** Coding agents are often a team's single largest LLM spend.
+   Traces carry token usage per turn, so cost per developer, per project, or per model
+   becomes a dashboard query instead of a guess.
+3. **Governance.** Platform teams rolling agents out across an organization want usage
+   grouped by user, an audit trail of what ran on which machine, and a clear policy on
+   whether prompt and code content is captured or only metadata. Tracing gives the
+   infrastructure for all three.
+
+## Supported coding agents
+
+All nine developer-tool integrations, as of July 2026:
+
+| Agent                                                          | Mechanism                                          | Setup shape                                              |
+| -------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
+| [Claude Code](/integrations/developer-tools/claude-code)       | Stop hook script (runs after each response)        | Hook script + Langfuse keys in env                       |
+| [OpenAI Codex](/integrations/developer-tools/codex)            | Plugin hooks (Stop hook per turn)                  | Plugin in `~/.codex/config.toml`; Node 22+, Codex 0.128+ |
+| [GitHub Copilot](/integrations/developer-tools/github-copilot) | Native OpenTelemetry export                        | Point OTLP exporter at Langfuse; no SDK, no code changes |
+| [Cursor](/integrations/developer-tools/cursor)                 | Agent-session tracing                              | See integration page                                     |
+| [Kiro IDE](/integrations/developer-tools/kiro)                 | Agent activity tracing                             | See integration page                                     |
+| [Kiro CLI](/integrations/developer-tools/kiro-cli)             | Terminal session tracing                           | See integration page                                     |
+| [OpenCode](/integrations/developer-tools/opencode)             | Session tracing (turns, tools, retries, reasoning) | See integration page                                     |
+| [Augment Code](/integrations/developer-tools/augment-code)     | Conversation + tool execution tracing              | See integration page                                     |
+| [VS Code (MCP)](/integrations/developer-tools/vscode)          | Langfuse MCP server in Copilot agent mode          | Query prompts/traces/datasets from the editor            |
+
+The VS Code entry is the inverse direction: instead of tracing the agent, it gives the agent
+access to your Langfuse data via MCP. This becomes useful once traces exist and you want to analyze them
+without leaving the editor.
+
+## What the traces let you do
+
+- **Per-developer and per-model cost dashboards.** Hook- and OTel-based integrations attach a
+  user identifier, so [dashboards](/docs/metrics/features/custom-dashboards) can break down
+  token spend by developer, project, or model: the numbers platform teams need for rollout
+  decisions and budget planning.
+- **Tool-usage analysis.** Every tool call is an observation. Which tools dominate, which
+  fail, and which precede session abandonment are all queryable.
+- **Reconstructing failed sessions.** Long agent sessions that went wrong are hard to reconstruct from
+  terminal scrollback. The trace timeline preserves the full sequence, including retries and
+  reasoning summaries where the agent exposes them.
+- **Full-text search across sessions** to find who used a specific API, pattern, or skill,
+  one of the most common asks from teams running Claude Code at scale.
+
+## Limits
+
+- **Session context files are not captured.** What `CLAUDE.md`, skills, or auto-loaded
+  context contributed to the effective system prompt is not part of what the hooks can read
+  today. You see the conversation and tool calls, not the assembled context.
+- **Hooks are per-machine and user-serviceable.** A developer can disable a hook in their
+  local config. If you need guaranteed capture for compliance, treat hook-based tracing as
+  telemetry, not enforcement. Enforcement belongs at a gateway or provider level.
+- **Web-based agents are out of scope.** Tools without hooks or telemetry export (e.g.,
+  purely web-hosted assistants) can't be traced this way.
+
+## FAQ
+
+### Can I track which Claude Code skills or rules are used?
+
+Indirectly. Skill invocations that run as tool calls appear in traces, and full-text search
+over session content finds skill mentions. The assembled context itself (which skills were
+loaded) is not captured, see limits above.
+
+### Does this work with self-hosted Langfuse?
+
+Yes. The integrations target the standard ingestion and OTLP endpoints. Check each
+integration page for minimum version requirements: the Claude Code integration requires a
+current Langfuse version, and older self-hosted deployments (v1/v2) predate the OTLP
+endpoint.
+
+### What does tracing a coding agent cost in Langfuse units?
+
+The same as any trace: sessions produce one trace per turn or per session (integration-
+dependent), with observations for model calls and tool executions. High-volume agent use is
+observable in your [billable units page](/docs/administration/billable-units) before it becomes a billing
+surprise.
+
+### Can developers opt out?
+
+Yes, hooks live in the developer's local config. For team rollouts, make tracing part of the
+standard dotfiles/setup and be explicit about what is captured. The Copilot integration's
+metadata-only default is a good template for a privacy-conservative baseline.

--- a/content/resources/engineering/llm-gateway.mdx
+++ b/content/resources/engineering/llm-gateway.mdx
@@ -1,0 +1,133 @@
+---
+title: "What Is an LLM Gateway? When You Need One (and When You Don't)"
+description: "An LLM gateway is a proxy layer between your application and model providers: one API, failover, caching, cost controls. How gateways work and how to pick one."
+tags: [guide]
+---
+
+# What Is an LLM Gateway?
+
+An LLM gateway is a proxy layer that sits between your application and model providers. Your
+code sends requests to one endpoint in one format, and the gateway translates them to each
+provider's native API, applies policies on the way through, and returns the response. Most
+gateways expose an OpenAI-compatible API, so switching providers becomes a change of model
+string rather than a code change.
+
+**TL;DR:** Use a gateway when you call more than one provider, need failover or cost
+controls, or want central key management for many teams. Skip it when a single provider and
+an SDK are serving you fine: a gateway is one more hop and one more system to operate. The
+gateway and your observability platform are complementary layers, not substitutes; the
+gateway controls traffic, observability explains behavior.
+
+## What an LLM gateway does
+
+Across the major gateways, the recurring capabilities are:
+
+- **A unified API** translates one request format (usually OpenAI-compatible) to many
+  providers, so provider switches and A/B tests don't touch application code.
+- **Routing and failover** retries failed requests, falls back to alternate models or
+  providers, and load-balances across keys or regions.
+- **Cost controls** cache repeated requests, enforce rate limits and budgets per team or per
+  key, and attribute spend.
+- **Key management** stores provider credentials centrally so application teams hold one
+  gateway token instead of a drawer of provider keys.
+- **Policy enforcement** applies guardrails, request logging, and data-handling rules in one
+  place instead of in every service.
+
+Not every gateway ships every feature, and the depth varies a lot, which is what the
+selection below turns on.
+
+## When you need a gateway
+
+The strongest signals that a gateway earns its operational cost:
+
+1. **Multiple providers or models in production.** Hand-rolled provider switching grows into
+   an unmaintained routing library. A gateway makes it configuration.
+2. **Reliability requirements above a single provider's SLA.** Provider outages happen;
+   failover across providers is the standard mitigation, and it belongs in infrastructure
+   rather than application code.
+3. **Many teams calling LLMs.** Central key custody, per-team budgets, and one place to
+   enforce policy beat distributing provider keys across dozens of services.
+4. **Developer tooling at scale.** Routing coding agents and internal tools through a
+   gateway gives platform teams usage visibility and spend control without touching each
+   developer's setup.
+
+And the counter-case is just as real: one provider, one team, moderate volume. An SDK with
+retries covers that, and skipping the gateway removes a latency hop, an availability
+dependency, and an operational surface.
+
+## The gateway landscape
+
+A non-exhaustive map of commonly used gateways (details verified July 2026; capabilities
+move fast, check the linked docs):
+
+| Gateway                                                                | Model                                  | Notable traits                                                                               |
+| ---------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [LiteLLM](https://github.com/BerriAI/litellm)                          | Open source; Python SDK + proxy server | Calls 100+ LLM APIs in OpenAI format; the default self-hosted choice                         |
+| [OpenRouter](https://openrouter.ai/)                                   | Hosted                                 | OpenAI-compatible API over 280+ models and providers; per-request provider routing           |
+| [Portkey](https://portkey.ai/)                                         | Hosted + self-host options             | Unified interface to 250+ models with control, visibility, and security tooling              |
+| [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | Hosted (Cloudflare)                    | Analytics, logging, caching, rate limiting, retries, model fallback; on all Cloudflare plans |
+| [Kong AI Gateway](https://konghq.com/)                                 | Open-core API gateway + AI plugins     | Brings existing API-gateway policy machinery (auth, rate limits) to LLM traffic              |
+| [Vercel AI Gateway](https://vercel.com/)                               | Hosted (Vercel)                        | Provider routing for apps in the Vercel ecosystem, OpenAI-compatible                         |
+| [Helicone](https://helicone.ai/)                                       | Open source                            | AI gateway to 100+ models with routing, failover, caching, and cost tracking                 |
+| [TrueFoundry](https://www.truefoundry.com/ai-gateway)                  | Enterprise                             | Gateway + control plane with governance, cost controls, and on-prem support                  |
+
+Selection usually comes down to three questions. Where must it run (a self-hosted gateway
+like LiteLLM for VPC-only environments, a hosted one when operating it is undesirable)? What
+depth of policy do you need (budgets, guardrails, audit)? And what does it do to latency and
+availability on your critical path?
+
+## Gateways and observability are different layers
+
+A gateway sees every request that passes through it, so gateway logs answer "what did we
+send and what did it cost". They stop at the request boundary. What they cannot show is why
+your application made that request: the chain of agent steps, retrieved context, tool calls,
+and intermediate model outputs that produced it.
+
+That is the observability layer's job. [Langfuse](/) traces the full application execution
+(a trace with nested [observations](/docs/observability/data-model)) and works with any
+gateway on this page, because tracing happens in your application, not in the proxy:
+
+- The [Langfuse SDKs](/docs/observability/sdk/overview) wrap your LLM calls regardless of whether they hit
+  a provider directly or a gateway URL.
+- Several gateways also emit telemetry directly: [OpenRouter's Broadcast
+  feature](/integrations/gateways/openrouter) sends traces to Langfuse without code changes,
+  and [Cloudflare AI Gateway exports OpenTelemetry
+  spans](https://developers.cloudflare.com/ai-gateway/observability/otel-integration/) that
+  Langfuse ingests on its [OTLP endpoint](/integrations/native/opentelemetry).
+- Langfuse has step-by-step integration guides for
+  [LiteLLM](/integrations/gateways/litellm), [OpenRouter](/integrations/gateways/openrouter),
+  [Portkey](/integrations/gateways/portkey), [Kong](/integrations/gateways/kong-ai-plugin),
+  [Vercel AI Gateway](/integrations/gateways/vercel-ai-gateway),
+  [Helicone](/integrations/gateways/helicone),
+  [TrueFoundry](/integrations/gateways/truefoundry), and
+  [Anannas](/integrations/gateways/anannas).
+
+The practical pattern for teams running both: route traffic through the gateway for control,
+trace from the application with Langfuse for understanding, and keep cost attribution
+consistent by passing user and session identifiers through both layers.
+
+## FAQ
+
+### Is Langfuse an LLM gateway?
+
+No. Langfuse is an [LLM observability and evaluation platform](/docs): it traces, evaluates,
+and analyzes what your application does, but your requests never pass through Langfuse on
+the way to a provider. It complements whichever gateway you choose, and works without one.
+
+### Does an LLM gateway add latency?
+
+Yes, one network hop plus processing time; how much depends on the gateway and deployment
+(a sidecar LiteLLM adds less than a cross-region hosted hop). Response caching can make
+repeated requests faster than going direct. Measure with your own traffic before and after.
+
+### Do I need a gateway to get LLM observability?
+
+No. Tracing instruments your application code and works with direct provider SDK calls.
+Gateway logs add a useful traffic-level view, but application-level traces carry the context
+(agent steps, retrievals, tool calls) that debugging and evaluation need.
+
+### Can I use multiple gateways?
+
+Teams sometimes run a self-hosted gateway inside the VPC for sensitive workloads and a hosted
+one for experimentation. It works, but every extra layer multiplies configuration and
+debugging surface, so consolidate unless there is a hard requirement.

--- a/content/resources/engineering/llm-gateway.mdx
+++ b/content/resources/engineering/llm-gateway.mdx
@@ -1,10 +1,10 @@
 ---
-title: "What Is an LLM Gateway? When You Need One (and When You Don't)"
+title: "What is an LLM gateway? When you need one (and when you don't)"
 description: "An LLM gateway is a proxy layer between your application and model providers: one API, failover, caching, cost controls. How gateways work and how to pick one."
 tags: [guide]
 ---
 
-# What Is an LLM Gateway?
+# What is an LLM gateway?
 
 An LLM gateway is a proxy layer that sits between your application and model providers. Your
 code sends requests to one endpoint in one format, and the gateway translates them to each
@@ -67,7 +67,7 @@ move fast, check the linked docs):
 | [Portkey](https://portkey.ai/)                                         | Hosted + self-host options             | Unified interface to 250+ models with control, visibility, and security tooling              |
 | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | Hosted (Cloudflare)                    | Analytics, logging, caching, rate limiting, retries, model fallback; on all Cloudflare plans |
 | [Kong AI Gateway](https://konghq.com/)                                 | Open-core API gateway + AI plugins     | Brings existing API-gateway policy machinery (auth, rate limits) to LLM traffic              |
-| [Vercel AI Gateway](https://vercel.com/)                               | Hosted (Vercel)                        | Provider routing for apps in the Vercel ecosystem, OpenAI-compatible                         |
+| [Vercel AI Gateway](https://vercel.com/docs/ai-gateway)                | Hosted (Vercel)                        | Provider routing for apps in the Vercel ecosystem, OpenAI-compatible                         |
 | [Helicone](https://helicone.ai/)                                       | Open source                            | AI gateway to 100+ models with routing, failover, caching, and cost tracking                 |
 | [TrueFoundry](https://www.truefoundry.com/ai-gateway)                  | Enterprise                             | Gateway + control plane with governance, cost controls, and on-prem support                  |
 

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -6,6 +6,9 @@
     "best-phoenix-arize-alternatives",
     "best-galileo-ai-alternatives",
     "best-braintrustdata-alternatives",
-    "migrate-from-helicone"
+    "migrate-from-helicone",
+    "migrate-from-phoenix",
+    "llm-gateway",
+    "coding-agent-tracing"
   ]
 }

--- a/content/resources/engineering/migrate-from-phoenix.mdx
+++ b/content/resources/engineering/migrate-from-phoenix.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate from Arize Phoenix to Langfuse
 description: "Step-by-step guide to migrating from Arize Phoenix to Langfuse: keep your OpenInference instrumentation, repoint one OTLP endpoint, and map datasets, experiments, and prompts."
-tags: [comparison, guide]
+tags: [migration, guide]
 ---
 
 # Migrate from Arize Phoenix to Langfuse
@@ -64,7 +64,7 @@ PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
 
 # After (Langfuse): standard OTel exporter variables
 OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"  # EU region
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING}"
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
 ```
 
 `AUTH_STRING` is your base64-encoded Langfuse project keys

--- a/content/resources/engineering/migrate-from-phoenix.mdx
+++ b/content/resources/engineering/migrate-from-phoenix.mdx
@@ -1,0 +1,174 @@
+---
+title: Migrate from Arize Phoenix to Langfuse
+description: "Step-by-step guide to migrating from Arize Phoenix to Langfuse: keep your OpenInference instrumentation, repoint one OTLP endpoint, and map datasets, experiments, and prompts."
+tags: [comparison, guide]
+---
+
+# Migrate from Arize Phoenix to Langfuse
+
+This guide walks through migrating LLM observability from
+[Arize Phoenix](https://phoenix.arize.com) to [Langfuse](/): tracing first (usually a
+same-day change), then datasets, experiments, and prompts.
+
+**TL;DR:** Phoenix and Langfuse both ingest OpenTelemetry traces, and Langfuse recognizes
+OpenInference instrumentation natively. That means the tracing migration is not a
+re-instrumentation project: you keep your existing OpenInference setup and change the OTLP
+endpoint and auth headers. Datasets, prompts, and evaluators are recreated via the Langfuse
+SDK/API; experiments re-run against the migrated datasets.
+
+## Why teams migrate
+
+Teams tend to evaluate a Phoenix-to-Langfuse move for a few recurring reasons:
+
+- **Hosting and licensing model.** Phoenix is source-available under the Elastic License 2.0
+  with self-hosted images and a hosted offering at app.phoenix.arize.com (as of July 2026).
+  Langfuse's core is MIT-licensed open source, self-hosting is a
+  [first-class deployment mode](/self-hosting) with full tracing/evals/prompt-management
+  parity, and [Langfuse Cloud](https://cloud.langfuse.com) offers managed EU/US regions.
+- **Team and access management.** Growing teams often want org/project separation,
+  [role-based access control](/docs/administration/rbac), and SSO enforcement as the number
+  of people touching LLM data grows.
+- **One platform for the whole loop.** Langfuse combines tracing,
+  [evaluation](/docs/evaluation/overview), [prompt management](/docs/prompt-management), and
+  [dashboards](/docs/metrics/features/custom-dashboards) on one data model, so production
+  traces feed datasets, experiments, and online evaluators without an export step.
+
+Phoenix remains a capable tool, particularly for notebook-centric experimentation, and if it
+serves your team well, there is no urgency to move. This guide is for teams that have decided
+to consolidate on Langfuse.
+
+## Concept mapping
+
+Phoenix and Langfuse share most concepts, which keeps the mental migration small:
+
+| Phoenix                        | Langfuse                                                                                                                                                   | Notes                                                              |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Project                        | Project                                                                                                                                                    | Langfuse adds organizations above projects                         |
+| Traces / spans (OpenInference) | [Traces / observations](/docs/observability/data-model)                                                                                                    | Same OTel foundation; spans map to observations                    |
+| Datasets                       | [Datasets](/docs/evaluation/experiments/datasets)                                                                                                          | Versioned example collections in both                              |
+| Experiments                    | [Experiments / dataset runs](/docs/evaluation/experiments)                                                                                                 | Runs linked to dataset items and scores                            |
+| Evals (LLM evals)              | [Evaluators / LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) + [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) | Langfuse evaluators can also run continuously on production traces |
+| Playground                     | [Playground](/docs/prompt-management/features/playground)                                                                                                  | Replay and iterate on traced calls                                 |
+| Prompt Management              | [Prompt Management](/docs/prompt-management)                                                                                                               | Versions, labels, and deployment via SDK                           |
+
+## Step 1: Repoint your tracing (no re-instrumentation)
+
+If you instrumented with OpenInference, the common case for Phoenix users, your spans
+already speak OpenTelemetry, and Langfuse's [OTLP endpoint](/integrations/native/opentelemetry)
+lists `openinference.*` among its known LLM instrumentation scopes. The change is
+configuration, not code:
+
+```bash
+# Before (Phoenix)
+PHOENIX_COLLECTOR_ENDPOINT="http://localhost:6006"
+
+# After (Langfuse): standard OTel exporter variables
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"  # EU region
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING}"
+```
+
+`AUTH_STRING` is your base64-encoded Langfuse project keys
+(`echo -n "pk-lf-...:sk-lf-..." | base64`). If your exporter requires signal-specific
+configuration, the traces path is `/api/public/otel/v1/traces`. Langfuse accepts OTLP over
+HTTP in both protobuf and JSON encodings (no gRPC).
+
+Framework auto-instrumentation (LangChain, LlamaIndex, OpenAI SDK, and the other
+OpenInference instrumentations) keeps working unchanged: the spans simply arrive in Langfuse,
+where GenAI/OpenInference attributes map to Langfuse generations, tool observations, token
+usage, and cost tracking.
+
+Two things to verify in the first hour:
+
+1. **Trace grouping**: check that multi-span requests arrive as one trace with the expected
+   hierarchy (see [OTel property mapping](/integrations/native/opentelemetry) if attributes
+   land differently than expected).
+2. **User/session attribution**: Langfuse reads `user.id` and `session.id` attributes;
+   populate them where you previously relied on Phoenix-specific metadata.
+
+You can also run both backends in parallel during a validation window by configuring an OTel
+collector with two exporters, a common pattern for de-risking the cutover.
+
+## Step 2: Migrate datasets
+
+Export dataset examples from Phoenix (via its API/SDK) and recreate them with the Langfuse
+SDK. The shapes are close: each example's input, expected output, and metadata map directly:
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+for example in phoenix_examples:  # from Phoenix's dataset export
+    langfuse.create_dataset_item(
+        dataset_name="my-dataset",
+        input=example.input,
+        expected_output=example.output,
+        metadata=example.metadata,
+    )
+```
+
+Fields that have no direct Langfuse column (tags, split labels, provenance) belong in
+`metadata`: keep them, they cost nothing and preserve history.
+
+## Step 3: Recreate prompts and evaluators
+
+- **Prompts:** create prompt versions in
+  [Langfuse Prompt Management](/docs/prompt-management) via SDK, using labels (e.g.
+  `production`, `staging`) where Phoenix used tags. Application code then fetches prompts by
+  name+label instead of embedding them.
+- **Evaluators:** recreate LLM evals as [managed or custom LLM-as-a-judge
+  evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge), or as
+  [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) where they were
+  Python functions. Evaluators in Langfuse can target production traces continuously (online
+  evaluation) in addition to experiment runs. This is worth setting up from day one, since it
+  removes the pull-traces-out-to-evaluate loop entirely.
+- **Experiments:** re-run against the migrated datasets via the
+  [experiments SDK](/docs/evaluation/experiments) or from the UI. Historical Phoenix
+  experiment results are best kept as an archived reference rather than imported: scores are
+  cheap to regenerate on the current dataset, and cross-tool score comparability is shaky
+  anyway.
+
+## Step 4: Decide what to do with historical traces
+
+Most teams cut over fresh: old traces stay queryable in the old system for its retention
+window, and Langfuse becomes the system of record from cutover day. Bulk-importing historical
+traces is possible via the ingestion API but rarely worth it beyond a few showcase traces:
+volume-based pricing and the low value of stale traces argue against it.
+
+## Validation checklist
+
+- [ ] Traces arrive in Langfuse with correct hierarchy, timing, and token/cost data
+- [ ] User and session attribution works
+- [ ] Framework auto-instrumentation spans render as generations (not generic spans)
+- [ ] Datasets migrated with item counts matching the source
+- [ ] Evaluators produce scores on a sample of new traces
+- [ ] Prompts resolve by name+label from application code
+- [ ] Team access set up (org/project roles, SSO if applicable)
+- [ ] Old exporter removed (or parallel window scheduled to end)
+
+## FAQ
+
+### Do I have to re-instrument my application?
+
+No. If you use OpenInference/OpenTelemetry instrumentation, you change the OTLP endpoint and
+auth headers. Re-instrumenting with the [Langfuse SDKs](/docs/observability/sdk/overview) later is optional
+and adds SDK-native features, but it is not required to migrate.
+
+### Does Langfuse support the frameworks Phoenix instrumented?
+
+Langfuse has [native integrations](/integrations) for the major frameworks (LangChain,
+LlamaIndex, OpenAI, Vercel AI SDK, and more) and accepts any OpenInference instrumentation
+via OTLP, so framework coverage carries over rather than resetting.
+
+### Is Langfuse open source where Phoenix is?
+
+Langfuse's core platform is MIT-licensed and self-hostable with feature parity to Cloud;
+Phoenix is licensed under the Elastic License 2.0 (source-available) as of July 2026. Check
+both licenses against your compliance requirements: ELv2 restricts offering the software as
+a managed service, which matters to some platform teams.
+
+### Can I evaluate old Phoenix traces in Langfuse?
+
+Evaluators run on data in Langfuse, so historical evaluation requires importing those traces
+first (see Step 4). The pragmatic path: start evaluators on new traffic at cutover and
+backfill only if a specific analysis demands it.


### PR DESCRIPTION
## What

Three new pages under `/resources/engineering` plus a metadata fix on the LiteLLM integration page:

1. **`migrate-from-phoenix`** — migration guide targeting teams moving from Arize Phoenix; the technical hook is keeping existing OpenInference instrumentation and repointing the OTLP exporter at Langfuse.
2. **`llm-gateway`** — neutral explainer for the "what is an LLM gateway" query cluster; anchors our 8 gateway integration pages and answers the recurring "is Langfuse a gateway?" confusion from support.
3. **`coding-agent-tracing`** — roundup guide covering all nine developer-tool integrations (Claude Code, Codex, Copilot deep-dives + matrix), targeting the fast-growing `claude code trace` query family where we already rank top-5.
4. **`litellm.mdx`** — adds the missing `description` frontmatter and an answer-first opening line (page had no meta description at all).

## Why

From the internal GEO content pipeline: these target demand triangulated across search data (page-2 rankings on the gateway/agent-eval clusters), AI-answer visibility gaps, and recurring customer questions. Evidence and briefs live in the internal `langfuse/internal-geo` repo.

## Competitor / external claims for reviewer attention

- **Phoenix licensing**: stated as Elastic License 2.0 per https://github.com/Arize-ai/phoenix/blob/main/LICENSE (checked 2026-07-03); hosted offering at app.phoenix.arize.com per their README. No claims made about Phoenix RBAC or pricing.
- **Langfuse OpenInference ingestion**: per our own docs (`advanced-features.mdx`), `openinference.*` is a known instrumentation scope.
- **Gateway landscape table** (llm-gateway page): one-liners sourced from our own integration pages + official vendor docs; Cloudflare capabilities per developers.cloudflare.com/ai-gateway (checked 2026-07-03). No LiteLLM license claim (GitHub reports "Other").
- Model IDs in examples mirror current vendor docs.

All internal links verified against `content/`; files formatted with repo prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds three new engineering resource pages (`migrate-from-phoenix`, `llm-gateway`, `coding-agent-tracing`) and a frontmatter fix to the LiteLLM integration page, targeting content gaps identified via search analytics.

- **`migrate-from-phoenix.mdx`** provides a step-by-step migration guide that keeps existing OpenInference instrumentation and repoints the OTLP exporter; the concept-mapping table and validation checklist are thorough and technically accurate against the existing OTLP docs.
- **`llm-gateway.mdx`** is a neutral explainer covering when to use a gateway, a landscape comparison table (eight entries verified as of July 2026), and a clear \"gateways ≠ observability\" distinction anchoring Langfuse's own integration list.
- **`coding-agent-tracing.mdx`** enumerates all nine developer-tool integrations (all linked files verified to exist in `content/integrations/developer-tools/`) with per-integration mechanism notes and a governance/limits section.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the new pages are documentation-only and introduce no runtime code changes. Two minor content issues in two of the new pages are easy one-line fixes but not blockers.

The three new resource pages are well-researched and internally consistent with the rest of the docs: all internal links resolve, API usage patterns match existing examples, and factual claims (OTLP endpoints, licensing, agent counts) check out. Two small issues prevent a clean bill of health: the Phoenix migration guide's OTLP snippet omits a recommended header that affects real-time trace visibility during cutover validation, and the Vercel AI Gateway table entry links to the corporate homepage rather than the product page.

`migrate-from-phoenix.mdx` (OTLP headers snippet) and `llm-gateway.mdx` (Vercel AI Gateway URL) both have minor fixes worth applying before the pages go live.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application (Phoenix/OpenInference)
    participant Exporter as OTel Exporter
    participant Langfuse as Langfuse OTLP Endpoint
    participant UI as Langfuse UI

    Note over App: Before migration
    App->>Exporter: Emit spans (OpenInference format)
    Exporter->>App: PHOENIX_COLLECTOR_ENDPOINT

    Note over App,UI: After migration (env var change only)
    App->>Exporter: Emit spans (same OpenInference format)
    Exporter->>Langfuse: POST /api/public/otel/v1/traces Authorization + x-langfuse-ingestion-version:4
    Langfuse->>Langfuse: Map OpenInference attrs to generations/observations
    Langfuse->>UI: Real-time Fast Preview

    Note over App,UI: Optional parallel validation window
    App->>Exporter: Spans
    Exporter-->>Langfuse: Also send to Langfuse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application (Phoenix/OpenInference)
    participant Exporter as OTel Exporter
    participant Langfuse as Langfuse OTLP Endpoint
    participant UI as Langfuse UI

    Note over App: Before migration
    App->>Exporter: Emit spans (OpenInference format)
    Exporter->>App: PHOENIX_COLLECTOR_ENDPOINT

    Note over App,UI: After migration (env var change only)
    App->>Exporter: Emit spans (same OpenInference format)
    Exporter->>Langfuse: POST /api/public/otel/v1/traces Authorization + x-langfuse-ingestion-version:4
    Langfuse->>Langfuse: Map OpenInference attrs to generations/observations
    Langfuse->>UI: Real-time Fast Preview

    Note over App,UI: Optional parallel validation window
    App->>Exporter: Spans
    Exporter-->>Langfuse: Also send to Langfuse
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/resources/engineering/migrate-from-phoenix.mdx:67
The OTLP headers example omits `x-langfuse-ingestion-version=4`, which is the recommended header in the canonical OTLP setup docs (`content/integrations/native/opentelemetry.mdx`, line 134). Without it, spans are still ingested but do not appear in Langfuse Cloud's real-time Fast Preview. For a migration guide where a key step is "verify your first traces land correctly", this causes confusing delay exactly when users are watching the UI to confirm the cutover worked.

```suggestion
OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
```

### Issue 2 of 2
content/resources/engineering/llm-gateway.mdx:70
The Vercel AI Gateway row links to `https://vercel.com/` (the corporate homepage) rather than the specific AI Gateway product or docs page. Readers clicking this to learn more or verify capabilities land at the homepage with no clear path to the AI Gateway feature, unlike every other row in the table which links directly to the product or docs URL.

```suggestion
| [Vercel AI Gateway](https://vercel.com/docs/ai/vercel-ai-gateway)      | Hosted (Vercel)                        | Provider routing for apps in the Vercel ecosystem, OpenAI-compatible                         |
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add resources pages: Phoenix migration, ..."](https://github.com/langfuse/langfuse-docs/commit/2ecb339935d0de1c2cf733bc6a0f7185cf02fcb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41631737)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->