### PR TITLE
docs: document the usage_details exclusive-bucket contract

### DIFF
--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -292,7 +292,7 @@ You can also update the usage and cost via `generation.update()`.
 
 ### Usage types are mutually exclusive buckets [#usage-details-contract]
 
-Langfuse treats every key in `usage_details` as a separate, non-overlapping bucket: each token must be counted in exactly one key. In particular, `input` must exclude tokens that are already counted in another `input_*` key (such as `input_cached_tokens` or `input_cache_creation`), and `output` must exclude tokens counted in another `output_*` key (such as `output_reasoning_tokens`).
+Langfuse treats every key in `usage_details` as a separate, non-overlapping bucket: each token must be counted in exactly one key. In particular, `input` must exclude tokens that are already counted in another `input_*` key (such as `input_cached_tokens` or `input_cache_creation`), and `output` must exclude tokens counted in another `output_*` key (such as `output_reasoning_tokens`). The one exception is `total`: it is not a bucket itself but spans all buckets and equals their sum.
 
 Langfuse relies on this contract in three places:
 
@@ -300,17 +300,18 @@ Langfuse relies on this contract in three places:
 - **Cost inference**: each usage type is matched exactly against the per-usage-type prices of the model definition, and the resulting costs are summed.
 - **Total**: if no `total` is ingested, Langfuse derives it as the sum of all buckets.
 
-If buckets overlap — for example, if `input` still contains the tokens reported in `input_cached_tokens` — those tokens are displayed twice and billed twice.
+If buckets overlap — for example, if `input` still contains the tokens reported in `input_cached_tokens` — those tokens are displayed twice, and the inferred cost double-counts them: the cost shown in Langfuse overstates what your provider actually charged. Directly ingested `cost_details` are used verbatim and are not affected.
 
 Many LLM providers report **inclusive** counts. For example, OpenAI's `prompt_tokens` (Chat Completions API) and `input_tokens` (Responses API) include cached tokens. Anthropic's `input_tokens`, in contrast, already excludes cache reads and cache writes. Inclusive counts must be converted into exclusive buckets before they are stored, by subtracting the detail counts from the top-level count.
 
-For example, an OpenAI-style response with 17,903 prompt tokens of which 17,817 were cache hits:
+For example, an OpenAI-style response with 17,903 prompt tokens (of which 17,817 were cache hits) and 188 completion tokens:
 
 | Provider reports (inclusive)                      | Stored in Langfuse (exclusive) |
 | ------------------------------------------------- | ------------------------------ |
 | `prompt_tokens: 17903`                            | `input: 86`                    |
 | `prompt_tokens_details: { cached_tokens: 17817 }` | `input_cached_tokens: 17817`   |
-| `total_tokens: 17903`                             | `total: 17903`                 |
+| `completion_tokens: 188`                          | `output: 188`                  |
+| `total_tokens: 18091`                             | `total: 18091`                 |
 
 #### When Langfuse converts for you [#usage-details-normalization]
 
@@ -318,7 +319,7 @@ Whether you need to do this conversion yourself depends on how the usage data re
 
 - **Langfuse integrations and SDK wrappers** (e.g., the [OpenAI wrapper](/integrations/model-providers/openai-py)) capture usage from the provider response and convert it for you.
 - **OpenTelemetry usage attributes** (`gen_ai.usage.*` as defined by the OpenTelemetry GenAI semantic conventions, plus the `llm.token_count.*` namespace used by some instrumentation libraries): treated as inclusive. Langfuse normalizes them during ingestion by subtracting cache read and cache creation tokens from `input`.
