### PR TITLE
docs: blob export run-completion manifest + provider event recipes (LFE-10843)

### DIFF
--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -261,8 +261,12 @@ Trace and score exports contain the same fields in all file types.
 │   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
 ├── traces/                   # Traces and observations (legacy) mode only
 │   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
-└── observations/             # Traces and observations (legacy) mode only
-    └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
+├── observations/             # Traces and observations (legacy) mode only
+│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
+└── manifests/                # Run completion manifest, written last
+    └── {timestamp}.json
 ```
 
 Files are partitioned by the configured export frequency (every 20 minutes, hourly, daily, or weekly). Each file covers one time window. The `.gz` suffix applies only to gzip-compressed text formats — Parquet files are never gzip-compressed.
+
+The `manifests/` folder contains one JSON file per completed export run, listing every file the run wrote — see [Run completion manifest](/docs/api-and-data-platform/features/export-to-blob-storage#run-manifest).

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -207,7 +207,7 @@ Notes on the schema:
 
 ## React to completed export runs [#export-events]
 
-Langfuse does not send a webhook when an export run finishes. Instead, subscribe to your storage provider's native object-created events with a prefix filter on `{prefix}{project-id}/manifests/` — because the manifest is the last object of each run, this gives you exactly one event per completed run. When the event fires, download the manifest and process the objects listed in `files[].key`.
+Langfuse does not send a webhook when an export run finishes. Instead, subscribe to your storage provider's native object-created events with a prefix filter on `{prefix}{project-id}/manifests/` — because the manifest is the last object of each run, this gives you one event per completed run. When the event fires, download the manifest and process the objects listed in `files[].key`.
 
 Provider recipes:
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -154,7 +154,7 @@ A single export run writes one file per exported table — up to four, depending
 {prefix}{project-id}/manifests/{max-timestamp}.json
 ```
 
-The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in ISO 8601 format with colons replaced by dashes — the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's files and its manifest sort together.
+The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in UTC, truncated to whole seconds, with colons replaced by dashes and the milliseconds and trailing `Z` dropped (`2026-07-13T09:00:00.000Z` → `2026-07-13T09-00-00`). This is the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's files and its manifest sort together.
 
 Example manifest:
 
@@ -198,10 +198,10 @@ Example manifest:
 Notes on the schema:
 
 - `version` increments only on breaking changes; new fields may be added without a version bump, so ignore unknown fields when parsing.
-- `window` is the time range of data covered by the run. `maxTimestamp` duplicates `window.maxTimestamp` and matches the timestamp in the manifest file name.
+- `window` is the time range of data covered by the run. `maxTimestamp` duplicates `window.maxTimestamp`; the timestamp stem in the manifest file name is derived from it as described above.
 - `tables` and `files` reflect the selected export source; `scores` is always included regardless of the source.
 - `files[].key` is the full object key including your configured prefix, so consumers can fetch listed files without reconstructing paths.
