### PR TITLE
docs: add versions & compatibility overview page

### DIFF
--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -11,42 +11,42 @@ Reference for how Langfuse's server, SDK, and API versions relate across Langfus
 Langfuse Cloud runs the latest version, including both GA and preview features. New capabilities usually ship to **Langfuse Cloud** first (as preview), then become GA for **OSS / self-hosted** once validated. The current preview is the server v4 [Fast Preview](/docs/v4), an observations-first data model; self-hosted instances enable it with the `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` environment variable ("v4 preview opt-in" below). **On Langfuse Cloud, you can ignore the self-hosted minimums and opt-in notes on this page.**
 </Callout>
 
-Status labels used on this page: **GA** (recommended, fully supported), **Preview** (Cloud first; self-hosted via opt-in), **Legacy** (still works, superseded by a newer version), **Deprecated** (will be removed; migrate to the replacement), **End of life** (unsupported, no security patches).
+Status labels used on this page: **GA** (recommended, fully supported), **Preview** (Cloud first; self-hosted via opt-in), **Deprecated** (still works but superseded; will be removed, migrate to the replacement), **End of life** (unsupported, no security patches).
 
 ## GA versions [#ga]
 
-| Component | GA version | Package / repo | Notes |
-| --- | --- | --- | --- |
-| Server | v3 | [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) <a href="https://github.com/langfuse/langfuse/releases"><img className="inline" src="https://img.shields.io/github/v/release/langfuse/langfuse?style=flat-square&label=release" alt="Langfuse server release" /></a> | ClickHouse + Redis + S3/blob storage + worker |
-| Python SDK | v4 | [`langfuse`](https://pypi.org/project/langfuse/) <a href="https://pypi.org/project/langfuse/"><img className="inline" src="https://img.shields.io/pypi/v/langfuse?style=flat-square&label=pypi" alt="PyPI langfuse" /></a> | OpenTelemetry-based since v3. Requires Python 3.9+. |
-| JS/TS SDK | v5 | [`@langfuse/*`](https://www.npmjs.com/package/@langfuse/tracing) <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm" alt="NPM @langfuse/tracing" /></a> | OpenTelemetry-based since v4. Requires Node.js 20+. |
-| Other languages | n/a | [OpenTelemetry](/integrations/native/opentelemetry) | Any OTel SDK to the Langfuse OTel endpoint |
+| Component       | GA version | Package / repo                                                                                                                                                                                                                                                                          | Notes                                               |
+| --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Server          | v3         | [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) <a href="https://github.com/langfuse/langfuse/releases"><img className="inline" src="https://img.shields.io/github/v/release/langfuse/langfuse?style=flat-square&label=release" alt="Langfuse server release" /></a> | ClickHouse + Redis + S3/blob storage + worker       |
+| Python SDK      | v4         | [`langfuse`](https://pypi.org/project/langfuse/) <a href="https://pypi.org/project/langfuse/"><img className="inline" src="https://img.shields.io/pypi/v/langfuse?style=flat-square&label=pypi" alt="PyPI langfuse" /></a>                                                              | OpenTelemetry-based since v3. Requires Python 3.9+. |
+| JS/TS SDK       | v5         | [`@langfuse/*`](https://www.npmjs.com/package/@langfuse/tracing) <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm" alt="NPM @langfuse/tracing" /></a>                  | OpenTelemetry-based since v4. Requires Node.js 20+. |
+| Other languages | n/a        | [OpenTelemetry](/integrations/native/opentelemetry)                                                                                                                                                                                                                                     | Any OTel SDK to the Langfuse OTel endpoint          |
 
 ## SDK ↔ server compatibility [#sdk-server]
 
 Recent SDKs require a recent self-hosted server. Cloud always satisfies these minimums.
 
-| SDK & version | Min. self-hosted server | Status | Upgrade guide |
-| --- | --- | --- | --- |
-| Python SDK v4 | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | GA | |
-| Python SDK v3 | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | Legacy | [Python v3 → v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) |
-| Python SDK v2 | server v2+ | Legacy | [Python v2 → v3](/docs/observability/sdk/upgrade-path/python-v2-to-v3) |
-| Python SDK v1 | unsupported on v3 | End of life | [All paths](/docs/observability/sdk/upgrade-path) |
-| JS/TS SDK v5 | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) | GA | |
-| JS/TS SDK v4 | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) | Legacy | [JS v4 → v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) |
-| JS/TS SDK v3 / v2 | server v2+ | Legacy | [JS v3 → v4](/docs/observability/sdk/upgrade-path/js-v3-to-v4) |
-| JS/TS SDK v1 | unsupported on v3 | End of life | [All paths](/docs/observability/sdk/upgrade-path) |
+| SDK & version     | Min. self-hosted server                                                 | Status      | Upgrade guide                                                          |
+| ----------------- | ----------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| Python SDK v4     | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | GA          |                                                                        |
+| Python SDK v3     | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | Deprecated  | [Python v3 → v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) |
+| Python SDK v2     | server v2+                                                              | Deprecated  | [Python v2 → v3](/docs/observability/sdk/upgrade-path/python-v2-to-v3) |
+| Python SDK v1     | unsupported on v3                                                       | End of life | [All paths](/docs/observability/sdk/upgrade-path)                      |
+| JS/TS SDK v5      | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0)   | GA          |                                                                        |
+| JS/TS SDK v4      | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0)   | Deprecated  | [JS v4 → v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5)         |
+| JS/TS SDK v3 / v2 | server v2+                                                              | Deprecated  | [JS v3 → v4](/docs/observability/sdk/upgrade-path/js-v3-to-v4)         |
+| JS/TS SDK v1      | unsupported on v3                                                       | End of life | [All paths](/docs/observability/sdk/upgrade-path)                      |
 
 The server is backwards compatible with older SDKs. When upgrading an SDK, run a recent server too. See the [versioning policy](/self-hosting/upgrade/versioning).
 
 ## Server versions [#server]
 
