### PR TITLE
Switch vulnerability reporting to ClickHouse Bugcrowd program in security docs

### DIFF
--- a/content/handbook/product-engineering/playbooks/vulnerability-handling.mdx
+++ b/content/handbook/product-engineering/playbooks/vulnerability-handling.mdx
@@ -7,16 +7,14 @@ description: How we handle security vulnerabilities through manual reports and a
 
 We have two different processes for handling security reports. These security reports are always triaged by engineers within 24 hours to act on them promptly if needed.
 
-## Process 1: Manual Security Reports
+## Process 1: Manual security reports
 
-Security reports sent to `security@clickhouse.com` are forwarded to Pylon (our support tool), where an engineer is auto-assigned to triage and create a Linear ticket.
+Manual vulnerability reports should be submitted through the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse). Engineering triages Langfuse submissions and creates a Linear ticket in the Vulnerability Dashboard. If a report arrives through support or email, direct the reporter to Bugcrowd rather than requesting sensitive proof-of-concept details in those channels. For reports that suggest active exploitation or customer data exposure, also page engineering on Slack `#security` immediately.
 
 ```mermaid
 flowchart LR
-    Reporter["Security Researcher/Customer/Team"] --> Email["security[at]langfuse.com"]
-    Email --> Forward["Forward to Pylon (Support Tool)"]
-    Forward --> AutoAssign["Engineer Auto-Assigned"]
-    AutoAssign --> Triage["Engineer Triages"]
+    Reporter["Security Researcher/Customer/Team"] --> Bugcrowd["ClickHouse Bugcrowd Program"]
+    Bugcrowd --> Triage["Engineer Triages Langfuse Submission"]
     Triage --> Linear["Engineer Creates Linear Ticket (Vulnerability Dashboard)"]
 ```
 

--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -974,26 +974,26 @@ Best,
 
 <summary>Bug bounty / vulnerability disclosure</summary>
 
-**We do not run a formal bug bounty program.** Almost all inbound is one of:
+**Langfuse is included in the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse).** Almost all inbound is one of:
 
-1. Legitimate disclosure of a real security issue, escalate immediately to engineering.
+1. Legitimate disclosure of a real security issue, direct the reporter to Bugcrowd. If the report suggests active exploitation or customer data exposure, also escalate immediately to engineering.
 2. Outreach from agencies/freelancers offering paid security services, polite decline.
 3. Auto-generated reports of "vulnerabilities" that turn out to be expected behavior (subdomain redirects, password length DoS, etc.), polite explanation that the behavior is intended.
 
 **Triage steps:**
 
-1. Skim the report. Does it describe a _real, reproducible_ vulnerability? If yes → escalate.
-2. If it's an agency pitch or a generic templated report → use the standard reply.
-3. For ambiguous cases, ask for proof-of-concept before escalating.
+1. Direct vulnerability reports to the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse), where the reporter can review eligibility, scope, and reward details before submitting. Do not ask the reporter to send sensitive proof-of-concept details through support channels.
+2. If the report suggests active exploitation or customer data exposure, page engineering on Slack `#security` in parallel.
+3. If it's an agency pitch or a generic templated report → use the standard reply.
 
-**Reply template (no formal program):**
+**Reply template (vulnerability report or bug bounty inquiry):**
 
 ```text
 Hi {name},
 
-Thank you for reaching out. At the current time, Langfuse doesn't offer a formal bug bounty program. Please review our responsible disclosure page, which has the channel for reporting real security issues:
+Thank you for reaching out. Langfuse participates in the ClickHouse Bugcrowd program. Please review the program's eligibility, scope, and reward details and submit your report through Bugcrowd:
 
-https://langfuse.com/security/responsible-disclosure#bug-bounty-program
+https://bugcrowd.com/engagements/clickhouse
 
 Best,
 {you}

--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -576,8 +576,9 @@ Container scanners (Wiz, Snyk, Trivy, Black Duck) regularly produce long lists o
 **Triage steps:**
 
 1. Check the version the customer scanned. If it's not the latest, ask them to scan the current image first, many CVEs are already patched in the next release.
-2. For genuine concerns, route to `security@clickhouse.com` for triage.
-3. Do not promise fix timelines. We patch on rolling cadence with each release.
+2. For genuine concerns, direct the customer to the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse) for scope review and submission. Do not ask them to send sensitive proof-of-concept details through support channels.
+3. If the report suggests active exploitation or customer data exposure, page engineering on Slack `#security` in parallel.
+4. Do not promise fix timelines. We patch on rolling cadence with each release.
 
 **Reply template:**
 