-- `files[].format` is one of `parquet`, `json-raw`, `json-gzip`, `jsonl-raw`, `jsonl-gzip`, `csv-raw`, or `csv-gzip`.
+- `files[].fileType` is the configured file type: `JSON`, `CSV`, `JSONL`, or `PARQUET`. `files[].format` additionally encodes compression: one of `parquet`, `json-raw`, `json-gzip`, `jsonl-raw`, `jsonl-gzip`, `csv-raw`, or `csv-gzip`.
 - `files[].sizeBytes` is the uploaded size (after gzip for compressed text formats). `files[].rowCount` is the number of exported rows for text formats and `null` for Parquet files.
 - During [catch-up or backfill](#how-exports-run), each exported window is a separate run with its own manifest, so several manifests can appear in quick succession.
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -146,6 +146,79 @@ Each run exports one time window of data to your bucket, then advances and expor
 - **Export delay.** Data is exported with a short delay rather than right up to the current moment, so records still moving through ingestion are not exported half-written. Expect a brief lag between when an event is recorded and when it appears in your bucket.
 - **Catch-up / backfill.** When an integration starts from a historic point — or falls behind — it works forward through the backlog and may write many files in quick succession before settling into its normal cadence. A freshly created full-history integration does this until it catches up to the present.
 
+## Run completion manifest [#run-manifest]
+
+A single export run writes one file per exported table — up to four, depending on the selected export source — so the table files alone don't tell you when a run is complete. As the last object of every successful run, Langfuse writes a manifest file that lists everything the run produced:
+
+```
+{prefix}{project-id}/manifests/{max-timestamp}.json
+```
+
+The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in ISO 8601 format with colons replaced by dashes — the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's files and its manifest sort together.
+
+Example manifest:
+
+```json
+{
+  "version": 1,
+  "projectId": "cm0abcd1234efgh5678ijkl90",
+  "exportSource": "OBSERVATIONS_V2",
+  "window": {
+    "minTimestamp": "2026-07-13T08:00:00.000Z",
+    "maxTimestamp": "2026-07-13T09:00:00.000Z"
+  },
+  "maxTimestamp": "2026-07-13T09:00:00.000Z",
+  "createdAt": "2026-07-13T09:02:11.123Z",
+  "tables": ["observations_v2", "scores"],
+  "files": [
+    {
+      "key": "my-prefix/cm0abcd1234efgh5678ijkl90/observations_v2/2026-07-13T09-00-00.parquet",
+      "table": "observations_v2",
+      "fileType": "PARQUET",
+      "format": "parquet",
+      "compressed": false,
+      "contentType": "application/vnd.apache.parquet",
+      "sizeBytes": 1048576,
+      "rowCount": null
+    },
+    {
+      "key": "my-prefix/cm0abcd1234efgh5678ijkl90/scores/2026-07-13T09-00-00.parquet",
+      "table": "scores",
+      "fileType": "PARQUET",
+      "format": "parquet",
+      "compressed": false,
+      "contentType": "application/vnd.apache.parquet",
+      "sizeBytes": 20480,
+      "rowCount": null
+    }
+  ]
+}
+```
+
+Notes on the schema:
+
+- `version` increments only on breaking changes; new fields may be added without a version bump, so ignore unknown fields when parsing.
+- `window` is the time range of data covered by the run. `maxTimestamp` duplicates `window.maxTimestamp` and matches the timestamp in the manifest file name.
+- `tables` and `files` reflect the selected export source; `scores` is always included regardless of the source.
+- `files[].key` is the full object key including your configured prefix, so consumers can fetch listed files without reconstructing paths.
+- `files[].format` is one of `parquet`, `json-raw`, `json-gzip`, `jsonl-raw`, `jsonl-gzip`, `csv-raw`, or `csv-gzip`.
+- `files[].sizeBytes` is the uploaded size (after gzip for compressed text formats). `files[].rowCount` is the number of exported rows for text formats and `null` for Parquet files.
+- During [catch-up or backfill](#how-exports-run), each exported window is a separate run with its own manifest, so several manifests can appear in quick succession.
+
+## React to completed export runs [#export-events]
+
+Langfuse does not send a webhook when an export run finishes. Instead, subscribe to your storage provider's native object-created events with a prefix filter on `{prefix}{project-id}/manifests/` — because the manifest is the last object of each run, this gives you exactly one event per completed run. When the event fires, download the manifest and process the objects listed in `files[].key`.
+
+Provider recipes:
+
+- **AWS S3** — [Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html) on `s3:ObjectCreated:*` to SQS, SNS, or Lambda with a key prefix filter, or [EventBridge rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html) matching the object key prefix.
+- **Google Cloud Storage** — [Pub/Sub notifications](https://cloud.google.com/storage/docs/pubsub-notifications) for `OBJECT_FINALIZE` events; set the object name prefix when creating the notification configuration.
+- **Azure Blob Storage** — [Event Grid](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-event-overview) subscription on `Microsoft.Storage.BlobCreated` with a `subjectBeginsWith` filter, e.g. `/blobServices/default/containers/<container>/blobs/{prefix}{project-id}/manifests/`.
+- **MinIO** — [Bucket notifications](https://min.io/docs/minio/linux/administration/monitoring/bucket-notifications.html) on `s3:ObjectCreated:*` (webhook, Kafka, AMQP, and more) with a prefix filter.
+- **Backblaze B2** — [Event Notifications](https://www.backblaze.com/docs/cloud-storage-event-notifications) (webhooks) with a prefix filter.
+
+For S3-compatible providers without object-created events (for example, Wasabi or DigitalOcean Spaces), poll the manifest prefix instead: list `{prefix}{project-id}/manifests/` on a schedule and process any manifest newer than your last checkpoint. Manifest names sort lexicographically by export timestamp, so a marker-based (`start-after`) listing keeps polling cheap.
+
 ## Export status [#export-status]
 
 The integration settings page shows a status badge:

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -198,7 +198,7 @@ Example manifest:
 Notes on the schema:
 
 - `version` increments only on breaking changes; new fields may be added without a version bump, so ignore unknown fields when parsing.
-- `window` is the time range of data covered by the run. `maxTimestamp` duplicates `window.maxTimestamp`; the timestamp stem in the manifest file name is derived from it as described above.
+- `window` is the time range of data covered by the run, with both bounds inclusive — a record at exactly `maxTimestamp` also falls into the next run's window. `maxTimestamp` duplicates `window.maxTimestamp`; the timestamp stem in the manifest file name is derived from it as described above.
 - `tables` and `files` reflect the selected export source; `scores` is always included regardless of the source.
 - `files[].key` is the full object key including your configured prefix, so consumers can fetch listed files without reconstructing paths.
 - `files[].fileType` is the configured file type: `JSON`, `CSV`, `JSONL`, or `PARQUET`. `files[].format` additionally encodes compression: one of `parquet`, `json-raw`, `json-gzip`, `jsonl-raw`, `jsonl-gzip`, `csv-raw`, or `csv-gzip`.

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -154,7 +154,7 @@ A single export run writes one file per exported table — up to four, depending
 {prefix}{project-id}/manifests/{max-timestamp}.json
 ```
 
-The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in UTC, truncated to whole seconds, with colons replaced by dashes and the milliseconds and trailing `Z` dropped (`2026-07-13T09:00:00.000Z` → `2026-07-13T09-00-00`). This is the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's files and its manifest sort together.
+The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in UTC, truncated to whole seconds, with colons replaced by dashes and the milliseconds and trailing `Z` dropped (`2026-07-13T09:00:00.000Z` → `2026-07-13T09-00-00`). This is the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's table files and its manifest share the same timestamp stem.
 
 Example manifest:
 


### PR DESCRIPTION
## Summary

Documents the run-completion manifest introduced in langfuse/langfuse#14995 and how to react to completed export runs, closing out the docs half of [LFE-10843](https://linear.app/langfuse/issue/LFE-10843).

Adds two sections to **Export to Blob Storage**:

- **Run completion manifest** — the manifest contract: key layout (`{prefix}{project-id}/manifests/{max-timestamp}.json`), when it is written (strictly after all table files, i.e. the run's commit point), a full example payload, and schema/versioning notes (ignore-unknown-fields, `rowCount` null for Parquet, `scores` always included, one manifest per catch-up window).
- **React to completed export runs** — per-provider recipes for subscribing to object-created events with a prefix filter on the `manifests/` folder: S3 Event Notifications / EventBridge, GCS Pub/Sub notifications, Azure Event Grid, MinIO bucket notifications, Backblaze B2 event notifications, plus a marker-based polling fallback for providers without event support (Wasabi, DO Spaces).

## Checks

- `pnpm run format` — clean
- `node scripts/check-h1-headings.js` — pass
- Internal anchor links verified (`#how-exports-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents two new features in the Export to Blob Storage integration: a **run completion manifest** (the last object written per successful export run, enabling reliable run-completion detection) and **per-provider recipes** for subscribing to object-created events on the `manifests/` prefix.

- Adds the manifest key contract, full example payload, and schema/versioning notes (ignore-unknown-fields, `rowCount` null for Parquet, `scores` always included).
- Adds provider-specific event-subscription guidance for AWS S3, GCS, Azure Blob Storage, MinIO, and Backblaze B2, plus a marker-based polling fallback for S3-compatible providers without native event support (Wasabi, DigitalOcean Spaces).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code execution risk; the two identified issues are limited to text accuracy and an undocumented field in the new manifest section.

The manifest key timestamp description omits that milliseconds and the Z suffix are stripped in addition to colons — a reader following the docs literally would construct wrong keys. The undocumented `fileType` field in the example adds minor ambiguity for manifest parsers. Both issues are confined to the new section and don't affect existing behaviour.

content/docs/api-and-data-platform/features/export-to-blob-storage.mdx — the new Run completion manifest section's timestamp format description and the fileType field in the example payload.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant LF as Langfuse
    participant B as Blob Storage
    participant E as Event System (SQS / Pub/Sub / Event Grid)
    participant C as Consumer

    LF->>B: Upload table file(s) (observations, scores, …)
    Note over B: Files available in bucket
    LF->>B: Upload manifest JSON (last object of run)
    B-->>E: Object-created event (key matches manifests/ prefix)
    E-->>C: Event notification
    C->>B: Download manifest (files[].key listed inside)
    C->>B: Download each listed table file
    Note over C: Process completed export run
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant LF as Langfuse
    participant B as Blob Storage
    participant E as Event System (SQS / Pub/Sub / Event Grid)
    participant C as Consumer

    LF->>B: Upload table file(s) (observations, scores, …)
    Note over B: Files available in bucket
    LF->>B: Upload manifest JSON (last object of run)
    B-->>E: Object-created event (key matches manifests/ prefix)
    E-->>C: Event notification
    C->>B: Download manifest (files[].key listed inside)
    C->>B: Download each listed table file
    Note over C: Process completed export run
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:157
**Manifest key timestamp format is underspecified**

The text says the timestamp is "ISO 8601 format with colons replaced by dashes", but the example file keys in the JSON below show `2026-07-13T09-00-00` — the milliseconds (`.000`) and the UTC suffix (`Z`) are also stripped, not just the colons. A reader who constructs a manifest key by naïvely replacing colons in `maxTimestamp` would produce `2026-07-13T09-00-00.000Z`, not the actual `2026-07-13T09-00-00` the system writes. The description should precisely state all transformations applied so consumers can build the correct key without guessing.

### Issue 2 of 2
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:173-195
**`fileType` field in example is undocumented in schema notes**

The example manifest includes `fileType: "PARQUET"` (uppercase), while the schema-notes bullet below only documents `files[].format` (lowercase `"parquet"`). The two look like the same concept exposed under different names, but `fileType` has no documented value set and the relationship between the two fields is unexplained. Users writing a manifest parser will see both fields but only know what to expect from one of them.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: blob export run-completion manifes..."](https://github.com/langfuse/langfuse-docs/commit/7338af3082be9dd4c902437990c8cbc1e82ef1d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43833818)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->