### PR TITLE
docs(openclaw): update plugin install and drop OpenTelemetry path

### DIFF
--- a/content/integrations/other/openclaw.mdx
+++ b/content/integrations/other/openclaw.mdx
@@ -2,7 +2,7 @@
 title: "Trace OpenClaw with Langfuse"
 sidebarTitle: OpenClaw
 logo: /images/integrations/openclaw_icon.svg
-description: "Trace your OpenClaw AI agent with Langfuse using the OpenClaw x Langfuse plugin, or OpenClaw's native OpenTelemetry export for full visibility into prompts, reasoning, tool calls, and costs."
+description: "Trace your OpenClaw AI agent with Langfuse using the OpenClaw x Langfuse plugin for full visibility into prompts, reasoning, tool calls, and costs."
 category: Integrations
 ---
 
@@ -12,7 +12,7 @@ category: Integrations
   width="100%"
   className="aspect-[16/9] rounded border w-full"
   src="https://www.youtube-nocookie.com/embed/lT8XsHg3uZA"
-  title="YouTube video player"
+  title="Add full observability to your OpenClaw agent with Langfuse"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
@@ -25,22 +25,15 @@ category: Integrations
 
 ## Why trace OpenClaw?
 
+An autonomous agent makes a lot of decisions you never see: which model it called, what it reasoned about, which skills and tools it reached for, and how much each turn cost. Tracing surfaces all of it.
+
 - **Understand agent behavior.** Read the prompts, reasoning traces, and tool calls that OpenClaw makes under the hood.
-- **Improve your agent.** Identify where the agent gets confused so you can tweak skills, system prompts, and configurations.
-- **Track costs.** Monitor spending across models and sessions.
+- **Improve your agent.** Spot where the agent gets confused so you can tweak skills, system prompts, and configurations.
+- **Track costs.** Monitor token usage and spend across models and sessions.
 
 ## Set up tracing
 
-There are two ways to send OpenClaw data to Langfuse. Pick the one that fits your needs:
-
-- **OpenClaw x Langfuse plugin** _(recommended)_ — install a plugin from [ClawHub](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin), paste your Langfuse keys, and you're done. It forwards model usage as Langfuse generations grouped by session, including token counts, costs, and errors.
-- **OpenTelemetry export** — point OpenClaw's native OTLP exporter at Langfuse for the full span tree (model calls, tool execution, skill usage, harness lifecycle, and context assembly). Choose this when you want complete agent observability rather than usage and cost tracking alone.
-
-<Tabs items={["OpenClaw x Langfuse plugin (recommended)", "OpenTelemetry export"]}>
-
-<Tab>
-
-The [OpenClaw x Langfuse plugin](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin) (the "Langfuse Bridge") subscribes to OpenClaw's internal diagnostics bus and translates `model.usage` and error events into Langfuse generations, grouped by OpenClaw session. Input and output text is recovered from session transcripts when available.
+The [OpenClaw x Langfuse plugin](https://clawhub.ai/codecls/plugins/openclaw-x-langfuse-plugin) (the "Langfuse Bridge") subscribes to OpenClaw's internal diagnostics bus and turns each conversation turn into a nested Langfuse trace, with separate observations for model calls, tool executions, and retrieval steps. Traces are grouped into Langfuse sessions and include token usage, cost, latency, and any errors. Install it, paste your Langfuse keys, and you're done — no proxy and no code changes.
 
 <Steps>
 
@@ -50,7 +43,7 @@ Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse]
 
 ### Install the plugin
 
