### PR TITLE
docs: explain root observation defaults

### DIFF
--- a/content/changelog/2026-07-15-root-observations-default.mdx
+++ b/content/changelog/2026-07-15-root-observations-default.mdx
@@ -1,0 +1,41 @@
+---
+date: 2026-07-15
+title: "Start with root observations"
+description: "Projects using app-root-aware Langfuse SDKs now open the observations table with a focused view of outer roots and application entry points."
+author: Nimar
+canonical: https://langfuse.com/faq/all/explore-observations-in-v4
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book } from "lucide-react";
+
+<ChangelogHeader />
+
+The observations table now starts with `Is Root Observation = true` for projects ingesting with Python SDK v4.7.0+ or JS/TS SDK v5.4.0+. The focused view includes both outer roots and SDK-detected app roots, so you see the application entry points in your traces before their child operations.
+
+For example, you can now:
+
+- Scan the top-level requests and agent runs in a project without first filtering out every nested LLM, tool, or retrieval call.
+- Find the application input and output captured on a root observation, then open its trace to inspect the full execution.
+- Remove the visible root filter whenever you want to search or compare individual operations across traces.
+
+## Why app roots matter
+
+The latest major Langfuse SDKs filter some OpenTelemetry instrumentation and infrastructure spans by default. An excluded span can be the outer parent of the application observations you send to Langfuse. Because its exported children retain their parent span IDs, a filter that only checks for observations without a parent can return no application roots even though those observations were ingested.
+
+Python SDK v4.7.0+ and JS/TS SDK v5.4.0+ solve this by marking the highest exported application observation beneath a filtered parent as an **app root**. The `Is Root Observation` filter now matches an observation when it is either a top-level **outer root** or an SDK-marked **app root**.
+
+## A default that respects your view
+
+Langfuse applies the root filter only when you arrive at the observations table without table state of your own. Existing saved/default views and shared links with filters continue to open as configured. If you remove the automatic root filter, Langfuse remembers your choice. If the filter finds no roots while other observations exist, Langfuse removes it automatically so your data does not disappear behind an empty default.
+
+## Learn more
+
+<Cards num={1}>
+  <Card
+    title="Explore observations in Langfuse Fast Preview"
+    href="/faq/all/explore-observations-in-v4"
+    icon={<Book />}
+    arrow
+  />
+</Cards>

