### PR TITLE
docs: replace evaluation loop image with LoopDiagram component

### DIFF
--- a/content/docs/evaluation/core-concepts.mdx
+++ b/content/docs/evaluation/core-concepts.mdx
@@ -22,10 +22,7 @@ LLM applications often have a constant loop of testing and monitoring.
 
 **Online evaluation** scores live traces to catch issues in real traffic. When you find edge cases your dataset didn't cover, you add them back to your dataset so future experiments will catch them.
 
-<Frame fullWidth>
-  ![The Continuous Evaluation/Iteration
-  Loop](/images/docs/evaluation/continuous-evaluation-loop.png)
-</Frame>
+<LoopDiagram />
 
 > **Here's an example workflow** for building a customer support chatbot
 >


### PR DESCRIPTION
Replaces the static continuous-evaluation-loop image on the evaluation core concepts page with the interactive `<LoopDiagram />` component used in the academy. This gives the docs page the same loop graph, with Online/Offline labels, per-stage meta tags, cycling activity indicator, and links into the academy stages.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces the static `continuous-evaluation-loop.png` image (wrapped in a `<Frame>`) with the interactive `<LoopDiagram />` component on the evaluation core-concepts page.

- `LoopDiagram` is already registered globally in `mdx-components.tsx`, so no import is needed in the MDX file — the component will resolve correctly.
- The component renders an animated, responsive loop diagram with Online/Offline labels, per-stage meta tags, a cycling activity indicator, and links to the corresponding academy stages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line docs change swapping a static image for an already-registered interactive component.

The only change is removing 4 lines (a `<Frame>` wrapping a PNG) and adding `<LoopDiagram />`. The component is globally registered in `mdx-components.tsx` so it resolves without an explicit import, it is already live on `overview.mdx` and multiple academy pages, and no logic or configuration is affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    subgraph Online["Online Evaluation"]
        T["Trace\n(traces · sessions · agents · prompts)"]
        M["Monitor\n(dashboards · LLM-as-judge · feedback)"]
    end
    subgraph Offline["Offline Evaluation"]
        D["Build Datasets\n(datasets · features-as-tests)"]
        E["Experiment\n(prompts · models · code variants)"]
        EV["Evaluate\n(judges · custom evals · annotation)"]
    end
    T --> M --> D --> E --> EV
    EV -- Deploy --> T
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
    subgraph Online["Online Evaluation"]
        T["Trace\n(traces · sessions · agents · prompts)"]
        M["Monitor\n(dashboards · LLM-as-judge · feedback)"]
    end
    subgraph Offline["Offline Evaluation"]
        D["Build Datasets\n(datasets · features-as-tests)"]
        E["Experiment\n(prompts · models · code variants)"]
        EV["Evaluate\n(judges · custom evals · annotation)"]
    end
    T --> M --> D --> E --> EV
    EV -- Deploy --> T
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: replace evaluation loop image with..."](https://github.com/langfuse/langfuse-docs/commit/93adc718148eed8718730e95ee9426a3bb0bf603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41811038)</sub>

<!-- /greptile_comment -->