### PR TITLE
docs: redirect legacy otel python sdk cookbook

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -691,6 +691,10 @@ const mainDocsReorder202507 = [
     "/guides/cookbook/otel_integration_openllmetry",
   ],
   ["/docs/opentelemetry/get-started", "/integrations/native/opentelemetry"],
+  [
+    "/guides/cookbook/otel_integration_python_sdk",
+    "/docs/observability/sdk/instrumentation",
+  ],
   ["/docs/playground", "/docs/prompt-management/features/playground"],
   ["/docs/prompts/a-b-testing", "/docs/prompt-management/features/a-b-testing"],
   [


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/langfuse/langfuse-docs/issues/2508

  Adds a redirect for the legacy OpenTelemetry Python SDK cookbook URL:

  `/guides/cookbook/otel_integration_python_sdk`

  to the current SDK instrumentation docs:

  `/docs/observability/sdk/instrumentation`

  ## Test plan

  - `git diff --check`
  - `npm exec --yes prettier -- --check lib/redirects.js`
  - `node -c lib/redirects.js`
  - `node -e "const { permanentRedirects } = require('./lib/redirects.js'); const target = permanentRedirects.find(([from]) => from
  === '/guides/cookbook/otel_integration_python_sdk'); if (!target) throw new Error('missing redirect'); if (target[1] !== '/docs/
  observability/sdk/instrumentation') throw new Error('wrong target: ' + target[1]); console.log(target.join(' -> '));"`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single permanent redirect entry in `lib/redirects.js` to forward traffic from the removed legacy OTel Python SDK cookbook page (`/guides/cookbook/otel_integration_python_sdk`) to the current SDK instrumentation docs (`/docs/observability/sdk/instrumentation`). The target page exists and is already referenced as a destination by multiple other redirect rules.

- The redirect entry follows the correct `[source, destination]` tuple format and the target MDX file (`content/docs/observability/sdk/instrumentation.mdx`) is confirmed to exist on disk.
- The entry is inserted slightly out of alphabetical order within `mainDocsReorder202507` — placing a `/guides/` path between two `/docs/` paths — though this has no functional effect.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single redirect entry pointing to a confirmed live page with no redirect chaining.

The change is minimal and correct: the target page exists on disk, is already used as a destination by several other redirect rules, and the tuple format matches all surrounding entries. The only observation is a slight sort-order deviation within the array, which has no effect on how redirects are resolved at runtime.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits /guides/cookbook/otel_integration_python_sdk"] --> B["permanentRedirects lookup\n(mainDocsReorder202507 array)"]
    B --> C["301 Permanent Redirect"]
    C --> D["/docs/observability/sdk/instrumentation\n(content/docs/observability/sdk/instrumentation.mdx ✓)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User visits /guides/cookbook/otel_integration_python_sdk"] --> B["permanentRedirects lookup\n(mainDocsReorder202507 array)"]
    B --> C["301 Permanent Redirect"]
    C --> D["/docs/observability/sdk/instrumentation\n(content/docs/observability/sdk/instrumentation.mdx ✓)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/redirects.js:693-698
The new `/guides/cookbook/otel_integration_python_sdk` entry is placed between two `/docs/` paths, but since it starts with `/guides/`, it sorts after all `/docs/` entries alphabetically. This breaks the loose alphabetical ordering maintained throughout `mainDocsReorder202507`. Consider moving it after the last `/docs/tracing-features/...` entry (around line 807) alongside the other `/guides/cookbook/...` entries that already appear there (lines 839–847). This has no functional impact but keeps the array easier to scan.

```suggestion
  ["/docs/opentelemetry/get-started", "/integrations/native/opentelemetry"],
  ["/docs/playground", "/docs/prompt-management/features/playground"],
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect legacy otel python sdk co..."](https://github.com/langfuse/langfuse-docs/commit/46a1df290622f5e64c056c97cf7ecb530ed52a6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43069749)</sub>

<!-- /greptile_comment -->