### PR TITLE
docs: recommend app-root-aware SDK versions for v4

### DIFF
--- a/content/changelog/2026-03-10-simplify-for-scale.mdx
+++ b/content/changelog/2026-03-10-simplify-for-scale.mdx
@@ -22,7 +22,7 @@ Langfuse is rolling out a simplified architecture built for significantly faster
 </Cards>
 
 <Callout type="info">
-To avoid delays in the new experience and see your data in real time, upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
+To avoid delays in the new experience and see your data in real time, upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
 </Callout>
 
 ## What changes for you

--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -24,7 +24,7 @@ Older trace and observation read APIs remain available, but are not recommended 
 
 **Cloud-only:** The v2 Observations API is only available on Langfuse Cloud. We are working on a robust migration path for self-hosted deployments.
 
-**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
+**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
 
 </Callout>
 

--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -25,7 +25,7 @@ The older Metrics API remains available, but is not recommended as the default f
 
 **Cloud-only:** The v2 Metrics API is only available on Langfuse Cloud. We are working on a robust migration path for self-hosted deployments.
 
-**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
+**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
 
 </Callout>
 

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -22,7 +22,7 @@ Langfuse is now observations-first. Queries that used to require expensive joins
 
 **How to adopt:**
 
-- **SDK:** Upgrade to [Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
+- **SDK:** Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
 - **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
 - **UI:** If your organization was created before April 14, 2026, 14:00 UTC (15:00 CET), enable the **Preview** toggle (bottom-left) to opt in. Organizations created on/after this cutoff are already on "Fast Preview" and do not see the toggle. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
 - **Evals:** Migrate LLM-as-a-Judge evals to the observation level. [See evals migration guide](/faq/all/llm-as-a-judge-migration)
@@ -85,8 +85,8 @@ Data from SDKs `langfuse-js` < `5.0.0`, `langfuse-python` < `4.0.0`, or direct O
 
 To take advantage of the new data model and explore your data in real time, use one of these ingestion paths:
 
-- **Python SDK:** v4 ([migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4))
-- **JS/TS SDK:** v5 ([migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5))
+- **Python SDK:** v4.7.0+ ([migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4))
+- **JS/TS SDK:** v5.4.0+ ([migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5))
 - **Direct OpenTelemetry ingestion:** set `x-langfuse-ingestion-version: 4` on your OTEL span exporter ([OpenTelemetry setup](/integrations/native/opentelemetry))
 
 For SDK users, the key change is that `update_current_trace()` and `updateActiveTrace()` are replaced by `propagate_attributes()`, which automatically pushes attributes like `user_id`, `session_id`, `metadata`, and `tags` to all child observations.

--- a/content/faq/all/explore-observations-in-v4.mdx
+++ b/content/faq/all/explore-observations-in-v4.mdx
@@ -46,8 +46,8 @@ We recommend setting up 2-3 saved views for your most common debugging workflows
 
 Use one of these ingestion paths so your data appears in the unified table in real time:
 
-- Python SDK v4: [migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4)
-- JS/TS SDK v5: [migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5)
+- Python SDK v4.7.0+: [migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4)
+- JS/TS SDK v5.4.0+: [migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5)
 - Direct OpenTelemetry ingestion: set `x-langfuse-ingestion-version: 4` on your OTEL span exporter. If you use OTLP HTTP environment variables, add `x-langfuse-ingestion-version=4` to `OTEL_EXPORTER_OTLP_HEADERS`. See [OpenTelemetry setup](/integrations/native/opentelemetry).
 
 <Callout type="info">
@@ -77,7 +77,7 @@ If something feels confusing, missing, or slower than expected, share feedback v
 
 The most common reason is that data is still being sent via older SDK versions or through a direct OpenTelemetry exporter without `x-langfuse-ingestion-version: 4`.
 In the new Fast Preview experience, those setups can lead to multi-minute delays before traces show up in the unified table.
-If this happens, upgrade to Python SDK v4 or JS/TS SDK v5, or add the ingestion version header to your OTEL exporter.
+If this happens, upgrade to Python SDK v4.7.0+ or JS/TS SDK v5.4.0+, or add the ingestion version header to your OTEL exporter.
 
 ### How can I get a focused view of my most important operations?
 

--- a/content/faq/all/v3-sdk-observation-lookup-404.mdx
+++ b/content/faq/all/v3-sdk-observation-lookup-404.mdx
@@ -28,6 +28,6 @@ langfuse.api.observations.get(
 )
 ```
 
-**2. Migrate to v4 SDKs**
+**2. Migrate to a current SDK**
 
-[Python SDK v4](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5](/docs/observability/sdk/upgrade-path/js-v4-to-v5) use the v4 data model natively — the `useEventsTable` flag is implicit and no workaround is needed.
+[Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) and [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5) use the v4 data model natively — the `useEventsTable` flag is implicit and no workaround is needed.


### PR DESCRIPTION
## Summary

- recommend Python SDK v4.7.0+ and JS/TS SDK v5.4.0+ across the Langfuse v4 / Fast Preview guidance
- update the main v4 guide, API data-availability callouts, related FAQs, and launch changelog
- replace the ambiguous "Migrate to v4 SDKs" heading with version-neutral wording

## Why

Python 4.7.0 and JS/TS 5.4.0 are the first stable SDK releases that include app-root detection. Calling out these minimum versions ensures users upgrading for the v4 platform get the root-observation behavior the new data model expects.

## Validation

- `pnpm run format`
- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates six documentation files to recommend specific minimum SDK versions — Python SDK v4.7.0+ and JS/TS SDK v5.4.0+ — rather than the generic "v4" / "v5" labels previously used. These are the first releases that include app-root detection, which is required for the v4 observations-first data model.

- Version strings updated consistently across the main v4 guide, the changelog, API data-availability callouts, and two FAQ pages.
- The heading "Migrate to v4 SDKs" in `v3-sdk-observation-lookup-404.mdx` is replaced with "Migrate to a current SDK" for better version-neutrality.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are documentation-only and consistently applied across six files.

The version string updates are accurate and uniformly applied. One callout in observations-api.mdx and metrics-api.mdx states that SDKs below 4.0.0 / 5.0.0 cause delays, then recommends upgrading to 4.7.0+ / 5.4.0+ to see new data in real time — which may mislead users on 4.0.x–4.6.x or 5.0.x–5.3.x into thinking they still have delays when they do not. It is a documentation clarity issue, not a broken feature.

content/docs/api-and-data-platform/features/observations-api.mdx and content/docs/metrics/features/metrics-api.mdx — the data-availability callout conflates the delay threshold (< 4.0.0 / < 5.0.0) with the app-root-detection threshold (< 4.7.0 / < 5.4.0).
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User upgrading to Langfuse v4] --> B{Which SDK?}
    B --> C[Python SDK]
    B --> D[JS/TS SDK]
    B --> E[Direct OTEL]

    C --> C1{Version?}
    C1 -->|>= 4.7.0| C2[✅ Full v4 support\nApp-root detection\nReal-time data]
    C1 -->|4.0.0 – 4.6.x| C3[⚠️ Real-time data\nNo app-root detection]
    C1 -->|< 4.0.0| C4[❌ Up to 10 min delay\nNo app-root detection]

    D --> D1{Version?}
    D1 -->|>= 5.4.0| D2[✅ Full v4 support\nApp-root detection\nReal-time data]
    D1 -->|5.0.0 – 5.3.x| D3[⚠️ Real-time data\nNo app-root detection]
    D1 -->|< 5.0.0| D4[❌ Up to 10 min delay\nNo app-root detection]

    E --> E1[Set header:\nx-langfuse-ingestion-version: 4]
    E1 --> E2[✅ Real-time data]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User upgrading to Langfuse v4] --> B{Which SDK?}
    B --> C[Python SDK]
    B --> D[JS/TS SDK]
    B --> E[Direct OTEL]

    C --> C1{Version?}
    C1 -->|>= 4.7.0| C2[✅ Full v4 support\nApp-root detection\nReal-time data]
    C1 -->|4.0.0 – 4.6.x| C3[⚠️ Real-time data\nNo app-root detection]
    C1 -->|< 4.0.0| C4[❌ Up to 10 min delay\nNo app-root detection]

    D --> D1{Version?}
    D1 -->|>= 5.4.0| D2[✅ Full v4 support\nApp-root detection\nReal-time data]
    D1 -->|5.0.0 – 5.3.x| D3[⚠️ Real-time data\nNo app-root detection]
    D1 -->|< 5.0.0| D4[❌ Up to 10 min delay\nNo app-root detection]

    E --> E1[Set header:\nx-langfuse-ingestion-version: 4]
    E1 --> E2[✅ Real-time data]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/api-and-data-platform/features/observations-api.mdx:27
**Inconsistent delay threshold vs. recommended version**

The callout states that SDKs `< 4.0.0` / `< 5.0.0` cause up to 10-minute delays, but then says to upgrade to v4.7.0+ / v5.4.0+ "to see new data in real time." Users already on, say, Python SDK 4.2.0 (above the delay threshold) could reasonably conclude they still have delays and need to jump to 4.7.0+ for real-time data, when in fact they are already receiving data in real time. The same pattern appears in `content/docs/metrics/features/metrics-api.mdx`. Consider either (a) updating the delay threshold to `< 4.7.0` / `< 5.4.0` if those versions truly affect delay, or (b) separating the delay concern from the app-root-detection concern so the two version ranges are not conflated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: recommend app-root-aware SDK versi..."](https://github.com/langfuse/langfuse-docs/commit/0caec94d5dae41cfb9caf47884a1670e2ed55458) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43285787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->