--- a/content/faq/all/explore-observations-in-v4.mdx
+++ b/content/faq/all/explore-observations-in-v4.mdx
@@ -29,6 +29,7 @@ These are some of the most useful starting points. Each can be saved as a [saved
 | Errors for a specific user            | Filter by `user_id` and `level = ERROR`                                                                |
 | Operations scoped to a session        | Filter by `session_id`, sort by `latency` descending                                                   |
 | All operations for one trace          | Filter by `trace_id`                                                                                   |
+| Application entry points              | Filter `Is Root Observation = true`                                                                    |
 | Model latency comparison              | Filter `type = generation`, group by `model` in a [dashboard](/docs/metrics) or sort by `model` column |
 | Cost, latency, or errors by dimension | [Self-serve dashboards](/docs/metrics)                                                                 |
 
@@ -39,6 +40,19 @@ We recommend setting up 2-3 saved views for your most common debugging workflows
   aspectRatio={16 / 9}
   className="mt-3"
 />
+
+## Start with root observations
+
+For projects that ingest with Python SDK v4.7.0+ or JS/TS SDK v5.4.0+, Langfuse applies `Is Root Observation = true` when you open the observations table without a saved view, shared filter link, or other table state. This gives you a focused list of application entry points before you drill into their child operations.
+
+The filter includes both kinds of roots:
+
+- **Outer roots** are top-level observations with no parent.
+- **App roots** are the highest exported application observations beneath parents excluded by SDK span filtering.
+
+App roots matter when an OpenTelemetry instrumentation or infrastructure span is the outer parent of your application spans. The Langfuse SDK may filter that parent from export, but the exported child still carries its parent span ID. A filter based only on observations without a parent would therefore miss the application entry point. App-root-aware SDKs mark that entry point so `Is Root Observation` can include it alongside outer roots.
+
+The filter is visible in the sidebar and you can remove it to inspect every operation. Langfuse remembers that choice. Existing saved/default views and links with table filters keep their own state. If the automatic filter finds no matching roots while other observations exist, Langfuse removes it automatically.
 
 ## Upgrade checklist
 


### PR DESCRIPTION
## What changed

- Add a changelog post for the new root-observation default in the observations table.
- Document the difference between outer roots and SDK-detected app roots in the Fast Preview observations guide.
- Explain when the default applies, how saved/default views and shared links take precedence, and how the empty-result fallback behaves.
- Call out the first app-root-aware SDK versions: Python 4.7.0+ and JS/TS 5.4.0+.

## Why

Default SDK span filtering can exclude an OpenTelemetry instrumentation or infrastructure span that is the outer parent of exported application observations. Those exported children retain their parent span IDs, so a root filter based only on a missing parent can hide the application's useful entry point.

The SDKs now mark the highest exported application observation beneath a filtered parent as an app root. The product's `Is Root Observation` filter matches both top-level outer roots and these SDK-marked app roots, and is now automatically applied for projects using compatible SDKs.

Related implementation:

- langfuse/langfuse#15066
- langfuse/langfuse#13718
- langfuse/langfuse-python#1651
- langfuse/langfuse-js#804

## User impact

Users with compatible SDKs start from a cleaner observations-table view focused on application entry points, while retaining full control through visible filters, saved views, shared links, and the automatic fallback.

## Validation

- Targeted Prettier check
- `node scripts/check-h1-headings.js`
- `git diff --check`
- Rendered both the guide and changelog locally and confirmed HTTP 200 responses

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a changelog entry and expands the observations guide to document the new `Is Root Observation = true` default for projects using app-root-aware SDKs (Python v4.7.0+, JS/TS v5.4.0+). Both files are accurate, internally consistent, and the SDK version references match throughout.

- **Changelog** (`2026-07-15-root-observations-default.mdx`): New entry explaining outer roots vs. app roots, how the default is applied, and when it falls back — with a link back to the guide.
- **Guide** (`explore-observations-in-v4.mdx`): Adds "Application entry points" to the common views table and a new "Start with root observations" section covering the filter behavior, both root types, and the automatic fallback.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code execution paths; safe to merge.

Both files are factually consistent with each other and with existing content in the guide. The only item worth a second look is the `author` field in the changelog, which uses a first name only where all other recent entries use full names.

The `author` field in `content/changelog/2026-07-15-root-observations-default.mdx` should use a full name to match the established convention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens observations table] --> B{Has saved view,\nshared link, or\nother table state?}
    B -- Yes --> C[Open with that saved state]
    B -- No --> D{Project uses Python SDK\nv4.7.0+ or JS/TS SDK\nv5.4.0+?}
    D -- No --> E[Open without default filter]
    D -- Yes --> F[Apply Is Root Observation = true]
    F --> G{Filter returns\nzero results but\nother observations exist?}
    G -- Yes --> H[Remove filter automatically]
    G -- No --> I[Show filtered results]
    H --> J[Show all observations]
    I --> K{User removes\nroot filter?}
    K -- Yes --> L[Langfuse remembers choice]
    L --> E

    subgraph Root Types Matched
        M[Outer roots: observations with no parent]
        N[App roots: highest exported observation beneath a filtered SDK parent]
    end

    F -.->|matches both| M
    F -.->|matches both| N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens observations table] --> B{Has saved view,\nshared link, or\nother table state?}
    B -- Yes --> C[Open with that saved state]
    B -- No --> D{Project uses Python SDK\nv4.7.0+ or JS/TS SDK\nv5.4.0+?}
    D -- No --> E[Open without default filter]
    D -- Yes --> F[Apply Is Root Observation = true]
    F --> G{Filter returns\nzero results but\nother observations exist?}
    G -- Yes --> H[Remove filter automatically]
    G -- No --> I[Show filtered results]
    H --> J[Show all observations]
    I --> K{User removes\nroot filter?}
    K -- Yes --> L[Langfuse remembers choice]
    L --> E

    subgraph Root Types Matched
        M[Outer roots: observations with no parent]
        N[App roots: highest exported observation beneath a filtered SDK parent]
    end

    F -.->|matches both| M
    F -.->|matches both| N
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/changelog/2026-07-15-root-observations-default.mdx:5
Other recent changelogs in this repo use full names in the `author` field (e.g., `"Nikita Kabardin"`, `"Ben Bachem"`). Using just `"Nimar"` breaks that convention and could look incomplete on the rendered changelog page.

```suggestion
author: Nimar <last-name>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: explain root observation defaults"](https://github.com/langfuse/langfuse-docs/commit/c8daed5f861d7339c533f1b529d370fab8b5dae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44408302)</sub>

<!-- /greptile_comment -->