### PR TITLE
disable-ai-eng-banner

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -2,21 +2,22 @@ import Link from "next/link";
 import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 
 export function Banner() {
-  return (
-    <FumadocsBanner
-      id="fd-top-banner-ai-engineer-world-fair-2026"
-      height="2rem"
-      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
-    >
-      <Link href="https://www.ai.engineer/worldsfair">
-        <span className="sm:hidden">
-          Langfuse @ AI Engineer · Booth LG-39 →
-        </span>
-        <span className="hidden sm:inline">
-          Langfuse @ AI Engineer World Fair in San Francisco · Find us at booth
-          LG-39 →
-        </span>
-      </Link>
-    </FumadocsBanner>
-  );
+  return null;
+  // return (
+  //   <FumadocsBanner
+  //     id="fd-top-banner-ai-engineer-world-fair-2026"
+  //     height="2rem"
+  //     className="bg-black text-white [&_a]:text-white [&_button]:text-white"
+  //   >
+  //     <Link href="https://www.ai.engineer/worldsfair">
+  //       <span className="sm:hidden">
+  //         Langfuse @ AI Engineer · Booth LG-39 →
+  //       </span>
+  //       <span className="hidden sm:inline">
+  //         Langfuse @ AI Engineer World Fair in San Francisco · Find us at booth
+  //         LG-39 →
+  //       </span>
+  //     </Link>
+  //   </FumadocsBanner>
+  // );
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables the AI Engineer World Fair 2026 top-of-page banner by making the `Banner` component return `null` instead of the event-specific JSX.

- The `Link` and `FumadocsBanner` imports are left in place but are now unused, which may trigger a lint error depending on the ESLint configuration.
- The old banner JSX is commented out rather than removed, leaving dead code in the file that could simply be deleted since git history preserves it.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change safely hides the banner, but leaves two unused imports that could fail a lint check in CI.

The banner is effectively disabled and the logic change is correct. The unused `Link` and `FumadocsBanner` imports introduced by commenting out the code rather than deleting it may cause a lint failure, depending on how strict the project's ESLint rules are. The commented-out block is harmless but is unnecessary dead code.

components/layout/Banner.tsx — unused imports and commented-out dead code should be cleaned up.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page renders Banner component] --> B{return null}
    B -->|Before this PR| C[Render FumadocsBanner with AI Engineer event link]
    B -->|After this PR| D[Render nothing - banner hidden]
    C --> E[Visible top banner on all docs pages]
    D --> F[No banner displayed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Page renders Banner component] --> B{return null}
    B -->|Before this PR| C[Render FumadocsBanner with AI Engineer event link]
    B -->|After this PR| D[Render nothing - banner hidden]
    C --> E[Visible top banner on all docs pages]
    D --> F[No banner displayed]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/layout/Banner.tsx:1-5
The `Link` and `FumadocsBanner` imports are now unreachable — the code that consumed them is commented out — leaving two unused imports at the top of the file. Many Next.js/ESLint setups treat `no-unused-vars` as an error, which would cause a lint failure on this file.

```suggestion
export function Banner() {
  return null;
```

### Issue 2 of 2
components/layout/Banner.tsx:5-23
The old banner JSX is left as a large block of commented-out code. Since the event has passed and the intent is to disable the banner, removing the dead code entirely would keep the file clean — version control preserves the history if the snippet is needed again later.

```suggestion
  return null;
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["disable-ai-eng-banner"](https://github.com/langfuse/langfuse-docs/commit/8a87490e16663faf122d41398239a9ee847c4a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41686208)</sub>

<!-- /greptile_comment -->