-| Version | Highlights | Status | Security patches | Upgrade guide |
-| --- | --- | --- | --- | --- |
-| v1 | PostgreSQL, synchronous ingestion. | End of life | No | [v1 → v2](/self-hosting/upgrade/upgrade-guides/upgrade-v1-to-v2) |
-| v2 | PostgreSQL, synchronous ingestion. Rebuilt usage & cost tracking. Supports SDK v1+. | End of life | No | [v2 → v3](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3) |
-| v3 | ClickHouse + Redis + S3/blob storage + worker; asynchronous, event-driven. Requires SDK v2+. | GA | Yes | |
-| v4 ([Fast Preview](/docs/v4)) | Observations-first data model, faster at scale. GA on Cloud; self-hosted via env opt-in (migration in progress). | Preview | Yes | [Adopt](/docs/v4) |
+| Version                       | Highlights                                                                                                       | Status      | Security patches | Upgrade guide                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------- | ---------------- | ---------------------------------------------------------------- |
+| v1                            | PostgreSQL, synchronous ingestion.                                                                               | End of life | No               | [v1 → v2](/self-hosting/upgrade/upgrade-guides/upgrade-v1-to-v2) |
+| v2                            | PostgreSQL, synchronous ingestion. Rebuilt usage & cost tracking. Supports SDK v1+.                              | End of life | No               | [v2 → v3](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3) |
+| v3                            | ClickHouse + Redis + S3/blob storage + worker; asynchronous, event-driven. Requires SDK v2+.                     | GA          | Yes              |                                                                  |
+| v4 ([Fast Preview](/docs/v4)) | Observations-first data model, faster at scale. GA on Cloud; self-hosted via env opt-in (migration in progress). | Preview     | Yes              | [Adopt](/docs/v4)                                                |
 
 v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructure migration (adds ClickHouse, Redis, blob storage). Self-hosted v3 requires [PostgreSQL ≥ 12](/self-hosting/deployment/infrastructure/postgres), [ClickHouse ≥ 24.3](/self-hosting/deployment/infrastructure/clickhouse), and [Redis/Valkey ≥ 7](/self-hosting/deployment/infrastructure/cache) (`maxmemory-policy=noeviction`).
 
@@ -54,31 +54,31 @@ v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructur
 
 ### Ingestion [#ingestion]
 
-| Endpoint | Status | Notes |
-| --- | --- | --- |
-| `POST /api/public/otel/v1/traces` | GA | OpenTelemetry (OTLP) endpoint, server v3+ (self-hosted ≥ 3.22.0). The path forward for all ingestion. |
-| `POST /api/public/ingestion` | Deprecated | Legacy batch ingestion; async on v3+ (returns `207`). Use the OTel endpoint. |
+| Endpoint                          | Status     | Notes                                                                                                 |
+| --------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
+| `POST /api/public/otel/v1/traces` | GA         | OpenTelemetry (OTLP) endpoint, server v3+ (self-hosted ≥ 3.22.0). The path forward for all ingestion. |
+| `POST /api/public/ingestion`      | Deprecated | Batch ingestion; async on v3+ (returns `207`). Use the OTel endpoint.                                 |
 
 ### Read APIs [#read-apis]
 
 GA read endpoints use cursor pagination and selective field groups.
 
