### PR TITLE
docs: add support disclaimer for custom ClickHouse schema changes

### DIFF
--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -100,6 +100,20 @@ If you do query ClickHouse directly:
 - Do not write directly to Langfuse tables. Use the Public API or SDKs for creating and updating Langfuse data.
 - If a missing API filter or field forces you to query ClickHouse directly, please open a [GitHub issue](https://github.com/langfuse/langfuse/issues) with your use case; APIs are the preferred long-term extension point.
 
+## Custom Schema Changes [#custom-schema-changes]
+
+We recommend running Langfuse on the unmodified ClickHouse schema.
+
+<Callout type="warning">
+
+Langfuse's ClickHouse schema and migrations are designed, tested, and versioned as a unit with each release.
+Customizing the `observations`, `events`, or other table definitions moves that schema outside of what we test against — which means keeping it compatible with future upgrades becomes your responsibility.
+We'll provide best-effort support for issues arising from custom schema changes.
+
+</Callout>
+
+If a missing column, index, or table setting makes you consider a custom schema change, please open a [GitHub issue](https://github.com/langfuse/langfuse/issues) with your use case first; improvements to the standard schema benefit all deployments and are covered by our regular testing and upgrade process.
+
 ## Deployment Options
 
 This section covers different deployment options and provides example environment variables.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Custom Schema Changes" section to the ClickHouse self-hosting documentation, explaining the support disclaimer and encouraging users to open GitHub issues for missing schema capabilities instead of modifying the schema themselves.

- Adds a warning callout clarifying that Langfuse only tests against its own schema and that keeping a customized schema compatible with future upgrades becomes the deployer's responsibility.
- Closes the gap between "Direct ClickHouse Access" (already documented) and schema-modification, a common next step users attempt when the standard schema lacks a needed column or index.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a documentation-only addition with no code changes.

The change adds a single new documentation section with accurate, well-placed prose. The only note is a minor inconsistency between the example table names used here (`observations`, `events`) and those used in the adjacent section (`traces`, `observations`, `scores`), which is cosmetic.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User needs custom column/index/setting] --> B{Covered by standard schema?}
    B -- Yes --> C[Use Langfuse as-is]
    B -- No --> D[Open GitHub issue with use case]
    D --> E{Improvement merged?}
    E -- Yes --> F[Covered by standard schema\nTested & supported by Langfuse]
    E -- No / Urgent --> G[Apply custom schema change]
    G --> H[Schema outside Langfuse test coverage]
    H --> I[User responsible for upgrade compatibility]
    I --> J[Best-effort support only from Langfuse team]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User needs custom column/index/setting] --> B{Covered by standard schema?}
    B -- Yes --> C[Use Langfuse as-is]
    B -- No --> D[Open GitHub issue with use case]
    D --> E{Improvement merged?}
    E -- Yes --> F[Covered by standard schema\nTested & supported by Langfuse]
    E -- No / Urgent --> G[Apply custom schema change]
    G --> H[Schema outside Langfuse test coverage]
    H --> I[User responsible for upgrade compatibility]
    I --> J[Best-effort support only from Langfuse team]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/self-hosting/deployment/infrastructure/clickhouse.mdx:110
The example tables in the new callout (`observations`, `events`) don't match the table names cited in the adjacent "Direct ClickHouse Access" callout above (`traces`, `observations`, `scores`). A reader following both sections may not realise these describe the same schema. Aligning them improves consistency.

```suggestion
Customizing the `traces`, `observations`, `scores`, or other table definitions moves that schema outside of what we test against — which means keeping it compatible with future upgrades becomes your responsibility.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add support disclaimer for custom ..."](https://github.com/langfuse/langfuse-docs/commit/af9f57d5bd132e137c8d8cfafd604b14cd3ad605) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42980539)</sub>

<!-- /greptile_comment -->