### PR TITLE
docs: clarify release configuration scope

### DIFF
--- a/content/docs/observability/features/releases-and-versioning.mdx
+++ b/content/docs/observability/features/releases-and-versioning.mdx
@@ -29,6 +29,14 @@ flowchart LR
 
 A `release` tracks the overall version of your application. Commonly it is set to the _semantic version_ or _git commit hash_ of your application.
 
+<Callout type="info">
+  `release` is a trace-level deployment attribute and should be configured via
+  SDK initialization, the `LANGFUSE_RELEASE` environment variable, or automatic
+  platform detection. It is not an observation-level attribute and cannot be set
+  on individual spans or generations via span/generation update helpers. Use
+  [`version`](#versions) for observation-level versioning.
+</Callout>
+
 The SDKs look for a `release` in the following order:
 
 1. SDK initialization


### PR DESCRIPTION
## What does this PR do?

  Closes https://github.com/langfuse/langfuse-docs/issues/1668

  Clarifies that `release` is a trace-level deployment attribute configured via SDK initialization, `LANGFUSE_RELEASE`, or automatic
  platform detection.

  It also points users to `version` for observation-level versioning instead of trying to set `release` through span/generation
  update helpers.

  ## Test plan

  - `git diff --check`
  - `npm exec --yes prettier -- --check content/docs/observability/features/releases-and-versioning.mdx`
  - `node scripts/check-h1-headings.js content/docs/observability/features/releases-and-versioning.mdx`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `<Callout>` block to the Releases & Versioning documentation page clarifying that `release` is a trace-level attribute configured only via SDK initialization, the `LANGFUSE_RELEASE` env var, or auto-detected platform variables — not settable on individual spans or generations.

- Adds a clear informational callout after the opening description of `release`, explaining its scope and directing users to `version` for observation-level versioning.
- The anchor link `[version](#versions)` correctly targets the existing `## Versions` heading later in the same page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only addition of a single callout block — no code or config changes.

The change is a single Callout inserted into one MDX file. The content accurately reflects the SDK behavior shown in the surrounding code examples, the anchor link targets a heading that exists on the same page, and there are no cross-file dependencies to break.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Configure Application Version] --> B{Scope?}
    B -->|Whole application deployment| C[release - Trace-level]
    B -->|Individual span or generation| D[version - Observation-level]

    C --> C1["SDK initialization: Langfuse(release=...)"]
    C --> C2["Env var: LANGFUSE_RELEASE"]
    C --> C3["Auto-detected platform vars - Vercel, Heroku, Netlify"]

    D --> D1["span or generation with version param or propagate_attributes"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Configure Application Version] --> B{Scope?}
    B -->|Whole application deployment| C[release - Trace-level]
    B -->|Individual span or generation| D[version - Observation-level]

    C --> C1["SDK initialization: Langfuse(release=...)"]
    C --> C2["Env var: LANGFUSE_RELEASE"]
    C --> C3["Auto-detected platform vars - Vercel, Heroku, Netlify"]

    D --> D1["span or generation with version param or propagate_attributes"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify release configuration scop..."](https://github.com/langfuse/langfuse-docs/commit/f5ccce9667426959dbfc370daadc0e59d2ffe8c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43059529)</sub>

<!-- /greptile_comment -->