### PR TITLE
docs: add StatsD configuration details for worker container scaling

### DIFF
--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -35,11 +35,11 @@ In addition, the Langfuse worker also publishes queue length metrics via StatsD 
 
 #### Configuring StatsD
 
-Langfuse uses the [`dd-trace`](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/) package (DataDog's tracing library) which includes a DogStatsD client. The client auto-configures using standard DataDog environment variables:
+Langfuse uses the [`dd-trace`](https://docs.datadoghq.com/developers/dogstatsd/?tab=nodejs) package (DataDog's tracing library) which includes a DogStatsD client. The client auto-configures using standard DataDog environment variables:
 
 | Environment Variable    | Default       | Description                                |
 | ----------------------- | ------------- | ------------------------------------------ |
-| `DD_AGENT_HOST`         | `localhost`   | StatsD agent hostname or IP                |
+| `DD_AGENT_HOST`         | `localhost`   | DataDog Agent hostname or IP (must run a DogStatsD listener) |
 | `DD_DOGSTATSD_PORT`     | `8125`        | DogStatsD server port                      |
 | `DD_ENV`                | —             | Environment tag applied to all metrics     |
 | `DD_SERVICE`            | —             | Service name tag applied to all metrics    |

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -30,8 +30,30 @@ On very high loads, it may become necessary to apply additional settings that in
 For most environments, we recommend to scale the worker containers by their CPU load as this is a straightforward metric to measure.
 A load above 50% for a 2 CPU container is an indicator that the instance is saturated and that the throughput should increase by adding more containers.
 
-In addition, the Langfuse worker also publishes queue length metrics via statsd that can be used to scale the worker containers.
+In addition, the Langfuse worker also publishes queue length metrics via StatsD (DogStatsD format) that can be used to scale the worker containers.
 `langfuse.queue.ingestion.length` is the main metric that we use to make scaling decisions.
+
+#### Configuring StatsD
+
+Langfuse uses the [`dd-trace`](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/) package (DataDog's tracing library) which includes a DogStatsD client. The client auto-configures using standard DataDog environment variables:
+
+| Environment Variable    | Default       | Description                                |
+| ----------------------- | ------------- | ------------------------------------------ |
+| `DD_AGENT_HOST`         | `localhost`   | StatsD agent hostname or IP                |
+| `DD_DOGSTATSD_PORT`     | `8125`        | DogStatsD server port                      |
+| `DD_ENV`                | —             | Environment tag applied to all metrics     |
+| `DD_SERVICE`            | —             | Service name tag applied to all metrics    |
+
+These variables apply to both the web and worker containers.
+
+Langfuse-specific queue metric configuration (worker container only):
+
+| Environment Variable                           | Default  | Description                                                    |
+| ---------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `LANGFUSE_QUEUE_METRICS_ENABLED`               | `true`   | Master toggle for publishing queue metrics via StatsD          |
+| `LANGFUSE_QUEUE_METRICS_INTERVAL_MS`           | `1000`   | Poll interval for queue depth metrics (minimum 100ms)          |
+| `LANGFUSE_QUEUE_METRICS_SAMPLE_RATE`           | `0.3`    | Probability for recording sharded queue depth metrics (0-1)    |
+
 The queue metrics can also be published to AWS CloudWatch by setting `ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING=true` to configure auto-scalers based on AWS metrics.
 
 ### Reducing ClickHouse reads within the ingestion processing


### PR DESCRIPTION
Closes #12645

Adds documentation for the StatsD/DogStatsD environment variables needed to configure queue metrics publishing from worker containers.

### Changes
- Clarified that StatsD uses DogStatsD format via dd-trace
- Added table of standard DataDog environment variables (`DD_AGENT_HOST`, `DD_DOGSTATSD_PORT`, `DD_ENV`, `DD_SERVICE`)
- Added table of Langfuse-specific queue metric env vars (`LANGFUSE_QUEUE_METRICS_ENABLED`, `LANGFUSE_QUEUE_METRICS_INTERVAL_MS`, `LANGFUSE_QUEUE_METRICS_SAMPLE_RATE`)
- Noted that DD_* vars apply to both web and worker, while queue metric vars are worker-only
- Kept existing note about `ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING`

Related code:
- `packages/shared/src/server/instrumentation/index.ts` - uses dd-trace DogStatsD client
- `worker/src/env.ts` - defines LANGFUSE_QUEUE_METRICS_* env vars

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Configuring StatsD" sub-section to the worker scaling documentation, explaining how Langfuse's `dd-trace`-based DogStatsD client is configured via environment variables.

- Introduces a table of standard DataDog environment variables (`DD_AGENT_HOST`, `DD_DOGSTATSD_PORT`, `DD_ENV`, `DD_SERVICE`) and notes they apply to both web and worker containers.
- Adds a second table of Langfuse-specific queue-metric variables (`LANGFUSE_QUEUE_METRICS_ENABLED`, `LANGFUSE_QUEUE_METRICS_INTERVAL_MS`, `LANGFUSE_QUEUE_METRICS_SAMPLE_RATE`), scoped to the worker container only.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change that adds helpful configuration details; no runtime code is affected.

The added tables and prose are accurate. Two small wording issues exist: the dd-trace hyperlink points at the APM instrumentation page rather than the DogStatsD-specific docs, and the DD_AGENT_HOST description says 'StatsD agent' where 'DataDog Agent' is the correct term. Neither would break anything at runtime, but they could send operators down the wrong path when configuring the DataDog Agent.

content/self-hosting/configuration/scaling.mdx — the dd-trace link target and the DD_AGENT_HOST description wording are the two spots worth a quick fix.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WC[Worker Container\nLANGFUSE_QUEUE_METRICS_*] -->|DogStatsD UDP| DA[DataDog Agent\nDD_AGENT_HOST:DD_DOGSTATSD_PORT]
    WEB[Web Container\nDD_AGENT_HOST / DD_DOGSTATSD_PORT] -->|APM traces| DA
    DA -->|Metrics & Traces| DD[(DataDog Platform)]
    DA -->|langfuse.queue.*| AS[Auto-Scaler\ne.g. KEDA / ECS ASG]
    AWS[AWS CloudWatch\nENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING] -->|Queue metrics| AS
    WC -->|Optional| AWS
    DD -->|Dashboard / Alerts| OPS[Operator]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    WC[Worker Container\nLANGFUSE_QUEUE_METRICS_*] -->|DogStatsD UDP| DA[DataDog Agent\nDD_AGENT_HOST:DD_DOGSTATSD_PORT]
    WEB[Web Container\nDD_AGENT_HOST / DD_DOGSTATSD_PORT] -->|APM traces| DA
    DA -->|Metrics & Traces| DD[(DataDog Platform)]
    DA -->|langfuse.queue.*| AS[Auto-Scaler\ne.g. KEDA / ECS ASG]
    AWS[AWS CloudWatch\nENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING] -->|Queue metrics| AS
    WC -->|Optional| AWS
    DD -->|Dashboard / Alerts| OPS[Operator]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/self-hosting/configuration/scaling.mdx:42
The description for `DD_AGENT_HOST` says "StatsD agent hostname or IP", but since Langfuse uses DogStatsD format (not vanilla StatsD), this host must point to a **DataDog Agent** running a DogStatsD listener — a plain StatsD server would not understand the DogStatsD wire format and metrics would be silently dropped. Calling it a "StatsD agent" could lead operators to point it at a generic StatsD endpoint and wonder why nothing shows up in DataDog.

```suggestion
| `DD_AGENT_HOST`         | `localhost`   | DataDog Agent hostname or IP (must run a DogStatsD listener) |
```

### Issue 2 of 2
content/self-hosting/configuration/scaling.mdx:38
The link targets DataDog's APM/distributed-tracing instrumentation page, which focuses on trace collection rather than StatsD/metrics configuration. Readers following this link to learn how to configure `DD_AGENT_HOST` or `DD_DOGSTATSD_PORT` will land on unrelated APM setup content. The DataDog DogStatsD docs (`https://docs.datadoghq.com/developers/dogstatsd/`) more directly describe the DogStatsD client and its environment variables.

```suggestion
Langfuse uses the [`dd-trace`](https://docs.datadoghq.com/developers/dogstatsd/?tab=nodejs) package (DataDog's tracing library) which includes a DogStatsD client. The client auto-configures using standard DataDog environment variables:
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add StatsD configuration details f..."](https://github.com/langfuse/langfuse-docs/commit/08153ed74522feec71edd59fa61c633274e7c068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42716600)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->