### PR TITLE
docs: update supported media formats to match current media validation

### DIFF
--- a/content/docs/observability/features/multi-modality.mdx
+++ b/content/docs/observability/features/multi-modality.mdx
@@ -45,8 +45,6 @@ Langfuse supports a wide range of media types, including:
 - **Documents**: .pdf, .docx, .xlsx, .pptx
 - **Data & archives**: .json, .xml, .zip
 
-Many more formats are supported, see the full list:
-
 <details>
 <summary>Full list of supported MIME types</summary>
 

--- a/content/docs/observability/features/multi-modality.mdx
+++ b/content/docs/observability/features/multi-modality.mdx
@@ -36,11 +36,74 @@ Multi-modal attachments are available today. You need to configure your own obje
 
 ## Supported media formats
 
-Langfuse supports:
+Langfuse supports a wide range of media types, including:
 
-- **Images**: .png, .jpg, .webp
-- **Audio files**: .mpeg, .mp3, .wav, .ogg
-- **Other attachments**: .pdf, plain text
+- **Images**: .png, .jpg, .webp, .gif
+- **Audio**: .mp3, .wav, .ogg
+- **Video**: .mp4, .webm, .mov
+- **Text & code**: .txt, .md, .html, .csv
+- **Documents**: .pdf, .docx, .xlsx, .pptx
+- **Data & archives**: .json, .xml, .zip
+
+Many more formats are supported, see the full list:
+
+<details>
+<summary>Full list of supported MIME types</summary>
+
+| Category        | MIME type                                                                   | File extension  |
+| --------------- | --------------------------------------------------------------------------- | --------------- |
+| Images          | `image/png`                                                                 | `.png`          |
+| Images          | `image/jpeg`, `image/jpg`                                                   | `.jpg`, `.jpeg` |
+| Images          | `image/webp`                                                                | `.webp`         |
+| Images          | `image/gif`                                                                 | `.gif`          |
+| Images          | `image/svg+xml`                                                             | `.svg`          |
+| Images          | `image/tiff`                                                                | `.tiff`         |
+| Images          | `image/bmp`                                                                 | `.bmp`          |
+| Images          | `image/avif`                                                                | `.avif`         |
+| Images          | `image/heic`                                                                | `.heic`         |
+| Audio           | `audio/mpeg`, `audio/mp3`                                                   | `.mp3`          |
+| Audio           | `audio/wav`                                                                 | `.wav`          |
+| Audio           | `audio/ogg`                                                                 | `.ogg`          |
+| Audio           | `audio/oga`                                                                 | `.oga`          |
+| Audio           | `audio/aac`                                                                 | `.aac`          |
+| Audio           | `audio/mp4`                                                                 | `.m4a`          |
+| Audio           | `audio/flac`                                                                | `.flac`         |
+| Audio           | `audio/opus`                                                                | `.opus`         |
+| Audio           | `audio/webm`                                                                | `.weba`         |
+| Video           | `video/mp4`                                                                 | `.mp4`          |
+| Video           | `video/webm`                                                                | `.webm`         |
+| Video           | `video/ogg`                                                                 | `.ogv`          |
+| Video           | `video/mpeg`                                                                | `.mpeg`         |
+| Video           | `video/quicktime`                                                           | `.mov`          |
+| Video           | `video/x-msvideo`                                                           | `.avi`          |
+| Video           | `video/x-matroska`                                                          | `.mkv`          |
+| Text & code     | `text/plain`                                                                | `.txt`          |
+| Text & code     | `text/html`                                                                 | `.html`         |
+| Text & code     | `text/css`                                                                  | `.css`          |
+| Text & code     | `text/csv`                                                                  | `.csv`          |
+| Text & code     | `text/markdown`                                                             | `.md`           |
+| Text & code     | `text/x-python`                                                             | `.py`           |
+| Text & code     | `application/javascript`                                                    | `.js`           |
+| Text & code     | `text/x-typescript`                                                         | `.ts`           |
+| Text & code     | `application/x-yaml`                                                        | `.yaml`         |
+| Documents       | `application/pdf`                                                           | `.pdf`          |
+| Documents       | `application/msword`                                                        | `.doc`          |
+| Documents       | `application/vnd.openxmlformats-officedocument.wordprocessingml.document`   | `.docx`         |
+| Documents       | `application/vnd.ms-excel`                                                  | `.xls`          |
+| Documents       | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`         | `.xlsx`         |
+| Documents       | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | `.pptx`         |
+| Documents       | `application/rtf`                                                           | `.rtf`          |
+| Data & archives | `application/json`                                                          | `.json`         |
+| Data & archives | `application/x-ndjson`                                                      | `.jsonl`        |
+| Data & archives | `application/xml`                                                           | `.xml`          |
+| Data & archives | `application/vnd.apache.parquet`                                            | `.parquet`      |
+| Data & archives | `application/zip`                                                           | `.zip`          |
+| Data & archives | `application/gzip`                                                          | `.gz`           |
+| Data & archives | `application/x-tar`                                                         | `.tar`          |
+| Data & archives | `application/x-7z-compressed`                                               | `.7z`           |
+| Data & archives | `application/octet-stream`                                                  | `.bin`          |
+
+</details>
 
 If you require support for additional file types, please let us know in our [GitHub Discussion](https://github.com/orgs/langfuse/discussions/3004) where we're actively gathering feedback on multi-modal support.
 


### PR DESCRIPTION
## Summary

- The "Supported media formats" section on the multi-modality page listed only 9 formats, while the media upload validation in `langfuse/web/src/features/media/validation.ts` accepts ~50 MIME types. Updated the docs to reflect what is actually supported.
- The visible section now shows the common formats per category (images, audio, video, text & code, documents, data & archives); the full MIME type / file extension table is tucked into a collapsible `<details>` element, following the collapsible pattern used across the rest of the docs.

## Linear

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the "Supported media formats" section of the multi-modality docs page to reflect the ~50 MIME types actually accepted by `langfuse/web/src/features/media/validation.ts`, replacing a stale 9-item list. A collapsible `<details>` table with MIME type → file extension mappings is added, consistent with the docs site's existing collapsible pattern.

- The quick-reference bullets are reorganized into six categories (Images, Audio, Video, Text & code, Documents, Data & archives) with representative extensions.
- A full MIME type table covering all ~50 supported types is tucked inside a `<details>` element.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; purely a documentation update with no runtime or logic changes.

The change accurately expands the documented format list to match the actual validation code. The only loose end is that the frontmatter description and opening sentence still say 'text, images, audio, and attachments' without mentioning video, which is now a documented first-class category — a small inconsistency introduced by the PR.

The frontmatter description and intro paragraph of content/docs/observability/features/multi-modality.mdx still omit 'video'.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application / SDK
    participant LF as Langfuse API
    participant Val as Media Validation
    participant S3 as Object Storage (S3)
    participant UI as Langfuse UI

    App->>LF: POST /api/media (base64 data URI or file)
    LF->>Val: Validate MIME type against ~50 allowed types
    alt MIME type accepted
        Val-->>LF: OK
        LF->>S3: Upload media file
        S3-->>LF: Storage URL
        LF-->>App: Media ID + reference
        App->>LF: Create trace with media reference
        UI->>S3: Fetch media asset directly
        S3-->>UI: File content
    else MIME type rejected
        Val-->>LF: Error: unsupported type
        LF-->>App: 400 Bad Request
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application / SDK
    participant LF as Langfuse API
    participant Val as Media Validation
    participant S3 as Object Storage (S3)
    participant UI as Langfuse UI

    App->>LF: POST /api/media (base64 data URI or file)
    LF->>Val: Validate MIME type against ~50 allowed types
    alt MIME type accepted
        Val-->>LF: OK
        LF->>S3: Upload media file
        S3-->>LF: Storage URL
        LF-->>App: Media ID + reference
        App->>LF: Create trace with media reference
        UI->>S3: Fetch media asset directly
        S3-->>UI: File content
    else MIME type rejected
        Val-->>LF: Error: unsupported type
        LF-->>App: 400 Bad Request
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/observability/features/multi-modality.mdx:1-9
The frontmatter `description` and the opening paragraph both still list only "text, images, audio, and attachments" — they don't mention video, which is now an explicitly documented and first-class supported category. This leaves the page metadata and intro out of sync with the expanded content below.

```suggestion
---
title: Multi-Modality
description: Langfuse fully supports multi-modal LLM traces, including text, images, audio, video, and attachments.
sidebarTitle: Multi-Modality
---

# Multi-Modality and Attachments

Langfuse supports multi-modal traces including **text, images, audio, video, and other attachments**.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update supported media formats to ..."](https://github.com/langfuse/langfuse-docs/commit/6281675cf04d8c644726bdc2f9bd9be9850e80e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42956431)</sub>

<!-- /greptile_comment -->