### PR TITLE
docs: clarify immutable data model, remove re-insert update guidance

### DIFF
--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -520,7 +520,7 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 By default, Langfuse allows for multiple scores of the same `name` on the same trace. This is useful if you'd like to track the evolution of a score over time or if e.g. you've received multiple user feedback scores on the same trace.
 
-In some cases, you want to prevent this behavior or update an existing score. This can be achieved by creating an **idempotency key** on the score and passing this as an `id` (JS/TS) / `score_id` (Python) when creating the score, for example `trace_id-score_name`.
+In some cases, you want to prevent this behavior or overwrite an existing score. A score is identified by three fields — its `id`, its `name`, and its date (`toDate(timestamp)`) — and a new score only replaces an existing one when all three match. To achieve this, create an **idempotency key** and pass it as the `id` (JS/TS) / `score_id` (Python) when creating the score (for example `trace_id-score_name`), and keep the `name` and `timestamp` unchanged across calls. If any of the three differs, you get an additional score rather than a replacement.
 
 See [How to update traces, observations, and scores](/faq/all/tracing-data-updates) for more details on Langfuse's immutable data model.
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -520,9 +520,13 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 By default, Langfuse allows for multiple scores of the same `name` on the same trace. This is useful if you'd like to track the evolution of a score over time or if e.g. you've received multiple user feedback scores on the same trace.
 
-In some cases, you want to prevent this behavior or overwrite an existing score. A score is identified by three fields — its `id`, its `name`, and its date (`toDate(timestamp)`) — and a new score only replaces an existing one when all three match. To achieve this, create an **idempotency key** and pass it as the `id` (JS/TS) / `score_id` (Python) when creating the score (for example `trace_id-score_name`), and keep the `name` and `timestamp` unchanged across calls. If any of the three differs, you get an additional score rather than a replacement.
+In some cases, you want to prevent this behavior or overwrite an existing score. A score is identified by three fields — its `id`, its `name`, and its date (`toDate(timestamp)`) — and a new score only replaces an existing one when all three match. To achieve this, create an **idempotency key** and pass it as the `id` (JS/TS) / `score_id` (Python) when creating the score (for example `trace_id-score_name`), and keep the `name` and `timestamp` unchanged across calls. If any of the three differs — for example the same `id` with a different `name` — you get an additional score rather than a replacement.
 
