### PR TITLE
style(academy): use sentence case for guide and prompt callout ribbons

### DIFF
--- a/components/academy/AgentPromptCallout.tsx
+++ b/components/academy/AgentPromptCallout.tsx
@@ -120,9 +120,9 @@ export function AgentPromptCallout({
           align-items: center;
           gap: 10px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           color: var(--text-primary);
         }
 

--- a/components/academy/ManualGuideCallout.tsx
+++ b/components/academy/ManualGuideCallout.tsx
@@ -120,9 +120,9 @@ export function ManualGuideCallout({
           justify-content: space-between;
           gap: 16px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           color: var(--text-primary);
         }
 
@@ -153,9 +153,9 @@ export function ManualGuideCallout({
           align-items: center;
           gap: 8px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           font-weight: 500;
           color: var(--text-secondary);
           white-space: nowrap;

--- a/components/academy/ManualGuideList.tsx
+++ b/components/academy/ManualGuideList.tsx
@@ -67,9 +67,9 @@ export function ManualGuideList({
           align-items: center;
           gap: 16px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           color: var(--text-primary);
         }
 

--- a/components/academy/japan/AgentPromptCallout.tsx
+++ b/components/academy/japan/AgentPromptCallout.tsx
@@ -120,9 +120,9 @@ export function AgentPromptCallout({
           align-items: center;
           gap: 10px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           color: var(--text-primary);
         }
 

--- a/components/academy/japan/ManualGuideCallout.tsx
+++ b/components/academy/japan/ManualGuideCallout.tsx
@@ -120,9 +120,9 @@ export function ManualGuideCallout({
           justify-content: space-between;
           gap: 16px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           color: var(--text-primary);
         }
 
@@ -153,9 +153,9 @@ export function ManualGuideCallout({
           align-items: center;
           gap: 8px;
           font-family: var(--font-mono);
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+          font-size: 13px;
+          letter-spacing: 0.02em;
+          text-transform: none;
           font-weight: 500;
           color: var(--text-secondary);
           white-space: nowrap;


### PR DESCRIPTION
Experiment with dropping the all-caps styling on the academy guide/prompt callout ribbons.

## Changes

- Switch `text-transform: uppercase` → `none` on the ribbon and CTA labels of the academy callout components, so `Guide:`, the guide topic, `Open`, `Guides`, and `Run with your agent` render in their natural casing.
- Relax `letter-spacing` from `0.12em` → `0.02em` (the wide tracking was tuned for caps and reads awkwardly on lowercase).
- Bump the ribbon/CTA `font-size` from `11px` → `13px`, since the smaller size felt cramped once no longer in caps.

Applied to both the default components and their `japan` variants:

- `components/academy/ManualGuideCallout.tsx`
- `components/academy/ManualGuideList.tsx`
- `components/academy/AgentPromptCallout.tsx`
- `components/academy/japan/ManualGuideCallout.tsx`
- `components/academy/japan/AgentPromptCallout.tsx`

These components appear across academy pages including `/academy/monitoring/error-analysis`, `/academy/datasets`, `/academy/evaluate`, and `/academy/experiments`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the typography styling for academy callout ribbon and CTA labels across five components (and their Japan variants), switching from uppercase to sentence-case rendering.

- Removes `text-transform: uppercase` (set to `none`), reduces `letter-spacing` from `0.12em` to `0.02em`, and increases `font-size` from `11px` to `13px` — the three properties are consistently updated together across all affected components.
- Both the base components (`ManualGuideCallout`, `ManualGuideList`, `AgentPromptCallout`) and their `japan/` variants receive identical changes, ensuring visual consistency across locales.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure CSS typography adjustments with no logic or data changes — safe to merge.

All five files receive identical, mechanically consistent changes to three CSS properties. The change is isolated to inline style blocks; no component logic, props, or markup is touched. Both base and Japan variants are updated in lock-step.

No files require special attention.
</details>

<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class ManualGuideCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
        cta: font-size 13px
        cta: letter-spacing 0.02em
        cta: text-transform none
    }
    class ManualGuideList {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    class AgentPromptCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    class japan_ManualGuideCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
        cta: font-size 13px
        cta: letter-spacing 0.02em
        cta: text-transform none
    }
    class japan_AgentPromptCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    ManualGuideCallout <|-- japan_ManualGuideCallout : japan variant
    AgentPromptCallout <|-- japan_AgentPromptCallout : japan variant
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class ManualGuideCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
        cta: font-size 13px
        cta: letter-spacing 0.02em
        cta: text-transform none
    }
    class ManualGuideList {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    class AgentPromptCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    class japan_ManualGuideCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
        cta: font-size 13px
        cta: letter-spacing 0.02em
        cta: text-transform none
    }
    class japan_AgentPromptCallout {
        ribbon: font-size 13px
        ribbon: letter-spacing 0.02em
        ribbon: text-transform none
    }
    ManualGuideCallout <|-- japan_ManualGuideCallout : japan variant
    AgentPromptCallout <|-- japan_AgentPromptCallout : japan variant
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["style(academy): use sentence case for gu..."](https://github.com/langfuse/langfuse-docs/commit/c43c3b7f4e31eddd68aa0eda875ee91d5ad1c7bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42030426)</sub>

<!-- /greptile_comment -->