### PR TITLE
docs(self-hosting): document LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM

### DIFF
--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -83,7 +83,7 @@ To configure batch exports in your environment, configure the following environm
 
 #### S3 Compatibility
 
-The following settings apply to all S3 use-cases (events, media, batch exports) and help with S3-compatible stores that do not support the full AWS S3 API.
+The following settings apply to all S3 use-cases (events, media, batch exports) and help with S3-compatible stores that are not fully compatible with the AWS S3 API.
 
 | Variable                                        | Required / Default | Description                                                                                                                                                                                                                                                                          |
 | ----------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -81,6 +81,14 @@ To configure batch exports in your environment, configure the following environm
 | `BATCH_EXPORT_PAGE_SIZE`                     | `500`              | Optional page size for streaming exports to S3 to avoid memory issues. The page size can be adjusted if needed to optimize performance.                                            |
 | `BATCH_EXPORT_ROW_LIMIT`                     | `1_500_000`        | Maximum amount of rows that can be exported in a single batch export.                                                                                                              |
 
+#### S3 Compatibility
+
+The following settings apply to all S3 use-cases (events, media, batch exports) and help with S3-compatible stores that do not support the full AWS S3 API.
+
+| Variable                                        | Required / Default | Description                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM` |                    | Checksum algorithm for S3 DeleteObjects requests: `MD5`, `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, or `SHA256`. If unset, the AWS SDK default (`CRC32`) is used. Set to `MD5` if your storage provider rejects deletions with a `MissingContentMD5` error (e.g. older MinIO versions). |
+
 ## Deployment Options
 
 This section covers different deployment options and provides example environment variables.
@@ -201,6 +209,13 @@ LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
 
 This example setup uses an ephemeral volume, i.e. on restarts MinIO will discard all event data.
 Please follow the MinIO documentation or use a cloud provider managed blob store for persistent data storage.
+
+<Callout type="info">
+
+MinIO versions before `RELEASE.2025-02-03` reject S3 DeleteObjects requests with a `MissingContentMD5` error, which breaks data retention and deletion jobs.
+If you cannot upgrade MinIO, set `LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM=MD5` to send the legacy `Content-MD5` header instead.
+
+</Callout>
 
 #### Configuring Minio for Media Uploads [#minio-media-uploads]
 


### PR DESCRIPTION
Documents the new env var that selects the checksum algorithm for S3 DeleteObjects requests. Setting "MD5" restores the legacy Content-MD5 header for S3-compatible stores that reject the SDK's CRC32 default with MissingContentMD5, e.g. MinIO before RELEASE.2025-02-03 as bundled by langfuse-k8s (langfuse/langfuse-k8s#356). Adds an S3 Compatibility table under optional configuration and a callout in the MinIO section.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation for the new `LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM` environment variable, which controls the checksum algorithm used in S3 DeleteObjects requests. It also adds a callout in the MinIO section explaining the compatibility issue with older MinIO versions (before `RELEASE.2025-02-03`) that reject CRC32-checksummed requests.

- Adds an "S3 Compatibility" subsection under "Optional Configuration" with a table documenting the new variable and its valid values (`MD5`, `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, `SHA256`).
- Adds a `<Callout>` in the MinIO section pointing users to this variable as a workaround if they cannot upgrade MinIO.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no executable code is modified. Safe to merge.

The change adds a new configuration table and a MinIO compatibility callout. The documented values and defaults match the PR description and referenced upstream issues. MDX structure is valid and consistent with surrounding content.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Langfuse DeleteObjects request] --> B{LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM set?}
    B -- No --> C[AWS SDK default: CRC32 checksum]
    B -- Yes: MD5 --> D[Send Content-MD5 header]
    B -- Yes: CRC32 --> C
    B -- Yes: CRC32C/CRC64NVME/SHA1/SHA256 --> E[Use specified algorithm]
    C --> F{S3-compatible store}
    D --> F
    E --> F
    F -- AWS S3 / modern MinIO --> G[✅ Success]
    F -- MinIO before RELEASE.2025-02-03 + CRC32 --> H[❌ MissingContentMD5 error]
    D --> I[✅ Legacy MinIO compatible]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Langfuse DeleteObjects request] --> B{LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM set?}
    B -- No --> C[AWS SDK default: CRC32 checksum]
    B -- Yes: MD5 --> D[Send Content-MD5 header]
    B -- Yes: CRC32 --> C
    B -- Yes: CRC32C/CRC64NVME/SHA1/SHA256 --> E[Use specified algorithm]
    C --> F{S3-compatible store}
    D --> F
    E --> F
    F -- AWS S3 / modern MinIO --> G[✅ Success]
    F -- MinIO before RELEASE.2025-02-03 + CRC32 --> H[❌ MissingContentMD5 error]
    D --> I[✅ Legacy MinIO compatible]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/self-hosting/deployment/infrastructure/blobstorage.mdx:84-90
**Section placement may hide setting from mandatory-config users**

The "S3 Compatibility" section sits inside `### Optional Configuration`, whose intro explicitly calls its contents "opt-in" use-cases. However, `LANGFUSE_S3_DELETE_OBJECTS_CHECKSUM_ALGORITHM` also applies to the mandatory event-upload path. A user who configures only the mandatory bucket and never reads the optional section will miss this workaround when hitting `MissingContentMD5` errors. Consider placing the section directly under `## Configuration` (as a new `### S3 Compatibility` heading) or adding a cross-reference from `### Mandatory Configuration`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document LANGFUSE\_S3..."](https://github.com/langfuse/langfuse-docs/commit/87f9e668dcdf1b21b8de8a1125110de780c7ba37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43813373)</sub>

<!-- /greptile_comment -->