-Install the plugin from ClawHub:
+Install the plugin from [ClawHub](https://clawhub.ai/codecls/plugins/openclaw-x-langfuse-plugin):
 
 ```bash
 openclaw plugins install clawhub:openclaw-x-langfuse-plugin
@@ -80,7 +73,7 @@ Enable the plugin in `openclaw.json` and provide your Langfuse credentials:
 
 `baseUrl` selects your Langfuse data region: 🇪🇺 EU `https://cloud.langfuse.com`, 🇺🇸 US `https://us.cloud.langfuse.com`, 🇯🇵 Japan `https://jp.cloud.langfuse.com`, ⚕️ HIPAA `https://hipaa.cloud.langfuse.com`, or your own URL for a 🏠 local deployment (e.g. `http://localhost:3000`).
 
-You can also supply the credentials through the `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` environment variables instead of putting them in `openclaw.json`.
+You can also supply the credentials through the `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` environment variables instead of putting them in `openclaw.json`. If the keys are missing, the plugin logs a warning and keeps running — it never blocks the gateway.
 
 ### Restart the gateway
 
@@ -92,79 +85,9 @@ openclaw gateway restart
 
 ### View traces in Langfuse
 
-Run OpenClaw as usual. Open your Langfuse project to see generations grouped by session, with token usage, costs, and any forwarded errors.
+Run OpenClaw as usual. Open your Langfuse project to see traces grouped by session, where you can inspect each turn's model calls, tool and skill executions, token usage, costs, and any forwarded errors.
 
 </Steps>
-
-</Tab>
-
-<Tab>
-
-OpenClaw has built-in [OpenTelemetry](https://docs.openclaw.ai/gateway/opentelemetry) export, and Langfuse is an [OpenTelemetry backend](/integrations/native/opentelemetry). Point OpenClaw's exporter directly at Langfuse's OTLP endpoint and traces flow in with no plugin, no proxy, and no code changes.
-
-Because the export happens inside OpenClaw itself, it is **model-agnostic** (it works whether you call Claude, GPT, DeepSeek, or a local model) and captures OpenClaw's full span tree: model calls, tool execution, skill usage, harness lifecycle, and context assembly, along with `gen_ai.*` attributes for model, token usage, and cost.
-
-<Callout type="info">
-  OpenClaw exports **OTLP over HTTP (`http/protobuf`)**, which is exactly what Langfuse's OTLP endpoint accepts. OpenClaw ignores `grpc`, and Langfuse does not support gRPC, so no extra configuration is needed.
-</Callout>
-
-<Steps>
-
-### Set up Langfuse
-
-Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting). Create a project and copy your public and secret API keys from the project settings.
-
-### Create your Basic Auth header
-
-Langfuse authenticates OTLP requests with [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Generate the header value by base64-encoding your keys as `public_key:secret_key`:
-
-```bash
-# macOS / BSD
-echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64
-# Linux / GNU (disable line wrapping)
-echo -n "pk-lf-1234567890:sk-lf-1234567890" | base64 -w 0
-```
-
-### Enable OpenTelemetry export in OpenClaw
-
-Add the `diagnostics.otel` block to your OpenClaw configuration, pointing it at the Langfuse OTLP endpoint and passing the auth header from the previous step:
-
-```json5
-{
-  diagnostics: {
-    enabled: true,
-    otel: {
-      enabled: true,
-      endpoint: "https://cloud.langfuse.com/api/public/otel", // 🇪🇺 EU data region
-      // Other Langfuse data regions: 🇺🇸 US https://us.cloud.langfuse.com/api/public/otel,
-      // 🇯🇵 Japan https://jp.cloud.langfuse.com/api/public/otel, ⚕️ HIPAA https://hipaa.cloud.langfuse.com/api/public/otel
-      // 🏠 Local deployment: http://localhost:3000/api/public/otel
-      protocol: "http/protobuf",
-      traces: true,
-      headers: {
-        Authorization: "Basic <AUTH_STRING>", // the base64 value from the previous step
-        "x-langfuse-ingestion-version": "4", // surfaces spans in real time in Fast Preview
-      },
-    },
-  },
-}
-```
-
-For the richest GenAI attributes, opt in to the latest OpenTelemetry GenAI semantic conventions by setting an environment variable before starting OpenClaw:
-
-```bash
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-```
-
-### View traces in Langfuse
-
-Run OpenClaw as usual. Open your Langfuse project to see captured traces, where you can inspect individual LLM calls, tool and skill executions, token usage, costs, and the full content of prompts and responses.
-
-</Steps>
-
-</Tab>
-
-</Tabs>
 
 <Callout type="info" title="Did you know?">
   Already routing OpenClaw's LLM calls through [OpenRouter](https://openrouter.ai/)? You can also capture traces without touching OpenClaw's config by connecting your Langfuse keys in [OpenRouter settings](https://openrouter.ai/settings) to enable [Broadcast](/integrations/gateways/openrouter#broadcast). Note that this only traces the LLM calls routed through OpenRouter, not OpenClaw's tool and skill spans.
@@ -172,7 +95,6 @@ Run OpenClaw as usual. Open your Langfuse project to see captured traces, where 
 
 ## Learn more
 
-- [OpenClaw x Langfuse plugin](https://clawhub.ai/plugins/openclaw-x-langfuse-plugin): Install and configuration details on ClawHub
-- [Langfuse OpenTelemetry endpoint](/integrations/native/opentelemetry): Endpoint, authentication, and supported protocols
+- [OpenClaw x Langfuse plugin](https://clawhub.ai/codecls/plugins/openclaw-x-langfuse-plugin): Install and configuration details on ClawHub
 - [Getting started with Langfuse](/docs/observability/get-started): Setting up API keys and projects
-- [OpenClaw OpenTelemetry docs](https://docs.openclaw.ai/gateway/opentelemetry): Full list of OTel configuration options
+- [OpenClaw documentation](https://docs.openclaw.ai): Configuration and plugin reference


### PR DESCRIPTION
Updates the [Trace OpenClaw with Langfuse](https://langfuse.com/integrations/other/openclaw) integration page against the [ClawHub plugin page](https://clawhub.ai/codecls/plugins/openclaw-x-langfuse-plugin) and the demo video.

## Changes

- **Fix ClawHub URLs** to the canonical `/codecls/plugins/...` path (3 occurrences).
- **Update the capture description** — the plugin (now v1.5.0) creates a nested trace per conversation turn with separate observations for model calls, tool executions, and retrieval steps, grouped into sessions with token usage, cost, latency, and errors. The previous copy undersold it as "generations grouped by session."
- **Remove the OpenTelemetry export path** — dropped the second tab, the "two ways" intro, the OTLP callout, the frontmatter mention, and the OTel "Learn more" link. The plugin now captures the full nested trace tree, so nothing is lost.
- **Slightly more engaging** — added a short lead-in to "Why trace OpenClaw?" and matched the iframe title to the video ("Add Full Observability to Your OpenClaw Agent with Langfuse").

Install command, `openclaw.json` config, env-var fallbacks, and `openclaw gateway restart` were verified correct against ClawHub — no changes needed there.

Net −78 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies the OpenClaw integration docs by removing the OpenTelemetry export path (now superseded by the v1.5.0 plugin's full nested-trace support) and fixing ClawHub URLs to the canonical `/codecls/plugins/…` path.

- **URL correction**: All three `clawhub.ai/plugins/…` links updated to the canonical `clawhub.ai/codecls/plugins/…` path.
- **Plugin description refresh**: Updated to reflect v1.5.0's per-turn nested traces with observations for model calls, tool executions, and retrieval steps — previously described as "generations grouped by session."
- **OTel tab removal**: Dropped the second tab, the `<Tabs>`/`<Tab>` wrappers, the OTLP callout, and OTel-specific "Learn more" links; the remaining `<Steps>` block is correctly unwrapped to top-level.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no executable code; all URLs are updated consistently and the MDX structure is valid after removing the Tabs wrapper.

All three ClawHub URLs are updated uniformly to the canonical path. The Tabs/Tab wrappers and the now-standalone Steps block render correctly without the tab container. The updated plugin description accurately reflects what the PR claims v1.5.0 provides, and no other integration pages were touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenClaw Agent] -->|diagnostics bus events| B[OpenClaw x Langfuse Plugin\n'Langfuse Bridge' v1.5.0]
    B -->|per conversation turn| C{Langfuse Trace}
    C --> D[Model Call Observation]
    C --> E[Tool Execution Observation]
    C --> F[Retrieval Step Observation]
    C --> G[Token Usage / Cost / Latency]
    C --> H[Errors]
    C -->|grouped by OpenClaw session| I[Langfuse Session]
    I --> J[Langfuse UI]
    subgraph config [Configuration]
        K[openclaw.json\npublicKey / secretKey / baseUrl]
        L[Env vars\nLANGFUSE_PUBLIC_KEY\nLANGFUSE_SECRET_KEY\nLANGFUSE_BASE_URL]
    end
    config --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OpenClaw Agent] -->|diagnostics bus events| B[OpenClaw x Langfuse Plugin\n'Langfuse Bridge' v1.5.0]
    B -->|per conversation turn| C{Langfuse Trace}
    C --> D[Model Call Observation]
    C --> E[Tool Execution Observation]
    C --> F[Retrieval Step Observation]
    C --> G[Token Usage / Cost / Latency]
    C --> H[Errors]
    C -->|grouped by OpenClaw session| I[Langfuse Session]
    I --> J[Langfuse UI]
    subgraph config [Configuration]
        K[openclaw.json\npublicKey / secretKey / baseUrl]
        L[Env vars\nLANGFUSE_PUBLIC_KEY\nLANGFUSE_SECRET_KEY\nLANGFUSE_BASE_URL]
    end
    config --> B
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(openclaw): update plugin install/li..."](https://github.com/langfuse/langfuse-docs/commit/e7701248a34d9bad7586e68fb58780037b720d3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41646066)</sub>

<!-- /greptile_comment -->