### PR TITLE
docs: clarify data region backup table

### DIFF
--- a/content/security/data-regions.mdx
+++ b/content/security/data-regions.mdx
@@ -7,7 +7,7 @@ description: Details on Langfuse Cloud data regions, high availability, and the 
 
 Langfuse Cloud is designed for high availability and offers multiple data regions to meet your needs.
 
-Our database and application run on AWS infrastructure, partly managed by Clickhouse.
+Our database and application run on AWS infrastructure, partly managed by ClickHouse.
 
 ## Langfuse Cloud Regions
 
@@ -66,11 +66,11 @@ To allow recovery from the permanent loss of an AWS region, a subset of data at 
 This is a disaster-recovery control and does not provide active-active failover; on a full regional outage, Langfuse would rebuild the application stack in the secondary region and restore from the replicated backups.
 The expected rebuild time is up to 12 hours.
 
-| Data store                    | Primary region                                                           | Secondary region                                        | Mechanism                                                         | Retention             |
-| ----------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------- | --------------------- |
-| **Postgres**                  | EU: `eu-west-1` <br/> US / HIPAA: `us-west-2` <br/> JP: `ap-northeast-1` | `eu-central-1` <br/> `us-east-2` <br/> `ap-northeast-3` | AWS Backup daily snapshot copy, re-encrypted with a dedicated CMK | 7 days in each region |
-| **ClickHouse** (tracing data) | Same as the Cloud region above                                           | Not replicated                                          | —                                                                 | —                     |
-| **S3 media bucket**           | Same as the Cloud region above                                           | Not replicated                                          | —                                                                 | —                     |
+| Data store                    | Primary region                                                           | Secondary region                                                            | Mechanism                                                         | Retention             |
+| ----------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------- |
+| **Postgres**                  | EU: `eu-west-1` <br/> US / HIPAA: `us-west-2` <br/> JP: `ap-northeast-1` | EU: `eu-central-1` <br/> US / HIPAA: `us-east-2` <br/> JP: `ap-northeast-3` | AWS Backup daily snapshot copy, re-encrypted with a dedicated CMK | 7 days in each region |
+| **ClickHouse** (tracing data) | Same as the Cloud region above                                           | Not replicated                                                              | —                                                                 | —                     |
+| **S3 media bucket**           | Same as the Cloud region above                                           | Not replicated                                                              | —                                                                 | —                     |
 
 Postgres contains organization, project, user, API key, prompt, dataset, annotation, and score configuration data.
 Replicating it cross-region allows projects, credentials, and prompt management to be restored without customer intervention following a regional outage.


### PR DESCRIPTION
## What does this PR do?

  Follow-up to https://github.com/langfuse/langfuse-docs/pull/2844.

  Clarifies the Cross-Region Backup table by labeling the secondary AWS regions with the same EU / US / JP mapping used for the
  primary regions.

  Also fixes `Clickhouse` -> `ClickHouse` casing in the Data Regions page.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the Cross-Region Backup table in the Data Regions security page and fixes a casing typo.

- The secondary AWS region column now includes the same EU / US / HIPAA / JP geographic labels used in the primary region column, making the mapping between primary and secondary regions unambiguous.
- `Clickhouse` is corrected to `ClickHouse` in the opening paragraph.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a purely editorial documentation update with no code, logic, or configuration changes.

Both changes are accurate and self-consistent: secondary region labels mirror the primary region labels exactly (EU → eu-central-1, US / HIPAA → us-east-2, JP → ap-northeast-3), and the ClickHouse casing correction matches the product's official branding. Nothing about the underlying backup architecture or region assignments was altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph EU["EU Region"]
        EU_P["Postgres\neu-west-1"]
        EU_CH["ClickHouse\neu-west-1"]
        EU_S3["S3 Media\neu-west-1"]
    end

    subgraph US["US / HIPAA Region"]
        US_P["Postgres\nus-west-2"]
        US_CH["ClickHouse\nus-west-2"]
        US_S3["S3 Media\nus-west-2"]
    end

    subgraph JP["JP Region"]
        JP_P["Postgres\nap-northeast-1"]
        JP_CH["ClickHouse\nap-northeast-1"]
        JP_S3["S3 Media\nap-northeast-1"]
    end

    subgraph Secondary["Secondary Regions (Disaster Recovery)"]
        EU_SEC["EU: eu-central-1"]
        US_SEC["US / HIPAA: us-east-2"]
        JP_SEC["JP: ap-northeast-3"]
    end

    EU_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> EU_SEC
    US_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> US_SEC
    JP_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> JP_SEC

    EU_CH -. "Not replicated" .-> EU_SEC
    EU_S3 -. "Not replicated" .-> EU_SEC
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph EU["EU Region"]
        EU_P["Postgres\neu-west-1"]
        EU_CH["ClickHouse\neu-west-1"]
        EU_S3["S3 Media\neu-west-1"]
    end

    subgraph US["US / HIPAA Region"]
        US_P["Postgres\nus-west-2"]
        US_CH["ClickHouse\nus-west-2"]
        US_S3["S3 Media\nus-west-2"]
    end

    subgraph JP["JP Region"]
        JP_P["Postgres\nap-northeast-1"]
        JP_CH["ClickHouse\nap-northeast-1"]
        JP_S3["S3 Media\nap-northeast-1"]
    end

    subgraph Secondary["Secondary Regions (Disaster Recovery)"]
        EU_SEC["EU: eu-central-1"]
        US_SEC["US / HIPAA: us-east-2"]
        JP_SEC["JP: ap-northeast-3"]
    end

    EU_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> EU_SEC
    US_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> US_SEC
    JP_P -- "AWS Backup daily snapshot copy\nre-encrypted with CMK\n7-day retention" --> JP_SEC

    EU_CH -. "Not replicated" .-> EU_SEC
    EU_S3 -. "Not replicated" .-> EU_SEC
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify data region backup table"](https://github.com/langfuse/langfuse-docs/commit/3824f903c9075d0f0a523e4df173bb50accc85b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43085890)</sub>

<!-- /greptile_comment -->