-| Endpoint | Status | Notes |
-| --- | --- | --- |
-| `GET /api/public/v2/observations` | GA | Cloud; self-hosted via the v4 preview opt-in |
-| `GET /api/public/observations` | Legacy | |
-| `GET /api/public/observations/{id}` | Legacy | Superseded by `GET /api/public/v2/observations` |
-| `GET /api/public/v2/metrics` | GA | Cloud; self-hosted via the v4 preview opt-in |
-| `GET /api/public/metrics` | Legacy | |
-| `GET /api/public/v3/scores` | GA | Cloud and self-hosted |
-| `GET /api/public/scores` | Legacy | |
-| `GET /api/public/v2/scores` | Deprecated | Use `GET /api/public/v3/scores` |
-| `GET /api/public/traces/{id}` | GA | Single trace with nested observations and scores |
-| `GET /api/public/sessions` | Legacy | Not recommended for extraction; use `GET /api/public/v2/observations` with a `sessionId` filter |
-| `GET /api/public/sessions/{sessionId}` | Legacy | Single session with traces; use `GET /api/public/v2/observations` with a `sessionId` filter |
-| `/api/public/mcp` | GA | [MCP server](/docs/api-and-data-platform/features/mcp-server); its observations and metrics tools follow the v2 preview availability above |
+| Endpoint                               | Status     | Notes                                                                                                                                      |
+| -------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GET /api/public/v2/observations`      | GA         | Cloud; self-hosted via the v4 preview opt-in                                                                                               |
+| `GET /api/public/observations`         | Deprecated |                                                                                                                                            |
+| `GET /api/public/observations/{id}`    | Deprecated | Superseded by `GET /api/public/v2/observations`                                                                                            |
+| `GET /api/public/v2/metrics`           | GA         | Cloud; self-hosted via the v4 preview opt-in                                                                                               |
+| `GET /api/public/metrics`              | Deprecated |                                                                                                                                            |
+| `GET /api/public/v3/scores`            | GA         | Cloud and self-hosted                                                                                                                      |
+| `GET /api/public/scores`               | Deprecated |                                                                                                                                            |
+| `GET /api/public/v2/scores`            | Deprecated | Use `GET /api/public/v3/scores`                                                                                                            |
+| `GET /api/public/traces/{id}`          | GA         | Single trace with nested observations and scores                                                                                           |
+| `GET /api/public/sessions`             | Deprecated | Not recommended for extraction; use `GET /api/public/v2/observations` with a `sessionId` filter                                            |
+| `GET /api/public/sessions/{sessionId}` | Deprecated | Single session with traces; use `GET /api/public/v2/observations` with a `sessionId` filter                                                |
+| `/api/public/mcp`                      | GA         | [MCP server](/docs/api-and-data-platform/features/mcp-server); its observations and metrics tools follow the v2 preview availability above |
 
-- SDKs default to the GA resources (`api.observations`, `api.scores`, `api.metrics`); legacy versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted without the v4 preview opt-in, use the legacy observations and metrics resources.
+- SDKs default to the GA resources (`api.observations`, `api.scores`, `api.metrics`); older versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted without the v4 preview opt-in, use the `api.legacy.*` observations and metrics resources.
 - Metrics v2 has no `traces` view.
 
 <Callout type="warning">
@@ -89,18 +89,18 @@ See the [Observations API](/docs/api-and-data-platform/features/observations-api
 
 ## Evaluations & integrations [#evals-integrations]
 
-Each has a GA version (built on the v4 data model) and a legacy version that still works and may be deprecated later. Some capabilities also require a specific plan or edition; see [Cloud pricing](/pricing) and [self-hosting pricing](/pricing-self-host).
+Each has a GA version (built on the v4 data model) and a deprecated version that still works but will be removed. Some capabilities also require a specific plan or edition; see [Cloud pricing](/pricing) and [self-hosting pricing](/pricing-self-host).
 
-| Capability | GA | Legacy |
-| --- | --- | --- |
-| [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Span / observation-level (server ≥ 3.153.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
-| [Dataset evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Experiment-level | Dataset-run-level |
-| [PostHog](/integrations/analytics/posthog) | Enriched observations | Traces and observations |
-| [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations | Traces and observations |
-| [Mixpanel](/integrations/analytics/mixpanel) | Enriched observations | Traces and observations |
+| Capability                                                                         | GA                                                                       | Deprecated                                |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------- |
+| [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge)                   | Span / observation-level (server ≥ 3.153.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
+| [Dataset evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge)           | Experiment-level                                                         | Dataset-run-level                         |
+| [PostHog](/integrations/analytics/posthog)                                         | Enriched observations                                                    | Traces and observations                   |
+| [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations                                                    | Traces and observations                   |
+| [Mixpanel](/integrations/analytics/mixpanel)                                       | Enriched observations                                                    | Traces and observations                   |
 
 - Enriched observations are observations with trace attributes attached (v4 data model); on self-hosted these exports require the v4 preview opt-in (Cloud is unaffected).
-- On Cloud, projects created on or after 2026-05-20 can no longer select the legacy export source (existing projects and self-hosted are unaffected).
+- On Cloud, projects created on or after 2026-05-20 can no longer select the deprecated export source (existing projects and self-hosted are unaffected).
 
 ## How versioning works [#policy]
 

--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -1,0 +1,103 @@
+---
+title: Versions & compatibility
+description: How Langfuse server, SDK, and API versions relate across GA versions, minimum server requirements, and Cloud vs self-hosted availability.
+---
+
+# Versions & compatibility
+
+Reference for how Langfuse's server, SDK, and API versions relate across Langfuse Cloud and self-hosted deployments.
+
+<Callout type="info">
+Langfuse Cloud runs the latest version, including both GA and preview features. New capabilities usually ship to **Langfuse Cloud** first (as preview), then become GA for **OSS / self-hosted** once validated. Availability therefore differs between the two. This page calls out the difference per version, API, and endpoint.
+</Callout>
+
+## GA versions [#ga]
+
+Generally available versions. Forward-looking tracks that are not yet GA, such as the server v4 [Fast Preview](/docs/v4), are in **preview**.
+
+| Component | GA version | Package / repo | Notes |
+| --- | --- | --- | --- |
+| Server | v3 | [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) <a href="https://github.com/langfuse/langfuse/releases"><img className="inline" src="https://img.shields.io/github/v/release/langfuse/langfuse?style=flat-square&label=release" alt="Langfuse server release" /></a> | ClickHouse + Redis + S3/blob storage + worker |
+| Python SDK | v4 | [`langfuse`](https://pypi.org/project/langfuse/) <a href="https://pypi.org/project/langfuse/"><img className="inline" src="https://img.shields.io/pypi/v/langfuse?style=flat-square&label=pypi" alt="PyPI langfuse" /></a> | OpenTelemetry-based since v3 |
+| JS/TS SDK | v5 | [`@langfuse/*`](https://www.npmjs.com/package/@langfuse/tracing) <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm" alt="NPM @langfuse/tracing" /></a> | OpenTelemetry-based since v4 |
+| Other languages | n/a | [OpenTelemetry](/integrations/native/opentelemetry) | Any OTel SDK to the Langfuse OTel endpoint |
+
+## SDK ↔ server compatibility [#sdk-server]
+
+Recent SDKs require a recent self-hosted server. Cloud always satisfies these minimums.
+
+| SDK & version | Min. self-hosted server | Status | Upgrade guide |
+| --- | --- | --- | --- |
+| Python SDK v4 | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | GA | |
+| Python SDK v3 | [≥ 3.125.0](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) | Legacy | [Python v3 → v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) |
+| Python SDK v2 | server v2+ | Legacy | [Python v2 → v3](/docs/observability/sdk/upgrade-path/python-v2-to-v3) |
+| Python SDK v1 | unsupported on v3 | End of life | [All paths](/docs/observability/sdk/upgrade-path) |
+| JS/TS SDK v5 | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) | GA | |
+| JS/TS SDK v4 | [≥ 3.95.0](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) | Legacy | [JS v4 → v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) |
+| JS/TS SDK v3 / v2 | server v2+ | Legacy | [JS v3 → v4](/docs/observability/sdk/upgrade-path/js-v3-to-v4) |
+| JS/TS SDK v1 | unsupported on v3 | End of life | [All paths](/docs/observability/sdk/upgrade-path) |
+
+The server is backwards compatible with older SDKs. When upgrading an SDK, run a recent server too. See the [versioning policy](/self-hosting/upgrade/versioning).
+
+## Server versions [#server]
+
+| Version | Highlights | Status | Security patches | Upgrade guide |
+| --- | --- | --- | --- | --- |
+| v1 | PostgreSQL, synchronous ingestion. | End of life | No | [v1 → v2](/self-hosting/upgrade/upgrade-guides/upgrade-v1-to-v2) |
+| v2 | PostgreSQL, synchronous ingestion. Rebuilt usage & cost tracking. Supports SDK v1+. | End of life | No | [v2 → v3](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3) |
+| v3 | ClickHouse + Redis + S3/blob storage + worker; asynchronous, event-driven. Requires SDK v2+. | GA | Yes | |
+| v4 ([Fast Preview](/docs/v4)) | Observations-first data model, faster at scale. Cloud-only preview. | Preview | Yes | [Adopt](/docs/v4) |
+
+v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructure migration (adds ClickHouse, Redis, blob storage).
+
+## API versions [#api]
+
+### Ingestion [#ingestion]
+
+| Endpoint | Status | Notes |
+| --- | --- | --- |
+| `POST /api/public/otel/v1/traces` | Recommended | OpenTelemetry (OTLP) endpoint, server v3+ (self-hosted ≥ 3.22.0). The path forward for all ingestion. |
+| `POST /api/public/ingestion` | Deprecated | Legacy batch ingestion; async on v3+ (returns `207`). Use the OTel endpoint. |
+
+### Read APIs [#read-apis]
+
+Current versions use cursor pagination and selective field groups. **Legacy** endpoints still work but are superseded by a current version. **Deprecated** endpoints will be removed in a future version; migrate to the replacement shown in Notes.
+
+| Endpoint | Status | Notes |
+| --- | --- | --- |
+| `GET /api/public/v2/observations` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
+| `GET /api/public/observations` | Legacy | |
+| `GET /api/public/observations/{id}` | Deprecated | Use `GET /api/public/v2/observations` |
+| `GET /api/public/v2/metrics` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
+| `GET /api/public/metrics` | Legacy | |
+| `GET /api/public/v3/scores` | Current | GA (Cloud and self-hosted) |
+| `GET /api/public/scores` | Legacy | |
+| `GET /api/public/v2/scores` | Deprecated | Use `GET /api/public/v3/scores` |
+| `GET /api/public/traces/{id}` | Deprecated | Use `GET /api/public/v2/observations` |
+| `GET /api/public/sessions` | Deprecated | Use `GET /api/public/v2/observations` |
+| `/api/public/mcp` | Preview | [MCP server](/docs/api-and-data-platform/features/mcp-server); v4 ([Fast Preview](/docs/v4)) only |
+
+- Self-hosted Observations/Metrics v2 require the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`).
+- SDKs default to the current resources (`api.observations`, `api.scores`, `api.metrics`); legacy versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted, use the legacy observations and metrics resources until their v2 APIs are GA there.
+- Metrics v2 has no `traces` view.
+
+<Callout type="warning">
+Real-time v2 data requires Python SDK ≥ 4.0.0, JS/TS SDK ≥ 5.0.0, or `x-langfuse-ingestion-version: 4` on your OTEL exporter. Otherwise data can lag up to 10 minutes.
+</Callout>
+
+See the [Observations API](/docs/api-and-data-platform/features/observations-api) and [Metrics API](/docs/metrics/features/metrics-api) pages for details.
+
+## Evaluations & integrations [#evals-integrations]
+
+Each has a current version (built on the v4 data model) and a deprecated version that still works but will be removed. Both run on Cloud and self-hosted. Some also require a specific plan or edition; see [pricing](/pricing).
+
+| Capability | Current | Deprecated |
+| --- | --- | --- |
+| [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Span / observation-level (server ≥ 3.150.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
+| [PostHog](/integrations/analytics/posthog) | Enriched observations | Traces and observations (legacy) |
+| [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations | Traces and observations (legacy) |
+| [Mixpanel](/integrations/analytics/mixpanel) | Enriched observations | Traces and observations (legacy) |
+
+## How versioning works [#policy]
+
+Langfuse uses [semantic versioning](/self-hosting/upgrade/versioning): a major bump means a breaking change (infrastructure or public-API removal). Server and SDKs are versioned independently. Release notes: [server](https://github.com/langfuse/langfuse/releases), [Python SDK](https://github.com/langfuse/langfuse-python/releases), [JS/TS SDK](https://github.com/langfuse/langfuse-js/releases).

--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -18,8 +18,8 @@ Generally available versions. Forward-looking tracks that are not yet GA, such a
 | Component | GA version | Package / repo | Notes |
 | --- | --- | --- | --- |
 | Server | v3 | [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) <a href="https://github.com/langfuse/langfuse/releases"><img className="inline" src="https://img.shields.io/github/v/release/langfuse/langfuse?style=flat-square&label=release" alt="Langfuse server release" /></a> | ClickHouse + Redis + S3/blob storage + worker |
-| Python SDK | v4 | [`langfuse`](https://pypi.org/project/langfuse/) <a href="https://pypi.org/project/langfuse/"><img className="inline" src="https://img.shields.io/pypi/v/langfuse?style=flat-square&label=pypi" alt="PyPI langfuse" /></a> | OpenTelemetry-based since v3 |
-| JS/TS SDK | v5 | [`@langfuse/*`](https://www.npmjs.com/package/@langfuse/tracing) <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm" alt="NPM @langfuse/tracing" /></a> | OpenTelemetry-based since v4 |
+| Python SDK | v4 | [`langfuse`](https://pypi.org/project/langfuse/) <a href="https://pypi.org/project/langfuse/"><img className="inline" src="https://img.shields.io/pypi/v/langfuse?style=flat-square&label=pypi" alt="PyPI langfuse" /></a> | OpenTelemetry-based since v3. Requires Python 3.9+. |
+| JS/TS SDK | v5 | [`@langfuse/*`](https://www.npmjs.com/package/@langfuse/tracing) <a href="https://www.npmjs.com/package/@langfuse/tracing"><img className="inline" src="https://img.shields.io/npm/v/@langfuse/tracing?style=flat-square&label=npm" alt="NPM @langfuse/tracing" /></a> | OpenTelemetry-based since v4. Requires Node.js 20+. |
 | Other languages | n/a | [OpenTelemetry](/integrations/native/opentelemetry) | Any OTel SDK to the Langfuse OTel endpoint |
 
 ## SDK ↔ server compatibility [#sdk-server]
@@ -46,9 +46,9 @@ The server is backwards compatible with older SDKs. When upgrading an SDK, run a
 | v1 | PostgreSQL, synchronous ingestion. | End of life | No | [v1 → v2](/self-hosting/upgrade/upgrade-guides/upgrade-v1-to-v2) |
 | v2 | PostgreSQL, synchronous ingestion. Rebuilt usage & cost tracking. Supports SDK v1+. | End of life | No | [v2 → v3](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3) |
 | v3 | ClickHouse + Redis + S3/blob storage + worker; asynchronous, event-driven. Requires SDK v2+. | GA | Yes | |
-| v4 ([Fast Preview](/docs/v4)) | Observations-first data model, faster at scale. Cloud-only preview. | Preview | Yes | [Adopt](/docs/v4) |
+| v4 ([Fast Preview](/docs/v4)) | Observations-first data model, faster at scale. GA on Cloud; self-hosted via env opt-in (migration in progress). | Preview | Yes | [Adopt](/docs/v4) |
 
-v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructure migration (adds ClickHouse, Redis, blob storage).
+v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructure migration (adds ClickHouse, Redis, blob storage). Self-hosted v3 requires [PostgreSQL ≥ 12](/self-hosting/deployment/infrastructure/postgres), [ClickHouse ≥ 24.3](/self-hosting/deployment/infrastructure/clickhouse), and [Redis/Valkey ≥ 7](/self-hosting/deployment/infrastructure/cache) (`maxmemory-policy=noeviction`).
 
 ## API versions [#api]
 
@@ -67,15 +67,16 @@ Current versions use cursor pagination and selective field groups. **Legacy** en
 | --- | --- | --- |
 | `GET /api/public/v2/observations` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
 | `GET /api/public/observations` | Legacy | |
-| `GET /api/public/observations/{id}` | Deprecated | Use `GET /api/public/v2/observations` |
+| `GET /api/public/observations/{id}` | Legacy | Superseded by `GET /api/public/v2/observations` |
 | `GET /api/public/v2/metrics` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
 | `GET /api/public/metrics` | Legacy | |
 | `GET /api/public/v3/scores` | Current | GA (Cloud and self-hosted) |
 | `GET /api/public/scores` | Legacy | |
 | `GET /api/public/v2/scores` | Deprecated | Use `GET /api/public/v3/scores` |
-| `GET /api/public/traces/{id}` | Deprecated | Use `GET /api/public/v2/observations` |
-| `GET /api/public/sessions` | Deprecated | Use `GET /api/public/v2/observations` |
-| `/api/public/mcp` | Preview | [MCP server](/docs/api-and-data-platform/features/mcp-server); v4 ([Fast Preview](/docs/v4)) only |
+| `GET /api/public/traces/{id}` | Current | Single trace with nested observations and scores |
+| `GET /api/public/sessions` | Legacy | Not recommended for extraction; use `GET /api/public/v2/observations` with a `sessionId` filter |
+| `GET /api/public/sessions/{sessionId}` | Legacy | Single session with traces; use `GET /api/public/v2/observations` with a `sessionId` filter |
+| `/api/public/mcp` | Current | [MCP server](/docs/api-and-data-platform/features/mcp-server); its observations and metrics tools follow the v2 preview availability above |
 
 - Self-hosted Observations/Metrics v2 require the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`).
 - SDKs default to the current resources (`api.observations`, `api.scores`, `api.metrics`); legacy versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted, use the legacy observations and metrics resources until their v2 APIs are GA there.
@@ -89,14 +90,18 @@ See the [Observations API](/docs/api-and-data-platform/features/observations-api
 
 ## Evaluations & integrations [#evals-integrations]
 
-Each has a current version (built on the v4 data model) and a deprecated version that still works but will be removed. Both run on Cloud and self-hosted. Some also require a specific plan or edition; see [pricing](/pricing).
+Each has a current version (built on the v4 data model) and a legacy version that still works and may be deprecated later. Some capabilities also require a specific plan or edition; see [Cloud pricing](/pricing) and [self-hosting pricing](/pricing-self-host).
 
-| Capability | Current | Deprecated |
+| Capability | Current | Legacy |
 | --- | --- | --- |
-| [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Span / observation-level (server ≥ 3.150.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
-| [PostHog](/integrations/analytics/posthog) | Enriched observations | Traces and observations (legacy) |
-| [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations | Traces and observations (legacy) |
-| [Mixpanel](/integrations/analytics/mixpanel) | Enriched observations | Traces and observations (legacy) |
+| [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Span / observation-level (server ≥ 3.153.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
+| [Dataset evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Experiment-level | Dataset-run-level |
+| [PostHog](/integrations/analytics/posthog) | Enriched observations | Traces and observations |
+| [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations | Traces and observations |
+| [Mixpanel](/integrations/analytics/mixpanel) | Enriched observations | Traces and observations |
+
+- The enriched (current) analytics exports build on the v4 data model; on self-hosted they require the v4 preview opt-in (Cloud is unaffected).
+- On Cloud, projects created on or after 2026-05-20 can no longer select the legacy export source (existing projects and self-hosted are unaffected).
 
 ## How versioning works [#policy]
 

--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -8,12 +8,12 @@ description: How Langfuse server, SDK, and API versions relate across GA version
 Reference for how Langfuse's server, SDK, and API versions relate across Langfuse Cloud and self-hosted deployments.
 
 <Callout type="info">
-Langfuse Cloud runs the latest version, including both GA and preview features. New capabilities usually ship to **Langfuse Cloud** first (as preview), then become GA for **OSS / self-hosted** once validated. Availability therefore differs between the two. This page calls out the difference per version, API, and endpoint.
+Langfuse Cloud runs the latest version, including both GA and preview features. New capabilities usually ship to **Langfuse Cloud** first (as preview), then become GA for **OSS / self-hosted** once validated. The current preview is the server v4 [Fast Preview](/docs/v4), an observations-first data model; self-hosted instances enable it with the `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` environment variable ("v4 preview opt-in" below). **On Langfuse Cloud, you can ignore the self-hosted minimums and opt-in notes on this page.**
 </Callout>
 
-## GA versions [#ga]
+Status labels used on this page: **GA** (recommended, fully supported), **Preview** (Cloud first; self-hosted via opt-in), **Legacy** (still works, superseded by a newer version), **Deprecated** (will be removed; migrate to the replacement), **End of life** (unsupported, no security patches).
 
-Generally available versions. Forward-looking tracks that are not yet GA, such as the server v4 [Fast Preview](/docs/v4), are in **preview**.
+## GA versions [#ga]
 
 | Component | GA version | Package / repo | Notes |
 | --- | --- | --- | --- |
@@ -56,30 +56,29 @@ v1 and v2 are end of life; upgrade is recommended. v2 → v3 is an infrastructur
 
 | Endpoint | Status | Notes |
 | --- | --- | --- |
-| `POST /api/public/otel/v1/traces` | Recommended | OpenTelemetry (OTLP) endpoint, server v3+ (self-hosted ≥ 3.22.0). The path forward for all ingestion. |
+| `POST /api/public/otel/v1/traces` | GA | OpenTelemetry (OTLP) endpoint, server v3+ (self-hosted ≥ 3.22.0). The path forward for all ingestion. |
 | `POST /api/public/ingestion` | Deprecated | Legacy batch ingestion; async on v3+ (returns `207`). Use the OTel endpoint. |
 
 ### Read APIs [#read-apis]
 
-Current versions use cursor pagination and selective field groups. **Legacy** endpoints still work but are superseded by a current version. **Deprecated** endpoints will be removed in a future version; migrate to the replacement shown in Notes.
+GA read endpoints use cursor pagination and selective field groups.
 
 | Endpoint | Status | Notes |
 | --- | --- | --- |
-| `GET /api/public/v2/observations` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
+| `GET /api/public/v2/observations` | GA | Cloud; self-hosted via the v4 preview opt-in |
 | `GET /api/public/observations` | Legacy | |
 | `GET /api/public/observations/{id}` | Legacy | Superseded by `GET /api/public/v2/observations` |
-| `GET /api/public/v2/metrics` | Current | Cloud (GA); self-hosted via the v4 preview opt-in |
+| `GET /api/public/v2/metrics` | GA | Cloud; self-hosted via the v4 preview opt-in |
 | `GET /api/public/metrics` | Legacy | |
-| `GET /api/public/v3/scores` | Current | GA (Cloud and self-hosted) |
+| `GET /api/public/v3/scores` | GA | Cloud and self-hosted |
 | `GET /api/public/scores` | Legacy | |
 | `GET /api/public/v2/scores` | Deprecated | Use `GET /api/public/v3/scores` |
-| `GET /api/public/traces/{id}` | Current | Single trace with nested observations and scores |
+| `GET /api/public/traces/{id}` | GA | Single trace with nested observations and scores |
 | `GET /api/public/sessions` | Legacy | Not recommended for extraction; use `GET /api/public/v2/observations` with a `sessionId` filter |
 | `GET /api/public/sessions/{sessionId}` | Legacy | Single session with traces; use `GET /api/public/v2/observations` with a `sessionId` filter |
-| `/api/public/mcp` | Current | [MCP server](/docs/api-and-data-platform/features/mcp-server); its observations and metrics tools follow the v2 preview availability above |
+| `/api/public/mcp` | GA | [MCP server](/docs/api-and-data-platform/features/mcp-server); its observations and metrics tools follow the v2 preview availability above |
 
-- Self-hosted Observations/Metrics v2 require the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`).
-- SDKs default to the current resources (`api.observations`, `api.scores`, `api.metrics`); legacy versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted, use the legacy observations and metrics resources until their v2 APIs are GA there.
+- SDKs default to the GA resources (`api.observations`, `api.scores`, `api.metrics`); legacy versions are under `api.legacy.*` (e.g. `api.legacy.observations_v1` / `observationsV1`). On self-hosted without the v4 preview opt-in, use the legacy observations and metrics resources.
 - Metrics v2 has no `traces` view.
 
 <Callout type="warning">
@@ -90,9 +89,9 @@ See the [Observations API](/docs/api-and-data-platform/features/observations-api
 
 ## Evaluations & integrations [#evals-integrations]
 
-Each has a current version (built on the v4 data model) and a legacy version that still works and may be deprecated later. Some capabilities also require a specific plan or edition; see [Cloud pricing](/pricing) and [self-hosting pricing](/pricing-self-host).
+Each has a GA version (built on the v4 data model) and a legacy version that still works and may be deprecated later. Some capabilities also require a specific plan or edition; see [Cloud pricing](/pricing) and [self-hosting pricing](/pricing-self-host).
 
-| Capability | Current | Legacy |
+| Capability | GA | Legacy |
 | --- | --- | --- |
 | [Evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Span / observation-level (server ≥ 3.153.0; Python SDK v3+ / JS SDK v4+) | Trace-level (Python SDK v2+ / JS SDK v3+) |
 | [Dataset evaluation](/docs/evaluation/evaluation-methods/llm-as-a-judge) | Experiment-level | Dataset-run-level |
@@ -100,7 +99,7 @@ Each has a current version (built on the v4 data model) and a legacy version tha
 | [Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) | Enriched observations | Traces and observations |
 | [Mixpanel](/integrations/analytics/mixpanel) | Enriched observations | Traces and observations |
 
-- The enriched (current) analytics exports build on the v4 data model; on self-hosted they require the v4 preview opt-in (Cloud is unaffected).
+- Enriched observations are observations with trace attributes attached (v4 data model); on self-hosted these exports require the v4 preview opt-in (Cloud is unaffected).
 - On Cloud, projects created on or after 2026-05-20 can no longer select the legacy export source (existing projects and self-hosted are unaffected).
 
 ## How versioning works [#policy]

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -17,6 +17,7 @@
     "api-and-data-platform",
     "administration",
     "security-and-guardrails",
+    "compatibility",
     "---More---",
     "glossary",
     "roadmap",

--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -41,6 +41,7 @@ This section documents tracing related features of the Langfuse SDK. To use the 
 If you are self-hosting Langfuse, the Python SDK v3 requires [**Langfuse platform version ≥ 3.125.0**](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) and the TypeScript SDK v4 requires [**Langfuse platform version ≥ 3.95.0**](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) for all features to work correctly.
 
 See the full [versions & compatibility overview](/docs/compatibility) for the SDK ↔ server matrix and API version availability.
+
 </Callout>
 
 </Details>

--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -39,6 +39,8 @@ This section documents tracing related features of the Langfuse SDK. To use the 
 
 <Callout type="info">
 If you are self-hosting Langfuse, the Python SDK v3 requires [**Langfuse platform version ≥ 3.125.0**](https://github.com/langfuse/langfuse/releases/tag/v3.125.0) and the TypeScript SDK v4 requires [**Langfuse platform version ≥ 3.95.0**](https://github.com/langfuse/langfuse/releases/tag/v3.95.0) for all features to work correctly.
+
+See the full [versions & compatibility overview](/docs/compatibility) for the SDK ↔ server matrix and API version availability.
 </Callout>
 
 </Details>

--- a/content/faq/all/compatibility-langfuse-ui-and-python-sdk.mdx
+++ b/content/faq/all/compatibility-langfuse-ui-and-python-sdk.mdx
@@ -6,3 +6,5 @@ tags: [self-hosting]
 # What is the compatibility between Langfuse application / UI and Python SDK?
 
 Generally, the UI is backwards compatible with older SDK versions. However, if you update the SDK, you also need to update the Langfuse Application to the latest version.
+
+For the full SDK ↔ server compatibility matrix, minimum version requirements, and API version availability, see [Versions & compatibility](/docs/compatibility).

--- a/content/self-hosting/upgrade/versioning.mdx
+++ b/content/self-hosting/upgrade/versioning.mdx
@@ -8,6 +8,10 @@ sidebarTitle: "Versioning"
 
 Versioning is key to ensure compatibility between Langfuse Server, SDKs, and custom integrations via the Public API. Thus, we take [semantic versioning](https://semver.org/) seriously.
 
+<Callout type="info">
+For an overview of current and legacy versions, the SDK ↔ server compatibility matrix, and API version availability, see [Versions & compatibility](/docs/compatibility).
+</Callout>
+
 ## Scope of semantic versioning
 
 The following changes **result in a major version bump** as they are considered breaking:


### PR DESCRIPTION
## What

Adds `/docs/compatibility` as a single reference for how Langfuse **server**, **SDK**, and **API** versions relate across Langfuse Cloud and self-hosted, plus a few cross-links to it.

New page sections:
- **GA versions** — current server / Python / JS-TS majors (with live version badges).
- **SDK ↔ server compatibility** — minimum self-hosted server per SDK version, status, and per-version upgrade guides.
- **Server versions** — v1–v4 (incl. v4 "Fast Preview"), with a dedicated **security-patches** column (v3 + v4 supported; v1 + v2 end of life).
- **API versions** — ingestion (OTel vs legacy) and a single read-APIs table covering current / legacy / deprecated endpoints plus the `/api/public/mcp` MCP server (v4-only).
- **Evaluations & integrations** — current vs deprecated versions for evals (observation vs trace level) and the PostHog / blob-storage-export / Mixpanel integrations (enriched vs legacy).
- **How versioning works** — semver policy + release-note links.

Cross-links added from the SDK overview, the self-hosting versioning page, and the compatibility FAQ.

## Notes for reviewers

- All version facts were ground-truthed against the `langfuse`, `langfuse-python`, and `langfuse-js` source (not just docs).
- A couple of items intentionally follow product intent over the current spec/docs and are worth a sanity check:
  - `observations/{id}`, `traces/{id}`, and `sessions` are shown **Deprecated** (not yet flagged in the OpenAPI/Fern spec).
  - Trace-level evals are shown **deprecated**, which conflicts with a line in `llm-as-a-judge-migration.mdx` ("not a deprecation") — that FAQ line likely needs updating for consistency.
  - The `/docs/v4` MCP note says "v4 only"; the existing `mcp-server.mdx` says the MCP server is available today for prompt management — may need reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `/docs/compatibility` reference page consolidating Langfuse server, SDK, and API version information in one place, with cross-links added from three existing pages (SDK overview, versioning page, and the compatibility FAQ).

- The new page covers GA versions with live badges, an SDK ↔ server compatibility matrix, server version history, API endpoint status (ingestion + read APIs), and an evaluations/integrations table.
- Two factual inconsistencies with existing docs exist that need resolving before merge: the MCP server is labeled "v4 only" while `mcp-server.mdx` lists it as available on all Cloud regions today; and trace-level evaluations are labeled "Deprecated" while `llm-as-a-judge-migration.mdx` explicitly says it is "not a deprecation."
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The page itself is purely documentation with no runtime risk, but two of its factual claims directly contradict existing live pages, which would mislead users about what is available today.

The new compatibility page conflicts with two existing docs: the MCP server page shows Cloud endpoints are live today while this page labels the endpoint 'v4 only', and the LLM-as-a-judge migration FAQ explicitly says trace-level evaluation is 'an upgrade path, not a deprecation' while this page labels it Deprecated. Both conflicts are acknowledged in the PR description but left unresolved.

content/docs/compatibility.mdx — the MCP server row and the trace-level evaluation row both need to be reconciled with their source-of-truth pages before merge.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User / SDK] -->|OTel OTLP| B["POST /api/public/otel/v1/traces\n(Recommended)"]
    A -->|Legacy batch| C["POST /api/public/ingestion\n(Deprecated)"]

    B --> D[Langfuse Server v3 GA]
    C --> D

    D --> E["GET /api/public/v3/scores\n(Current - GA)"]
    D --> F["GET /api/public/v2/observations\n(Current - v4 preview opt-in)"]
    D --> G["GET /api/public/v2/metrics\n(Current - v4 preview opt-in)"]
    D --> H["Legacy endpoints\n(observations, scores, metrics)\n(Still work)"]
    D --> I["Deprecated endpoints\n(observations/{id}, traces/{id}, sessions)\n(Will be removed)"]

    D --> J{v4 Fast Preview?}
    J -->|Cloud GA / self-hosted opt-in| F
    J -->|Cloud GA / self-hosted opt-in| G
    J -->|Cloud| K["/api/public/mcp\n(MCP Server)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User / SDK] -->|OTel OTLP| B["POST /api/public/otel/v1/traces\n(Recommended)"]
    A -->|Legacy batch| C["POST /api/public/ingestion\n(Deprecated)"]

    B --> D[Langfuse Server v3 GA]
    C --> D

    D --> E["GET /api/public/v3/scores\n(Current - GA)"]
    D --> F["GET /api/public/v2/observations\n(Current - v4 preview opt-in)"]
    D --> G["GET /api/public/v2/metrics\n(Current - v4 preview opt-in)"]
    D --> H["Legacy endpoints\n(observations, scores, metrics)\n(Still work)"]
    D --> I["Deprecated endpoints\n(observations/{id}, traces/{id}, sessions)\n(Will be removed)"]

    D --> J{v4 Fast Preview?}
    J -->|Cloud GA / self-hosted opt-in| F
    J -->|Cloud GA / self-hosted opt-in| G
    J -->|Cloud| K["/api/public/mcp\n(MCP Server)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/docs/compatibility.mdx:78
**MCP server availability contradicts existing docs**

The table marks `/api/public/mcp` as "v4 ([Fast Preview](/docs/v4)) only", but `content/docs/api-and-data-platform/features/mcp-server.mdx` lists active endpoints for Cloud EU, Cloud US, Cloud Japan, and HIPAA today with no v4 prerequisite. Users reading this page will incorrectly conclude the MCP server is unavailable to them, while the dedicated MCP page will tell them it is. The PR description flags this as needing reconciliation — one of the two pages needs to be authoritative before this goes live.

### Issue 2 of 3
content/docs/compatibility.mdx:96
**"Deprecated" label for trace-level evals directly contradicts existing FAQ**

`content/faq/all/llm-as-a-judge-migration.mdx` explicitly states: *"Trace-level evaluators will continue to work. This is an upgrade path, not a deprecation."* Labeling trace-level evaluation as **Deprecated** here contradicts that page and will confuse users who read both. The PR description acknowledges this conflict. Both pages will be live simultaneously, so one of them needs to be corrected before this merges — either the FAQ line should be updated or the deprecation label here should be softened to "Legacy".

### Issue 3 of 3
content/docs/compatibility.mdx:76-77
**Misleading replacement endpoint for `traces/{id}` and `sessions`**

Both `GET /api/public/traces/{id}` and `GET /api/public/sessions` point users to `GET /api/public/v2/observations` as their replacement. Observations, traces, and sessions are conceptually distinct resources; a user migrating from the sessions list endpoint to an observations list endpoint would get fundamentally different data. If the v4 data model intentionally collapses these, a brief note explaining the conceptual change would reduce confusion — otherwise readers may assume the replacement is a straightforward semantic equivalent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add versions &amp; compatibility overv..."](https://github.com/langfuse/langfuse-docs/commit/0badb5c82b39aa340af89f7e967c158d97f667f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42649426)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->