### PR TITLE
docs: promote trace best practices FAQ to observability docs

### DIFF
--- a/content/docs/observability/best-practices.mdx
+++ b/content/docs/observability/best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 title: What does a good trace look like?
-description: A guide to structuring your Langfuse traces for effective debugging, evaluation, and cost tracking.
-tags: [observability, observability-get-started]
+sidebarTitle: Best Practices
+description: Best practices for structuring Langfuse traces — scope, naming, input/output, and attributes — so that debugging, evaluation, and cost tracking work well.
 ---
 
 import { Fan, Wrench } from "lucide-react";
@@ -9,6 +9,15 @@ import { Fan, Wrench } from "lucide-react";
 # What does a good trace look like?
 
 You see traces appearing in Langfuse, but how do you know if you've done it well? Here are a couple of things you can look at and optimize.
+
+Trace structure is not just cosmetic — many Langfuse features build on top of it:
+
+- [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) target observations by name and type, and read their input and output.
+- [Dashboards](/docs/metrics/features/custom-dashboards) filter and aggregate metrics by trace and observation names.
+- [Dataset experiments](/docs/evaluation/experiments) compare trace input and output across runs.
+- Saved views on the tracing table reference names and attributes.
+
+A well-structured trace makes debugging faster today, and stable names with meaningful input/output keep your evaluators, dashboards, and experiments working as your application evolves.
 
 ## What's the scope of one trace?
 
@@ -20,7 +29,7 @@ A trace represents one self-contained unit of work in your application. Good exa
 - One agent run (the agent receives a task, reasons, calls tools, and produces a result)
 - One pipeline execution (a document comes in, gets chunked, embedded, and stored)
 
-If multiple of these happen in sequence, e.g. a multi-turn conversation, or several agent runs that feed into a final report, that's where [sessions](/docs/observability/features/sessions) come in. Each step is its own trace, and the session ties them together.
+If multiple of these happen in sequence, e.g. a multi-turn conversation, or several agent runs that feed into a final report, that's where [sessions](/docs/observability/features/sessions) come in. Each step is its own trace, and the session ties them together. For a chatbot this means one trace per turn and one session per conversation — you don't know upfront when a conversation ends, and the per-turn model keeps traces small and easy to navigate in the session view.
 
 A trace shows up in the Langfuse UI as a trace tree and an [agent graph](/docs/observability/features/agent-graphs):
 
@@ -65,13 +74,23 @@ Observation- and trace names are used in many places:
 - In [dashboards](/docs/metrics/features/custom-dashboards), you can filter and aggregate metrics by observation name.
 - In the tracing table, names help you quickly identify what each step does.
 
-Try to name the observations after what they do: `classify-intent`, `generate-response`, `summarize-results`. This makes it easier to understand what each step does when you're looking at the trace tree, and makes filtering on a specific step easier.
+Because names are referenced in all these places, treat them like an API: when a name changes, evaluators, dashboard queries, and saved filters that target the old name silently stop matching. Pick names deliberately, and expect to keep them stable.
 
-> Try not to name observations after the AI model used (`gpt-4o`, `claude-sonnet`). It breaks as soon as you swap models. The model is already a separate attribute on `generation` observations, use that instead.
+**Use active language.** Name observations after the action they perform, verb first: `classify-intent`, `retrieve-context`, `generate-response`, `summarize-results`. This makes the trace tree read like a description of what your application did, and makes filtering on a specific step easier.
+
+**Keep dynamic values out of names.** Use `process-order`, not `process-order-8945` or `generate-response-retry-2`. A name should identify the operation, not a single execution of it — otherwise every trace produces new names and you can no longer group, filter, or target them. Put run-specific values in [metadata](/docs/observability/features/metadata) instead. (This is the same low-cardinality rule that OpenTelemetry recommends for span names.)
+
+<Callout type="warning">
+
+Try not to name observations after the AI model used (`gpt-4o`, `claude-sonnet`). All filters, evaluators, and dashboards that reference the name break as soon as you swap models. The model is already a separate attribute on `generation` observations, use that instead.
+
+</Callout>
 
 ## Choose meaningful input and output
 
 In general, it's recommended that operations have an input and/or output. If an observation has neither, ask yourself if an observation is actually useful or if you can drop it.
