### PR TITLE
docs(changelog): experiments public API and MCP tools

### DIFF
--- a/content/changelog/2026-07-07-experiments-public-api-and-mcp.mdx
+++ b/content/changelog/2026-07-07-experiments-public-api-and-mcp.mdx
@@ -20,7 +20,7 @@ This unlocks workflows beyond the Langfuse UI:
 
 ```
 GET /api/public/experiments?fromStartTime=2026-07-01T00:00:00Z&fields=core,scores
-GET /api/public/experiment-items?experimentId=exp-123&fields=io,scores
+GET /api/public/experiment-items?fromStartTime=2026-07-01T00:00:00Z&experimentId=exp-123&fields=io,scores
 ```
 
 ## Get started

--- a/content/changelog/2026-07-07-experiments-public-api-and-mcp.mdx
+++ b/content/changelog/2026-07-07-experiments-public-api-and-mcp.mdx
@@ -1,0 +1,47 @@
+---
+date: 2026-07-07
+title: Query experiments via API and MCP
+description: Fetch experiments and their items programmatically through the new public API endpoints, or let AI agents explore experiment results via the Langfuse MCP server.
+author: Tobias Wochinger
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book, Code, FlaskConical } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now access experiment results programmatically. The new `GET /api/public/experiments` and `GET /api/public/experiment-items` endpoints list experiments and their items with cursor-based pagination. The Langfuse MCP server exposes them as `listExperiments` and `listExperimentItems` tools.
+
+This unlocks workflows beyond the Langfuse UI:
+
+- Analyze experiments from AI agents: agents can list recent experiments, drill into individual items, and follow the deep links in MCP responses back into Langfuse.
+- Export experiment results: pull item inputs, outputs, expected outputs, and scores into a notebook or data warehouse for custom analysis.
+- Gate deployments in CI/CD: fetch the scores of an experiment run and fail the pipeline if they regress.
+
+```
+GET /api/public/experiments?fromStartTime=2026-07-01T00:00:00Z&fields=core,scores
+GET /api/public/experiment-items?experimentId=exp-123&fields=io,scores
+```
+
+## Get started
+
+<Cards num={3}>
+  <Card
+    title="Experiments documentation"
+    href="/docs/evaluation/experiments/experiments-via-sdk"
+    icon={<FlaskConical />}
+    arrow
+  />
+  <Card
+    title="API reference"
+    href="https://api.reference.langfuse.com/#tag/experiments"
+    icon={<Code />}
+    arrow
+  />
+  <Card
+    title="MCP server documentation"
+    href="/docs/api-and-data-platform/features/mcp-server"
+    icon={<Book />}
+    arrow
+  />
+</Cards>


### PR DESCRIPTION
Adds a changelog entry for the new experiments public API and MCP tools.

## Related PRs

- https://github.com/langfuse/langfuse/pull/14579
- https://github.com/langfuse/langfuse/pull/14830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a changelog entry announcing the new `GET /api/public/experiments` and `GET /api/public/experiment-items` endpoints plus the two corresponding `listExperiments` / `listExperimentItems` MCP tools.

- The frontmatter, imports, and `<ChangelogHeader />` usage all follow existing changelog conventions, and both referenced internal doc paths (`/docs/evaluation/experiments/experiments-via-sdk` and `/docs/api-and-data-platform/features/mcp-server`) resolve to real files in the repo.
- The only minor gap is the fenced code block at line 21 has no language tag; adding `http` would enable syntax highlighting consistent with the rest of the docs site.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change adding a single changelog file; no logic, migrations, or API surface is modified.

The change is a single new MDX file with correct frontmatter, valid internal links, and proper component usage. The only observation is a missing language specifier on a code block, which has no functional impact.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / AI Agent] -->|HTTP GET| B[GET /api/public/experiments]
    A -->|HTTP GET| C[GET /api/public/experiment-items]
    A -->|MCP tool call| D[listExperiments]
    A -->|MCP tool call| E[listExperimentItems]
    B --> F[Cursor-paginated list of experiments]
    C --> G[Cursor-paginated list of experiment items]
    D --> F
    E --> G
    F --> H{Use case}
    G --> H
    H --> I[Analyze in notebook / data warehouse]
    H --> J[Gate CI/CD pipeline on score regression]
    H --> K[AI agent explores results via MCP deep links]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Developer / AI Agent] -->|HTTP GET| B[GET /api/public/experiments]
    A -->|HTTP GET| C[GET /api/public/experiment-items]
    A -->|MCP tool call| D[listExperiments]
    A -->|MCP tool call| E[listExperimentItems]
    B --> F[Cursor-paginated list of experiments]
    C --> G[Cursor-paginated list of experiment items]
    D --> F
    E --> G
    F --> H{Use case}
    G --> H
    H --> I[Analyze in notebook / data warehouse]
    H --> J[Gate CI/CD pipeline on score regression]
    H --> K[AI agent explores results via MCP deep links]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/changelog/2026-07-07-experiments-public-api-and-mcp.mdx:21-24
The fenced code block has no language specifier. Adding `http` (or `bash`) will enable syntax highlighting on most MDX-based doc sites and makes the snippet render more clearly for readers.

```suggestion
```http
GET /api/public/experiments?fromStartTime=2026-07-01T00:00:00Z&fields=core,scores
GET /api/public/experiment-items?experimentId=exp-123&fields=io,scores
```
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add experiments public ..."](https://github.com/langfuse/langfuse-docs/commit/d72f9281e58608effc4241157bfed839763db460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42419803)</sub>

<!-- /greptile_comment -->