### PR TITLE
docs: warn about undetectable Parquet export failures on ClickHouse < 25.11 (LFE-10843)

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -47,6 +47,10 @@ Exports can be written as Apache Parquet, CSV, JSON, or JSONL files. New integra
 
 Parquet observation exports do not include the per-unit model price columns (`input_price`, `output_price`, `total_price`). These columns snapshot model definition prices at export time and may be deprecated in the future — use `cost_details` and `total_cost` for cost data, which are included in every file type. See [Notes on Parquet exports](/docs/api-and-data-platform/features/blob-storage-export-fields#parquet-exports) in the field reference for details.
 
+<Callout type="warning">
+**Self-hosted deployments running ClickHouse < 25.11:** Parquet export failures may not surface as errors. A run can complete — and its [manifest](#run-manifest) be written — while the Parquet output is incomplete or invalid. Upgrade to ClickHouse >= 25.11, or use a text format (CSV, JSON, or JSONL) for reliable failure detection.
+</Callout>
+
 ## Export source (Fast Preview)
 
 Blob Storage integrations now include an `Export Source` selector. New integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations).


### PR DESCRIPTION
## Summary

Adds a warning callout to the [Blob Storage export](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage) **File formats** section covering a self-hosting limitation with Parquet exports.

On self-hosted deployments running **ClickHouse < 25.11**, Parquet export failures may not surface as errors. A run can complete — and its run-completion manifest be written — while the Parquet output is incomplete or invalid. The callout recommends upgrading to ClickHouse >= 25.11, or using a text format (CSV, JSON, or JSONL) for reliable failure detection.

There's no good way to detect or resolve this in code (the failure is silent on the ClickHouse side), so we document it instead.

Related: [LFE-10843](https://linear.app/langfuse/issue/LFE-10843). Complements the run-completion manifest docs in #3295.

## Change

- One `<Callout type="warning">` added after the Parquet pricing paragraph in `content/docs/api-and-data-platform/features/export-to-blob-storage.mdx`, linking to the `#run-manifest` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `<Callout type="warning">` to the Blob Storage export docs noting that on self-hosted deployments running ClickHouse < 25.11, Parquet export failures may be silent — a run can finish and write a manifest while the Parquet output is incomplete or invalid. The diff also includes the new "Run completion manifest" and "React to completed export runs" sections, which are well-structured with schema notes, a JSON example, and per-provider event-subscription recipes.

- A focused warning callout is added in the File formats section, correctly linking to `#run-manifest` and recommending either upgrading ClickHouse or switching to a text format.
- The manifest section documents the file naming convention, schema fields, and the guarantee that the manifest is written only after all table files are uploaded.
- Provider-specific object-event recipes (S3, GCS, Azure, MinIO, Backblaze B2) are added, with a polling fallback noted for S3-compatible stores that lack object-created events.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a documentation-only change with no runtime code affected.

The change is a single documentation callout accurately describing a known ClickHouse limitation, plus well-structured manifest and event-subscription sections. Content is factually consistent, the anchor link resolves correctly, and there are no code changes involved.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: warn about undetectable Parquet ex..."](https://github.com/langfuse/langfuse-docs/commit/6bed6776f6dac53c17ffaf986f93b40f8bee55d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44175391)</sub>

<!-- /greptile_comment -->