### PR TITLE
fix(docs): redirect legacy python instrumentation path

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -153,6 +153,7 @@ const nonPermanentRedirects = [
   ["/docs/guides/sdk-integration", "/docs/sdk/overview"],
   ["/docs/sdk", "/docs/sdk/overview"],
   ["/docs/sdk/python", "/docs/observability/sdk/overview"],
+  ["/docs/sdk/python/instrumentation", "/docs/observability/sdk/instrumentation"],
   ["/cookbook", "/guides"],
   ["/cookbook/:path*", "/guides/cookbook/:path*"],
   ["/docs/sdk/typescript", "/docs/sdk/typescript/guide"],


### PR DESCRIPTION
## Summary

Adds a missing redirect for the legacy Python SDK instrumentation URL:

- `/docs/sdk/python/instrumentation` -> `/docs/observability/sdk/instrumentation`

This addresses https://github.com/langfuse/langfuse-docs/issues/3222.

## Verification

- `node -e "<redirect assertion>"` confirmed the new redirect resolves to `/docs/observability/sdk/instrumentation`
- `node -c lib/redirects.js`
- `git diff --check HEAD^ HEAD`

Note: I attempted a full locked `pnpm install --frozen-lockfile` to run the repo formatter, but dependency linking on the Windows-mounted checkout stayed active for an extended period and was terminated. The one-line addition matches the surrounding redirect table style, and the targeted syntax/redirect/whitespace checks passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds one missing redirect entry to `lib/redirects.js` to handle the legacy Python SDK instrumentation path (`/docs/sdk/python/instrumentation`) that previously returned a 404. The destination page (`/docs/observability/sdk/instrumentation`) exists in the content tree and matches the pattern of the adjacent `/docs/sdk/python` → `/docs/observability/sdk/overview` redirect.

- The source path had no wildcard parent redirect covering sub-paths, so the 404 was genuine; this entry correctly fills the gap.
- The destination file `content/docs/observability/sdk/instrumentation.mdx` exists and is already the target for related hash-anchor redirects further down in the same file (lines ~1147–1165).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A single-line redirect addition to a well-established table; the destination page exists and the source had no existing wildcard coverage.

The change adds one entry that correctly maps a previously broken legacy URL to an existing destination page. The destination is confirmed by content/docs/observability/sdk/instrumentation.mdx, the placement is consistent with the surrounding redirect table, and there are no conflicts with wildcard rules or duplicate entries.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits /docs/sdk/python/instrumentation\n(legacy URL)"] -->|"New redirect (this PR)"| B["/docs/observability/sdk/instrumentation"]
    C["User visits /docs/sdk/python\n(existing redirect)"] -->|"Already covered"| D["/docs/observability/sdk/overview"]
    E["User visits /docs/observability/sdk/python/instrumentation\n(interim path)"] -->|"Existing redirect"| B
    B --> F["content/docs/observability/sdk/instrumentation.mdx\n(page exists ✓)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User visits /docs/sdk/python/instrumentation\n(legacy URL)"] -->|"New redirect (this PR)"| B["/docs/observability/sdk/instrumentation"]
    C["User visits /docs/sdk/python\n(existing redirect)"] -->|"Already covered"| D["/docs/observability/sdk/overview"]
    E["User visits /docs/observability/sdk/python/instrumentation\n(interim path)"] -->|"Existing redirect"| B
    B --> F["content/docs/observability/sdk/instrumentation.mdx\n(page exists ✓)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): redirect legacy python instru..."](https://github.com/langfuse/langfuse-docs/commit/664ae21d55fa419375b0e80f400b6f46488dbccc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41886368)</sub>

<!-- /greptile_comment -->