### PR TITLE
fix(style): Avoid code marks in tables overlapping

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -932,6 +932,13 @@ ul[data-gh-discussions-list] {
   font-feature-settings:
     "liga" 0,
     "calt" 0;
+  padding: 0 0.25rem;
+}
+
+.prose
+  table
+  :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  line-height: 1.5rem;
 }
 
 /* Links whose primary label is inline <code> (e.g. [`api()`](/ref)): underline


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes inline `code` elements inside tables in the prose layout overlapping adjacent content. It moves `padding: 0 0.25rem` into the existing inline code rule and adds a table-scoped override to set `line-height: 1.5rem` on code marks, giving bordered chips enough vertical clearance.

- **Padding added to base code rule** (`src/overrides.css` line 935): horizontal padding is added to the `.prose :where(code)` selector, ensuring the border doesn't clip directly against the text for all inline code.
- **New table-scoped `line-height` rule** (lines 938–942): a more-specific selector targets only `code` inside `.prose table`, setting `line-height: 1.5rem` to prevent bordered code chips from bleeding into adjacent rows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A clean, targeted two-line CSS fix; no regressions expected for code elements outside tables, and the new table selector only narrows scope further.

Both changes are additive overrides to existing prose styles. The padding addition closes the visual gap between the border and text for all inline code, and the table-specific line-height rule only applies in a more-specific context. Neither rule removes or conflicts with existing properties.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".prose :where(code)"] -->|"base styles: border, bg, color,\nfont-feature-settings,\npadding: 0 0.25rem (new)"| B[All inline code in prose]
    B --> C{Inside a table?}
    C -->|No| D[Rendered with base styles]
    C -->|Yes| E[".prose table :where(code)"]
    E -->|"line-height: 1.5rem (new)"| F[Code chip with vertical clearance,\nno row overlap]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[".prose :where(code)"] -->|"base styles: border, bg, color,\nfont-feature-settings,\npadding: 0 0.25rem (new)"| B[All inline code in prose]
    B --> C{Inside a table?}
    C -->|No| D[Rendered with base styles]
    C -->|Yes| E[".prose table :where(code)"]
    E -->|"line-height: 1.5rem (new)"| F[Code chip with vertical clearance,\nno row overlap]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(style): Avoid code marks in tables o..."](https://github.com/langfuse/langfuse-docs/commit/a5cb47938a5d651a15c0d1a3044295d96cbc70a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43245721)</sub>

<!-- /greptile_comment -->