### PR TITLE
docs: add career link to  readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Repo for [langfuse.com](https://langfuse.com). Built with [Fumadocs](https://fumadocs.vercel.app/) and Next.js App Router.
 
+> ### 🧑‍💻 We're hiring
+>
+> Langfuse is growing fast (we doubled the team in the last 6 months) - since January 2026 we're part of ClickHouse, we're hiring engineering hybrid across the EU.
+> We hire engineers who love open source and great developer experiences.
+> **[See open roles →](https://langfuse.com/careers?utm_source=github&utm_medium=readme&utm_campaign=hiring&utm_content=langfuse-docs)**
+
 ## Local Development
 
 Pre-requisites: Node.js 22, pnpm v9.5.0


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a "We're hiring" callout block to the top of the `README.md`, pointing visitors to Langfuse's careers page with a UTM-tracked link.

- Inserts a blockquote above the "Local Development" section with a brief hiring pitch and a link to `langfuse.com/careers` with UTM parameters for GitHub readme tracking.
- One sentence contains a grammatical ambiguity ("we're hiring engineering hybrid across the EU") that may confuse readers about the role type and work arrangement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a README-only change adding a hiring notice — no code, logic, or configuration is touched.

The change adds a single blockquote with static text and a UTM-tracked marketing link. The careers URL is well-formed and the UTM parameters look intentional. The only issue is a minor grammatical awkwardness in one sentence that doesn't affect functionality.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Hero Image]
    B --> C[Project Title & Description]
    C --> D["🧑‍💻 We're hiring callout (NEW)"]
    D --> E[careers link with UTM params]
    D --> F[Local Development section]
    F --> G[Formatting section]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[README.md] --> B[Hero Image]
    B --> C[Project Title & Description]
    C --> D["🧑‍💻 We're hiring callout (NEW)"]
    D --> E[careers link with UTM params]
    D --> F[Local Development section]
    F --> G[Formatting section]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:9
The phrase "we're hiring engineering hybrid across the EU" is grammatically awkward — "engineering hybrid" doesn't parse cleanly as a noun or adjective phrase. A reader could misread it as a job title. Consider rephrasing to make the hybrid-work arrangement and the role type explicit.

```suggestion
> Langfuse is growing fast (we doubled the team in the last 6 months) - since January 2026 we're part of ClickHouse, and we're hiring engineers (hybrid) across the EU.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add career link to  readme"](https://github.com/langfuse/langfuse-docs/commit/821e36d70cf77ae0a906bdd336b74dff658244ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42832944)</sub>

<!-- /greptile_comment -->