### PR TITLE
docs(support): add refund approval limits to support playbook

### DIFF
--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -302,7 +302,13 @@ Best,
 2. Determine if the charge was correct (customer's mistake / they didn't downgrade in time) or our error (billing bug / contract misalignment / EE-license-removal-doesn't-cancel confusion above).
 3. Customer error and they're on a small plan: explain politely, offer goodwill credit if appropriate.
 4. Our error or genuine misunderstanding: refund.
-5. For approval limits and when to loop in the team, follow the internal refund handling guidelines in the private handbook. Do not approve refunds beyond your limit unilaterally.
+5. Follow the approval limits below. Do not approve refunds beyond your limit unilaterally.
+
+**Approval limits:**
+
+- **Under $500:** it's reasonable to decide yourself whether to give the refund.
+- **$500 and above:** contact the leading support engineers at Langfuse and ClickHouse before issuing the refund.
+- **$2,000 and above:** contact Clemens.
 
 **Reply template:**
 


### PR DESCRIPTION
## Summary

Adds concrete refund approval limits to the **Refund request** branch of the "How to Answer Support Questions" playbook (`content/handbook/support/how-to-answer-support-questions.mdx`).

Replaces the vague "follow the internal refund handling guidelines in the private handbook" line with explicit thresholds:

- **Under $500** — reasonable to decide yourself whether to give the refund.
- **$500 and above** — contact the leading support engineers at Langfuse and ClickHouse.
- **$2,000 and above** — contact Clemens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds concrete refund approval limits to the "Refund request" branch of the support playbook, replacing the previous vague pointer to an unspecified private handbook.

- **Explicit tiers added**: under $500 (self-approve), $500–$1,999 (loop in leading support engineers), $2,000+ (contact Clemens).
- **Stale reference remains**: A sibling accordion ("Billing / payment issue," line 291) still tells readers to "follow the approval limits in the private handbook," which now contradicts the limits defined in this same file.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe, but a leftover sentence in a sibling section will direct support engineers to a private handbook that no longer holds the canonical refund limits.

The new thresholds are clear and well-structured, but line 291 still tells readers to consult the private handbook for refund limits — directly contradicting the limits now defined in this file. A support engineer encountering the billing accordion first would follow the wrong guidance.

content/handbook/support/how-to-answer-support-questions.mdx — line 291 needs to be updated to match the new policy location.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Refund request received] --> B{Charge correct?}
    B -- Our error --> C[Issue refund]
    B -- Customer error / small plan --> D[Explain politely, offer goodwill credit]
    C --> E{Refund amount?}
    E -- Under $500 --> F[Decide yourself]
    E -- $500–$1999 --> G[Contact leading support engineers at Langfuse & ClickHouse]
    E -- $2000 and above --> H[Contact Clemens]
    F --> I[Process refund in Stripe]
    G --> I
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Refund request received] --> B{Charge correct?}
    B -- Our error --> C[Issue refund]
    B -- Customer error / small plan --> D[Explain politely, offer goodwill credit]
    C --> E{Refund amount?}
    E -- Under $500 --> F[Decide yourself]
    E -- $500–$1999 --> G[Contact leading support engineers at Langfuse & ClickHouse]
    E -- $2000 and above --> H[Contact Clemens]
    F --> I[Process refund in Stripe]
    G --> I
    H --> I
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/handbook/support/how-to-answer-support-questions.mdx:291
**Stale private-handbook reference contradicts new limits**

Line 291 is in the "Billing / payment issue" accordion and still says "For refunds, follow the approval limits in the private handbook." This PR replaces that private-handbook reference with explicit limits in the "Refund request" accordion below, so this sentence now contradicts the new policy. A support engineer hitting the billing section first would be directed to a private document that no longer contains the canonical limits.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(support): add refund approval limit..."](https://github.com/langfuse/langfuse-docs/commit/6df1b653ccec37fd2c0d46d7263c19b0b47db873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42960311)</sub>

<!-- /greptile_comment -->