### PR TITLE
docs(handbook): describe how on-call works at Langfuse

### DIFF
--- a/content/handbook/product-engineering/how-we-work/code-review.mdx
+++ b/content/handbook/product-engineering/how-we-work/code-review.mdx
@@ -7,7 +7,7 @@ description: Code review process and guidelines at Langfuse.
 
 ## When a PR author should ask for review
 
-- Low risk (2 way door): go ahead and merge. Engineer is responsible for monitoring Datadog in case something goes wrong. Notify on-call engineer for roll-backs if required.
+- Low risk (2 way door): go ahead and merge. Engineer is responsible for monitoring Datadog in case something goes wrong. Notify the [on-call engineer](/handbook/product-engineering/how-we-work/on-call) for roll-backs if required.
   - Product expert review: sometimes we build a larger change in someone else’s area of responsibility. Feel free to ask for feedback from [DRI](https://docs.google.com/spreadsheets/d/1gOvWf_uSAtcXxWkR_gMuWX8-OYmSJNIPXTmPGfZ2DGY/edit?gid=0#gid=0).
 - Risk (1 way door): Assign Max as reviewer (Max sees open PR reviews in Linear, SLA 24h, ping if more urgent). **Non exhaustive list of PRs which require a review**: database migrations, changes in the public API, changes in SDK signatures, auth changes, major changes in the ingestion pipeline, larger infra changes. If you are unsure, ask Max for a review.
 - New joiners should get all their PRs reviewed for the first 1 month at least. By this, new joiners will learn about the code base and how our system works.

--- a/content/handbook/product-engineering/how-we-work/meta.json
+++ b/content/handbook/product-engineering/how-we-work/meta.json
@@ -5,6 +5,7 @@
     "how-we-ship",
     "onboarding",
     "code-review",
-    "product-ops"
+    "product-ops",
+    "on-call"
   ]
 }

--- a/content/handbook/product-engineering/how-we-work/on-call.mdx
+++ b/content/handbook/product-engineering/how-we-work/on-call.mdx
@@ -1,0 +1,18 @@
+---
+title: On-call
+description: How the on-call rotation works at Langfuse.
+---
+
+# On-call at Langfuse
+
+Langfuse Cloud is covered by an on-call rotation around the clock. If you are paged, follow the [incident response plan](/handbook/product-engineering/incident-response).
+
+## Rotation
+
+- **Daytime (level 1)**: newer joiners in the data and platform group take the daytime shifts. Being paged during working hours, with the whole team around to help, is one of the fastest ways to learn how our systems behave in production.
+- **Nights and weekends**: more experienced engineers share these shifts.
+- **Daytime (level 2)**: the more experienced engineers also act as the escalation level behind the daytime level 1.
+
+## Weekly review
+
+We review all pages weekly — reasons and times, per engineer — to keep the load manageable. Noisy or non-actionable alerts get fixed or removed, and we escalate quickly if alert volume becomes excessive.

--- a/content/handbook/product-engineering/incident-response.mdx
+++ b/content/handbook/product-engineering/incident-response.mdx
@@ -17,7 +17,7 @@ Langfuse incidents are handled in the **ClickHouse incident.io account**.
 
 For urgent issues, use `/inc escalate` to page Langfuse directly. You can also tag `@langfuse-oncall` in Slack. ClickHouse teammates can find the team in `#langfuse`; if the issue is related to ClickHouse instances, also involve `#ch-sre-team`.
 
-incident.io will automatically create a Slack channel and route the escalation to the Langfuse on-call team. Salesforce support escalations should use the same Langfuse on-call flow.
+incident.io will automatically create a Slack channel and route the escalation to the Langfuse on-call team. Salesforce support escalations should use the same Langfuse on-call flow. See [On-call at Langfuse](/handbook/product-engineering/how-we-work/on-call) for how the rotation is staffed and reviewed.
 
 **When to page:** platform outages, ClickHouse instance issues affecting Langfuse, security issues, elevated errors, a broken core product flow, or a customer seeing another customer's data.
 


### PR DESCRIPTION
Add a brief on-call page to the product engineering how-we-work section covering the rotation (newer joiners on daytime level 1, experienced engineers on nights/weekends and daytime level 2) and the weekly page review. Link to it from the incident response plan and the code review guidelines.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a brief on-call handbook page to the "how we work" section, documenting the two-tier daytime rotation (newer joiners on level 1, experienced engineers on level 2 and nights/weekends) and the weekly page review process.

- **New `on-call.mdx` page**: introduces the rotation structure and links back to the incident response plan.
- **Cross-links added**: `code-review.mdx` and `incident-response.mdx` now reference the new page so engineers can find rotation details from the places they already look during incidents.
- **Sidebar registration**: `meta.json` adds `on-call` to the navigation list.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no executable code or configuration is modified.

All four files contain only handbook prose and navigation metadata. The new on-call page is clear and internally consistent, cross-links resolve to real paths, and the sidebar registration is correct. One minor ordering suggestion was noted on the rotation bullets, but it has no impact on correctness.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incident / Page fired] --> B{Time of day?}
    B -- Daytime --> C[Level 1 on-call\nnewer joiner]
    B -- Night / Weekend --> D[Experienced engineer\non-call]
    C -- Escalate --> E[Level 2 on-call\nexperienced engineer]
    D --> E
    E --> F[Follow incident\nresponse plan]
    C --> F
    G[Weekly review] --> H{Alert noisy\nor non-actionable?}
    H -- Yes --> I[Fix or remove alert]
    H -- No --> J[Keep & monitor load]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incident / Page fired] --> B{Time of day?}
    B -- Daytime --> C[Level 1 on-call\nnewer joiner]
    B -- Night / Weekend --> D[Experienced engineer\non-call]
    C -- Escalate --> E[Level 2 on-call\nexperienced engineer]
    D --> E
    E --> F[Follow incident\nresponse plan]
    C --> F
    G[Weekly review] --> H{Alert noisy\nor non-actionable?}
    H -- Yes --> I[Fix or remove alert]
    H -- No --> J[Keep & monitor load]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/handbook/product-engineering/how-we-work/on-call.mdx:12-14
**Rotation bullet ordering breaks the level pairing**

The "Nights and weekends" bullet sits between the two daytime tiers, visually separating level 1 and level 2 even though they are a related pair. Readers building a mental model of the escalation chain have to skip over the unrelated third bullet to connect the two daytime levels. Putting daytime level 1 and daytime level 2 side-by-side, then listing nights/weekends afterward, would match the escalation flow more naturally.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): describe how on-call wor..."](https://github.com/langfuse/langfuse-docs/commit/2dc65b908312fe6156827e79b40e110436f37eb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42730435)</sub>

<!-- /greptile_comment -->