@@ -587,6 +588,8 @@ Hi {name},
 Thanks for the scan output. Could you re-run the scan against the latest image ({current_version}, released {date})? Several of the high-severity CVEs in your list are already addressed in recent releases.
 
 For any that still appear after that, our security team will triage and prioritize. Most CVEs in transitive Node.js dependencies are in code paths Langfuse doesn't exercise, we don't ship a fix for every transient CVE, but we do for anything reachable.
+
+If you believe a remaining finding is exploitable, please review the scope and submit it through the ClickHouse Bugcrowd program: https://bugcrowd.com/engagements/clickhouse.
 
 Best,
 {you}

--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -15,7 +15,7 @@ Langfuse is built with enterprise needs in mind, focusing on:
 - **Security Measures:** Robust [Encryption](/security/encryption), access controls, and regular [Penetration Testing](/security/penetration-testing).
 - **Privacy Measures:** Protecting user data according to regulations like [GDPR](/security/gdpr). We offer a [DPA](/dpa), provide a [HIPAA-ready region](/security/hipaa), and adhere to our [Privacy Policy](/privacy).
 - **Transparency:** Open-source core and clear information on [software dependencies](/security/dependencies).
-- **Reporting:** Clear channels for [Responsible Disclosure](/security/responsible-disclosure) and [Whistleblowing](/security/whistleblowing).
+- **Reporting:** Clear channels for [Bugcrowd vulnerability disclosure program](https://bugcrowd.com/engagements/clickhouse) and [Whistleblowing](/security/whistleblowing).
 
 import { CredibilitySentence } from "@/components/CredibilitySentence";
 

--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -15,7 +15,7 @@ Langfuse is built with enterprise needs in mind, focusing on:
 - **Security Measures:** Robust [Encryption](/security/encryption), access controls, and regular [Penetration Testing](/security/penetration-testing).
 - **Privacy Measures:** Protecting user data according to regulations like [GDPR](/security/gdpr). We offer a [DPA](/dpa), provide a [HIPAA-ready region](/security/hipaa), and adhere to our [Privacy Policy](/privacy).
 - **Transparency:** Open-source core and clear information on [software dependencies](/security/dependencies).
-- **Reporting:** Clear channels for [Bugcrowd vulnerability disclosure program](https://bugcrowd.com/engagements/clickhouse) and [Whistleblowing](/security/whistleblowing).
+- **Reporting:** Clear channels for [responsible disclosure through Bugcrowd](/security/responsible-disclosure) and [Whistleblowing](/security/whistleblowing).
 
 import { CredibilitySentence } from "@/components/CredibilitySentence";
 

--- a/content/security/responsible-disclosure.mdx
+++ b/content/security/responsible-disclosure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Responsible Disclosure
-description: How to responsibly disclose security vulnerabilities found in Langfuse.
+description: Report Langfuse security vulnerabilities through the ClickHouse Bugcrowd program.
 ---
 
 # Responsible Disclosure
@@ -9,7 +9,7 @@ We value the security community and prioritize the security of our systems. We e
 
 ## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability in Langfuse, please send an actionable vulnerability report to **security@clickhouse.com**.
+If you believe you have found a security vulnerability in Langfuse, please submit an actionable vulnerability report through the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse).
 
 Please include the following details in your report:
 
@@ -45,7 +45,7 @@ The following issues are considered out of scope and will not be accepted:
 
 ## Bug Bounty Program
 
-Please note that we **currently do not operate a formal bug bounty program** with monetary rewards.
+Langfuse is included in the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse). Please use Bugcrowd for eligibility, scope, and reward details before testing or submitting a report.
 
 ## Hall of Fame
 
