### PR TITLE
move goat banner

### DIFF
--- a/components/home/layout/RightSidebarHiringAndCommunity.tsx
+++ b/components/home/layout/RightSidebarHiringAndCommunity.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { HiringBadge } from "@/components/HiringBadge";
 import TocCommunity from "@/components/TocCommunity";
 
 type RightSidebarHiringAndCommunityProps = {
   /**
    * When the block is not under a previous section with `pb-px bg-line-structure`
    * (e.g. blog right aside: spacer + footer), a full-width top rule is needed so
-   * the hiring row does not look flush/buggy next to the main nav surface. Home
+   * the community row does not look flush next to the main nav surface. Home
    * `HomeAside` already gets a 1px rule from the TOC block above, so keep false.
    */
   withTopRule?: boolean;
 };
 
 /**
- * Hiring + community strip for marketing right sidebars (HomeLayout + PageChrome).
- * The marketing `Navbar` has no hiring badge; `NavbarDocs` shows it in the top
- * bar — so docs layouts should not render this block (they use fumadocs TOC only).
+ * Community strip for marketing right sidebars (HomeLayout + PageChrome).
+ * The hiring badge lives in the marketing `Navbar` (left of Product); docs
+ * layouts use `NavbarDocs` instead and should not render this block.
  */
 export function RightSidebarHiringAndCommunity({
   withTopRule = false,
@@ -26,11 +25,6 @@ export function RightSidebarHiringAndCommunity({
       {withTopRule && (
         <div className="h-px w-full bg-line-structure shrink-0" aria-hidden />
       )}
-      <div className="pb-px bg-line-structure">
-        <div className="px-3 py-3 rounded-sm bg-surface-1">
-          <HiringBadge />
-        </div>
-      </div>
       <div className="bg-line-structure">
         <div className="rounded-sm bg-surface-1">
           <TocCommunity />

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,3 +1,4 @@
+import { HiringBadge } from "@/components/HiringBadge";
 import { NavbarExtraContent } from "@/components/NavbarExtraContent";
 import { NavLinks } from "@/components/NavLinks";
 import { type SectionNavData } from "@/lib/nav-tree";
@@ -40,9 +41,12 @@ export function Navbar() {
         <div className={cn(cornersStyle, "hidden relative px-0 lg:flex")}>
           <div className="absolute bottom-[-6px] left-0 w-[6px] h-[5px] bg-left-corner" />
           <div className="absolute hidden wide:block bottom-[-6px] right-0 w-[6px] h-[5px] bg-right-corner" />
-          <div className="flex flex-row-reverse flex-1 gap-2 px-2.5 py-3 rounded-sm md:flex-row md:items-center md:justify-center md:gap-4 bg-surface-1">
-            <InkeepSearchBar className="hidden" />
-            <NavLinks sectionNavData={sectionNavData} />
+          <div className="flex flex-1 gap-2 items-center px-2.5 py-3 rounded-sm bg-surface-1">
+            <HiringBadge className="shrink-0" />
+            <div className="flex flex-1 justify-center items-center min-w-0 gap-4">
+              <InkeepSearchBar className="hidden" />
+              <NavLinks sectionNavData={sectionNavData} />
+            </div>
           </div>
         </div>
         <div


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the `HiringBadge` ("GOAT" hiring banner) from the right marketing sidebar into the main `Navbar`, placing it to the left of the centered nav links. The sidebar component's comments are updated to reflect that it now only renders the community strip.

- `Navbar.tsx` gains a `HiringBadge` with `shrink-0` inside a restructured flex layout; the badge is correctly guarded by the parent's `hidden … lg:flex` container so it only appears at large breakpoints.
- `RightSidebarHiringAndCommunity.tsx` drops the `HiringBadge` block but retains its old name and a `"use client"` directive that appears to be a leftover from before the removal.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the badge simply relocates from the sidebar to the navbar with no logic changes.

The layout refactor and badge relocation look correct. The two leftover artifacts in `RightSidebarHiringAndCommunity.tsx` — the stale "Hiring" in the component/type names and the unnecessary `"use client"` directive — are cosmetic and do not affect runtime behaviour.

`components/home/layout/RightSidebarHiringAndCommunity.tsx` — name and `"use client"` directive should be cleaned up.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (HiringBadge in sidebar)"]
        N1[Navbar] --> NL1[NavLinks]
        RS1[RightSidebarHiringAndCommunity] --> HB1[HiringBadge]
        RS1 --> TC1[TocCommunity]
    end

    subgraph After["After (HiringBadge moved to Navbar)"]
        N2[Navbar] --> HB2[HiringBadge]
        N2 --> NL2[NavLinks]
        RS2[RightSidebarHiringAndCommunity] --> TC2[TocCommunity]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (HiringBadge in sidebar)"]
        N1[Navbar] --> NL1[NavLinks]
        RS1[RightSidebarHiringAndCommunity] --> HB1[HiringBadge]
        RS1 --> TC1[TocCommunity]
    end

    subgraph After["After (HiringBadge moved to Navbar)"]
        N2[Navbar] --> HB2[HiringBadge]
        N2 --> NL2[NavLinks]
        RS2[RightSidebarHiringAndCommunity] --> TC2[TocCommunity]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/home/layout/RightSidebarHiringAndCommunity.tsx:5-13
The component and its prop type still include "Hiring" in their names even though the hiring badge has been removed. The comments have been updated correctly, but the exported identifier and the type alias still mislead callers and any future search for hiring-related UI.

```suggestion
type RightSidebarCommunityProps = {
  /**
   * When the block is not under a previous section with `pb-px bg-line-structure`
   * (e.g. blog right aside: spacer + footer), a full-width top rule is needed so
   * the community row does not look flush next to the main nav surface. Home
   * `HomeAside` already gets a 1px rule from the TOC block above, so keep false.
   */
  withTopRule?: boolean;
};
```

### Issue 2 of 2
components/home/layout/RightSidebarHiringAndCommunity.tsx:1-3
The `"use client"` directive was likely here to support `HiringBadge`'s hooks. With `HiringBadge` removed, neither `RightSidebarHiringAndCommunity` nor `TocCommunity` directly uses any React hooks or browser APIs — `TocCommunity`'s own client sub-component (`AskAIButton`) carries its own boundary. Keeping `"use client"` unnecessarily opts the entire module into the client bundle.

```suggestion
import TocCommunity from "@/components/TocCommunity";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["move goat banner"](https://github.com/langfuse/langfuse-docs/commit/495edfdb9fe58113b63a97abe5ffcc35fcfd3153) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41688377)</sub>

<!-- /greptile_comment -->