### PR TITLE
docs: redirect legacy OpenTelemetry introduction page

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -145,6 +145,7 @@ const nonPermanentRedirects = [
   ["/docs/flowise", "/docs/integrations/flowise"],
   ["/docs/litellm", "/docs/integrations/litellm/tracing"],
   ["/docs/integrations/opentelemetry", "/integrations/native/opentelemetry"],
+  ["/docs/opentelemetry/introduction", "/integrations/native/opentelemetry"],
   ["/docs/integrations/litellm", "/docs/integrations/litellm/tracing"],
   ["/docs/langflow", "/docs/integrations/langflow"],
   ["/docs/local", "/docs/deployment/local"],


### PR DESCRIPTION
Adds a redirect for the legacy OpenTelemetry introduction URL reported in #3167.\n\nThe old path currently returns 404:\n\n\\/docs/opentelemetry/introduction\\\n\nThe redirect points to the current OpenTelemetry integration page:\n\n\\/integrations/native/opentelemetry\\\n\nFixes #3167.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single redirect entry to fix the 404 reported for `/docs/opentelemetry/introduction`, pointing it to the current canonical page at `/integrations/native/opentelemetry`.

- The new entry follows the existing pattern for OpenTelemetry-related redirects already present in the file (e.g., `/docs/integrations/opentelemetry` → `/integrations/native/opentelemetry`) and uses the same destination URL.
- The redirect is correctly placed in `nonPermanentRedirects`, consistent with the file-level comment that all redirects are intentionally non-permanent to avoid caching issues.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A single-line redirect addition with no logic changes — extremely low risk to merge.

The change adds one redirect tuple that mirrors an already-working entry in the same file. The destination is known-good, the format is correct, and there are no side effects.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits /docs/opentelemetry/introduction\n(legacy URL — was 404)"] -->|"nonPermanentRedirect"| B["/integrations/native/opentelemetry\n(current canonical page)"]
    C["User visits /docs/integrations/opentelemetry\n(pre-existing redirect)"] -->|"nonPermanentRedirect"| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User visits /docs/opentelemetry/introduction\n(legacy URL — was 404)"] -->|"nonPermanentRedirect"| B["/integrations/native/opentelemetry\n(current canonical page)"]
    C["User visits /docs/integrations/opentelemetry\n(pre-existing redirect)"] -->|"nonPermanentRedirect"| B
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect legacy OpenTelemetry intr..."](https://github.com/langfuse/langfuse-docs/commit/eea2d94f3046dfe5b06a88e1b1390eecc50ab481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42264306)</sub>

<!-- /greptile_comment -->