+
+The **root observation** deserves the most care: the trace-level input and output are derived from it. They are shown in the tracing table, read by evaluators, and compared across runs in [dataset experiments](/docs/evaluation/experiments). Set them to what a reviewer needs at a glance — for a chatbot, the user message as input and the assistant response as output — not a raw JSON blob of function arguments. If you need the raw payload for debugging, put it in [metadata](/docs/observability/features/metadata).
 
 For your **most viewed observations**, take some extra care to set them up. You will likely create pre-filtered views on your tracing and session screens. The observations you filter for here are the ones that will get looked at the most. For these, ask yourself: **what do I need to see to quickly evaluate a trace/session at a glance?**
 
@@ -91,11 +110,15 @@ Observations have a number of attributes that can be useful for your use cases. 
 
 ### Add metadata for context
 
-[Metadata](/docs/observability/features/metadata) is a flexible key-value store on each observation. Some data that might be useful to save under metadata:
+[Metadata](/docs/observability/features/metadata) is a flexible key-value store on each observation. It's the right place for anything that is useful context but doesn't belong in the name or the input/output. Examples of metadata that is useful in practice:
 
-- **Evaluation context**: When configuring [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge), you can reference metadata fields. This is useful for passing ground truth, expected behavior, or other context that the evaluator needs but that isn't part of the actual input/output.
-- **Filtering**: You can filter by metadata keys in the Langfuse UI, which is helpful when you need to find traces with specific characteristics.
+- **Evaluation context**: Ground truth, expected behavior, or other context an [LLM-as-a-judge evaluator](/docs/evaluation/evaluation-methods/llm-as-a-judge) needs but that isn't part of the actual input/output. Evaluators can reference metadata fields in their variable mapping.
+- **Request context**: Internal request IDs, the API route or app version that handled the request, or the experiment variant / feature flags that were active. This lets you correlate a trace with your other systems and filter by rollout.
+- **Retrieval context**: For RAG steps, things like the data source, number of chunks retrieved, or the index queried — useful when debugging why a retrieval step returned poor results.
+- **Raw payloads**: Full request/response objects that would clutter the input/output fields but are occasionally needed for debugging.
 - **Annotation context**: When doing manual review, metadata gives annotators extra information to make better judgments.
+
+You can filter by metadata keys in the Langfuse UI, which is helpful when you need to find traces with specific characteristics.
 
 ### Track model, tokens, and cost on generations [#track-model-tokens-and-cost-on-generations]
 

--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -467,7 +467,7 @@ After running your application, visit the Langfuse interface to view the trace y
   gifStyle
 />
 
-_[What does a good trace look like?](/faq/all/what-does-a-good-trace-look-like)_
+_[What does a good trace look like?](/docs/observability/best-practices)_
 
 </Steps>
 

--- a/content/docs/observability/meta.json
+++ b/content/docs/observability/meta.json
@@ -4,6 +4,7 @@
     "overview",
     "get-started",
     "data-model",
+    "best-practices",
     "features",
     "sdk",
     "external:[Integrations ↗](/integrations)",

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1531,6 +1531,13 @@ const cookbookJsImagesMove202606 = [
   ],
 ];
 
