### PR TITLE
docs: link HIPAA BAA to DocuSign

### DIFF
--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -934,13 +934,13 @@ Best,
 
 <summary>BAA / HIPAA</summary>
 
-HIPAA is available on a dedicated cloud region: `hipaa.cloud.langfuse.com`. Legal agreement terms for HIPAA-regulated use are not published or downloadable on langfuse.com. Route customers with legal requirements to [legal@clickhouse.com](mailto:legal@clickhouse.com) before they process PHI.
+HIPAA is available on a dedicated cloud region: `hipaa.cloud.langfuse.com`. Customers must [complete and sign the BAA via DocuSign](https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98) before they process PHI.
 
 **Triage steps:**
 
 1. Confirm the customer is using or about to use `hipaa.cloud.langfuse.com` (not the standard US/EU regions).
 2. **Account migration:** customers moving from EU/US must create a fresh account on `hipaa.cloud.langfuse.com`. Past trace data can be moved via the [data migration cookbook](/guides/cookbook/example_data_migration).
-3. For HIPAA-related legal requirements, route the customer to [legal@clickhouse.com](mailto:legal@clickhouse.com). Do not send public agreement text or tell customers it applies automatically.
+3. For HIPAA-related legal requirements, direct the customer to [complete and sign the BAA via DocuSign](https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98). Do not tell customers that the BAA applies automatically.
 4. For HIPAA-region IP allowlisting (egress from Langfuse to customer infra, e.g. for LLM-as-a-judge): static IPs are `35.82.248.193`, `34.211.191.155`, `52.43.164.18` (us-west-2). Full list at [langfuse.com/security/networking](https://langfuse.com/security/networking). **Ingress** to `hipaa.cloud.langfuse.com` sits behind AWS ALBs without static IPs, we cannot publish a stable ingress IP range.
 
 **Reply template:**
@@ -948,7 +948,7 @@ HIPAA is available on a dedicated cloud region: `hipaa.cloud.langfuse.com`. Lega
 ```text
 Hi {name},
 
-For HIPAA usage you'll need to be on hipaa.cloud.langfuse.com (separate region from us./cloud.) and on a HIPAA-eligible plan (Pro or higher). Legal agreement terms for HIPAA-regulated use are not published or downloadable on langfuse.com. Please contact legal@clickhouse.com before processing PHI.
+For HIPAA usage you'll need to be on hipaa.cloud.langfuse.com (separate region from us./cloud.) and on a HIPAA-eligible plan (Pro or higher). Please complete and sign the BAA before processing PHI: https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98
 
 A note for completeness: HIPAA accounts are provisioned fresh on hipaa.cloud.langfuse.com. If your team is currently on us.cloud or cloud., past trace data can be moved via our data migration cookbook: https://langfuse.com/guides/cookbook/example_data_migration.
 

--- a/content/security/hipaa.mdx
+++ b/content/security/hipaa.mdx
@@ -7,7 +7,7 @@ description: Information about Langfuse's HIPAA-ready cloud region.
 
 Langfuse offers a dedicated HIPAA-ready cloud region for eligible customers with healthcare or life-sciences workloads. This region is separate from the EU, US, and Japan Langfuse Cloud regions.
 
-Eligible customers can enter into a signed Business Associate Agreement (BAA) with Langfuse for HIPAA-regulated use. Customers with HIPAA requirements should contact [legal@clickhouse.com](mailto:legal@clickhouse.com) before processing Protected Health Information (PHI) in Langfuse.
+Eligible customers can enter into a signed Business Associate Agreement (BAA) with Langfuse for HIPAA-regulated use. Customers with HIPAA requirements should [complete the BAA via DocuSign](https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98) before processing Protected Health Information (PHI) in Langfuse.
 
 ## Availability
 
@@ -17,13 +17,13 @@ Eligible customers can enter into a signed Business Associate Agreement (BAA) wi
 
 ## Signed BAA
 
-Customers on Pro plan or higher in the HIPAA data region can request a signed BAA by contacting [legal@clickhouse.com](mailto:legal@clickhouse.com). Do not process PHI in Langfuse until the signed BAA is in place.
+Customers on Pro plan or higher in the HIPAA data region can [complete and sign the BAA via DocuSign](https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98). Do not process PHI in Langfuse until the signed BAA is in place.
 
 ## How to get started
 
 1. Create a fresh Langfuse Cloud account in the [HIPAA data region](https://langfuse.com/security/data-regions).
 2. Subscribe to [Pro plan or higher](https://langfuse.com/pricing).
-3. Contact [legal@clickhouse.com](mailto:legal@clickhouse.com) to request and enter into a signed BAA before processing PHI.
+3. [Complete and sign the BAA via DocuSign](https://powerforms.docusign.net/39437499-4b13-4604-b373-2b1f2ae6f6fd?env=eu&acct=33986eaf-fde8-48d4-8d61-cf8c0f573e98&accountId=33986eaf-fde8-48d4-8d61-cf8c0f573e98) before processing PHI.
 4. Configure your application to send HIPAA-regulated data only to `https://hipaa.cloud.langfuse.com`.
 
 The HIPAA region is completely separate from the [other data regions](https://langfuse.com/security/data-regions). Data migration is possible via the [data migration cookbook](https://langfuse.com/guides/cookbook/example_data_migration).


### PR DESCRIPTION
## Summary

- Replace the `legal@clickhouse.com` instructions on the public HIPAA page with the new DocuSign PowerForm.
- Align the support handbook triage guidance and customer reply template with the same self-service flow.

## Why

The documentation still described the previous email-based BAA process after the DocuSign workflow became available. This update sends eligible Langfuse Cloud customers directly to the current signing flow.

## Impact

Customers on Pro or higher in the HIPAA region can start the BAA signing process directly from the website, while support guidance remains consistent with the public page.

## Validation

- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- `git diff --check`
- Confirmed the DocuSign PowerForm returns HTTP 200

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous email-based BAA process (`legal@clickhouse.com`) with a self-service DocuSign PowerForm link across two documentation files. All six occurrences of the old email are replaced with the same DocuSign URL consistently.

- **`content/security/hipaa.mdx`**: Three mentions updated (intro paragraph, "Signed BAA" section, and "How to get started" step 3) to point customers directly to the DocuSign form.
- **`content/handbook/support/how-to-answer-support-questions.mdx`**: Support triage guidance and the copy-paste reply template are updated to match, removing the routing instruction to `legal@clickhouse.com` and replacing it with the same self-service DocuSign link.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only change replacing a stale email address with a validated self-service URL.

Both files are updated consistently: all six occurrences of the old email are replaced with the identical DocuSign PowerForm URL, and the PR author confirmed the URL returns HTTP 200. The reply template and public-facing page now agree, eliminating the risk of support staff directing customers to a defunct contact.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer needs HIPAA BAA] --> B{On hipaa.cloud.langfuse.com?}
    B -- No --> C[Create fresh account on HIPAA region]
    C --> D[Subscribe to Pro plan or higher]
    B -- Yes --> E{Pro plan or higher?}
    D --> E
    E -- No --> F[Upgrade plan]
    F --> G[Complete BAA via DocuSign PowerForm]
    E -- Yes --> G
    G --> H[BAA signed & in place]
    H --> I[Safe to process PHI in Langfuse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Customer needs HIPAA BAA] --> B{On hipaa.cloud.langfuse.com?}
    B -- No --> C[Create fresh account on HIPAA region]
    C --> D[Subscribe to Pro plan or higher]
    B -- Yes --> E{Pro plan or higher?}
    D --> E
    E -- No --> F[Upgrade plan]
    F --> G[Complete BAA via DocuSign PowerForm]
    E -- Yes --> G
    G --> H[BAA signed & in place]
    H --> I[Safe to process PHI in Langfuse]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link HIPAA BAA to DocuSign"](https://github.com/langfuse/langfuse-docs/commit/4494e20063046e882fc643b60d192399cdb63f96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44120870)</sub>

<!-- /greptile_comment -->