### PR TITLE
chore: update v2 metrics API limits

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -722,13 +722,25 @@ const sections: Section[] = [
         },
       },
       {
-        name: "Rate limit (metrics api)",
+        name: "Rate limit (Metrics API v2)",
         href: "/faq/all/api-limits",
         tiers: {
           cloud: {
             Hobby: "100 requests / day",
-            Core: "200 requests / day",
-            Pro: "2000 requests / day",
+            Core: "100 requests / hour",
+            Pro: "500 requests / hour",
+            Enterprise: "Custom",
+          },
+        },
+      },
+      {
+        name: "Rate limit (legacy Metrics API)",
+        href: "/faq/all/api-limits",
+        tiers: {
+          cloud: {
+            Hobby: "100 requests / day",
+            Core: "2,000 requests / day",
+            Pro: "2,000 requests / day",
             Enterprise: "Custom",
           },
         },

--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -351,7 +351,7 @@ Categorical scores have an additional dimension:
 
 <Callout type="warning">
 
-This endpoint is legacy and is no longer listed in the [public API reference](https://api.reference.langfuse.com/). It remains available for backward compatibility, but for new use cases please use the [Metrics API v2](#v2) above. It has higher rate limits and offers more flexibility.
+This endpoint is legacy and is no longer listed in the [public API reference](https://api.reference.langfuse.com/). It remains available for backward compatibility, but for new use cases please use the [Metrics API v2](#v2) above. It offers more flexibility and uses the separate Metrics API v2 rate-limit bucket listed in the [API limits FAQ](/faq/all/api-limits).
 
 </Callout>
 

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -24,18 +24,19 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 ### Rate Limits
 
-Rate limits are applied per-organization.
+Rate limits are applied per-organization. Metrics API v2 uses a separate rate-limit bucket from the legacy Metrics API.
 
-| Resource                                                                                                             | Hobby              | Core               | Pro/Team/Enterprise |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
-| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.              | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
-| **Legacy Tracing**. Legacy ingestion endpoints.                                                                      | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
-| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores. | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
-| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                 | No limit           | No limit           | No limit            |
-| **Metrics**. GET APIs used to fetch analytics data, e.g. [metrics api](/docs/analytics/metrics-api).                 | 100&nbsp;req/day   | 200&nbsp;req/day   | 2000&nbsp;req/day   |
-| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                     | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **Legacy read APIs**. Older trace, observation, and session read endpoints, listed below.                            | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
-| **API**. All other APIs.                                                                                             | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| Resource                                                                                                                                       | Hobby              | Core               | Pro/Team/Enterprise |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
+| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                        | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
+| **Legacy Tracing**. Legacy ingestion endpoints.                                                                                                | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                           | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
+| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                           | No limit           | No limit           | No limit            |
+| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                        | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
+| **[Legacy Metrics API](/docs/metrics/features/metrics-api#v1)**. Legacy `GET /api/public/metrics` endpoint.                                    | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
+| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                               | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Legacy read APIs**. Older trace, observation, and session read endpoints, listed below.                                                      | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
+| **API**. All other APIs.                                                                                                                       | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
 
 The legacy read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -26,17 +26,17 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 Rate limits are applied per-organization. Metrics API v2 uses a separate rate-limit bucket from the legacy Metrics API.
 
-| Resource                                                                                                                                       | Hobby              | Core               | Pro/Team/Enterprise |
-| ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
-| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                        | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
-| **Legacy Tracing**. Legacy ingestion endpoints.                                                                                                | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
-| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                           | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
-| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                           | No limit           | No limit           | No limit            |
-| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                        | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
-| **[Legacy Metrics API](/docs/metrics/features/metrics-api#v1)**. Legacy `GET /api/public/metrics` endpoint.                                    | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
-| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                               | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **Legacy read APIs**. Older trace, observation, and session read endpoints, listed below.                                                      | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
-| **API**. All other APIs.                                                                                                                       | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| Resource                                                                                                                | Hobby              | Core               | Pro/Team/Enterprise |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
+| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                 | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
+| **Legacy Tracing**. Legacy ingestion endpoints.                                                                         | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.    | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
+| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                    | No limit           | No limit           | No limit            |
+| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data. | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
+| **[Legacy Metrics API](/docs/metrics/features/metrics-api#v1)**. Legacy `GET /api/public/metrics` endpoint.             | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
+| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                        | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Legacy read APIs**. Older trace, observation, and session read endpoints, listed below.                               | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
+| **API**. All other APIs.                                                                                                | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
 
 The legacy read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -127,7 +127,8 @@ Optional **Yearly Commitment**:
 | [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Rate limit (general API)](/faq/all/api-limits)                                                     | 30 req/min          | 100 req/min         | 1,000 req/min       | Custom                       |
 | [Rate limit (datasets API)](/faq/all/api-limits)                                                    | 100 req/min         | 200 req/min         | 1,000 req/min       | Custom                       |
-| [Rate limit (metrics API)](/faq/all/api-limits)                                                     | 100 req/day         | 200 req/day         | 2,000 req/day       | Custom                       |
+| [Rate limit (Metrics API v2)](/faq/all/api-limits)                                                  | 100 req/day         | 100 req/hour        | 500 req/hour        | Custom                       |
+| [Rate limit (legacy Metrics API)](/faq/all/api-limits)                                              | 100 req/day         | 2,000 req/day       | 2,000 req/day       | Custom                       |
 | [SLA](/enterprise#faq)                                                                              | --                  | --                  | --                  | Yes                          |
 | **Exports**                                                                                         |                     |                     |                     |                              |
 | [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                 | Yes                 | Yes                 | Yes                          |


### PR DESCRIPTION
## Summary
- Clarify that Metrics API v2 uses its own rate-limit bucket in the API limits FAQ
- Replace the legacy metrics row with separate entries for Metrics API v2 and the legacy Metrics API
- Update the legacy metrics warning to point readers to the FAQ rate-limit details

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the API limits FAQ and the metrics-api documentation to clarify rate-limit details for Metrics API v2 vs. the legacy Metrics API. The old single "Metrics" row has been replaced with two distinct rows, and the legacy callout now points users to the FAQ instead of making a blanket "higher rate limits" claim.

- Splits the rate-limits table in `api-limits.mdx` into separate **Metrics API v2** and **Legacy Metrics API** rows with explicit per-tier limits (e.g., v2 Core = 100 req/hour vs legacy Core = 2,000 req/day).
- Adds a sentence clarifying that Metrics API v2 uses its own rate-limit bucket, separate from the legacy bucket.
- Updates the legacy callout in `metrics-api.mdx` to remove the vague "higher rate limits" wording and link readers directly to the FAQ for exact bucket details.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are documentation-only and do not touch application code.

The rate-limit table now correctly separates Metrics API v2 and Legacy Metrics API v1, but the Legacy Metrics row's description only names GET /api/public/metrics, leaving GET /api/public/metrics/daily (the Daily Metrics Legacy endpoint) without a clearly assigned bucket in the FAQ — even though the daily-metrics callout now directs users here.

content/faq/all/api-limits.mdx — the Legacy Metrics API row description should clarify whether GET /api/public/metrics/daily shares this bucket.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User calls Metrics endpoint] --> B{Which endpoint?}
    B -->|GET /api/public/v2/metrics| C[Metrics API v2]
    B -->|GET /api/public/metrics| D[Legacy Metrics API v1]
    B -->|GET /api/public/metrics/daily| E[Daily Metrics API Legacy]
    C --> F[Metrics API v2 rate-limit bucket\nHobby: 100/day · Core: 100/hr · Pro: 500/hr]
    D --> G[Legacy Metrics API rate-limit bucket\nHobby: 100/day · Core: 2000/day · Pro: 2000/day]
    E --> H[?? Bucket unclear in FAQ\nNot explicitly listed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User calls Metrics endpoint] --> B{Which endpoint?}
    B -->|GET /api/public/v2/metrics| C[Metrics API v2]
    B -->|GET /api/public/metrics| D[Legacy Metrics API v1]
    B -->|GET /api/public/metrics/daily| E[Daily Metrics API Legacy]
    C --> F[Metrics API v2 rate-limit bucket\nHobby: 100/day · Core: 100/hr · Pro: 500/hr]
    D --> G[Legacy Metrics API rate-limit bucket\nHobby: 100/day · Core: 2000/day · Pro: 2000/day]
    E --> H[?? Bucket unclear in FAQ\nNot explicitly listed]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/faq/all/api-limits.mdx:36
**Daily metrics endpoint rate-limit bucket not covered**

The legacy row description only mentions `GET /api/public/metrics`, but `GET /api/public/metrics/daily` (the "Daily Metrics API (Legacy)" section) is a distinct endpoint that also links users here from its callout. Readers arriving from that callout won't find a row that matches their endpoint path, leaving it ambiguous whether the daily endpoint shares the Legacy Metrics API bucket or falls under the general **API** bucket.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify Metrics API v2 rate limits"](https://github.com/langfuse/langfuse-docs/commit/5b17d1e0f9b231f4734d679c3c52ac622c090d78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42365707)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->