### PR TITLE
docs: clarify immutable data model, remove re-insert update guidance

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -30,7 +30,7 @@ Select whether you want to use S3, a S3 compatible storage, Google Cloud Storage
 To set up the export navigate to `Your Project` > `Settings` > `Integrations` > `Blob Storage`.
 
 Fill in the settings to authenticate with your vendor, enable the integration, and press save.
-An initial export starts shortly after you enable the integration and then continues on the schedule you selected.
+For a newly created and enabled integration, the first export starts running within the next 30 minutes and then continues on the schedule you selected.
 The export supports CSV, JSON, and JSONL file formats.
 Read [our blob storage documentation](/self-hosting/deployment/infrastructure/blobstorage) for more information on how to get credentials for your specific vendor.
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -151,7 +151,7 @@ The status card on the same page also surfaces:
 - **Export mode** — `Full history`, `From setup date`, or `From custom date` (plus the start date where applicable).
 - A **Last export failed** alert with the error message and time when in the Error state.
 
-While an export is running, the UI polls for updates every few seconds so the badge refreshes automatically. If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed.
+If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed. Reload the page to see the latest status.
 
 A failed export is retried automatically on the next run; repeated failures trigger a notification.
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -138,6 +138,7 @@ The integration settings page shows a status badge:
 | Badge        | Meaning                                                                                |
 | ------------ | -------------------------------------------------------------------------------------- |
 | **Active**   | Enabled and synced; the next export is scheduled for the future.                       |
+| **Running**  | An export job is currently in progress (shown with a spinner).                         |
 | **Queued**   | An export is due and waiting to run.                                                   |
 | **Pending**  | Enabled but has not run an export yet (`Data exported up to` shows `Never (pending)`). |
 | **Disabled** | The integration is turned off.                                                         |
@@ -149,6 +150,8 @@ The status card on the same page also surfaces:
 - **Next export scheduled** — when the next run will happen.
 - **Export mode** — `Full history`, `From setup date`, or `From custom date` (plus the start date where applicable).
 - A **Last export failed** alert with the error message and time when in the Error state.
+
+While an export is running, the UI polls for updates every few seconds so the badge refreshes automatically. If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed.
 
 A failed export is retried automatically on the next run; repeated failures trigger a notification.
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -516,13 +516,13 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 ## Advanced
 
-### Preventing Duplicate Scores
+### Preventing Duplicate Scores [#preventing-duplicate-scores]
 
 By default, Langfuse allows for multiple scores of the same `name` on the same trace. This is useful if you'd like to track the evolution of a score over time or if e.g. you've received multiple user feedback scores on the same trace.
 
 In some cases, you want to prevent this behavior or update an existing score. This can be achieved by creating an **idempotency key** on the score and passing this as an `id` (JS/TS) / `score_id` (Python) when creating the score, for example `trace_id-score_name`.
 