+const goodTraceBestPracticesMove202607 = [
+  [
+    "/faq/all/what-does-a-good-trace-look-like",
+    "/docs/observability/best-practices",
+  ],
+];
+
 const permanentRedirects = [
   ...selfHostFolders202508,
   ...newSelfHostingSection,
@@ -1567,6 +1574,7 @@ const permanentRedirects = [
   ...howWeShipRename202606,
   ...cookbookJsImagesMove202606,
   ...resourcesEngineeringMove202606,
+  ...goodTraceBestPracticesMove202607,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -147,6 +147,10 @@ async function generateLLMsList() {
     markdownContent += `Install the Langfuse skill before implementing anything with Langfuse. The skill provides up-to-date documentation, best-practice workflows for instrumentation, prompt management, and programmatic API access via the Langfuse CLI.\n\n`;
     markdownContent += `Install from: [github.com/langfuse/skills](https://github.com/langfuse/skills/tree/main/skills/langfuse)\n\n`;
 
+    // Tracing best practices section
+    markdownContent += `## Tracing Best Practices\n\n`;
+    markdownContent += `Before instrumenting an application with Langfuse, read [What does a good trace look like?](https://langfuse.com/docs/observability/best-practices.md) — it covers trace scope, observation naming, meaningful input/output, and the attributes (metadata, tags, users, sessions) that evaluators, dashboards, and experiments rely on.\n\n`;
+
     // Section-specific intro sentences that mention the Langfuse skill
     const sectionIntros = {
       docs: `For the best results, install the [Langfuse skill](https://github.com/langfuse/skills/tree/main/skills/langfuse) before using these docs.`,


### PR DESCRIPTION
## What

Moves the FAQ page [What does a good trace look like?](https://langfuse.com/faq/all/what-does-a-good-trace-look-like) into the main docs as **Observability → Best Practices** (`/docs/observability/best-practices`), and updates its content based on our team discussion on unifying trace-structure conventions.

## Why

The guidance existed but wasn't findable (buried in the FAQ, not in the nav). At the same time, more features depend on trace structure — observation-level evaluators target by name/type, dashboards aggregate by name, experiments compare trace I/O — so users need one canonical page telling them what good structure looks like and why it matters.

## Content changes

- **New intro** explaining why structure matters: evaluators, dashboards, dataset experiments, and saved views all reference names and trace I/O
- **Naming guidance**: use active verb-first names (`classify-intent`, `retrieve-context`); treat names like an API since renaming silently breaks evaluators and saved filters; keep dynamic values out of names (low-cardinality rule, aligned with OpenTelemetry); no-model-names rule promoted to a warning callout with rationale
- **Root observation**: new paragraph — trace-level input/output derive from it and are read by evaluators/experiments; set the user message / final response, not raw JSON blobs (those go to metadata)
- **Metadata examples**: expanded to concrete categories (evaluation context/ground truth, request context, retrieval context, raw payloads, annotation context)
- **Trace scope**: sharpened turn-vs-session guidance (one trace per turn, one session per conversation)

## Wiring

- Sidebar entry after Data Model (`sidebarTitle: Best Practices`, H1 keeps the question for search)
- Permanent redirect `/faq/all/what-does-a-good-trace-look-like` → `/docs/observability/best-practices`
- Updated inbound link in observability get-started
- Hard-coded "Tracing Best Practices" section in `generate_llms_txt.js` so the page is prominent in llms.txt for coding agents

## Verified

- Page renders on the dev server with all new sections; sidebar shows "Best Practices"; callout renders
- Old FAQ URL 308-redirects to the new page
- `prettier`, `check-h1-headings`, and `node --check` on edited JS all pass

A follow-up PR on `langfuse/skills` points the skill's instrumentation reference at this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the FAQ page "What does a good trace look like?" into the main Observability docs section as `/docs/observability/best-practices`, and significantly expands its content with new guidance on naming stability, root observation importance, and metadata categories.

- A permanent redirect is added from the old FAQ URL to the new docs path, the sidebar (`meta.json`) is updated, and the inbound link in `get-started.mdx` is corrected.
- The `generate_llms_txt.js` script gets a hardcoded "Tracing Best Practices" section so the new page is surfaced prominently in `llms.txt` for coding agents; the `.md`-suffixed link is consistent with `generateSubFile`'s URL convention throughout the rest of the script.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are purely documentation content and build configuration with no runtime logic changes.

The redirect is wired correctly into permanentRedirects, the sidebar meta.json entry is in the right position, the inbound link in get-started.mdx is updated, and no other files in the repo reference the old FAQ URL (only lib/redirects.js and an auto-generated contributors JSON). The .md URL in generate_llms_txt.js is consistent with generateSubFile's existing convention. Content changes are additive improvements with no broken MDX syntax observed.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits old FAQ URL\n/faq/all/what-does-a-good-trace-look-like"] -->|308 Permanent Redirect| B["/docs/observability/best-practices"]
    C["get-started.mdx link\n(updated in this PR)"] --> B
    D["Sidebar meta.json\n(best-practices entry added)"] --> B
    E["llms.txt / coding agents\n(hardcoded section in generate_llms_txt.js)"] -->|.md suffix URL| F["https://langfuse.com/docs/observability/best-practices.md"]
    F --> B
    B --> G["Observability → Best Practices page\n(new canonical location)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User visits old FAQ URL\n/faq/all/what-does-a-good-trace-look-like"] -->|308 Permanent Redirect| B["/docs/observability/best-practices"]
    C["get-started.mdx link\n(updated in this PR)"] --> B
    D["Sidebar meta.json\n(best-practices entry added)"] --> B
    E["llms.txt / coding agents\n(hardcoded section in generate_llms_txt.js)"] -->|.md suffix URL| F["https://langfuse.com/docs/observability/best-practices.md"]
    F --> B
    B --> G["Observability → Best Practices page\n(new canonical location)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: promote trace best practices FAQ t..."](https://github.com/langfuse/langfuse-docs/commit/cc8a2928e3ce6c879f940db18379b5f90e09e933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42341351)</sub>

<!-- /greptile_comment -->