### PR TITLE
feat(navbar): keyboard shortcuts for Launch App region dropdown

### DIFF
--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/cloud-regions";
 import { useCloudRegionSignIn } from "@/lib/use-cloud-region-sign-in";
 import { isCloudAppHref } from "@/lib/google-ads";
+import { reportLaunchAppConversion } from "@/lib/ad-conversions";
 
 const REGION_SHORTCUTS: Partial<Record<CloudRegionKey, string>> = {
   us: "U",
@@ -162,6 +163,7 @@ function MultiRegionButton({
       );
       if (match) {
         e.preventDefault();
+        reportLaunchAppConversion();
         window.location.href = match.url;
         setOpen(false);
       }

--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Plus, Loader2 } from "lucide-react";
@@ -19,6 +19,13 @@ import {
 } from "@/lib/cloud-regions";
 import { useCloudRegionSignIn } from "@/lib/use-cloud-region-sign-in";
 import { isCloudAppHref } from "@/lib/google-ads";
+
+const REGION_SHORTCUTS: Partial<Record<CloudRegionKey, string>> = {
+  us: "U",
+  hipaa: "H",
+  eu: "E",
+  jp: "J",
+};
 
 function isEditableElement(el: Element | null): boolean {
   if (!el) return false;
@@ -128,16 +135,38 @@ function MultiRegionButton({
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
+  const visibleRegions = useMemo(
+    () =>
+      cloudRegionSelectorOrder
+        .filter((key) => signedInRegions[key])
+        .map((key) => ({ key, ...cloudRegions[key] })),
+    [signedInRegions],
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.key.toLowerCase() !== "l") return;
       if (isEditableTarget(e.target)) return;
-      if (open) return;
-      e.preventDefault();
-      setOpen(true);
+
+      if (!open) {
+        if (e.key.toLowerCase() === "l") {
+          e.preventDefault();
+          setOpen(true);
+        }
+        return;
+      }
+
+      const match = visibleRegions.find(
+        ({ key }) =>
+          REGION_SHORTCUTS[key]?.toLowerCase() === e.key.toLowerCase(),
+      );
+      if (match) {
+        e.preventDefault();
+        window.location.href = match.url;
+        setOpen(false);
+      }
     },
-    [open],
+    [open, visibleRegions],
   );
 
   useEffect(() => {
@@ -164,18 +193,21 @@ function MultiRegionButton({
           triggerRef.current?.focus();
         }}
       >
-        {cloudRegionSelectorOrder.map((key) => {
-          const region = cloudRegions[key];
-          return (
-            signedInRegions[key] && (
-              <DropdownMenuItem asChild key={key}>
-                <Link href={region.url} data-launch-app-cta="">
-                  {region.label}
-                </Link>
-              </DropdownMenuItem>
-            )
-          );
-        })}
+        {visibleRegions.map(({ key, label, url }) => (
+          <DropdownMenuItem asChild key={key}>
+            <Link href={url} data-launch-app-cta="">
+              {label}
+              {REGION_SHORTCUTS[key] && (
+                <kbd
+                  className="ml-auto flex justify-center items-center not-italic shrink-0 w-[20px] h-[20px] rounded-px font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px] p-0 border border-[rgba(64,61,57,0.20)] dark:border-[rgba(184,182,160,0.30)] bg-[rgba(64,61,57,0.10)] dark:bg-[rgba(184,182,160,0.12)]"
+                  aria-hidden
+                >
+                  {REGION_SHORTCUTS[key]}
+                </kbd>
+              )}
+            </Link>
+          </DropdownMenuItem>
+        ))}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link


### PR DESCRIPTION
## Summary

- Pressing `L` opens the region picker (unchanged)
- When the picker is open, `U` / `H` / `E` / `J` navigates directly to US / HIPAA / EU / Japan
- Each region item shows its shortcut letter in a styled `<kbd>` badge matching the secondary button key style (same as the \"G\" badge on \"Get Demo\")
- Shortcuts are only active while the dropdown is open

## Test plan

- [ ] Open the navbar and press `L` — region dropdown opens
- [ ] With the dropdown open, press `E` — navigates to EU region
- [ ] With the dropdown open, press `U` — navigates to US region
- [ ] With the dropdown open, press `H` — navigates to HIPAA region
- [ ] Badge letters are visible and styled consistently with other key badges on the page
- [ ] Pressing `U`/`H`/`E`/`J` while the dropdown is closed does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing `L` keyboard shortcut on the "Launch App" button so that once the region dropdown is open, pressing `U`, `H`, `E`, or `J` navigates directly to the US, HIPAA, EU, or Japan region respectively. Each dropdown item also gains a styled `<kbd>` badge to advertise its shortcut, matching the visual style already used by other shortcut keys on the page.

- Adds a `REGION_SHORTCUTS` map and a `visibleRegions` memo to derive shortcut-to-URL pairs from the signed-in region state, then extends `handleKeyDown` to intercept the shortcut letters only while `open === true`.
- Renders a `<kbd aria-hidden>` badge next to each region label, reusing the exact border/background tokens from the existing secondary-button key style in `button.tsx`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive and well-scoped, affecting only the multi-region dropdown keyboard behavior.

The shortcut scoping (active only while open === true), editable-target guard, window.location.href for external URLs, and the kbd aria-hidden badge style all follow existing patterns in the codebase. rounded-px is valid under Tailwind v4. No logic errors, edge-case gaps, or accessibility regressions were found.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Window as window keydown
    participant MRB as MultiRegionButton handleKeyDown
    participant Btn as Button (shortcutKey=L) handler
    participant Radix as DropdownMenu (Radix)

    User->>Window: press L (dropdown closed)
    Window->>MRB: keydown event
    MRB->>MRB: "open=false → setOpen(true)"
    Window->>Btn: keydown event
    Btn->>Radix: triggerRef.click() → onOpenChange(true)
    Note over MRB,Radix: Both converge on open=true (no conflict)

    User->>Window: press E/U/H/J (dropdown open)
    Window->>MRB: keydown event
    MRB->>MRB: "open=true → find match in visibleRegions"
    MRB->>MRB: e.preventDefault() + setOpen(false)
    MRB-->>User: "window.location.href = region URL (navigate)"

    User->>Window: press L (dropdown open)
    Window->>MRB: keydown event
    MRB->>MRB: "open=true → no L match → no-op"
    Window->>Btn: keydown event
    Btn->>Radix: triggerRef.click() → onOpenChange(false)
    Note over Radix: dropdown closes (toggle)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Window as window keydown
    participant MRB as MultiRegionButton handleKeyDown
    participant Btn as Button (shortcutKey=L) handler
    participant Radix as DropdownMenu (Radix)

    User->>Window: press L (dropdown closed)
    Window->>MRB: keydown event
    MRB->>MRB: "open=false → setOpen(true)"
    Window->>Btn: keydown event
    Btn->>Radix: triggerRef.click() → onOpenChange(true)
    Note over MRB,Radix: Both converge on open=true (no conflict)

    User->>Window: press E/U/H/J (dropdown open)
    Window->>MRB: keydown event
    MRB->>MRB: "open=true → find match in visibleRegions"
    MRB->>MRB: e.preventDefault() + setOpen(false)
    MRB-->>User: "window.location.href = region URL (navigate)"

    User->>Window: press L (dropdown open)
    Window->>MRB: keydown event
    MRB->>MRB: "open=true → no L match → no-op"
    Window->>Btn: keydown event
    Btn->>Radix: triggerRef.click() → onOpenChange(false)
    Note over Radix: dropdown closes (toggle)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(navbar): add keyboard shortcuts to ..."](https://github.com/langfuse/langfuse-docs/commit/4c56a5be1f525dc74dd5542f6b7b089c42f5c2b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42024376)</sub>

<!-- /greptile_comment -->