-See [How to update traces, observations, and scores](/faq/all/tracing-data-updates) for more details on Langfuse's immutable data model.
+<Callout type="warning">
+Do not send partial score updates (only the changed fields) and rely on Langfuse to merge them into the existing record. This merge only happens for a limited window after creation, is deprecated, and will be removed. Always send the complete score.
+</Callout>
+
+See [How to update traces, observations, and scores](/faq/all/tracing-data-updates#updating-scores) for more details on Langfuse's immutable data model.
 
 ### Enforcing a Score Config
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -516,13 +516,13 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 ## Advanced
 
-### Preventing Duplicate Scores
+### Preventing Duplicate Scores [#preventing-duplicate-scores]
 
 By default, Langfuse allows for multiple scores of the same `name` on the same trace. This is useful if you'd like to track the evolution of a score over time or if e.g. you've received multiple user feedback scores on the same trace.
 
 In some cases, you want to prevent this behavior or update an existing score. This can be achieved by creating an **idempotency key** on the score and passing this as an `id` (JS/TS) / `score_id` (Python) when creating the score, for example `trace_id-score_name`.
 
-Note that if you expect API calls for the same score to be 30+ days apart, you should also use the same timestamp. See [How to update traces, observations, and scores](/faq/all/tracing-data-updates#updating-traces-observations-and-scores) for more details.
+See [How to update traces, observations, and scores](/faq/all/tracing-data-updates) for more details on Langfuse's immutable data model.
 
 ### Enforcing a Score Config
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -938,9 +938,9 @@ For example, let's assume you'd like to ingest a text score to capture **reviewe
 
 ## Update Existing Scores via API/SDKs [#update]
 
-When creating a score, you can provide an optional `id` (JS/TS) / `score_id` (Python) parameter. This will update the score if it already exists within your project.
+When creating a score, you can provide an optional `id` (JS/TS) / `score_id` (Python) parameter. A re-ingested score overwrites an existing one only when its `id`, `name`, and `timestamp` (at date granularity, `toDate(timestamp)`) all match — a matching `id` alone is not sufficient, and any difference creates a duplicate instead of an update.
 
-If you want to update a score without needing to fetch the list of existing scores from Langfuse, you can set your own `id` parameter as an idempotency key when initially creating the score.
+To overwrite a score without fetching existing scores first, set a stable `id` as an idempotency key when initially creating the score, and keep the `name` and `timestamp` unchanged on subsequent calls. See [Preventing Duplicate Scores](#preventing-duplicate-scores) for details.
 
 ## Related guides
 

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -36,6 +36,8 @@ UI-based updates — [tags](/docs/observability/features/tags), bookmarks, and [
 
 ## Updating scores [#updating-scores]
 
-Unlike traces and observations, scores are designed to be added and overwritten. By default, Langfuse allows multiple scores with the same `name` on the same trace. To prevent duplicates or overwrite an existing score, pass a stable idempotency key as the `id` (JS/TS) / `score_id` (Python) when creating the score — for example `trace_id-score_name`.
+Unlike traces and observations, scores are designed to be added and overwritten. By default, Langfuse allows multiple scores with the same `name` on the same trace. To overwrite an existing score rather than create a duplicate, the new score must match the original on all three fields that identify it: its `id`, its `name`, and its date (`toDate(timestamp)`).
+
+In practice, pass a stable idempotency key as the `id` (JS/TS) / `score_id` (Python) — for example `trace_id-score_name` — and keep the `name` and `timestamp` unchanged across calls. If any of the three differs, you get a new score instead of a replacement.
 
 See [Scores via SDK/API](/docs/evaluation/evaluation-methods/scores-via-sdk#preventing-duplicate-scores) for details.

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -5,7 +5,7 @@ tags: [observability]
 
 # How to update traces, observations, and scores?
 
-Langfuse uses a **mostly immutable data model** for observability data (traces and observations in the Langfuse [data model](/docs/observability/data-model)). Once ingested, traces and observations should be treated as final and cannot be reliably updated.
+Langfuse treats [traces and observations](/docs/observability/data-model) as **immutable**. Once ingested, they are final and cannot be reliably updated.
 
 If you want to enrich traces or observations after they were ingested with evaluations or annotations, use [scores](/docs/evaluation/evaluation-methods/custom-scores). Scores can be added to traces, observations, sessions, and dataset runs at any time.
 

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -32,7 +32,7 @@ Use [scores](/docs/evaluation/evaluation-methods/custom-scores) to attach evalua
 
 **Via the Langfuse UI**
 
-UI-based updates — [tags](/docs/observability/features/tags), bookmarks, and [publishing](/docs/observability/features/url) — can be applied to traces and scores at any time.
+UI-based updates — bookmarks and [publishing](/docs/observability/features/url) — can be applied to traces and scores at any time. [Tags](/docs/observability/features/tags) are set at creation and follow the immutable data model, so they can't be edited in the UI afterward.
 
 ## Updating scores [#updating-scores]
 

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -36,8 +36,12 @@ UI-based updates — [tags](/docs/observability/features/tags), bookmarks, and [
 
 ## Updating scores [#updating-scores]
 
-Unlike traces and observations, scores are designed to be added and overwritten. By default, Langfuse allows multiple scores with the same `name` on the same trace. To overwrite an existing score rather than create a duplicate, the new score must match the original on all three fields that identify it: its `id`, its `name`, and its date (`toDate(timestamp)`).
+Unlike traces and observations, scores can be overwritten. A score is identified by three fields: its `id`, its `name`, and its `timestamp` at date granularity (`toDate(timestamp)`). A re-ingested score overwrites the existing one only when **all three match**. If any of them differs, you get a **separate** score, not an update.
 
-In practice, pass a stable idempotency key as the `id` (JS/TS) / `score_id` (Python) — for example `trace_id-score_name` — and keep the `name` and `timestamp` unchanged across calls. If any of the three differs, you get a new score instead of a replacement.
+This is easy to trip over: sending a score with the same `id` but a different `name` — or a `timestamp` that falls on a different calendar date — creates a duplicate record instead of overwriting the original. To reliably overwrite a score, always send the same `id` (a stable idempotency key such as `trace_id-score_name`), `name`, and `timestamp`, and include the full score payload rather than only the changed fields.
+
+<Callout type="warning">
+**Deprecated:** For up to 30 days after a score is created, Langfuse may merge a re-ingested score that shares the same `id` into the existing record, backfilling any fields you leave unset. This partial-update behavior is deprecated and will be removed in a future version — do not rely on it. Always send the complete score with a matching `id`, `name`, and `timestamp`.
+</Callout>
 
 See [Scores via SDK/API](/docs/evaluation/evaluation-methods/scores-via-sdk#preventing-duplicate-scores) for details.

--- a/content/faq/all/tracing-data-updates.mdx
+++ b/content/faq/all/tracing-data-updates.mdx
@@ -5,51 +5,37 @@ tags: [observability]
 
 # How to update traces, observations, and scores?
 
-This guide covers how to update traces, observations, and scores in Langfuse, highlighting differences between available update methods.
+Langfuse uses a **mostly immutable data model** for observability data (traces and observations in the Langfuse [data model](/docs/observability/data-model)). Once ingested, traces and observations should be treated as final and cannot be reliably updated.
 
-## What can I update?
+If you want to enrich traces or observations after they were ingested with evaluations or annotations, use [scores](/docs/evaluation/evaluation-methods/custom-scores). Scores can be added to traces, observations, sessions, and dataset runs at any time.
 
-Langfuse is moving to a mostly immutable data model for observability data (traces and observations in the Langfuse [data model](/docs/observability/data-model)).
+## Traces and observations are immutable [#traces-and-observations]
 
-If you want to enrich traces or observations after they were ingested with evaluations/annotations, please look into scores ([docs](/docs/evaluation/evaluation-methods/custom-scores)) that can be added to traces, observations, sessions, and dataset runs at any time.
+<Callout type="warning">
+Do not attempt to update a trace or observation after ingestion by re-sending an event with the same `id`.
 
-## Updating Traces, Observations, and Scores
+In Langfuse v4, ingested data is **not deduplicated on the read path**, and the underlying storage does **not** guarantee consistency (not even eventual consistency) across records that share an `id`. Re-inserting therefore creates **duplicate records** rather than replacing the original. Duplicates inflate metrics (for example, `sum(totalCost)` in the Metrics API counts every version) and cause inconsistent results in dashboards, filtering, and exports.
+
+</Callout>
+
+This immutability applies to data that has already been ingested. Building up a trace over the course of a request — for example, updating a span with its output before the trace is flushed by the SDK — is normal, supported usage. The constraint only concerns re-ingesting data that Langfuse has already persisted.
+
+If you need to correct or re-process data, the recommended approach is to add the corrected information as [scores](/docs/evaluation/evaluation-methods/custom-scores) rather than mutating the original record.
+
+## Enriching data after ingestion [#enriching-data]
+
+There are two supported ways to add information to existing traces and observations without re-ingesting them:
+
+**Via scores**
+
+Use [scores](/docs/evaluation/evaluation-methods/custom-scores) to attach evaluations, annotations, or other metadata to traces, observations, sessions, and dataset runs at any time. This is the recommended way to enrich data after it has been ingested.
 
 **Via the Langfuse UI**
 
-UI-based updates ([tags](/docs/observability/features/tags), bookmarks, [publishing](/docs/observability/features/url)) can be made at any time for Traces and Scores.
+UI-based updates — [tags](/docs/observability/features/tags), bookmarks, and [publishing](/docs/observability/features/url) — can be applied to traces and scores at any time.
 
-**Via SDK or Ingestion API**
+## Updating scores [#updating-scores]
 
-- You can upsert traces, observations, and scores based on their `id` (and, optionally, `timestamp` for traces, `startTime` for observations, and `timestamp` for scores, respectively).
-- **Within 30 days of creation**, updates will be merged into the existing trace, observation, or score.
-- **After 30 days**, updates may create duplicate entries containing only the changed fields. This can lead to inconsistencies in dashboards and historical filtering.
-- Sending a full event with `id`, same `timestamp/startTime`, and all desired properties will always replace the existing record instead of producing a duplicate and is recommended for long-term updates.
+Unlike traces and observations, scores are designed to be added and overwritten. By default, Langfuse allows multiple scores with the same `name` on the same trace. To prevent duplicates or overwrite an existing score, pass a stable idempotency key as the `id` (JS/TS) / `score_id` (Python) when creating the score — for example `trace_id-score_name`.
 
-**Example behaviour**
-
-In the following code block, we run through multiple update cases and their expected results.
-We will pretend that only the first statement run in the context of each of the updates, i.e. the calls are not considered to be run in order.
-We will use traces as the example case, but the same applies to observations and scores.
-
-```bash
-## Create a new trace
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }
-
-## Send a delta-update within 30 days (e.g. on 2025-01-20). This updates the original trace.
-{ id: "foo", userId: "user_1" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace", userId: "user_1" }
-
-## Send a delta-update after more than 30 days (e.g. on 2025-05-01). This creates a duplicate record.
-{ id: "foo", userId: "user_2" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace" }, { id: "foo", timestamp: "2025-05-01T00:00:00Z", userId: "user_2" }
-
-## Send a delta-update after more than 30 days (e.g. on 2025-05-01) with the original timestamp. This will replace the original record.
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", userId: "user_3" }
--> { id: "foo", timestamp: "2025-01-01T12:00:00Z", userId: "user_3" }
-
-## Send a full replacement after more than 30 days (e.g. on 2025-05-01) with the original timestamp. This will replace the original record.
-{ id: "foo", timestamp: "2025-01-01T12:00:00Z", name: "My Trace", userId: "user_4" }
--> { id: "foo", timestamp: "2025-01-01T00:00:00Z", name: "My Trace", userId: "user_4" }
-```
+See [Scores via SDK/API](/docs/evaluation/evaluation-methods/scores-via-sdk#preventing-duplicate-scores) for details.

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -387,11 +387,9 @@ Over time, this data accumulates and increases storage costs.
 It is recommended to configure a bucket lifecycle (expiration) policy to automatically delete objects after a defined number of days.
 
 <Callout type="warning">
-Langfuse uses raw event data from the bucket to merge delta-updates into existing traces, observations, and scores.
-The bucket lifecycle expiration period determines how long these updates can be merged into existing records.
-Once the raw events are deleted by the lifecycle policy, delta-updates will create duplicate entries instead of merging.
+Langfuse uses raw event data from the bucket for its **internal** ingestion processing — combining the multiple events an SDK emits for a single record (for example, the start and end events of one observation) into the final trace, observation, or score. The bucket lifecycle expiration period determines how long these related events can still be combined; once the raw events are deleted by the lifecycle policy, this internal reprocessing is no longer possible.
 
-On Langfuse Cloud, this is set to 30 days. For details on update behavior, see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates).
+This governs Langfuse's internal event handling, **not** a user-facing update window. Traces and observations are immutable once ingested: re-sending an event with the same `id` to update a record is not supported and creates a duplicate regardless of the lifecycle period. On Langfuse Cloud, the retention period is 30 days. See [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
 
 </Callout>
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -387,9 +387,9 @@ Over time, this data accumulates and increases storage costs.
 It is recommended to configure a bucket lifecycle (expiration) policy to automatically delete objects after a defined number of days.
 
 <Callout type="warning">
-Langfuse uses raw event data from the bucket for its **internal** ingestion processing — combining the multiple events an SDK emits for a single record (for example, the start and end events of one observation) into the final trace, observation, or score. The bucket lifecycle expiration period determines how long these related events can still be combined; once the raw events are deleted by the lifecycle policy, this internal reprocessing is no longer possible.
+Langfuse keeps these raw events so it can finish assembling and, if needed, reprocess records. Set your lifecycle expiration no shorter than the window over which related events for a single record may arrive — on Langfuse Cloud this is 30 days. If events expire too early, Langfuse may be unable to reconstruct the full record.
 
-This governs Langfuse's internal event handling, **not** a user-facing update window. Traces and observations are immutable once ingested: re-sending an event with the same `id` to update a record is not supported and creates a duplicate regardless of the lifecycle period. On Langfuse Cloud, the retention period is 30 days. See [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
+Note that this retention window is not a way to update data. Traces and observations are immutable once ingested; see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
 
 </Callout>
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -387,9 +387,9 @@ Over time, this data accumulates and increases storage costs.
 It is recommended to configure a bucket lifecycle (expiration) policy to automatically delete objects after a defined number of days.
 
 <Callout type="warning">
-Langfuse keeps these raw events so it can finish assembling and, if needed, reprocess records. Set your lifecycle expiration no shorter than the window over which related events for a single record may arrive — on Langfuse Cloud this is 30 days. If events expire too early, Langfuse may be unable to reconstruct the full record.
+Langfuse re-reads raw events from the bucket to retry failed ingestion jobs, for replay/disaster recovery, and — on the legacy `/api/public/ingestion` path — to combine incremental events sent for the same record. Size your lifecycle expiration to cover these needs (30 days on Langfuse Cloud). OpenTelemetry ingestion is self-contained (each span is a single complete event), so it does not depend on this retention for assembling records.
 
-Note that this retention window is not a way to update data. Traces and observations are immutable once ingested; see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
+This retention window is not a way to update data. Traces and observations are immutable once ingested; see [How to update traces, observations, and scores?](/faq/all/tracing-data-updates) for details.
 
 </Callout>
 


### PR DESCRIPTION
Addresses [LFE-10636](https://linear.app/langfuse/issue/LFE-10636). Per the team decision in the ticket, we are fading out the guidance that suggested updating traces/observations by re-ingesting with the same `id`.

Replaces #3228, which was accidentally branched on top of the unrelated `docs/blob-storage-running-status` work. This branch is cut from a fresh `main` and contains only the data-updates changes.

## Why
In Langfuse v4, ingested data is **not deduplicated on the read path**, and the underlying storage gives **no consistency guarantee** (not even eventual). Re-inserting with the same `id` therefore creates **duplicate records** rather than replacing the original — inflating metrics (e.g. `sum(totalCost)`) and corrupting dashboards, filtering, and exports.

## Changes
- **`faq/all/tracing-data-updates.mdx`** — rewritten around the immutable data model. Removed the 30-day merge / re-insert-to-replace instructions and the worked example. Added a strong warning, clarified that building a trace before flush is still normal usage, and pointed users to scores for post-ingestion enrichment.
- **`scores-via-sdk.mdx`** — removed the dead deep link + deprecated "same timestamp 30+ days apart" note; added explicit `[#preventing-duplicate-scores]` anchor.
- **`blobstorage.mdx`** — reframed the lifecycle callout to make clear the retention window governs Langfuse's *internal* event reprocessing, not a user-facing update window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rewrites the `tracing-data-updates` FAQ to document Langfuse v4's immutable data model for traces and observations, removes the now-incorrect 30-day merge / re-insert-to-replace guidance, and updates two cross-referencing pages to match.

- **`tracing-data-updates.mdx`**: Replaced the old upsert-by-ID guidance with an explicit warning callout, a clear immutability statement, and a redirect to scores for post-ingestion enrichment. The \"building up a trace before SDK flush is fine\" carve-out is accurate but doesn't define the boundary precisely enough for multi-turn sessions.
- **`scores-via-sdk.mdx`**: Adds a stable `[#preventing-duplicate-scores]` anchor and replaces the deleted \"30+ days apart\" footnote with a link to the updated FAQ.
- **`blobstorage.mdx`**: Reframes the lifecycle callout to clarify the 30-day window is an internal event-reprocessing window, not a user-facing update window.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The docs changes are safe to merge; the primary risk is that the showcase chatbot blog post now actively contradicts the new guidance and could lead v4 users to corrupt their trace data.

The three changed files are accurate and well-structured. The outstanding concern is content/blog/showcase-llm-chatbot.mdx, which still explicitly advises re-using the same trace ID across conversation turns and describes it as an upsert — exactly the pattern v4 breaks with silent duplicate creation. A user following both documents would get conflicting, potentially damaging guidance.

content/blog/showcase-llm-chatbot.mdx — still documents the now-broken re-use-trace-id-as-upsert pattern and should be updated or annotated alongside this PR.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SDK emits event] --> B{Already ingested\nby Langfuse?}
    B -- No / in-flight batch --> C[Normal SDK build-up\ne.g. start + end of one span]
    B -- Yes, already persisted --> D[Re-insert with same id]
    D --> E[⚠️ Creates DUPLICATE record\nnot an update]
    E --> F[Inflated metrics / corrupt dashboards]
    C --> G[Langfuse persists record\n→ now immutable]
    G --> H{Need to enrich?}
    H -- Evaluations / annotations --> I[Add a Score\nat any time]
    H -- Tags / bookmarks --> J[Use the Langfuse UI]
    H -- Correct raw data --> K[Not supported — data is immutable]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SDK emits event] --> B{Already ingested\nby Langfuse?}
    B -- No / in-flight batch --> C[Normal SDK build-up\ne.g. start + end of one span]
    B -- Yes, already persisted --> D[Re-insert with same id]
    D --> E[⚠️ Creates DUPLICATE record\nnot an update]
    E --> F[Inflated metrics / corrupt dashboards]
    C --> G[Langfuse persists record\n→ now immutable]
    G --> H{Need to enrich?}
    H -- Evaluations / annotations --> I[Add a Score\nat any time]
    H -- Tags / bookmarks --> J[Use the Langfuse UI]
    H -- Correct raw data --> K[Not supported — data is immutable]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/faq/all/tracing-data-updates.mdx:21
**In-flight trace boundary is undefined for long-lived sessions**

The document explains that building up a trace "before the trace is flushed by the SDK" is normal usage, but does not define when the flush occurs or what signals it. For short-lived request/response traces this is obvious, but for long-lived agentic workflows or chatbots (where users may call `trace()` repeatedly over multiple turns with the same ID, as the showcase chatbot blog post still recommends), the boundary between "building up before flush" and "re-inserting after ingestion" is unclear. Adding a short note — e.g. "once the SDK sends the batch and Langfuse stores the event, that record is immutable; do not reuse an existing trace `id` across separate SDK sessions or requests" — would prevent this grey area from being exploited unintentionally.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify immutable data model, remo..."](https://github.com/langfuse/langfuse-docs/commit/da95c22227686ccdeed1a310544117c7c7f663a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41649755)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->