-Note that if you expect API calls for the same score to be 30+ days apart, you should also use the same timestamp. See [How to update traces, observations, and scores](/faq/all/tracing-data-updates#updating-traces-observations-and-scores) for more details.
+See [How to update traces, observations, and scores](/faq/all/tracing-data-updates) for more details on Langfuse's immutable data model.
 
 ### Enforcing a Score Config
 

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -5,51 +5,37 @@ tags: [observability]
 
 # How to update traces, observations, and scores?
 
-This guide covers how to update traces, observations, and scores in Langfuse, highlighting differences between available update methods.
+Langfuse uses a **mostly immutable data model** for observability data (traces and observations in the Langfuse [data model](/docs/observability/data-model)). Once ingested, traces and observations should be treated as final and cannot be reliably updated.
 
-## What can I update?
+If you want to enrich traces or observations after they were ingested with evaluations or annotations, use [scores](/docs/evaluation/evaluation-methods/custom-scores). Scores can be added to traces, observations, sessions, and dataset runs at any time.
 
-Langfuse is moving to a mostly immutable data model for observability data (traces and observations in the Langfuse [data model](/docs/observability/data-model)).
+## Traces and observations are immutable [#traces-and-observations]
 
-If you want to enrich traces or observations after they were ingested with evaluations/annotations, please look into scores ([docs](/docs/evaluation/evaluation-methods/custom-scores)) that can be added to traces, observations, sessions, and dataset runs at any time.
+<Callout type="warning">
+Do not attempt to update a trace or observation after ingestion by re-sending an event with the same `id`.
 
-## Updating Traces, Observations, and Scores
+In Langfuse v4, ingested data is **not deduplicated on the read path**, and the underlying storage does **not** guarantee consistency (not even eventual consistency) across records that share an `id`. Re-inserting therefore creates **duplicate records** rather than replacing the original. Duplicates inflate metrics (for example, `sum(totalCost)` in the Metrics API counts every version) and cause inconsistent results in dashboards, filtering, and exports.
+
+</Callout>
+
+This immutability applies to data that has already been ingested. Building up a trace over the course of a request — for example, updating a span with its output before the trace is flushed by the SDK — is normal, supported usage. The constraint only concerns re-ingesting data that Langfuse has already persisted.
+
+If you need to correct or re-process data, the recommended approach is to add the corrected information as [scores](/docs/evaluation/evaluation-methods/custom-scores) rather than mutating the original record.
+
+## Enriching data after ingestion [#enriching-data]
+
+There are two supported ways to add information to existing traces and observations without re-ingesting them:
+
+**Via scores**
+
+Use [scores](/docs/evaluation/evaluation-methods/custom-scores) to attach evaluations, annotations, or other metadata to traces, observations, sessions, and dataset runs at any time. This is the recommended way to enrich data after it has been ingested.
 
 **Via the Langfuse UI**
 
-UI-based updates ([tags](/docs/observability/features/tags), bookmarks, [publishing](/docs/observability/features/url)) can be made at any time for Traces and Scores.
+UI-based updates — [tags](/docs/observability/features/tags), bookmarks, and [publishing](/docs/observability/features/url) — can be applied to traces and scores at any time.
 
-**Via SDK or Ingestion API**
+## Updating scores [#updating-scores]
 
-- You can upsert traces, observations, and scores based on their `id` (and, optionally, `timestamp` for traces, `startTime` for observations, and `timestamp` for scores, respectively).
-- **Within 30 days of creation**, updates will be merged into the existing trace, observation, or score.
-- **After 30 days**, updates may create duplicate entries containing only the changed fields. This can lead to inconsistencies in dashboards and historical filtering.
-- Sending a full event with `id`, same `timestamp/startTime`, and all desired properties will always replace the existing record instead of producing a duplicate and is recommended for long-term updates.
+Unlike traces and observations, scores are designed to be added and overwritten. By default, Langfuse allows multiple scores with the same `name` on the same trace. To prevent duplicates or overwrite an existing score, pass a stable idempotency key as the `id` (JS/TS) / `score_id` (Python) when creating the score — for example `trace_id-score_name`.
 
-**Example behaviour**
-
-In the following code block, we run through multiple update cases and their expected results.
-We will pretend that only the first statement run in the context of each of the updates, i.e. the calls are not considered to be run in order.
-We will use traces as the example case, but the same applies to observations and scores.
-
-```bash
-## Create a new trace
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }
-
-## Send a delta-update within 30 days (e.g. on 2025-01-20). This updates the original trace.
-{ id: "foo", userId: "user_1" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace", userId: "user_1" }
-
-## Send a delta-update after more than 30 days (e.g. on 2025-05-01). This creates a duplicate record.
-{ id: "foo", userId: "user_2" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }, { id: "foo", timestamp: "2025-05-01T00:00:00Z", userId: "user_2" }
-
-## Send a delta-update after more than 30 days (e.g. on 2025-05-01) with the original timestamp. This will replace the original record.
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", userId: "user_3" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", userId: "user_3" }
-
-## Send a full replacement after more than 30 days (e.g. on 2025-05-01) with the original timestamp. This will replace the original record.
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace", userId: "user_4" }
--> { id: "foo", timestamp: "2025-01-01T00:00:00Z", name: "My Trace", userId: "user_4" }
-```
+See [Scores via SDK/API](/docs/evaluation/evaluation-methods/scores-via-sdk#preventing-duplicate-scores) for details.

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -387,11 +387,9 @@ Over time, this data accumulates and increases storage costs.
 It is recommended to configure a bucket lifecycle (expiration) policy to automatically delete objects after a defined number of days.
 
 <Callout type="warning">
-Langfuse uses raw event data from the bucket to merge the multiple ingestion events that make up a single trace, observation, or score into the final record.
-The bucket lifecycle expiration period determines how long related events can still be merged.
-Once the raw events are deleted by the lifecycle policy, later events for the same record can create duplicate entries instead of merging.
+Langfuse uses raw event data from the bucket for its **internal** ingestion processing — combining the multiple events an SDK emits for a single record (for example, the start and end events of one observation) into the final trace, observation, or score. The bucket lifecycle expiration period determines how long these related events can still be combined; once the raw events are deleted by the lifecycle policy, this internal reprocessing is no longer possible.
 
-On Langfuse Cloud, this is set to 30 days. Note that traces and observations should be treated as immutable once ingested — see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
+This governs Langfuse's internal event handling, **not** a user-facing update window. Traces and observations are immutable once ingested: re-sending an event with the same `id` to update a record is not supported and creates a duplicate regardless of the lifecycle period. On Langfuse Cloud, the retention period is 30 days. See [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
 
 </Callout>
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -387,11 +387,11 @@ Over time, this data accumulates and increases storage costs.
 It is recommended to configure a bucket lifecycle (expiration) policy to automatically delete objects after a defined number of days.
 
 <Callout type="warning">
-Langfuse uses raw event data from the bucket to merge delta-updates into existing traces, observations, and scores.
-The bucket lifecycle expiration period determines how long these updates can be merged into existing records.
-Once the raw events are deleted by the lifecycle policy, delta-updates will create duplicate entries instead of merging.
+Langfuse uses raw event data from the bucket to merge the multiple ingestion events that make up a single trace, observation, or score into the final record.
+The bucket lifecycle expiration period determines how long related events can still be merged.
+Once the raw events are deleted by the lifecycle policy, later events for the same record can create duplicate entries instead of merging.
 
-On Langfuse Cloud, this is set to 30 days. For details on update behavior, see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates).
+On Langfuse Cloud, this is set to 30 days. Note that traces and observations should be treated as immutable once ingested — see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
 
 </Callout>
 


### PR DESCRIPTION
Addresses [LFE-10636](https://linear.app/langfuse/issue/LFE-10636). Per the team decision in the ticket, we are fading out the guidance that suggested updating traces/observations by re-ingesting with the same `id`.

## Why
In Langfuse v4, ingested data is **not deduplicated on the read path**, and the underlying storage gives **no consistency guarantee** (not even eventual). Re-inserting with the same `id` therefore creates **duplicate records** rather than replacing the original — inflating metrics (e.g. `sum(totalCost)`) and corrupting dashboards, filtering, and exports.

## Changes
- **`faq/all/tracing-data-updates.mdx`** — rewritten around the immutable data model. Removed the 30-day merge / re-insert-to-replace instructions and the worked example. Added a strong warning, clarified that building a trace before flush is still normal usage, and pointed users to scores for post-ingestion enrichment.
- **`scores-via-sdk.mdx`** — removed the dead deep link + deprecated "same timestamp 30+ days apart" note; added explicit `[#preventing-duplicate-scores]` anchor.
- **`blobstorage.mdx`** — reframed the lifecycle callout away from "delta-updates" toward the accurate ingestion-merge behavior.
- **`export-to-blob-storage.mdx`** — pre-existing export-timing clarification carried on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies Langfuse's immutable data model for v4 by removing guidance that suggested updating traces and observations by re-ingesting with the same `id` (which creates duplicate records in v4 rather than replacing them) and replacing it with a clear warning callout and a redirect to scores as the supported enrichment path.

- **`tracing-data-updates.mdx`** is rewritten around immutability: the 30-day merge-window examples are removed, a `<Callout type="warning">` explains the v4 duplicate-creation risk, and the in-flight trace-building use case is explicitly called out as still valid.
- **`scores-via-sdk.mdx`** adds the `[#preventing-duplicate-scores]` anchor needed by the new cross-link, and removes the stale "same timestamp 30+ days apart" note.
- **`blobstorage.mdx`** reframes the lifecycle-policy callout from "delta-updates" to "merging multiple ingestion events," though the 30-day window language alongside the new immutability note creates a potential mixed signal for readers (see inline comment).
- **`export-to-blob-storage.mdx`** adds the new "Running" badge state, its 2-hour TTL safety-valve behaviour, and a more precise first-export timing sentence.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only changes with accurate core messaging; the one callout in blobstorage.mdx mixes an internal 30-day merging window with an immutability note in a way that could confuse self-hosting users.

The rewritten FAQ and the updated scores cross-link are clear and consistent. The blobstorage.mdx callout retains language about events merging within the lifecycle period alongside the new immutability note, which may inadvertently suggest the old update-by-re-insertion pattern still works within 30 days — the opposite of what this PR intends to communicate.

content/self-hosting/deployment/infrastructure/blobstorage.mdx — the Bucket Lifecycle Policies callout needs the internal-merging vs. user-facing-immutability distinction to be made explicit.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SDK / Ingestion API] -->|send events| B[Raw event bucket]
    B -->|merge within lifecycle window| C[Trace / Observation record in DB]
    C -->|immutable once persisted| D{Need to enrich?}
    D -->|yes| E[Create Score via SDK or API]
    D -->|UI edits only| F[Tags / Bookmarks / Publishing via Langfuse UI]
    E --> G[Score attached to Trace / Observation]
    A -->|re-insert same id in v4| H[⚠️ Duplicate record created not a replacement]
    H --> I[Inflated metrics, broken dashboards and exports]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SDK / Ingestion API] -->|send events| B[Raw event bucket]
    B -->|merge within lifecycle window| C[Trace / Observation record in DB]
    C -->|immutable once persisted| D{Need to enrich?}
    D -->|yes| E[Create Score via SDK or API]
    D -->|UI edits only| F[Tags / Bookmarks / Publishing via Langfuse UI]
    E --> G[Score attached to Trace / Observation]
    A -->|re-insert same id in v4| H[⚠️ Duplicate record created not a replacement]
    H --> I[Inflated metrics, broken dashboards and exports]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/self-hosting/deployment/infrastructure/blobstorage.mdx:389-395
**Mixed merging/immutability signals in the same callout**

The callout's first three sentences describe an internal lifecycle-based merging window ("later events for the same record can create duplicate entries instead of merging"), which implies that *within* 30 days, re-sending events with the same `id` still merges cleanly. The appended note then says "traces and observations should be treated as immutable once ingested." A reader configuring their own blob-storage lifecycle may read the 30-day window as confirming the old update-by-re-insertion pattern, directly contradicting the `tracing-data-updates.mdx` warning that v4 always creates duplicates on re-insertion regardless of the lifecycle period.

Consider making explicit that the lifecycle policy governs Langfuse's *internal* reprocessing of SDK events (e.g. for trace construction across multiple spans), not user-facing update semantics — and that v4 never merges a re-inserted event regardless of bucket age.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify immutable data model, remo..."](https://github.com/langfuse/langfuse-docs/commit/5fef9d299fff2db8436214623a615b34abb008da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41638409)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->