-- **OpenAI usage schema** passed as usage details (nested `prompt_tokens_details` / `completion_tokens_details`, see [Compatibility with OpenAI](#openai-usage-schema)): recognized and normalized during ingestion.
+- **OpenAI usage schema** passed as usage details (nested `prompt_tokens_details` / `completion_tokens_details`, see [Compatibility with OpenAI](#openai-usage-schema)): recognized and normalized during ingestion. The match is strict: if the object contains any key beyond the OpenAI usage fields, it is treated as flat keys instead.
 - **Langfuse-style flat keys** passed as usage details via the SDKs or the API (`usage_details` / `usageDetails`, OTel attribute `langfuse.observation.usage_details`): stored verbatim, no normalization is applied. **Values must already be exclusive.**
 
 If you write your own instrumentation that sets usage details with flat keys, check how your provider reports usage and subtract cached or detail token counts from the top-level `input`/`output` counts — exactly once — before passing them to Langfuse.
@@ -326,6 +327,12 @@ If you write your own instrumentation that sets usage details with flat keys, ch
 ### Compatibility with OpenAI [#openai-usage-schema]
 
 For increased compatibility with OpenAI, you can also use the OpenAI Usage schema. `prompt_tokens` will be mapped to `input`, `completion_tokens` will be mapped to `output`, and `total_tokens` will be mapped to `total`. The keys nested in `prompt_tokens_details` will be flattened with an `input_` prefix and `completion_tokens_details` will be flattened with an `output_` prefix. Since OpenAI reports these detail counts inclusively, Langfuse subtracts them from `input` and `output` respectively, so that the stored buckets are [mutually exclusive](#usage-details-contract).
+
+<Callout type="warning">
+
+Schema recognition is strict: the usage object must contain **only** the OpenAI usage fields shown below. If it includes any additional key (for example, some gateways append a `cost` field), it is not recognized as OpenAI-style usage and is instead stored verbatim as [flat keys](#usage-details-contract) — without the mapping and without the subtraction. This failure mode is silent, so strip extra keys before ingesting.
+
+</Callout>
 
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>
 <Tab>

--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -317,7 +317,7 @@ For example, an OpenAI-style response with 17,903 prompt tokens of which 17,817 
 Whether you need to do this conversion yourself depends on how the usage data reaches Langfuse:
 
 - **Langfuse integrations and SDK wrappers** (e.g., the [OpenAI wrapper](/integrations/model-providers/openai-py)) capture usage from the provider response and convert it for you.
-- **OpenTelemetry semantic convention attributes** (`gen_ai.usage.*`, `llm.token_count.*`): treated as inclusive, following the OpenTelemetry GenAI semantic conventions. Langfuse normalizes them during ingestion by subtracting cache read and cache creation tokens from `input`.
+- **OpenTelemetry usage attributes** (`gen_ai.usage.*` as defined by the OpenTelemetry GenAI semantic conventions, plus the `llm.token_count.*` namespace used by some instrumentation libraries): treated as inclusive. Langfuse normalizes them during ingestion by subtracting cache read and cache creation tokens from `input`.
 - **OpenAI usage schema** passed as usage details (nested `prompt_tokens_details` / `completion_tokens_details`, see [Compatibility with OpenAI](#openai-usage-schema)): recognized and normalized during ingestion.
 - **Langfuse-style flat keys** passed as usage details via the SDKs or the API (`usage_details` / `usageDetails`, OTel attribute `langfuse.observation.usage_details`): stored verbatim, no normalization is applied. **Values must already be exclusive.**
 

--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -18,7 +18,7 @@ Langfuse tracks the usage and costs of your LLM generations and provides breakdo
 
 Usage types can be arbitrary strings and differ by LLM provider. At the highest level, they can be simply `input` and `output`. As LLMs grow more sophisticated, additional usage types are necessary, such as `cached_tokens`, `audio_tokens`, `image_tokens`.
 
-In the UI, Langfuse summarizes all usage types that include the string `input` as input usage types, similarly`output` as output usage types. If no `total` usage type is ingested, Langfuse sums up all usage type units to a total.
+In the UI, Langfuse summarizes all usage types that include the string `input` as input usage types, similarly `output` as output usage types. If no `total` usage type is ingested, Langfuse sums up all usage type units to a total. For this to work, usage types must be [mutually exclusive buckets](#usage-details-contract).
 
 Both usage details and cost details can be either
 
@@ -290,9 +290,42 @@ You can also update the usage and cost via `generation.update()`.
 </Tab>
 </LangTabs>
 
-### Compatibility with OpenAI
+### Usage types are mutually exclusive buckets [#usage-details-contract]
 
-For increased compatibility with OpenAI, you can also use the OpenAI Usage schema. `prompt_tokens` will be mapped to `input`, `completion_tokens` will be mapped to `output`, and `total_tokens` will be mapped to `total`. The keys nested in `prompt_tokens_details` will be flattened with an `input_` prefix and `completion_tokens_details` will be flattened with an `output_` prefix.
+Langfuse treats every key in `usage_details` as a separate, non-overlapping bucket: each token must be counted in exactly one key. In particular, `input` must exclude tokens that are already counted in another `input_*` key (such as `input_cached_tokens` or `input_cache_creation`), and `output` must exclude tokens counted in another `output_*` key (such as `output_reasoning_tokens`).
+
+Langfuse relies on this contract in three places:
+
+- **Display**: the UI sums all usage types containing `input` to show total input usage, and all usage types containing `output` to show total output usage.
+- **Cost inference**: each usage type is matched exactly against the per-usage-type prices of the model definition, and the resulting costs are summed.
+- **Total**: if no `total` is ingested, Langfuse derives it as the sum of all buckets.
+
+If buckets overlap — for example, if `input` still contains the tokens reported in `input_cached_tokens` — those tokens are displayed twice and billed twice.
+
+Many LLM providers report **inclusive** counts. For example, OpenAI's `prompt_tokens` (Chat Completions API) and `input_tokens` (Responses API) include cached tokens. Anthropic's `input_tokens`, in contrast, already excludes cache reads and cache writes. Inclusive counts must be converted into exclusive buckets before they are stored, by subtracting the detail counts from the top-level count.
+
+For example, an OpenAI-style response with 17,903 prompt tokens of which 17,817 were cache hits:
+
+| Provider reports (inclusive)                      | Stored in Langfuse (exclusive) |
+| ------------------------------------------------- | ------------------------------ |
+| `prompt_tokens: 17903`                            | `input: 86`                    |
+| `prompt_tokens_details: { cached_tokens: 17817 }` | `input_cached_tokens: 17817`   |
+| `total_tokens: 17903`                             | `total: 17903`                 |
+
+#### When Langfuse converts for you [#usage-details-normalization]
+
+Whether you need to do this conversion yourself depends on how the usage data reaches Langfuse:
+
+- **Langfuse integrations and SDK wrappers** (e.g., the [OpenAI wrapper](/integrations/model-providers/openai-py)) capture usage from the provider response and convert it for you.
+- **OpenTelemetry semantic convention attributes** (`gen_ai.usage.*`, `llm.token_count.*`): treated as inclusive, following the OpenTelemetry GenAI semantic conventions. Langfuse normalizes them during ingestion by subtracting cache read and cache creation tokens from `input`.
+- **OpenAI usage schema** passed as usage details (nested `prompt_tokens_details` / `completion_tokens_details`, see [Compatibility with OpenAI](#openai-usage-schema)): recognized and normalized during ingestion.
+- **Langfuse-style flat keys** passed as usage details via the SDKs or the API (`usage_details` / `usageDetails`, OTel attribute `langfuse.observation.usage_details`): stored verbatim, no normalization is applied. **Values must already be exclusive.**
+
+If you write your own instrumentation that sets usage details with flat keys, check how your provider reports usage and subtract cached or detail token counts from the top-level `input`/`output` counts — exactly once — before passing them to Langfuse.
+
+### Compatibility with OpenAI [#openai-usage-schema]
+
+For increased compatibility with OpenAI, you can also use the OpenAI Usage schema. `prompt_tokens` will be mapped to `input`, `completion_tokens` will be mapped to `output`, and `total_tokens` will be mapped to `total`. The keys nested in `prompt_tokens_details` will be flattened with an `input_` prefix and `completion_tokens_details` will be flattened with an `output_` prefix. Since OpenAI reports these detail counts inclusively, Langfuse subtracts them from `input` and `output` respectively, so that the stored buckets are [mutually exclusive](#usage-details-contract).
 
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>
 <Tab>

--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -80,7 +80,7 @@ def anthropic_completion(**kwargs):
           "input": response.usage.input_tokens,
           "output": response.usage.output_tokens,
           "cache_read_input_tokens": response.usage.cache_read_input_tokens
-          # "total": int,  # if not set, it is derived from input + cache_read_input_tokens + output
+          # "total": int,  # if not set, it is derived as the sum of all usage types
         },
       # Optionally, also ingest usd cost. Alternatively, you can infer it via a model definition in Langfuse.
       cost_details={
@@ -88,7 +88,7 @@ def anthropic_completion(**kwargs):
           "input": 1,
           "cache_read_input_tokens": 0.5,
           "output": 1,
-          # "total": float, # if not set, it is derived from input + cache_read_input_tokens + output
+          # "total": float, # if not set, it is derived as the sum of all usage types
       }
   )
 
@@ -135,7 +135,7 @@ with langfuse.start_as_current_observation(
             "input": response.usage.input_tokens,
             "output": response.usage.output_tokens,
             "cache_read_input_tokens": response.usage.cache_read_input_tokens
-            # "total": int,  # if not set, it is derived from input + cache_read_input_tokens + output
+            # "total": int,  # if not set, it is derived as the sum of all usage types
         },
         # Optionally, also ingest usd cost. Alternatively, you can infer it via a model definition in Langfuse.
         cost_details={
@@ -143,7 +143,7 @@ with langfuse.start_as_current_observation(
             "input": 1,
             "cache_read_input_tokens": 0.5,
             "output": 1,
-            # "total": float, # if not set, it is derived from input + cache_read_input_tokens + output
+            # "total": float, # if not set, it is derived as the sum of all usage types
         }
     )
 ```
@@ -183,7 +183,7 @@ await startActiveObservation("context-manager", async (span) => {
       output: 5,
       cache_read_input_tokens: 2,
       some_other_token_count: 10,
-      total: 17, // optional, it is derived from input + cache_read_input_tokens + output
+      total: 27, // optional, it is derived as the sum of all usage types
     },
     costDetails: {
       // If you don't want the costs to be calculated based on model definitions, you can pass the costDetails manually.
@@ -214,7 +214,7 @@ async function fetchData(source: string) {
         output: 5,
         cache_read_input_tokens: 2,
         some_other_token_count: 10,
-        total: 17, // optional, it is derived from input + cache_read_input_tokens + output
+        total: 27, // optional, it is derived as the sum of all usage types
       },
       costDetails: {
         // If you don't want the costs to be calculated based on model definitions, you can pass the costDetails manually.
@@ -264,7 +264,7 @@ generation.update({
     output: 5,
     cache_read_input_tokens: 2,
     some_other_token_count: 10,
-    total: 17, // optional, it is derived from input + cache_read_input_tokens + output
+    total: 27, // optional, it is derived as the sum of all usage types
   },
   costDetails: {
     // If you don't want the costs to be calculated based on model definitions, you can pass the costDetails manually.


### PR DESCRIPTION
## Summary

Documents the `usage_details` contract on the token-and-cost-tracking page. The exclusive-bucket convention previously existed only implicitly in code, and the page arguably implied OpenAI-style inclusive usage could be passed straight in — challenged by a user in [langfuse/langfuse#10592](https://github.com/langfuse/langfuse/issues/10592).

New "Usage types are mutually exclusive buckets" section covering:

- `usage_details` keys are mutually exclusive buckets: `input` must exclude all other `input_*` keys (e.g. `input_cached_tokens`, `input_cache_creation`); same for `output` vs `output_*`.
- Why Langfuse relies on this: the UI sums all keys containing `input` for display, cost matches each key exactly against model prices, and a missing `total` is derived as the sum of all buckets — overlapping buckets mean double display and double billing.
- Per-ingestion-path semantics, verified against `OtelIngestionProcessor` and the ingestion `UsageDetails` schema:
  - OTel semconv attributes (`gen_ai.usage.*`, `llm.token_count.*`) are treated as inclusive and normalized server-side (cache read/creation subtracted from `input`).
  - The OpenAI usage schema (nested `*_tokens_details`) is recognized and normalized (flattened and subtracted).
  - Flat Langfuse-style keys (`langfuse.observation.usage_details`) are stored verbatim and must already be exclusive.
- Worked example from the issue: provider reports `prompt_tokens=17903` with `cached_tokens=17817` → ingest `input=86`, `input_cached_tokens=17817`, `total=17903`.
- Guidance for custom instrumentors: OpenAI reports inclusively, Anthropic exclusively — convert exactly once.

Also gives the "Compatibility with OpenAI" section an explicit anchor and states that nested detail counts are subtracted, and fixes a missing space ("similarly`output`").

Closes [LFE-10742](https://linear.app/langfuse/issue/LFE-10742)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Usage types are mutually exclusive buckets" section to the token-and-cost-tracking docs, documenting a previously implicit contract that `usage_details` keys must not overlap (e.g. `input` must exclude tokens already counted in `input_cached_tokens`). It also retrofits the existing OpenAI compatibility section with an explicit anchor and clarifies that Langfuse subtracts nested detail counts to maintain exclusive buckets.

- New `#usage-details-contract` section explains the exclusive-bucket requirement, why Langfuse depends on it (display, cost inference, total derivation), and includes a worked example from the triggering issue (17903 prompt tokens, 17817 cached → stored as `input: 86`, `input_cached_tokens: 17817`).
- New `#usage-details-normalization` subsection maps each ingestion path (SDK wrappers, OTel attributes, OpenAI schema, flat Langfuse keys) to whether Langfuse normalizes for you or expects pre-converted values.
- Minor fixes: adds missing space before `output` and adds the `#openai-usage-schema` anchor to the existing compatibility section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

All changes are confined to a single MDX file with no code execution. The worked example arithmetic is correct (17903 − 17817 = 86), the ingestion-path matrix accurately reflects the described server-side normalization behaviour, and the cross-links are well-formed. The only note is a minor label imprecision around `llm.token_count.*` not being part of the official OTel GenAI semconv.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Usage data arrives at Langfuse] --> B{Ingestion path?}

    B -->|SDK wrapper e.g. OpenAI wrapper| C[Wrapper captures provider response\nand converts inclusive to exclusive]
    B -->|OTel attributes gen_ai.usage.* / llm.token_count.*| D[OtelIngestionProcessor\nsubtracts cache read + creation\nfrom input]
    B -->|OpenAI schema prompt_tokens_details\ncompletion_tokens_details| E[Schema normalizer\nflattens with input_/output_ prefix\nand subtracts from input/output]
    B -->|Flat Langfuse-style keys\nusage_details / usageDetails| F[Stored verbatim\nno normalization]

    C --> G[Exclusive buckets stored in DB]
    D --> G
    E --> G
    F -->|Must already be exclusive| G

    G --> H{Display / Cost / Total}
    H --> I[UI sums all keys containing input\nfor total input display]
    H --> J[Each key matched against\nmodel price for cost]
    H --> K[If no total ingested\nsum of all buckets used as total]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Usage data arrives at Langfuse] --> B{Ingestion path?}

    B -->|SDK wrapper e.g. OpenAI wrapper| C[Wrapper captures provider response\nand converts inclusive to exclusive]
    B -->|OTel attributes gen_ai.usage.* / llm.token_count.*| D[OtelIngestionProcessor\nsubtracts cache read + creation\nfrom input]
    B -->|OpenAI schema prompt_tokens_details\ncompletion_tokens_details| E[Schema normalizer\nflattens with input_/output_ prefix\nand subtracts from input/output]
    B -->|Flat Langfuse-style keys\nusage_details / usageDetails| F[Stored verbatim\nno normalization]

    C --> G[Exclusive buckets stored in DB]
    D --> G
    E --> G
    F -->|Must already be exclusive| G

    G --> H{Display / Cost / Total}
    H --> I[UI sums all keys containing input\nfor total input display]
    H --> J[Each key matched against\nmodel price for cost]
    H --> K[If no total ingested\nsum of all buckets used as total]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/observability/features/token-and-cost-tracking.mdx:320
The phrase "following the OpenTelemetry GenAI semantic conventions" is applied to both `gen_ai.usage.*` and `llm.token_count.*`, but `llm.token_count.*` is not part of the official OpenTelemetry GenAI semantic conventions — it's from an older/alternative instrumentation namespace that predates the standardised `gen_ai.*` convention. Labelling it as OTel GenAI semconv could confuse readers who look it up and find no match in the spec.

```suggestion
- **OpenTelemetry attributes** (`gen_ai.usage.*`, `llm.token_count.*`): treated as inclusive. Langfuse normalizes them during ingestion by subtracting cache read and cache creation tokens from `input`.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document the usage\_details exclusi..."](https://github.com/langfuse/langfuse-docs/commit/405bc3d71af0126829a57d8092c7d7a7839c602e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42641536)</sub>

<!-- /greptile_comment -->