@@ -75,4 +75,4 @@ We appreciate the efforts of security researchers who help keep Langfuse secure.
 
 ## Contact
 
-For all security-related inquiries, including vulnerability disclosures, please contact security@clickhouse.com.
+For vulnerability disclosures, please use the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse). For other security-related inquiries, contact security@clickhouse.com.

--- a/content/security/security-faq.mdx
+++ b/content/security/security-faq.mdx
@@ -145,7 +145,7 @@ The Change Management Policy ensures that all modifications to our infrastructur
 
 > **How is the disclosure program run?**
 
-Langfuse maintains a public responsible‑disclosure policy; CVSS drives remediation SLAs. See [penetration testing](/security/penetration-testing) for more details.
+Langfuse participates in the [ClickHouse Bugcrowd program](https://bugcrowd.com/engagements/clickhouse) for vulnerability disclosure; CVSS drives remediation SLAs. See [penetration testing](/security/penetration-testing) for more details.
 
 > **How does the information security policy look like?**
 

--- a/content/security/vulnerability-management.mdx
+++ b/content/security/vulnerability-management.mdx
@@ -13,7 +13,7 @@ We employ a multi-layered approach to identify potential vulnerabilities:
 
 - **Automated Scanning:** We utilize industry-standard tools, including **GitHub code scanning** and **Snyk**, to continuously scan our codebase, dependencies, and infrastructure for known vulnerabilities.
 - **External Penetration Testing:** Langfuse undergoes regular [penetration tests](/security/penetration-testing) conducted by independent third-party security experts. Findings from these tests are integrated into our remediation process.
-- **Responsible Disclosure Program:** We encourage security researchers to report potential vulnerabilities through our [responsible disclosure program](/security/responsible-disclosure).
+- **Responsible Disclosure Program:** We encourage security researchers to report potential vulnerabilities through our [Bugcrowd vulnerability disclosure program](https://bugcrowd.com/engagements/clickhouse).
 - **Internal Reviews:** Our engineering teams conduct regular security reviews of code and infrastructure configurations.
 
 ## Triage and Remediation

--- a/content/security/vulnerability-management.mdx
+++ b/content/security/vulnerability-management.mdx
@@ -13,7 +13,7 @@ We employ a multi-layered approach to identify potential vulnerabilities:
 
 - **Automated Scanning:** We utilize industry-standard tools, including **GitHub code scanning** and **Snyk**, to continuously scan our codebase, dependencies, and infrastructure for known vulnerabilities.
 - **External Penetration Testing:** Langfuse undergoes regular [penetration tests](/security/penetration-testing) conducted by independent third-party security experts. Findings from these tests are integrated into our remediation process.
-- **Responsible Disclosure Program:** We encourage security researchers to report potential vulnerabilities through our [Bugcrowd vulnerability disclosure program](https://bugcrowd.com/engagements/clickhouse).
+- **Responsible Disclosure Program:** We encourage security researchers to report potential vulnerabilities through our [responsible disclosure program](/security/responsible-disclosure), which routes submissions through Bugcrowd.
 - **Internal Reviews:** Our engineering teams conduct regular security reviews of code and infrastructure configurations.
 
 ## Triage and Remediation


### PR DESCRIPTION
### Motivation

- Consolidate and clarify the vulnerability disclosure channel by directing researchers to the ClickHouse Bugcrowd program rather than a direct email contact.
- Ensure public-facing security pages consistently reference the same external disclosure program and link.

### Description

- Replaced direct vulnerability reporting text and the `security@clickhouse.com` reporting instruction with the ClickHouse Bugcrowd program link across security docs.
- Updated the Bug Bounty section to state that Langfuse is included in the ClickHouse Bugcrowd program and to point researchers to Bugcrowd for scope and reward details.
- Modified `content/security/index.mdx`, `content/security/responsible-disclosure.mdx`, `content/security/security-faq.mdx`, and `content/security/vulnerability-management.mdx` to use the Bugcrowd disclosure wording and links.
- Kept `security@clickhouse.com` as the contact for non-vulnerability security inquiries.

### Testing

- Ran the documentation build and static checks (`npm run build` / docs lint) to validate MDX changes and internal linking, and they completed successfully.
- Performed a link check on the updated Bugcrowd URLs and confirmed they resolve correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5620c2b6d8832fad25a04bdf1475df)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates four security documentation pages to consolidate vulnerability reporting through the ClickHouse Bugcrowd program, replacing the previous direct `security@clickhouse.com` email channel and the "no formal bug bounty" statement with a unified Bugcrowd disclosure link.

- `responsible-disclosure.mdx`, `security-faq.mdx`, and `vulnerability-management.mdx` all consistently point researchers to `https://bugcrowd.com/engagements/clickhouse` for vulnerability submissions, while retaining `security@clickhouse.com` for non-vulnerability security inquiries.
- `index.mdx` (Reporting bullet) and `vulnerability-management.mdx` now link directly to the external Bugcrowd URL, bypassing the internal `/security/responsible-disclosure` page that contains Langfuse-specific focus areas and out-of-scope guidance.
- The internal support handbook (`content/handbook/support/how-to-answer-support-questions.mdx`) was not updated and still instructs support staff to tell inquirers that Langfuse has no formal bug bounty program, directly contradicting the updated public docs.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The docs changes are internally consistent across all four updated pages, but the internal support handbook still tells staff to deny the existence of a bug bounty program.

The internal support handbook still states 'We do not run a formal bug bounty program' and carries a template reply to that effect. When a security researcher is told by Langfuse support that no bug bounty exists after reading the public docs that it does, the contradiction erodes trust and could deter legitimate disclosures. This file should have been updated alongside the public security pages.

content/handbook/support/how-to-answer-support-questions.mdx — the bug bounty section and template reply need to be updated to reflect Bugcrowd participation.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Security Researcher] --> B{Type of inquiry?}
    B -->|Vulnerability report| C[ClickHouse Bugcrowd Program]
    B -->|Non-vulnerability inquiry| D[security at clickhouse.com]
    B -->|Whistleblowing| E[Whistleblowing page]
    C --> F[Bugcrowd triage and rewards]
    F --> G[Langfuse team notified]
    subgraph PublicDocs[Langfuse Docs updated pages]
        H[index.mdx]
        I[responsible-disclosure.mdx]
        J[vulnerability-management.mdx]
        K[security-faq.mdx]
    end
    H --> C
    I --> C
    J --> C
    K --> C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Security Researcher] --> B{Type of inquiry?}
    B -->|Vulnerability report| C[ClickHouse Bugcrowd Program]
    B -->|Non-vulnerability inquiry| D[security at clickhouse.com]
    B -->|Whistleblowing| E[Whistleblowing page]
    C --> F[Bugcrowd triage and rewards]
    F --> G[Langfuse team notified]
    subgraph PublicDocs[Langfuse Docs updated pages]
        H[index.mdx]
        I[responsible-disclosure.mdx]
        J[vulnerability-management.mdx]
        K[security-faq.mdx]
    end
    H --> C
    I --> C
    J --> C
    K --> C
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/security/vulnerability-management.mdx:16
**Responsible-disclosure internal page no longer linked**

`vulnerability-management.mdx` and `index.mdx` (Reporting bullet) now both link directly to `https://bugcrowd.com/engagements/clickhouse` instead of the internal `/security/responsible-disclosure` page. The internal page still exists and contains Langfuse-specific out-of-scope items, focus areas, and a Hall of Fame that researchers benefit from reading before submitting. Consider pointing to `/security/responsible-disclosure` (which in turn links to Bugcrowd) so researchers land on the Langfuse-scoped context first rather than jumping straight to the external program.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: route vulnerability reports to Bug..."](https://github.com/langfuse/langfuse-docs/commit/2645119e9c190e9ae57f59073017a0e956e4b7bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44114996)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->