### PR TITLE
Add 5 engineering resources pages; refresh LangSmith comparison + 2 agent blog posts

### DIFF
--- a/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
+++ b/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Agent Observability, Tracing & Evaluation with Langfuse"
-date: 2026/07/13
+date: 2026/07/15
 description: "Trace, monitor, evaluate, and test AI agents in production. Learn what agent observability is and how to use Langfuse with LangGraph, OpenAI Agents SDK, Claude Agent SDK, CrewAI, Pydantic AI, Vercel AI SDK, and more."
 ogImage: /images/blog/ai-agent-observability/ai-agent-observability.png
 tag: agents, guide, evaluation
@@ -12,7 +12,7 @@ import { BlogHeader } from "@/components/blog/BlogHeader";
 <BlogHeader
   title="AI Agent Observability, Tracing & Evaluation with Langfuse"
   description="Trace, monitor, evaluate, and test AI agents in production. Learn what agent observability is and how to use Langfuse with LangGraph, OpenAI Agents SDK, Claude Agent SDK, CrewAI, Pydantic AI, Vercel AI SDK, and more."
-  date="July 13, 2026"
+  date="July 15, 2026"
   authors={["jannikmaierhoefer"]}
 />
 
@@ -24,73 +24,48 @@ A complete agent observability setup captures:
 
 - **LLM calls** are recorded with their prompts, completions, model parameters, token usage, and [cost](/docs/observability/features/token-and-cost-tracking).
 - **Tool calls** are recorded with the tools that were available to the model, the tool it chose, and the arguments it passed.
-- **Control flow** is visible: which sub-agents, chains, or steps ran, in what order, and how often the agent looped.
-- **Context operations** such as retrievals, embeddings, and guardrail checks appear as typed steps in the trace.
+- **Control flow** is visible: which subagents, handoffs, or loop iterations ran, in what order, and how often the agent looped.
+- **Context** is captured: the prompt version, retrieved documents, and everything else the model actually saw at each step.
 - **Sessions and users** group multi-turn conversations so behavior can be analyzed per conversation and per user.
 - **Quality signals** such as [user feedback](/docs/observability/features/user-feedback) and evaluation scores are attached directly to traces.
 
-[Langfuse](/) is an open-source AI engineering platform that implements this end to end: [tracing](/docs/observability/overview) with typed observations, agent graph visualization, tool-call analytics, and [evaluation](/docs/evaluation/overview) on top of the captured data. The rest of this post walks through each of these capabilities and how to instrument the most common agent frameworks.
+[Langfuse](/) is an open-source AI engineering platform that implements this end to end: [tracing](/docs/observability/overview) with typed observations, agent graph visualization, tool-call analytics, production monitors, and [evaluation](/docs/evaluation/overview) on top of the captured data. The rest of this post walks through each of these capabilities and how to instrument the most common agent stacks.
 
-### Industry trends in agent observability
+## Why agents need dedicated observability
 
-The industry has converged on **OpenTelemetry (OTel)** as the standard for collecting agent telemetry. Many agent frameworks, including Pydantic AI, smolagents, Strands Agents, and LiveKit Agents, emit traces via OpenTelemetry, which [Langfuse natively supports](/docs/observability/sdk/instrumentation). This prevents vendor lock-in and lets you keep existing instrumentation when switching backends.
+Agents differ from single-call LLM applications in three ways that shape what observability has to do:
 
-There is also a shift from reactive log parsing to **structured tracing with typed observation data**. Rather than reconstructing behavior from unstructured logs after a failure, teams instrument agents with semantic types (tool calls, retriever steps, guardrail checks) that can be filtered, aggregated, and evaluated directly.
+- **Failures hide mid-trace.** An agent that picks the wrong tool, retrieves the wrong document, or loops on a failing step can still produce a plausible final answer. Finding these failures requires inspecting the full trace, and turning them into [dataset](/docs/evaluation/experiments/datasets) items so they stay fixed.
+- **Agents decide their own spend.** An agent autonomously chooses how many model calls, tool executions, and external API calls a task takes, so cost must be tracked in real time, attributed per trace, per user, and per model.
+- **Agents run long.** Plan-act-observe loops, subagent delegation, and long-horizon tasks produce traces with hundreds or thousands of observations, and teams running long-lived agents report traces reaching hundreds of thousands of observations. Tooling has to stay useful at that scale, which is why search, filtering, and aggregate views matter as much as the trace tree itself.
 
-Finally, **traces are getting long**. Agents that plan, loop, and delegate produce traces with hundreds or thousands of observations, and teams running long-lived agents report traces reaching hundreds of thousands of observations. Observability tooling has to stay useful at that scale, which is why search, filtering, and aggregate views matter as much as the trace tree itself.
+## How modern agents are built, and what that means for tracing
 
-## Why agent observability matters
+### The agentic loop and its harness
 
-### Debugging and edge cases
+An agent today is a model calling tools in a loop: the harness assembles context, sends it to the model, executes the tool calls the model requests, feeds results back, and decides when the loop stops. Frameworks like LangGraph, the OpenAI Agents SDK, and the Claude Agent SDK are harnesses in this sense, and the industry has converged on **OpenTelemetry (OTel)** for emitting their telemetry. Many agent frameworks, including Pydantic AI, smolagents, Strands Agents, and LiveKit Agents, ship OTel instrumentation that [Langfuse natively supports](/docs/observability/sdk/instrumentation), which prevents vendor lock-in and lets you keep existing instrumentation when switching backends.
 
-Agents use multiple steps to solve complex tasks, and inaccurate intermediary results can cause failures of the entire system. [Tracing](/docs/observability/overview) these intermediate steps and testing your application on known edge cases is essential.
+For observability, the loop is the unit of analysis: every iteration is a set of observations (a generation, its tool calls, their results), and questions like "why did the agent take 40 steps for this task" are answered by reading the loop, not the final answer.
 
-When deploying LLMs, some edge cases will always slip through in initial testing. A proper analytics setup helps identify these cases, allowing you to add them to future test sets for more robust agent evaluations. With [Datasets](/docs/evaluation/experiments/datasets), Langfuse allows you to collect examples of inputs and expected outputs to benchmark new releases before deployment. Datasets can be incrementally updated with new edge cases found in production and integrated with existing [CI/CD pipelines](/blog/2025-10-21-testing-llm-applications).
+### Tool calling and MCP
 
-### The tradeoff of accuracy and costs
+Tools are how agents act, and the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) has become the standard way to connect agents to external tools and data sources. When tracing MCP applications, client and server operations produce separate traces by default; Langfuse supports [linking them](/docs/observability/features/mcp-tracing) by propagating OpenTelemetry context through MCP's `_meta` field, so one request flows through client, server, and downstream APIs as a single connected trace.
 
-LLMs are stochastic by nature, meaning they are a statistical process that can produce errors or hallucinations. Calling language models multiple times while selecting the best or most common answer can increase accuracy. This can be a major advantage of using agentic workflows.
+### Subagents and multi-agent orchestration
 
-However, this comes with a cost. The agent often decides autonomously how many LLM calls or paid external API calls it needs to make to solve a task, potentially leading to high costs for single-task executions. Therefore, it is important to monitor model usage and costs in real time, attributed per trace, per user, and per model.
+Production agent systems increasingly delegate: a supervisor hands work to specialized subagents, the OpenAI Agents SDK models this as handoffs, and frameworks like [LangChain DeepAgents](/integrations/frameworks/langchain-deepagents) spawn subagents for research and critique. In a trace, each subagent's work nests under its parent as typed observations, so the delegation structure is visible in the trace tree and the agent graph. When the agents run as separate services, their spans are assembled into one trace via distributed tracing, covered [below](#assembling-multi-agent-and-distributed-traces).
 
-Langfuse monitors both [costs](/docs/observability/features/token-and-cost-tracking) and [accuracy](/docs/evaluation/overview), enabling you to optimize your application for production.
+### Context engineering
 
-### Understanding user interactions
+What an agent does is determined as much by its assembled context (system prompt, skills, retrieved documents, memory) as by the model, so two runs with the same user input can diverge purely because the context differed. Observability has to capture what the model actually saw:
 
-AI agent analytics allows you to capture how users interact with your LLM applications. This information is crucial for refining your AI application and tailoring responses to better meet user needs.
+- **Prompt versions** are linked to traces via [prompt management](/docs/prompt-management/features/link-to-traces), so quality metrics can be compared per prompt version.
+- **Retrieved context** is recorded in `retriever` observations, with the query as input and the returned documents as output.
+- **The full message history** sent to the model is the input of each `generation` observation, so the effective context of every step is inspectable after the fact.
 
-[Langfuse Analytics](/docs/metrics/overview) derives insights from production data, helping you measure quality through user feedback and model-based [scoring](/docs/evaluation/overview) over time and across different versions. It also allows you to monitor cost and latency metrics in real time, broken down by user, session, geography, and model version.
+### Coding agents
 
-## What are AI agents?
-
-An AI agent is a system that autonomously performs tasks by planning its task execution and utilizing available tools. AI agents leverage large language models (LLMs) to understand and respond to user inputs step by step and decide when to call external tools.
-
-**To solve tasks, agents use:**
-
-- **Planning** means the agent devises step-by-step actions from the given task.
-- **Tools** extend the agent's capabilities, for example RAG, external APIs, or code execution.
-- **Memory** stores and recalls past interactions for additional contextual information.
-
-**Common use cases include:**
-
-- **Customer support:** Agents use RAG to automate responses, autonomously take action, and handle inquiries with accurate information.
-- **Research:** Agents collect and synthesize information from various sources and deliver concise summaries to users.
-- **Software development:** Coding agents such as Claude Code and OpenAI Codex break tasks into sub-tasks, edit code, and run tests autonomously. Their sessions can be traced like any other agent; see our guide on [tracing coding agents](/resources/engineering/coding-agent-tracing).
-
-### Design patterns of AI agents
-
-An AI agent usually consists of 5 parts: a language model with general-purpose capabilities that serves as the main brain or **coordinator**, and four sub-modules: a **planning module** to divide the task into smaller steps, an **action module** that enables the agent to use external tools, a **memory module** to store and recall past interactions, and a **profile module** to describe the behavior of the agent.
-
-<div className="max-w-sm my-10">
-  ![AI Agent Design](/images/blog/ai-agent-observability/agent-design.png)
-</div>
-
-In **single-agent setups**, one agent is responsible for solving the entire task autonomously. In **multi-agent setups**, multiple specialized agents collaborate, each handling different aspects of the task to achieve a common goal. These agents are also often referred to as state-based or stateful agents as they route the task through different states.
-
-<div className="my-10">
-  ![Single and Multi Agent
-  Designs](/images/blog/ai-agent-observability/multi-agent.png)
-</div>
+Coding agents are now a mainstream agent class doing real engineering work: they edit files, run terminal commands, and call MCP tools. Langfuse traces the major ones, including Claude Code and OpenAI Codex via lifecycle hooks, GitHub Copilot via its native OpenTelemetry export, and Cursor, Kiro, OpenCode, and Augment Code via dedicated integrations. Teams use these traces for debugging agent sessions, per-developer cost dashboards, and rollout governance; our guide on [tracing coding agents](/resources/engineering/coding-agent-tracing) covers setup for all of them.
 
 ## Structured tracing with observation types
 
@@ -157,18 +132,19 @@ Tool-call parsing covers payloads from OpenAI, LangChain and LangGraph, the Verc
 
 ## Debugging long agent traces
 
-Production agent traces routinely reach thousands of observations, and long-lived agents can produce far more. At that size, scrolling a trace tree stops being a debugging strategy. Langfuse provides three tools for working with large traces:
+Production agent traces routinely reach thousands of observations, and long-horizon agents that plan, delegate, and retry can produce far more. At that size, scrolling a trace tree stops being a debugging strategy. Langfuse provides three tools for working with large traces:
 
 - The **trace log view** concatenates all observation data of a trace into a single scrollable document, so you can skim an agent run chronologically or Ctrl+F through the entire trace to find a specific string inside a loopy, verbose agent.
 - [Full-text search](/docs/observability/features/full-text-search) finds a keyword or phrase across the inputs, outputs, and metadata of all traces and observations in a project, which helps when you remember a piece of content but not which trace it belongs to.
 - The **observations table** treats every LLM call, tool execution, and agent step as a row you can query directly. Filter by observation name, type, or model, sort generations by cost, or pull up all `ERROR`-level observations for one user, then save the view for one-click access. See the [guide on working with observations](/faq/all/explore-observations-in-v4).
 
-## Assembling multi-agent and distributed traces
+## Assembling multi-agent and distributed traces [#assembling-multi-agent-and-distributed-traces]
 
 When an agent system spans multiple services, for example a supervisor service delegating to specialized agent services, the individual steps only become one coherent trace if they share a trace ID. Langfuse supports this through [trace IDs and distributed tracing](/docs/observability/features/trace-ids-and-distributed-tracing):
 
 - Propagate the trace ID across service boundaries via standard OpenTelemetry context propagation, and all spans land in the same Langfuse trace.
 - Derive deterministic trace IDs from a seed, such as an external request ID, so any service (and any later system, like an evaluation pipeline) can compute the same trace ID independently.
+- Link MCP client and server traces by carrying the trace context in the [MCP `_meta` field](/docs/observability/features/mcp-tracing).
 - Group related traces into [sessions](/docs/observability/features/sessions) to follow a multi-turn conversation where each turn is its own trace.
 
 Once assembled, the full multi-agent run gets the same treatment as a single-service trace: one trace tree, one graph view, one place to attach scores.
@@ -193,7 +169,7 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 ### OpenAI Agents SDK
 
-The OpenAI Agents SDK provides a simple yet powerful framework for building and orchestrating AI agents. By instrumenting the SDK with Langfuse, you can capture detailed traces of agent execution, including planning, function calls, and multi-agent handoffs.
+The OpenAI Agents SDK is a lightweight framework for building and orchestrating AI agents. By instrumenting the SDK with Langfuse, you can capture detailed traces of agent execution, including planning, function calls, and multi-agent handoffs.
 
 For a setup guide, see [Trace the OpenAI Agents SDK with Langfuse](/integrations/frameworks/openai-agents).
 
@@ -275,6 +251,7 @@ Langfuse has maintained integrations for many more agent frameworks; the full li
 | [Semantic Kernel](/integrations/frameworks/semantic-kernel)                     | Microsoft's SDK for orchestrating AI skills in C#, Python, and Java.                                  |
 | [AutoGen](/integrations/frameworks/autogen)                                     | Now in maintenance mode; Microsoft recommends the Agent Framework for new projects (as of July 2026). |
 | [Google ADK](/integrations/frameworks/google-adk)                               | Google's Agent Development Kit, traced via OpenTelemetry.                                             |
+| [LangChain DeepAgents](/integrations/frameworks/langchain-deepagents)           | LangChain-based framework for agents that plan, spawn subagents, and iterate on complex tasks.        |
 | [Mastra](/integrations/frameworks/mastra)                                       | TypeScript agent framework with workflows, RAG, and evals.                                            |
 | [LlamaIndex Workflows](/integrations/frameworks/llamaindex-workflows)           | Event-driven, step-based orchestration for LlamaIndex agents.                                         |
 | [Agno](/integrations/frameworks/agno-agents)                                    | Lightweight Python framework for multi-agent systems.                                                 |
@@ -337,43 +314,48 @@ Voice agents add a real-time pipeline (speech-to-text, LLM, text-to-speech) on t
 
 Audio itself is a first-class trace payload: Langfuse [multi-modality support](/docs/observability/features/multi-modality) attaches audio files (mp3, wav, ogg, and more) to traces, so you can listen to the exact input and output of a turn while reading its trace. For evaluation, most teams score voice agents on transcripts today, using the same LLM-as-a-judge and human annotation workflows as text agents; evaluating audio qualities like tone or interruption behavior directly is still an emerging practice across the industry.
 
-## Agent evaluation and testing
+## Monitoring agents in production
 
-Building an agent is only the first step. Agents can fail in nuanced ways: selecting the wrong tool, entering reasoning loops, or hallucinating in intermediate steps that produce a plausible-looking but incorrect final answer. To ship agents with confidence, you need a systematic approach to evaluation and testing. This section gives the short version; our [AI agent evaluation guide](/resources/engineering/ai-agent-evaluation) covers strategies, metrics, and worked examples in depth.
+Once an agent is live, observability shifts from inspecting individual traces to watching the system as a whole:
 
-### Three evaluation strategies
+- **Cost and token tracking** aggregates model usage per trace, user, session, and model, so an agent that starts burning budget shows up in [cost dashboards](/docs/observability/features/token-and-cost-tracking) immediately.
+- **Custom dashboards** chart any trace or observation metric over time, including the `toolCalls` and `toolDefinitions` metrics described above, with [dashboards](/docs/metrics/features/custom-dashboards) built from the same filters used in the tables.
+- **Monitors and alerts** watch a metric like average cost per trace, an evaluation score, or p95 latency, and fire through Slack, webhooks, or GitHub Actions when it leaves the expected range. [Monitors](/docs/metrics/features/monitors) are available on Langfuse Cloud.
+- **User feedback**, explicit (ratings) and implicit (retries, abandonment, corrections), lands as [scores on traces](/docs/observability/features/user-feedback), feeding the same dashboards and monitors as evaluator scores.
 
-Langfuse supports three complementary strategies for evaluating agents:
+For a method to turn this stream of production data into a concrete list of what to fix, the Langfuse Academy [monitoring module](/academy/monitoring) and its deep dive on [error analysis](/academy/monitoring/error-analysis) walk through finding and quantifying recurring failure patterns in traces.
 
-1. **Final response (black box):** This method only looks at the user's input and the agent's final answer, ignoring the intermediate steps. It is flexible and easy to set up, but does not tell you _why_ an agent failed.
+## Evaluating agents
 
-2. **Trajectory (glass box):** This strategy evaluates the full sequence of tool calls, reasoning steps, and decisions an agent made. You compare the actual trajectory against an expected one, catching issues like unnecessary tool calls, skipped steps, or inefficient reasoning paths. The structured `tool_calls` field makes trajectory checks like "did the agent call the right tool" a one-liner in [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators).
+Agents fail in nuanced ways: selecting the wrong tool, entering reasoning loops, or hallucinating in an intermediate step that produces a plausible-looking but incorrect final answer. Evaluation is how you catch these failures systematically, and it sits inside a larger loop: trace production behavior, monitor it, build datasets from real failures, experiment against them, and evaluate the results. The [Langfuse Academy](/academy) explains this AI engineering loop end to end, free and open; this section summarizes the agent-relevant core.
 
-3. **Single step (white box):** This zooms in on individual steps within the agent's execution, evaluating whether each tool call returned the right result or each reasoning step was sound. It provides the most granular feedback for debugging specific failures.
+### Start with manual review, then automate
 
-### Three phases of evaluation
+The [Academy's evaluation module](/academy/evaluate) describes how evaluation typically evolves, and agent teams follow the same path: you start by **manually reviewing traces** to build intuition for what good and bad look like for your agent, then **identify specific failure modes** worth checking for, and only then **automate with dedicated evaluators**. Teams that skip the manual step tend to measure things that do not matter. Manual review is also not a one-time phase: continuous review by human experts catches new failure modes and produces the ground-truth labels that keep automated evaluators calibrated.
 
-The evaluation process follows a natural progression as your application matures:
+Three evaluation methods cover agent quality, each suited to different checks:
 
-- **Phase 1, manual tracing:** During early development, the most valuable activity is simply inspecting traces in Langfuse to understand your agent's reasoning.
-- **Phase 2, online evaluation:** As you get your first users, implement [user feedback](/docs/observability/features/user-feedback) mechanisms and automated [LLM-as-a-Judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators to flag problematic traces in real time.
-- **Phase 3, offline evaluation:** At scale, create benchmark [datasets](/docs/evaluation/experiments/datasets) of inputs and expected outputs, then run automated [experiments](/docs/evaluation/experiments/experiments-via-sdk) to test your agent before each release, preventing regressions and enabling confident iteration.
+- **Human annotation** via [annotation queues](/docs/evaluation/evaluation-methods/annotation-queues) provides ground truth for ambiguous cases, such as whether a multi-step trajectory was reasonable.
+- **[Code evaluators](/docs/evaluation/evaluation-methods/code-evaluators)** check deterministic properties: the required tool was called (the `tool_calls` one-liner shown earlier), the step budget was respected, the output parses against a schema.
+- **[LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge)** evaluators handle semantic judgments like task completion or groundedness; they need calibration against human labels to be trustworthy.
 
-### Agent evaluation guides
+One practical recommendation from the Academy applies directly to agents: prefer binary pass/fail scores over graded 1-5 scales, because binary scores force a precise definition of what separates acceptable from unacceptable behavior.
 
-To dive deeper, explore these hands-on guides:
+### Evaluate offline before shipping, online after
 
-- [AI Agent Evaluation Guide](/resources/engineering/ai-agent-evaluation) covers evaluation strategies, metrics, and patterns for agents in depth.
-- [Agent Evaluation Cookbook](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) is an end-to-end walkthrough of all three evaluation strategies using Pydantic AI agents.
-- [Evaluating OpenAI Agents](/guides/cookbook/example_evaluating_openai_agents) shows online and offline evaluation for the OpenAI Agents SDK.
-- [LangGraph Agent Evaluation](/guides/cookbook/example_langgraph_agents) covers monitoring and evaluating LangGraph agents.
-- [Testing LLM Applications](/blog/2025-10-21-testing-llm-applications) builds a testing foundation with deterministic checks and LLM judges.
+Following the Academy's loop, agent evaluation runs in two places. **Offline**, you build [datasets](/academy/datasets) from failing production traces and hand-written edge cases, then run [experiments](/academy/experiments) that compare a change (new prompt, new model, new tool set, new agent architecture) against a baseline on that dataset, and [gate releases in CI](/docs/evaluation/experiments/experiments-ci-cd) on the resulting scores. **Online**, reference-free evaluators and user feedback score live traffic continuously, confirming that production quality matches what the experiments predicted. When production surfaces a new failure, it becomes a dataset item, and the loop closes.
+
+### Where to go deeper
+
+- [Langfuse Academy](/academy) covers the full loop with a module per step: [tracing](/academy/tracing), [monitoring](/academy/monitoring), [datasets](/academy/datasets), [experiments](/academy/experiments), and [evaluation](/academy/evaluate).
+- Our [AI agent evaluation guide](/resources/engineering/ai-agent-evaluation) is the agent-specific layer on top: tool-call checks, trajectory scoring, multi-turn evaluation, and CI gating in depth.
+- The [agent evaluation cookbook](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) is an end-to-end walkthrough of evaluating a Pydantic AI agent with MCP tools.
 
 ## Get started
 
 If you want to get started with building AI agents and monitoring them with Langfuse, here are the best places to begin:
 
 - **Build and trace an agent:** Follow our [end-to-end example](/guides/cookbook/integration_langgraph) of building a simple agent with LangGraph and tracking it with Langfuse.
-- **Compare agent frameworks:** Read our [AI Agent Comparison](/blog/2025-03-19-ai-agent-comparison) blog post for an in-depth guide on when to use which framework.
-- **Evaluate your agents:** Start with the [Agent Evaluation Cookbook](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) to set up black-box, trajectory, and step-level evaluations.
+- **Learn the concepts:** Work through the [Langfuse Academy](/academy) to understand the AI engineering loop from tracing to evaluation.
+- **Evaluate your agents:** Read the [AI agent evaluation guide](/resources/engineering/ai-agent-evaluation) and set up your first dataset and experiment.
 - **Explore all integrations:** Browse the full list of [supported integrations](/integrations) to find the right setup for your stack.

--- a/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
+++ b/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AI Agent Observability, Tracing & Evaluation with Langfuse"
-date: 2025/03/16
-description: "Trace, monitor, evaluate, and test AI agents in production. Learn about agent observability strategies, evaluation techniques, and how to use Langfuse with LangGraph, OpenAI Agents, Pydantic AI, CrewAI, and more."
+date: 2026/07/13
+description: "Trace, monitor, evaluate, and test AI agents in production. Learn what agent observability is and how to use Langfuse with LangGraph, OpenAI Agents SDK, Claude Agent SDK, CrewAI, Pydantic AI, Vercel AI SDK, and more."
 ogImage: /images/blog/ai-agent-observability/ai-agent-observability.png
 tag: agents, guide, evaluation
 author: Jannik
@@ -11,91 +11,177 @@ import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
   title="AI Agent Observability, Tracing & Evaluation with Langfuse"
-  description="Trace, monitor, evaluate, and test AI agents in production. Learn about agent observability strategies, evaluation techniques, and how to use Langfuse with LangGraph, OpenAI Agents, Pydantic AI, CrewAI, n8n, and more."
-  date="February 20, 2026"
+  description="Trace, monitor, evaluate, and test AI agents in production. Learn what agent observability is and how to use Langfuse with LangGraph, OpenAI Agents SDK, Claude Agent SDK, CrewAI, Pydantic AI, Vercel AI SDK, and more."
+  date="July 13, 2026"
   authors={["jannikmaierhoefer"]}
 />
 
-## What are AI Agents?
+## What is AI agent observability? [#what-is-ai-agent-observability]
 
-An AI agent is a system that autonomously performs tasks by planning its task execution and utilizing available tools. AI Agents leverage large language models (LLMs) to understand and respond to user inputs step-by-step and decide when to call external tools.
+AI agent observability is the practice of capturing every step an AI agent takes, including LLM calls, tool invocations, retrievals, and control-flow decisions, as structured traces that you can inspect, filter, and evaluate. It extends LLM observability from single completions to multi-step, non-deterministic workflows, where failures usually hide in an intermediate step rather than in the final answer.
+
+A complete agent observability setup captures:
+
+- **LLM calls** are recorded with their prompts, completions, model parameters, token usage, and [cost](/docs/observability/features/token-and-cost-tracking).
+- **Tool calls** are recorded with the tools that were available to the model, the tool it chose, and the arguments it passed.
+- **Control flow** is visible: which sub-agents, chains, or steps ran, in what order, and how often the agent looped.
+- **Context operations** such as retrievals, embeddings, and guardrail checks appear as typed steps in the trace.
+- **Sessions and users** group multi-turn conversations so behavior can be analyzed per conversation and per user.
+- **Quality signals** such as [user feedback](/docs/observability/features/user-feedback) and evaluation scores are attached directly to traces.
+
+[Langfuse](/) is an open-source AI engineering platform that implements this end to end: [tracing](/docs/observability/overview) with typed observations, agent graph visualization, tool-call analytics, and [evaluation](/docs/evaluation/overview) on top of the captured data. The rest of this post walks through each of these capabilities and how to instrument the most common agent frameworks.
+
+### Industry trends in agent observability
+
+The industry has converged on **OpenTelemetry (OTel)** as the standard for collecting agent telemetry. Many agent frameworks, including Pydantic AI, smolagents, Strands Agents, and LiveKit Agents, emit traces via OpenTelemetry, which [Langfuse natively supports](/docs/observability/sdk/instrumentation). This prevents vendor lock-in and lets you keep existing instrumentation when switching backends.
+
+There is also a shift from reactive log parsing to **structured tracing with typed observation data**. Rather than reconstructing behavior from unstructured logs after a failure, teams instrument agents with semantic types (tool calls, retriever steps, guardrail checks) that can be filtered, aggregated, and evaluated directly.
+
+Finally, **traces are getting long**. Agents that plan, loop, and delegate produce traces with hundreds or thousands of observations, and teams running long-lived agents report traces reaching hundreds of thousands of observations. Observability tooling has to stay useful at that scale, which is why search, filtering, and aggregate views matter as much as the trace tree itself.
+
+## Why agent observability matters
+
+### Debugging and edge cases
+
+Agents use multiple steps to solve complex tasks, and inaccurate intermediary results can cause failures of the entire system. [Tracing](/docs/observability/overview) these intermediate steps and testing your application on known edge cases is essential.
+
+When deploying LLMs, some edge cases will always slip through in initial testing. A proper analytics setup helps identify these cases, allowing you to add them to future test sets for more robust agent evaluations. With [Datasets](/docs/evaluation/experiments/datasets), Langfuse allows you to collect examples of inputs and expected outputs to benchmark new releases before deployment. Datasets can be incrementally updated with new edge cases found in production and integrated with existing [CI/CD pipelines](/blog/2025-10-21-testing-llm-applications).
+
+### The tradeoff of accuracy and costs
+
+LLMs are stochastic by nature, meaning they are a statistical process that can produce errors or hallucinations. Calling language models multiple times while selecting the best or most common answer can increase accuracy. This can be a major advantage of using agentic workflows.
+
+However, this comes with a cost. The agent often decides autonomously how many LLM calls or paid external API calls it needs to make to solve a task, potentially leading to high costs for single-task executions. Therefore, it is important to monitor model usage and costs in real time, attributed per trace, per user, and per model.
+
+Langfuse monitors both [costs](/docs/observability/features/token-and-cost-tracking) and [accuracy](/docs/evaluation/overview), enabling you to optimize your application for production.
+
+### Understanding user interactions
+
+AI agent analytics allows you to capture how users interact with your LLM applications. This information is crucial for refining your AI application and tailoring responses to better meet user needs.
+
+[Langfuse Analytics](/docs/metrics/overview) derives insights from production data, helping you measure quality through user feedback and model-based [scoring](/docs/evaluation/overview) over time and across different versions. It also allows you to monitor cost and latency metrics in real time, broken down by user, session, geography, and model version.
+
+## What are AI agents?
+
+An AI agent is a system that autonomously performs tasks by planning its task execution and utilizing available tools. AI agents leverage large language models (LLMs) to understand and respond to user inputs step by step and decide when to call external tools.
 
 **To solve tasks, agents use:**
 
-- **planning** by devising step-by-step actions from the given task
-- **tools** to extend their capabilities like RAG, external APIs, or code interpretation/execution
-- **memory** to store and recall past interactions for additional contextual information
-
-## What are Agents Used For?
+- **Planning** means the agent devises step-by-step actions from the given task.
+- **Tools** extend the agent's capabilities, for example RAG, external APIs, or code execution.
+- **Memory** stores and recalls past interactions for additional contextual information.
 
 **Common use cases include:**
 
-- **Customer Support:** AI agents use RAG to automate responses, autonomously take action and efficiently handle inquiries with accurate information.
-- **Market Research**: Agents collect and synthesize information from various sources, delivering accurate and concise summaries to users.
-- **Software Development:** AI agents break coding tasks into smaller sub-tasks and then recombine them to create a complete solution.
+- **Customer support:** Agents use RAG to automate responses, autonomously take action, and handle inquiries with accurate information.
+- **Research:** Agents collect and synthesize information from various sources and deliver concise summaries to users.
+- **Software development:** Coding agents such as Claude Code and OpenAI Codex break tasks into sub-tasks, edit code, and run tests autonomously. Their sessions can be traced like any other agent; see our guide on [tracing coding agents](/resources/engineering/coding-agent-tracing).
 
-## Design Patterns of AI Agents
+### Design patterns of AI agents
 
-An AI agent usually consists of 5 parts: A language model with general-purpose capabilities that serves as the main brain or **coordinator**, and four sub-modules: a **planning module** to divide the task into smaller steps, an **action module** that enables the agent to use external tools, a **memory module** to store and recall past interactions and a **profile module**, to describe the behavior of the agent.
+An AI agent usually consists of 5 parts: a language model with general-purpose capabilities that serves as the main brain or **coordinator**, and four sub-modules: a **planning module** to divide the task into smaller steps, an **action module** that enables the agent to use external tools, a **memory module** to store and recall past interactions, and a **profile module** to describe the behavior of the agent.
 
 <div className="max-w-sm my-10">
   ![AI Agent Design](/images/blog/ai-agent-observability/agent-design.png)
 </div>
 
-In **single-agent setups**, one agent is responsible for solving the entire task autonomously. In **multi-agent setups**, multiple specialized agents collaborate, each handling different aspects of the task to achieve a common goal more efficiently. These agents are also often referred to as state-based or stateful agents as they route the task through different states.
+In **single-agent setups**, one agent is responsible for solving the entire task autonomously. In **multi-agent setups**, multiple specialized agents collaborate, each handling different aspects of the task to achieve a common goal. These agents are also often referred to as state-based or stateful agents as they route the task through different states.
 
 <div className="my-10">
   ![Single and Multi Agent
   Designs](/images/blog/ai-agent-observability/multi-agent.png)
 </div>
 
-## What is AI Agent Observability?
+## Structured tracing with observation types
 
-Observing agents means tracking and analyzing the performance, behavior, and interactions of AI agents. This includes real-time monitoring of multiple LLM calls, control flows, decision-making processes, and outputs to ensure agents operate efficiently and accurately.
+Every step in a Langfuse trace is an observation with a semantic type. Langfuse supports 10 [observation types](/docs/observability/features/observation-types): `event`, `span`, `generation`, `agent`, `tool`, `chain`, `retriever`, `evaluator`, `embedding`, and `guardrail`. Framework integrations set these automatically; with the SDKs you set them explicitly:
 
-[Langfuse](/) is an open-source AI engineering platform that provides deep insights into metrics such as latency, cost, and error rates, enabling developers to debug, optimize, and enhance their LLM systems. Using Langfuse observability, teams can identify and resolve issues, streamline workflows, and maintain high-quality outputs by evaluating agent responses in complex, multi-step AI agents.
+```python
+from langfuse import observe
 
-### Industry Trends in Agent Observability
+@observe(as_type="agent")
+def run_agent_workflow(query):
+    return process_with_tools(query)
 
-As AI agents become more prevalent in production, the observability landscape is evolving rapidly. The industry is converging on **OpenTelemetry (OTEL)** as a standard for collecting agent telemetry data, preventing vendor lock-in and enabling interoperability across frameworks. Many agent frameworks — including Pydantic AI, smolagents, and Strands Agents — now emit traces via OpenTelemetry, which [Langfuse natively supports](/docs/observability/sdk/instrumentation).
+@observe(as_type="tool")
+def call_weather_api(location):
+    return weather_service.get_weather(location)
+```
 
-There is also a shift from reactive log-based monitoring to **proactive, structured tracing** with typed observation data. Rather than parsing unstructured logs after failures, teams now instrument agents with rich semantic types (tool calls, retriever steps, guardrail checks) for real-time insight into agent behavior.
+Typed observations make traces filterable ("show me all guardrail checks that failed") and they are what enables the agent graph view described next.
 
-Additionally, **cost optimization** is becoming critical as agent workloads scale. Agents that autonomously chain multiple LLM and API calls can incur unpredictable costs, making real-time cost tracking and per-trace cost attribution essential for production deployments.
+## Visualizing agent behavior with agent graphs
 
-### Why AI Agent Observability is Important
+The [agent graph view](/docs/observability/features/agent-graphs) turns a trace into a picture of what the agent did: nodes for steps, edges for how execution moved between them. Langfuse infers the graph automatically from observation timings and nesting; it appears for any trace that contains an observation type other than `span`, `event`, or `generation`, and automatically for the LangGraph integration. It works with any framework or custom instrumentation.
 
-#### Debugging and Edge Cases
+<Video
+  src="https://static.langfuse.com/docs-videos/graph-view-gif.mp4"
+  aspectRatio={1752 / 1080}
+  gifStyle
+/>
 
-Agents use multiple steps to solve complex tasks, and inaccurate intermediary results can cause failures of the entire system. [Tracing](/docs/observability/overview) these intermediate steps and testing your application on known edge cases is essential.
+Since July 2026, the graph view (currently in beta) offers two modes that answer different questions:
 
-When deploying LLMs, some edge cases will always slip through in initial testing. A proper analytics set-up helps identify these cases, allowing you to add them to future test sets for more robust agent evaluations. With [Datasets](/docs/evaluation/experiments/datasets), Langfuse allows you to collect examples of inputs and expected outputs to benchmark new releases before deployment. Datasets can be incrementally updated with new edge cases found in production and integrated with existing [CI/CD pipelines](/blog/2025-10-21-testing-llm-applications).
+|                | **Aggregated** (default)                      | **Expanded** ("as it ran")                  |
+| -------------- | --------------------------------------------- | ------------------------------------------- |
+| A node is      | one unique step name                          | one individual call                         |
+| Repeated calls | collapse into a single node with a counter    | appear as separate nodes                    |
+| Loops          | drawn as cycles                               | unrolled into an acyclic graph (DAG)        |
+| Best for       | grasping structure and complexity at a glance | following or debugging a specific execution |
 
-#### Tradeoff of Accuracy and Costs
+**Aggregated** shows the agent's overall shape: `retrieve_docs (3/3)` means that step ran three times, and loops draw as cycles, so even a busy agent stays readable. **Expanded** shows the run step by step: every call is its own node and loops unroll in execution order, which is the right view for pinning down exactly where something happened. The layout is deterministic, so a trace draws the same way every time you open it.
 
-LLMs are stochastic by nature, meaning they are a statistical process that can produce errors or hallucinations. Calling language models multiple times while selecting the best or most common answer can increase accuracy. This can be a major advantage of using agentic workflows.
+## Monitoring tool calls
 
-However, this comes with a cost. The tradeoff between accuracy and costs in LLM-based agents is crucial, as higher accuracy often leads to increased operational expenses. Often, the agent decides autonomously how many LLM calls or paid external API calls it needs to make to solve a task, potentially leading to high costs for single-task executions. Therefore, it is important to monitor model usage and costs in real-time.
+Tool calls are the core of agent behavior, so Langfuse treats them as a distinct data structure rather than raw JSON in a payload. It distinguishes **available tools** (the tools offered to the LLM) from **tool calls** (the tools the LLM actually invoked, with arguments).
 
-Langfuse monitors both [costs](/docs/observability/features/token-and-cost-tracking) and [accuracy](/docs/evaluation/overview), enabling you to optimize your application for production.
+This structure shows up in three places:
 
-#### Understanding User Interactions
+**1. In the trace view.** All tools available to an LLM render at the top of each generation, with called tools highlighted alongside their arguments and call IDs. You can see at a glance whether the model picked the right tool, and click any tool to inspect its full definition and parameters.
 
-AI agents analytics allows you to capture how users interact with your LLM applications. This information is crucial for refining your AI application and tailoring responses to better meet user needs.
+**2. In filters and dashboards.** The observations table can be filtered by tool-call count, available-tool count, and tool names, and dashboard widgets aggregate `toolCalls` and `toolDefinitions` metrics over time. This turns tool behavior into queries:
 
-[Langfuse Analytics](/docs/metrics/overview) derives insights from production data, helping you measure quality through user feedback and model-based [scoring](/docs/evaluation/overview) over time and across different versions. It also allows you to monitor cost and latency metrics in real-time, broken down by user, session, geography, and model version, enabling precise optimizations for your LLM application.
+- Find looping agents by filtering for observations with 30+ tool calls but only 1 available tool.
+- Find dead tools by filtering for observations where a tool like `get_weather` was available but never invoked.
+- Audit tool scope by filtering for observations where a sensitive tool was actually called, and alerting on the result.
 
-## Tools to build AI Agents
+**3. In evaluators.** [Code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) and [LLM-as-a-Judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators access recorded tool calls through a structured `tool_calls` field (each call carries `id`, `name`, `arguments`, `type`, and `index`), so checks like "did the agent call `search` before answering" are one line of code:
 
-You do not need any specific tools to build AI agents. However, there are several open-source frameworks that can help you build complex, stateful, multi-agent applications.
+```python
+used_search = any(
+    tool_call.name == "search" for tool_call in ctx.observation.tool_calls
+)
+```
 
-### Application Frameworks
+Tool-call parsing covers payloads from OpenAI, LangChain and LangGraph, the Vercel AI SDK, Google ADK, and the Microsoft Agent Framework, with support for further frameworks expanding (see the [changelog](/changelog/2025-12-22-tool-calls-filtering-visualization) for the current list).
 
-#### LangGraph
+## Debugging long agent traces
+
+Production agent traces routinely reach thousands of observations, and long-lived agents can produce far more. At that size, scrolling a trace tree stops being a debugging strategy. Langfuse provides three tools for working with large traces:
+
+- The **trace log view** concatenates all observation data of a trace into a single scrollable document, so you can skim an agent run chronologically or Ctrl+F through the entire trace to find a specific string inside a loopy, verbose agent.
+- [Full-text search](/docs/observability/features/full-text-search) finds a keyword or phrase across the inputs, outputs, and metadata of all traces and observations in a project, which helps when you remember a piece of content but not which trace it belongs to.
+- The **observations table** treats every LLM call, tool execution, and agent step as a row you can query directly. Filter by observation name, type, or model, sort generations by cost, or pull up all `ERROR`-level observations for one user, then save the view for one-click access. See the [guide on working with observations](/faq/all/explore-observations-in-v4).
+
+## Assembling multi-agent and distributed traces
+
+When an agent system spans multiple services, for example a supervisor service delegating to specialized agent services, the individual steps only become one coherent trace if they share a trace ID. Langfuse supports this through [trace IDs and distributed tracing](/docs/observability/features/trace-ids-and-distributed-tracing):
+
+- Propagate the trace ID across service boundaries via standard OpenTelemetry context propagation, and all spans land in the same Langfuse trace.
+- Derive deterministic trace IDs from a seed, such as an external request ID, so any service (and any later system, like an evaluation pipeline) can compute the same trace ID independently.
+- Group related traces into [sessions](/docs/observability/features/sessions) to follow a multi-turn conversation where each turn is its own trace.
+
+Once assembled, the full multi-agent run gets the same treatment as a single-service trace: one trace tree, one graph view, one place to attach scores.
+
+## Agent frameworks and how to trace them
+
+You do not need a specific framework to build AI agents, and Langfuse is deliberately framework-agnostic: it accepts traces from its native SDKs, from OpenTelemetry, and from 100+ library and framework integrations. Below are the integrations we see used most for agents, as of July 2026.
+
+### LangGraph
 
 LangGraph ([GitHub](https://github.com/langchain-ai/langgraph)) is an open-source framework by the LangChain team for building complex, stateful, multi-agent applications. LangGraph includes built-in persistence to save and resume state, which enables error recovery and human-in-the-loop workflows.
 
-LangGraph agents can be [monitored with Langfuse](/guides/cookbook/integration_langgraph) to observe and debug the steps of an agent.
+LangGraph agents can be [monitored with Langfuse](/guides/cookbook/integration_langgraph), and the agent graph view renders the LangGraph structure automatically.
 
 <Video
   src="https://static.langfuse.com/docs-videos/langgraph-overview.mp4"
@@ -105,21 +191,11 @@ LangGraph agents can be [monitored with Langfuse](/guides/cookbook/integration_l
 
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/a8b0cc9e-da3b-485f-a642-35431a6f9289)_
 
-#### Llama Agents
+### OpenAI Agents SDK
 
-Llama Agents ([GitHub](https://github.com/run-llama/llama-agents)) is an open-source framework designed to simplify the process of building, iterating, and deploying multi-agent AI systems and turn your agents into production microservices.
+The OpenAI Agents SDK provides a simple yet powerful framework for building and orchestrating AI agents. By instrumenting the SDK with Langfuse, you can capture detailed traces of agent execution, including planning, function calls, and multi-agent handoffs.
 
-Langfuse offers a simple [integration](/integrations/frameworks/llamaindex) for automatic capture of traces and metrics generated in LlamaIndex applications.
-
-![Llama Agents Example trace in Langfuse](/images/blog/ai-agent-observability/llama-agents.png)
-
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/a8b0cc9e-da3b-485f-a642-35431a6f9289)_
-
-#### OpenAI Agents SDK
-
-OpenAI Agents SDK provides a simple yet powerful framework for building and orchestrating AI agents. By instrumenting the SDK with Langfuse, you can capture detailed traces of agent execution, including planning, function calls, and multi-agent handoffs. This integration enables you to monitor performance metrics, trace issues in real time, and optimize your workflows effectively.
-
-For a comprehensive guide on setting up this integration, please refer to our [Trace the OpenAI Agents SDK with Langfuse](/integrations/frameworks/openai-agents) notebook.
+For a setup guide, see [Trace the OpenAI Agents SDK with Langfuse](/integrations/frameworks/openai-agents).
 
 <Video
   src="https://static.langfuse.com/docs-videos/openai-agents-sdk-trace.mp4"
@@ -129,21 +205,17 @@ For a comprehensive guide on setting up this integration, please refer to our [T
 
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/019593c74429a6d0489e9259703a1148?timestamp=2025-03-14T08%3A31%3A04.745Z&observation=e83609282c443b0d)_
 
-#### Hugging Face smolagents
+### Claude Agent SDK
 
-Hugging Face smolagents is a minimalist framework for building AI agents. With the Langfuse integration, you can effortlessly capture and visualize telemetry data from your agents. By initializing the SmolagentsInstrumentor, your agent interactions are traced using OpenTelemetry and displayed in Langfuse, enabling you to debug and optimize decision-making processes.
+The Claude Agent SDK is Anthropic's open-source framework for building tool-using AI agents, with native support for MCP. It emits traces via OpenTelemetry, so every prompt, model response, and tool call lands in Langfuse.
 
-For a comprehensive, step-by-step guide, see our integration notebook: [Observability for smolagents with Langfuse](/integrations/frameworks/smolagents).
+Setup guides are available for [Python](/integrations/frameworks/claude-agent-sdk) and [JS/TS](/integrations/frameworks/claude-agent-sdk-js).
 
-![Smolagents Example trace in Langfuse](/images/cookbook/integration-smolagents/smolagent_example_trace.png)
+### Pydantic AI
 
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/ce5160f9bfd5a6cd63b07d2bfcec6f54?timestamp=2025-02-11T09%3A25%3A45.163Z&display=details)_
+[Pydantic AI](https://ai.pydantic.dev/) brings Pydantic's type safety and ergonomic developer experience to agent development. You define your agent's inputs, tool signatures, and outputs as Python types, and the framework handles validation plus OpenTelemetry instrumentation under the hood.
 
-#### Pydantic AI
-
-[Pydantic AI](https://ai.pydantic.dev/) brings Pydantic's type safety and ergonomic developer experience to agent development. You define your agent's inputs, tool signatures, and outputs as Python types, and the framework handles validation plus OpenTelemetry instrumentation under the hood. The result is a FastAPI-style developer experience for building production-ready agents.
-
-For a step-by-step guide, see our integration notebook: [Trace Pydantic AI agents with Langfuse](/integrations/frameworks/pydantic-ai).
+For a step-by-step guide, see [Trace Pydantic AI agents with Langfuse](/integrations/frameworks/pydantic-ai).
 
 <Frame fullWidth>
   ![Pydantic AI trace visualization in Langfuse](https://langfuse.com/images/cookbook/otel-integration-pydantic-ai/pydanticai-openai-trace-tree.png)
@@ -151,11 +223,11 @@ For a step-by-step guide, see our integration notebook: [Trace Pydantic AI agent
 
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/25f4bdeebaab60e6e1bee7e8469554bc?timestamp=2025-06-06T14%3A39%3A55.786Z&display=details)_
 
-#### CrewAI
+### CrewAI
 
-[CrewAI](https://github.com/crewAIInc/crewAI) is all about role-based collaboration among multiple agents. You assign each agent a distinct skillset or role, then let them cooperate to solve a problem. The framework offers a higher-level abstraction called a "Crew" that coordinates workflows, allowing agents to share context and build upon one another's contributions. It is well-suited for tasks requiring multiple specialists working in parallel.
+[CrewAI](https://github.com/crewAIInc/crewAI) is all about role-based collaboration among multiple agents. You assign each agent a distinct skillset or role, then let them cooperate to solve a problem. The framework offers a higher-level abstraction called a "Crew" that coordinates workflows, allowing agents to share context and build upon one another's contributions.
 
-For setup instructions, see our integration guide: [Trace CrewAI agents with Langfuse](/integrations/frameworks/crewai).
+For setup instructions, see [Trace CrewAI agents with Langfuse](/integrations/frameworks/crewai).
 
 <Frame fullWidth>
   ![CrewAI trace visualization in Langfuse](/images/blog/2025-03-19-ai-agent-comparison/crewai-trace.png)
@@ -163,23 +235,29 @@ For setup instructions, see our integration guide: [Trace CrewAI agents with Lan
 
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/3b485ea0d723bab3e5e53e72c6b10a71?timestamp=2025-02-24T10%3A34%3A30.423Z&observation=0c53ff94ec9c3da9)_
 
-#### AutoGen
+### Vercel AI SDK
 
-[AutoGen](https://github.com/microsoft/autogen), from Microsoft Research, frames agent interactions as asynchronous conversations among specialized agents. Each agent can be a ChatGPT-style assistant or a tool executor, and you orchestrate how they pass messages back and forth. This event-driven approach reduces blocking and is well-suited for longer tasks or scenarios requiring real-time concurrency.
+The Vercel AI SDK is a TypeScript toolkit for building AI applications and agents in Next.js, React, and Node.js, including tool calling and agentic loops. Its built-in telemetry integrates with Langfuse for full traces of generations and tool calls.
 
-For tracing setup, see: [Trace AutoGen agents with Langfuse](/integrations/frameworks/autogen).
+For setup instructions, see [Observability for the Vercel AI SDK](/integrations/frameworks/vercel-ai-sdk).
+
+### Hugging Face smolagents
+
+Hugging Face smolagents is a minimalist framework for building AI agents. By initializing the `SmolagentsInstrumentor`, your agent interactions are traced using OpenTelemetry and displayed in Langfuse.
+
+For a step-by-step guide, see [Observability for smolagents with Langfuse](/integrations/frameworks/smolagents).
 
 <Frame fullWidth>
-  ![AutoGen trace visualization in Langfuse](/images/blog/2025-03-19-ai-agent-comparison/autogen-trace.png)
+  ![Smolagents Example trace in Langfuse](/images/cookbook/integration-smolagents/smolagent_example_trace.png)
 </Frame>
 
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/df850ab499107d4348584cf5933baabd?timestamp=2025-02-04T16%3A55%3A51.660Z&observation=286c648acb0105c2)_
+_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/ce5160f9bfd5a6cd63b07d2bfcec6f54?timestamp=2025-02-11T09%3A25%3A45.163Z&display=details)_
 
-#### Strands Agents
+### Strands Agents
 
-[Strands Agents SDK](https://strandsagents.com) is a model-agnostic agent framework that runs anywhere and supports multiple model providers including Amazon Bedrock, Anthropic, OpenAI, and Ollama via LiteLLM. It emphasizes production readiness with first-class OpenTelemetry tracing, giving you end-to-end observability with a clean, declarative API for defining agent behavior.
+[Strands Agents SDK](https://strandsagents.com) is a model-agnostic agent framework that supports multiple model providers including Amazon Bedrock, Anthropic, OpenAI, and Ollama via LiteLLM. It ships with first-class OpenTelemetry tracing.
 
-For setup instructions, see: [Trace Strands Agents with Langfuse](/integrations/frameworks/strands-agents).
+For setup instructions, see [Trace Strands Agents with Langfuse](/integrations/frameworks/strands-agents).
 
 <Frame fullWidth>
   ![Strands Agents trace visualization in Langfuse](https://langfuse.com/images/cookbook/integration_aws_strands_agents/strands-agents-trace.png)
@@ -187,19 +265,23 @@ For setup instructions, see: [Trace Strands Agents with Langfuse](/integrations/
 
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/c9d6f01342ca664464b2e56f649d9da4?timestamp=2025-05-17T13%3A22%3A14.561Z&display=details)_
 
-#### Semantic Kernel
+### More agent frameworks
 
-[Semantic Kernel](https://github.com/microsoft/semantic-kernel) is Microsoft's approach to orchestrating AI "skills" and combining them into workflows. It supports multiple programming languages (C#, Python, Java) and focuses on enterprise readiness, including security, compliance, and Azure integration. You can create a range of skills — some powered by AI, others by pure code — and compose them into multi-step plans.
+Langfuse has maintained integrations for many more agent frameworks; the full list is in the [integrations directory](/integrations).
 
-For tracing setup, see: [Trace Semantic Kernel with Langfuse](/integrations/frameworks/semantic-kernel).
+| Framework                                                                       | Notes                                                                                                 |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Microsoft Agent Framework](/integrations/frameworks/microsoft-agent-framework) | Microsoft's open-source agent framework with built-in OpenTelemetry support.                          |
+| [Semantic Kernel](/integrations/frameworks/semantic-kernel)                     | Microsoft's SDK for orchestrating AI skills in C#, Python, and Java.                                  |
+| [AutoGen](/integrations/frameworks/autogen)                                     | Now in maintenance mode; Microsoft recommends the Agent Framework for new projects (as of July 2026). |
+| [Google ADK](/integrations/frameworks/google-adk)                               | Google's Agent Development Kit, traced via OpenTelemetry.                                             |
+| [Mastra](/integrations/frameworks/mastra)                                       | TypeScript agent framework with workflows, RAG, and evals.                                            |
+| [LlamaIndex Workflows](/integrations/frameworks/llamaindex-workflows)           | Event-driven, step-based orchestration for LlamaIndex agents.                                         |
+| [Agno](/integrations/frameworks/agno-agents)                                    | Lightweight Python framework for multi-agent systems.                                                 |
+| [Amazon Bedrock AgentCore](/integrations/frameworks/amazon-agentcore)           | AWS runtime for deploying and operating agents at scale.                                              |
+| [Temporal](/integrations/frameworks/temporal)                                   | Durable-execution platform used to run long-lived, fault-tolerant agent workflows.                    |
 
-<Frame fullWidth>
-  ![Semantic Kernel trace visualization in Langfuse](/images/blog/2025-03-19-ai-agent-comparison/semantic-kernel-trace.png)
-</Frame>
-
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/14c7a9f1cc0d7ff16ac1a057a3d45be9?timestamp=2025-02-04T18%3A00%3A53.475Z&observation=cb3f0fb8a2369414)_
-
-### No-code Agent Builders
+### No-code agent builders
 
 For prototypes and development by non-developers, no-code builders can be a great starting point.
 
@@ -231,7 +313,7 @@ With the native [integration](/integrations/no-code/langflow), you can use Langf
 
 #### Dify
 
-Dify ([GitHub](https://github.com/langgenius/dify)) is an open-source LLM app development platform. Using their Agent Builder nd variety of templates, you can easily build an AI agent and then grow it into a more complex system via Dify workflows.
+Dify ([GitHub](https://github.com/langgenius/dify)) is an open-source LLM app development platform. Using their Agent Builder and variety of templates, you can easily build an AI agent and then grow it into a more complex system via Dify workflows.
 
 With the native Langfuse [integration](/integrations/no-code/dify), you can use Dify to quickly create complex LLM applications and then use Langfuse to monitor and improve them.
 
@@ -241,47 +323,57 @@ With the native Langfuse [integration](/integrations/no-code/dify), you can use 
 
 <span>_Example of a Dify Agent that summarizes meetings._</span>
 
-## Agent Evaluation and Testing
+#### n8n
 
-Building an agent is only the first step. Agents can fail in nuanced ways — selecting the wrong tool, entering reasoning loops, or hallucinating in intermediate steps that produce a plausible-looking but incorrect final answer. To ship agents with confidence, you need a systematic approach to evaluation and testing.
+n8n is a workflow automation platform with AI agent nodes. The native [Langfuse integration](/integrations/no-code/n8n) traces the LLM steps of n8n workflows.
 
-### Why Evaluate Agents?
+## Voice agent observability
 
-When working with agents, three problems show up again and again: **understanding**, **specification**, and **generalization**. You often lack understanding of what the agent actually does on real traffic because you are not systematically inspecting traces. The task is frequently underspecified — prompts and examples don't clearly encode what "good" behavior is, so the agent improvises in unpredictable ways. And even once you have tightened the spec, the agent may still struggle to generalize, performing well on handpicked examples but failing on slightly different real-world queries.
+Voice agents add a real-time pipeline (speech-to-text, LLM, text-to-speech) on top of the usual agent loop, and each stage can fail or add latency independently. Langfuse traces voice agents through dedicated integrations:
 
-### Three Evaluation Strategies
+- [LiveKit Agents](/integrations/frameworks/livekit) ships with built-in OpenTelemetry support; the Langfuse SDK registers as a span processor, capturing real-time voice sessions in Python and Node.js.
+- [Pipecat](/integrations/frameworks/pipecat) traces map conversations to turns and service calls, with dedicated spans for STT, LLM, and TTS, time-to-first-byte metrics for latency analysis, and usage statistics per service.
+- [Vapi](/integrations/no-code/vapi) connects Langfuse to no-code voice agents.
+
+Audio itself is a first-class trace payload: Langfuse [multi-modality support](/docs/observability/features/multi-modality) attaches audio files (mp3, wav, ogg, and more) to traces, so you can listen to the exact input and output of a turn while reading its trace. For evaluation, most teams score voice agents on transcripts today, using the same LLM-as-a-judge and human annotation workflows as text agents; evaluating audio qualities like tone or interruption behavior directly is still an emerging practice across the industry.
+
+## Agent evaluation and testing
+
+Building an agent is only the first step. Agents can fail in nuanced ways: selecting the wrong tool, entering reasoning loops, or hallucinating in intermediate steps that produce a plausible-looking but incorrect final answer. To ship agents with confidence, you need a systematic approach to evaluation and testing. This section gives the short version; our [AI agent evaluation guide](/resources/engineering/ai-agent-evaluation) covers strategies, metrics, and worked examples in depth.
+
+### Three evaluation strategies
 
 Langfuse supports three complementary strategies for evaluating agents:
 
-1. **Final Response (Black-Box):** This method only looks at the user's input and the agent's final answer, ignoring the intermediate steps. It is flexible and easy to set up, but does not tell you _why_ an agent failed.
+1. **Final response (black box):** This method only looks at the user's input and the agent's final answer, ignoring the intermediate steps. It is flexible and easy to set up, but does not tell you _why_ an agent failed.
 
-2. **Trajectory (Glass-Box):** This strategy evaluates the full sequence of tool calls, reasoning steps, and decisions an agent made. You compare the actual trajectory against an expected one, catching issues like unnecessary tool calls, skipped steps, or inefficient reasoning paths.
+2. **Trajectory (glass box):** This strategy evaluates the full sequence of tool calls, reasoning steps, and decisions an agent made. You compare the actual trajectory against an expected one, catching issues like unnecessary tool calls, skipped steps, or inefficient reasoning paths. The structured `tool_calls` field makes trajectory checks like "did the agent call the right tool" a one-liner in [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators).
 
-3. **Single Step (White-Box):** This zooms in on individual steps within the agent's execution, evaluating whether each tool call returned the right result or each reasoning step was sound. It provides the most granular feedback for debugging specific failures.
+3. **Single step (white box):** This zooms in on individual steps within the agent's execution, evaluating whether each tool call returned the right result or each reasoning step was sound. It provides the most granular feedback for debugging specific failures.
 
-### Three Phases of Evaluation
+### Three phases of evaluation
 
 The evaluation process follows a natural progression as your application matures:
 
-- **Phase 1 — Manual Tracing:** During early development, the most valuable activity is simply inspecting traces in Langfuse to understand your agent's reasoning.
-- **Phase 2 — Online Evaluation:** As you get your first users, implement [user feedback](/docs/observability/features/user-feedback) mechanisms and automated [LLM-as-a-Judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators to flag problematic traces in real-time.
-- **Phase 3 — Offline Evaluation:** At scale, create benchmark [datasets](/docs/evaluation/experiments/datasets) of inputs and expected outputs, then run automated [experiments](/docs/evaluation/experiments/experiments-via-sdk) to test your agent before each release, preventing regressions and enabling confident iteration.
+- **Phase 1, manual tracing:** During early development, the most valuable activity is simply inspecting traces in Langfuse to understand your agent's reasoning.
+- **Phase 2, online evaluation:** As you get your first users, implement [user feedback](/docs/observability/features/user-feedback) mechanisms and automated [LLM-as-a-Judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators to flag problematic traces in real time.
+- **Phase 3, offline evaluation:** At scale, create benchmark [datasets](/docs/evaluation/experiments/datasets) of inputs and expected outputs, then run automated [experiments](/docs/evaluation/experiments/experiments-via-sdk) to test your agent before each release, preventing regressions and enabling confident iteration.
 
-### Agent Evaluation Guides
+### Agent evaluation guides
 
 To dive deeper, explore these hands-on guides:
 
-- [Agent Evaluation Guide](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) — End-to-end walkthrough of all three evaluation strategies using Pydantic AI agents
-- [Evaluating OpenAI Agents](/guides/cookbook/example_evaluating_openai_agents) — Online and offline evaluation for OpenAI Agents SDK
-- [LangGraph Agent Evaluation](/guides/cookbook/example_langgraph_agents) — Monitoring and evaluating LangGraph agents
-- [Synthetic Dataset Generation](/guides/cookbook/example_synthetic_datasets) — Scale test coverage with LLM-generated data for agent evaluation
-- [Testing LLM Applications](/blog/2025-10-21-testing-llm-applications) — Build a testing foundation with deterministic checks and LLM judges
+- [AI Agent Evaluation Guide](/resources/engineering/ai-agent-evaluation) covers evaluation strategies, metrics, and patterns for agents in depth.
+- [Agent Evaluation Cookbook](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) is an end-to-end walkthrough of all three evaluation strategies using Pydantic AI agents.
+- [Evaluating OpenAI Agents](/guides/cookbook/example_evaluating_openai_agents) shows online and offline evaluation for the OpenAI Agents SDK.
+- [LangGraph Agent Evaluation](/guides/cookbook/example_langgraph_agents) covers monitoring and evaluating LangGraph agents.
+- [Testing LLM Applications](/blog/2025-10-21-testing-llm-applications) builds a testing foundation with deterministic checks and LLM judges.
 
-## Get Started
+## Get started
 
 If you want to get started with building AI agents and monitoring them with Langfuse, here are the best places to begin:
 
 - **Build and trace an agent:** Follow our [end-to-end example](/guides/cookbook/integration_langgraph) of building a simple agent with LangGraph and tracking it with Langfuse.
 - **Compare agent frameworks:** Read our [AI Agent Comparison](/blog/2025-03-19-ai-agent-comparison) blog post for an in-depth guide on when to use which framework.
-- **Evaluate your agents:** Start with the [Agent Evaluation Guide](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) to set up black-box, trajectory, and step-level evaluations.
+- **Evaluate your agents:** Start with the [Agent Evaluation Cookbook](/guides/cookbook/example_pydantic_ai_mcp_agent_evaluation) to set up black-box, trajectory, and step-level evaluations.
 - **Explore all integrations:** Browse the full list of [supported integrations](/integrations) to find the right setup for your stack.

--- a/content/blog/2025-03-19-ai-agent-comparison.mdx
+++ b/content/blog/2025-03-19-ai-agent-comparison.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comparing Open-Source AI Agent Frameworks"
-date: 2025/03/19
-description: Get an overview of the leading open-source AI agent frameworks—LangGraph, OpenAI Agents SDK, Google ADK, Smolagents, CrewAI, AutoGen, Semantic Kernel, Strands Agents, Pydantic AI, Agno, Mastra, and Microsoft Agent Framework. Compare features, learn when to use each, and see how to track agent behavior with Langfuse
+date: 2026/07/13
+description: Compare the leading open-source AI agent frameworks in 2026, including LangGraph, OpenAI Agents SDK, Claude Agent SDK, Google ADK, Pydantic AI, CrewAI, Strands Agents, Mastra, Vercel AI SDK, and Microsoft Agent Framework. Learn when to use each and how to trace agent behavior with Langfuse.
 ogImage: /images/blog/2025-03-19-ai-agent-comparison/agent-comparison.png
 tag: agents, guide
 author: Jannik
@@ -11,29 +11,59 @@ import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
   title="Open-Source AI Agent Frameworks: Which One Is Right for You?"
-  description="Explore the leading open-source AI agent frameworks—LangGraph, OpenAI Agents SDK, Google ADK, Smolagents, CrewAI, AutoGen, Semantic Kernel, Strands Agents, Pydantic AI, Agno, Mastra, and Microsoft Agent Framework. Compare features, learn when to use each, and see how to track agent behavior with Langfuse"
-  date="March 19, 2025"
+  description="Compare the leading open-source AI agent frameworks in 2026, including LangGraph, OpenAI Agents SDK, Claude Agent SDK, Google ADK, Pydantic AI, CrewAI, Strands Agents, Mastra, Vercel AI SDK, and Microsoft Agent Framework. Learn when to use each and how to trace agent behavior with Langfuse."
+  date="July 13, 2026"
   authors={["jannikmaierhoefer"]}
 />
 
-Building AI agents used to be a patchwork of scripts, prompt engineering, and trial-and-error. Today, there is a growing landscape of open-source frameworks designed to streamline the process of creating agents that reason, plan, and execute tasks autonomously. This post offers an in-depth look at some of the leading open-source AI agent frameworks out there: **LangGraph, the OpenAI Agents SDK, Google ADK, Smolagents, CrewAI, AutoGen, Semantic Kernel, Strands Agents, Pydantic AI, Agno, Mastra, and Microsoft Agent Framework**. By the time you finish reading, you should have a clearer view of each framework's sweet spot, how they differ, and where they excel in real-world development.
+Building AI agents used to be a patchwork of scripts, prompt engineering, and trial-and-error. Today, there is a mature landscape of open-source frameworks designed to streamline the process of creating agents that reason, plan, and execute tasks autonomously. This post offers an in-depth look at the leading open-source AI agent frameworks as of July 2026: **LangGraph, LangChain DeepAgents, the OpenAI Agents SDK, the Claude Agent SDK, Google ADK, Pydantic AI, CrewAI, Strands Agents, Mastra, the Vercel AI SDK, Microsoft Agent Framework, Agno, and Smolagents**. By the time you finish reading, you should have a clearer view of each framework's sweet spot, how they differ, and where they excel in real-world development.
 
-One of the biggest challenges in agent development is striking the right balance between giving the AI enough autonomy to handle tasks dynamically and maintaining enough structure for reliability. Each framework has its own philosophy, from explicit graph-based workflows to lightweight code-driven agents. We'll walk through their core ideas, trace how they might fit into your workflow, and examine how you can integrate them with monitoring solutions like Langfuse ([GitHub](https://github.com/langfuse/langfuse)) to evaluate and debug them to make sure they perform in production.
+One of the biggest challenges in agent development is striking the right balance between giving the AI enough autonomy to handle tasks dynamically and maintaining enough structure for reliability. Each framework has its own philosophy, from explicit graph-based workflows to lightweight model-driven loops. We walk through their core ideas, compare the pairs that teams most often evaluate against each other, and show how to integrate each with monitoring solutions like Langfuse ([GitHub](https://github.com/langfuse/langfuse)) to evaluate and debug them in production.
 
-## 🦜 LangGraph
+If you want the short answer before the details:
 
-[LangGraph](https://github.com/langchain-ai/langgraph) extends the well-known [LangChain](https://github.com/langchain-ai/langchain) library into a graph-based architecture that treats agent steps like nodes in a directed acyclic graph. Each node handles a prompt or sub-task, and edges control data flow and transitions. This is helpful for complex, multi-step tasks where you need precise control over branching and error handling. LangGraph's DAG philosophy makes it easier to visualize or debug how decisions flow from one step to another, and you still inherit a ton of useful tooling and integrations from LangChain.
+- **LangGraph** remains the default for complex, stateful workflows where you need explicit control over every step.
+- **Pydantic AI** is the strongest choice for Python teams that want type safety and validation without heavy orchestration.
+- **Mastra** and the **Vercel AI SDK** are the leading options for TypeScript teams.
+- **Strands Agents**, the **OpenAI Agents SDK**, the **Claude Agent SDK**, **Google ADK**, and **Microsoft Agent Framework** are the natural picks if you are committed to the AWS, OpenAI, Anthropic, Google, or Microsoft ecosystems respectively.
+- **CrewAI** is the most approachable way to build role-based multi-agent teams.
+
+## What changed in the agent framework landscape since early 2025
+
+The market consolidated around a smaller set of actively developed frameworks, and a few facts are worth knowing before you commit (all verified July 2026):
+
+- **AutoGen is in maintenance mode.** Microsoft's README states that AutoGen "will not receive new features or enhancements" and directs new users to [Microsoft Agent Framework](https://github.com/microsoft/agent-framework), which it calls the enterprise-ready successor. The last AutoGen release shipped in September 2025.
+- **Microsoft Agent Framework reached 1.x** and consolidates the ideas from AutoGen and Semantic Kernel into one Python and .NET framework with built-in OpenTelemetry support.
+- **The big frameworks stabilized.** LangGraph, CrewAI, Strands Agents, and Mastra all reached 1.x; Pydantic AI and Google ADK are on 2.x. The pre-1.0 churn that defined 2024 and early 2025 is largely over.
+- **Coding-agent SDKs became general-purpose agent frameworks.** The Claude Agent SDK exposes the same harness that powers Claude Code for arbitrary agent applications, and the Vercel AI SDK added first-class agent abstractions.
+
+## LangGraph
+
+[LangGraph](https://github.com/langchain-ai/langgraph) extends the well-known [LangChain](https://github.com/langchain-ai/langchain) ecosystem with a graph-based architecture that treats agent steps like nodes in a directed graph. Each node handles a prompt or sub-task, and edges control data flow and transitions. This is helpful for complex, multi-step tasks where you need precise control over branching and error handling. Since reaching 1.0, LangGraph has focused on production concerns: durable execution that resumes agents exactly where they left off after a failure, human-in-the-loop interrupts, and short-term plus long-term memory. It is available in Python and JavaScript and is used in production by companies including Klarna, Replit, and Elastic (per the project README, July 2026).
 
 <Video src="https://static.langfuse.com/docs-videos/langgraph-overview.mp4" gifStyle aspectRatio={1546 / 1080} />
 _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/a8b0cc9e-da3b-485f-a642-35431a6f9289)_
 
 [How to trace LangGraph agents with Langfuse →](/guides/cookbook/integration_langgraph)
 
-Developers who prefer to model AI tasks in stateful workflows often gravitate toward LangGraph. If your application demands robust task decomposition, parallel branching, or the ability to inject custom logic at specific stages, you might find LangGraph's explicit approach a good fit.
+Developers who prefer to model AI tasks as stateful workflows gravitate toward LangGraph. If your application demands robust task decomposition, parallel branching, or the ability to inject custom logic at specific stages, LangGraph's explicit approach is a good fit.
+
+## LangChain DeepAgents
+
+[DeepAgents](https://github.com/langchain-ai/deepagents) is LangChain's opinionated agent harness built on top of LangGraph. Where LangGraph gives you low-level primitives, DeepAgents ships the batteries: planning, subagents that delegate work into isolated context windows, a filesystem abstraction for reading and writing across local or sandboxed backends, context management that offloads long tool outputs to disk, and middleware for shell access, human-in-the-loop approvals, and reusable skills. It works with any tool-calling model and is available in Python and JavaScript.
+
+<Frame fullWidth>
+  ![LangChain DeepAgents trace visualization in
+  Langfuse](/images/cookbook/integration_langchain_deepagents/deepagents-trace-example.png)
+</Frame>
+
+[How to trace DeepAgents with Langfuse →](/integrations/frameworks/langchain-deepagents)
+
+If you want the "deep agent" pattern (a planner with subagents and file-backed memory) without assembling it yourself from LangGraph parts, DeepAgents is the fastest path inside the LangChain ecosystem.
 
 ## OpenAI Agents SDK
 
-The [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) is the latest entrant in the field. It packages OpenAI's capabilities into a more structured toolset for building agents that can reason, plan, and call external APIs or functions. By providing a specialized agent runtime and a straightforward API for assigning roles, tools, and triggers, OpenAI aims to simplify multi-step or multi-agent orchestration. While it's still evolving, developers appreciate the familiar style of prompts and the native integration with OpenAI's model endpoints.
+The [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) packages OpenAI's agent patterns into a small set of primitives: agents (an LLM with instructions and tools), handoffs for delegating between agents, guardrails for validating inputs and outputs, and sessions that manage conversation history automatically. Despite the name, it is provider-agnostic and supports over 100 non-OpenAI models via LiteLLM and any-llm integrations. It also ships built-in tracing and realtime voice agents. The SDK is still on 0.x versions but receives frequent releases (0.18 as of July 2026), and a separate JavaScript/TypeScript version exists.
 
 <Frame fullWidth>
   ![OpenAI Agents SDK trace visualization in
@@ -43,11 +73,24 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 [How to trace the OpenAI Agents SDK with Langfuse →](/integrations/frameworks/openai-agents)
 
-If you are already deep into OpenAI's stack and want an officially supported solution to spin up agents that utilize GPT-4o or GPT-o3, the OpenAI Agents SDK might be your first stop.
+If you are already deep in OpenAI's stack and want an officially supported way to build multi-agent workflows with minimal abstraction overhead, the OpenAI Agents SDK is the first stop.
+
+## Claude Agent SDK
+
+The [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) is Anthropic's framework for building agents on the same harness that powers Claude Code. Instead of writing your own agent loop, you get a production-tested one: the SDK bundles the Claude Code runtime and exposes it programmatically, with hooks that let your code intercept specific points of the agent loop, in-process MCP servers for defining custom tools without subprocess management, and granular tool permission allowlists. It is available for Python (3.10+) and TypeScript.
+
+<Frame fullWidth>
+  ![Claude Agent SDK trace visualization in
+  Langfuse](/images/cookbook/integration_claude_agent_sdk/claude-agent-sdk-example-trace.png)
+</Frame>
+
+[How to trace the Claude Agent SDK with Langfuse →](/integrations/frameworks/claude-agent-sdk)
+
+If your agents are Claude-based and you want file access, shell tools, subagents, and permissioning that have already been hardened in Claude Code, the Claude Agent SDK gives you that loop as a library instead of a framework you assemble yourself.
 
 ## Google Agent Development Kit (ADK)
 
-[Google ADK](https://github.com/google/adk-python) is Google's open-source framework for building, orchestrating, and tracing generative AI agents. It streamlines the path from prototype to production with built-in support for multi-agent orchestration, tool use, and session management. ADK integrates natively with Gemini models and Google's AI ecosystem, while also supporting other model providers. Its declarative agent definition and built-in runner abstraction make it easy to define agents with tools and manage conversational state.
+[Google ADK](https://github.com/google/adk-python) is Google's open-source, code-first framework for building, evaluating, and deploying AI agents. Now on 2.x, it centers on a workflow runtime (a graph-based execution engine with routing, loops, retry logic, and nested workflows) and a Task API for structured agent-to-agent delegation with multi-turn and human-in-the-loop support. ADK integrates natively with Gemini models while supporting other providers, and ships an interactive CLI and web UI for local testing.
 
 <Frame fullWidth>
   ![Google ADK trace visualization in
@@ -57,26 +100,26 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 [How to trace Google ADK with Langfuse →](/integrations/frameworks/google-adk)
 
-If you're in Google's ecosystem and want a framework that offers built-in multi-agent orchestration alongside Gemini model support, Google ADK is a strong fit. Its session management and runner abstractions handle much of the boilerplate, letting you focus on agent logic.
+If you are in Google's ecosystem and want built-in multi-agent orchestration alongside Gemini model support, Google ADK is a strong fit. Its session management and runner abstractions handle much of the boilerplate, letting you focus on agent logic.
 
-## 🤗 Smolagents
+## Pydantic AI
 
-Hugging Face's [smolagents](https://github.com/huggingface/smolagents) takes a radically simple, code-centric approach. Instead of juggling complex multi-step prompts or advanced orchestration, smolagents sets up a minimal loop where the agent writes and executes code to achieve a goal. It's ideal for scenarios where you want a small, self-contained agent that can call Python libraries or run quick computations without building an entire DAG or multi-agent conversation flow. That minimalism is the chief selling point: you can define a few lines of configuration and let the model figure out how to call your chosen tools or libraries.
+[Pydantic AI](https://ai.pydantic.dev/) brings Pydantic's type safety and ergonomic developer experience to agent development. You define your agent's inputs, tool signatures, and outputs as Python types, and the framework handles validation plus OpenTelemetry instrumentation under the hood, moving whole categories of errors from runtime to write-time. Since reaching 2.x, it adds durable execution (agents preserve progress across API failures and restarts), a type-hint-driven graph system, and support for virtually every major model provider, including OpenAI, Anthropic, Gemini, DeepSeek, Grok, Cohere, and Mistral.
 
 <Frame fullWidth>
-  ![Smolagents Example trace in
-  Langfuse](/images/cookbook/integration-smolagents/smolagent_example_trace.png)
+  ![Pydantic AI trace visualization in
+  Langfuse](/images/cookbook/otel-integration-pydantic-ai/pydanticai-openai-trace-tree.png)
 </Frame>
 
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/ce5160f9bfd5a6cd63b07d2bfcec6f54?timestamp=2025-02-11T09%3A25%3A45.163Z&display=details)_
+_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/25f4bdeebaab60e6e1bee7e8469554bc?timestamp=2025-06-06T14%3A39%3A55.786Z&display=details)_
 
-[How to trace smolagents with Langfuse →](/integrations/frameworks/smolagents)
+[How to trace Pydantic AI with Langfuse →](/integrations/frameworks/pydantic-ai)
 
-If you value fast setup and want to watch your AI generate Python code on the fly, smolagents provides a neat solution. It handles the "ReAct" style prompting behind the scenes, so you can focus on what the agent should do rather than how it strings its reasoning steps together.
+If you are a Python developer who values explicit type contracts, tests, and quick feedback loops, Pydantic AI offers a lightweight yet powerful path to production-ready agents with minimal boilerplate. It brings that FastAPI feeling to agent development.
 
 ## CrewAI
 
-[CrewAI](https://github.com/crewAIInc/crewAI) is all about role-based collaboration among multiple agents. Imagine giving each agent a distinct skillset or personality, then letting them cooperate (or even debate) to solve a problem. This framework offers a higher-level abstraction called a "Crew," which is basically a container for multiple agents that each has a role or function. The Crew coordinates workflows, allowing these agents to share context and build upon one another's contributions. I like CrewAI as it is easy to configure while still letting you attach advanced memory and error-handling logic.
+[CrewAI](https://github.com/crewAIInc/crewAI) is all about role-based collaboration among multiple agents. You give each agent a distinct role and skillset, then let them cooperate to solve a problem inside a "Crew" that coordinates workflows and shared context. CrewAI is a standalone framework (it is not built on LangChain) and, since 1.0, pairs autonomous Crews with **Flows**: event-driven workflows with conditional branching and state handling that let you wrap agent autonomy inside deterministic business logic. We like CrewAI because it is easy to configure while still letting you attach memory, checkpointing, and structured outputs.
 
 <Frame fullWidth>
   ![CrewAI trace visualization in
@@ -86,39 +129,11 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 [How to trace CrewAI agents with Langfuse →](/integrations/frameworks/crewai)
 
-If your use case calls for a multi-agent approach—like a "Planner" agent delegating tasks to a "Researcher" and "Writer" agent—CrewAI makes that easy. The built-in memory modules and fluid user experience have led to growing adoption where collaboration and parallelization of tasks are important.
-
-## AutoGen
-
-[AutoGen](https://github.com/microsoft/autogen), born out of Microsoft Research, frames everything as an asynchronous conversation among specialized agents. Each agent can be a ChatGPT-style assistant or a tool executor, and you orchestrate how they pass messages back and forth. This asynchronous approach reduces blocking, making it well-suited for longer tasks or scenarios where an agent needs to wait on external events. Developers who like the idea of "multiple LLMs in conversation" may find AutoGen's event-driven approach nice, especially for dynamic dialogues that need real-time concurrency or frequent role switching.
-
-<Frame fullWidth>
-  ![AutoGen trace visualization in
-  Langfuse](/images/cookbook/integration-autogen/autogen-example-trace.png)
-</Frame>
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/1b72c51fabed12ae7df83bfd4a09f545?timestamp=2025-06-06T11:31:33.965Z&display=details)_
-
-[How to trace AutoGen agents with Langfuse →](/integrations/frameworks/autogen)
-
-AutoGen is good if you're building an agent that heavily relies on multi-turn conversations and real-time tool invocation. It supports free-form chat among many agents and is backed by a research-driven community that consistently introduces new conversation patterns.
-
-## Semantic Kernel
-
-[Semantic Kernel](https://github.com/microsoft/semantic-kernel) is Microsoft's .NET-first approach to orchestrating AI "skills" and combining them into full-fledged plans or workflows. It supports multiple programming languages (C#, Python, Java) and focuses on enterprise readiness, such as security, compliance, and integration with Azure services. Instead of limiting you to a single orchestrator, you can create a range of "skills," some powered by AI, others by pure code, and combine them. This design makes it popular among teams that want to embed AI into existing business processes without a complete rewrite of their tech stack.
-
-<Frame fullWidth>
-  ![Semantic Kernel trace visualization in
-  Langfuse](/images/cookbook/integration-semantic-kernel/sematric-kernel-example-trace.png)
-</Frame>
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/51d7ea51af5cf9048f607ac6abb79b4f?timestamp=2025-06-04T08:17:14.026Z&display=details)_
-
-[How to trace Semantic Kernel with Langfuse →](/integrations/frameworks/semantic-kernel)
-
-If you want a more formal approach that merges AI with non-AI services, Semantic Kernel is a strong bet. It has a structured "Planner" abstraction that can handle multi-step tasks, making it well-suited for mission-critical enterprise apps.
+If your use case calls for a multi-agent approach, like a planner agent delegating to researcher and writer agents, CrewAI makes that easy, and Flows keep the surrounding process under your control.
 
 ## Strands Agents
 
-[Strands Agents SDK](https://strandsagents.com) is a model-agnostic agent framework that runs anywhere and supports multiple model providers with reasoning and tool use, including **Amazon Bedrock**, Anthropic, OpenAI, Ollama, and others via LiteLLM. It emphasizes production readiness with first-class OpenTelemetry tracing and optional deep AWS integrations. This gives you end-to-end observability with a clean, declarative API for defining agent behavior. For a deeper technical overview of its agent architectures and observability, see AWS’s [technical deep dive](https://aws.amazon.com/blogs/machine-learning/amazon-strands-agents-sdk-a-technical-deep-dive-into-agent-architectures-and-observability/).
+[Strands Agents](https://github.com/strands-agents/sdk-python) is AWS's open-source, model-driven agent framework: you define a model, tools, and a prompt, and the SDK runs the agent loop with context management, guardrails, and execution limits built in. It provides first-class support for Amazon Bedrock (the default), Anthropic, OpenAI, and Google Gemini, with more providers available, and ships SDKs for both Python (3.10+) and TypeScript (Node.js 20+). Strands emphasizes production readiness with OpenTelemetry-based tracing of every step in the loop. It is Apache-2.0 licensed and, as of July 2026, on an actively released 1.x line.
 
 <Frame fullWidth>
   ![Strands Agents trace visualization in
@@ -129,40 +144,11 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 [How to trace Strands Agents with Langfuse →](/integrations/frameworks/strands-agents)
 
-Strands Agents runs anywhere (AWS, other clouds, or on-prem). If you’re on AWS, you can opt into deep Bedrock integrations; otherwise, use any provider (Anthropic, OpenAI, Ollama, etc.) via LiteLLM—while still pairing nicely with Langfuse’s observability pipeline.
-
-## 🐍 Pydantic AI Agents
-
-[Pydantic AI](https://ai.pydantic.dev/) brings Pydantic's famous **type safety** and ergonomic developer experience to agent development. You define your agent's inputs, tool signatures, and outputs as Python types, and the framework handles validation plus OpenTelemetry instrumentation under the hood. The result is FastAPI-style DX for GenAI applications.
-
-<Frame fullWidth>
-  ![Pydantic AI trace visualization in
-  Langfuse](https://langfuse.com/images/cookbook/otel-integration-pydantic-ai/pydanticai-openai-trace-tree.png)
-</Frame>
-
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/25f4bdeebaab60e6e1bee7e8469554bc?timestamp=2025-06-06T14%3A39%3A55.786Z&display=details)_
-
-[How to trace Pydantic AI with Langfuse →](/integrations/frameworks/pydantic-ai)
-
-If you're a Python developer who values explicit type contracts, tests, and quick feedback loops, Pydantic AI offers a lightweight yet powerful path to building production-ready agents with minimal boilerplate.
-
-## Agno
-
-[Agno](https://github.com/agno-agi/agno) is a platform and framework for building and managing AI agents with a focus on speed and flexibility. It supports multiple model providers and offers built-in integrations for common tools like web search and financial data. Agno provides both a Python SDK for building agents and a hosted platform for managing them, making it suitable for teams that want to go from local development to a managed deployment quickly. Agents can be equipped with tools, knowledge bases, and memory to handle complex, stateful interactions.
-
-<Frame fullWidth>
-  ![Agno Agents trace visualization in
-  Langfuse](/images/cookbook/integration-agno-agents/agno-agents-openlit.png)
-</Frame>
-_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/080130871f53145aecf7c29d5dfb6e4c?timestamp=2025-06-11T14:01:32.598Z&display=details)_
-
-[How to trace Agno agents with Langfuse →](/integrations/frameworks/agno-agents)
-
-If you want a framework that combines a clean agent API with an optional managed platform for deployment and monitoring, Agno strikes a good balance between developer experience and operational convenience.
+Strands runs anywhere (AWS, other clouds, or on-prem). If you are on AWS you get deep Bedrock integration by default; otherwise you can use any supported provider while still pairing with Langfuse's observability pipeline.
 
 ## Mastra
 
-[Mastra](https://github.com/mastra-ai/mastra) is a TypeScript-first agent framework that provides the essential primitives for building AI applications. It enables developers to create AI agents with memory and tool-calling capabilities, implement deterministic LLM workflows, and leverage RAG for knowledge integration. Mastra has native OpenTelemetry support, making observability a first-class concern. For JavaScript and TypeScript teams, Mastra fills a gap that many Python-centric frameworks leave open.
+[Mastra](https://github.com/mastra-ai/mastra) is a TypeScript-first agent framework that provides the essential primitives for building AI applications: agents with memory and tool calling, graph-based workflows with `.then()`, `.branch()`, and `.parallel()` control flow, RAG for knowledge integration, and built-in evals and observability. Now on a stable 1.x line, it offers unified model routing across more than 40 providers, suspend-and-resume for human-in-the-loop steps, and integrations with React, Next.js, and Node environments. The core is Apache-2.0 licensed.
 
 <Frame fullWidth>
   ![Mastra trace visualization in
@@ -171,11 +157,29 @@ If you want a framework that combines a clean agent API with an optional managed
 
 [How to trace Mastra agents with Langfuse →](/integrations/frameworks/mastra)
 
-If you're building agents in TypeScript and want a framework designed from the ground up for the JS/TS ecosystem, with built-in support for workflows, RAG, and tool calling, Mastra is a compelling choice.
+If you are building agents in TypeScript and want a framework designed from the ground up for the JS/TS ecosystem, with workflows, RAG, and evals in one package, Mastra is a compelling choice.
+
+## Vercel AI SDK
+
+The [Vercel AI SDK](https://github.com/vercel/ai) started as a set of LLM primitives for TypeScript and has grown into a full agent toolkit. AI SDK 7 (current as of July 2026) ships three agent abstractions: `ToolLoopAgent` runs the classic tool-calling loop with configurable stopping conditions and typed runtime context, `HarnessAgent` runs preconfigured harnesses such as Claude Code or Codex instead of building the loop yourself, and `WorkflowAgent` makes each tool execution a durable, automatically retried step via Vercel's Workflow SDK. If your team already uses the AI SDK for LLM calls, you keep the same provider-agnostic model interface and UI streaming helpers and add agents on top.
+
+<Frame fullWidth>
+  ![Vercel AI SDK trace visualization in
+  Langfuse](/images/cookbook/integration_vercel-ai-sdk/ai-sdk_example-trace.png)
+</Frame>
+
+[How to trace the Vercel AI SDK with Langfuse →](/integrations/frameworks/vercel-ai-sdk)
+
+If your team builds product features in Next.js or Node and wants agents without adopting a separate framework, the AI SDK lets you add an agent loop to the stack you already have.
 
 ## Microsoft Agent Framework
 
-The [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) is a newer open-source framework from Microsoft, distinct from both AutoGen and Semantic Kernel. It provides a comprehensive set of tools for creating intelligent agents that can interact with various services, execute tasks, and handle complex workflows. The framework supports multiple LLM providers including Azure OpenAI and OpenAI, and offers built-in observability through OpenTelemetry.
+The [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) is Microsoft's consolidated agent framework and the successor to both AutoGen and Semantic Kernel for new agent work. It reached a stable 1.x release and combines AutoGen's multi-agent orchestration patterns with Semantic Kernel's enterprise focus: graph-based workflows (sequential, concurrent, handoff, and group collaboration), a middleware system, YAML-based declarative agent definitions, and consistent APIs across Python and .NET/C#. Observability comes built in through OpenTelemetry, and agents can be deployed to Microsoft Foundry for hosted execution.
+
+Two facts matter if you are choosing within the Microsoft ecosystem (verified July 2026):
+
+- **[AutoGen](https://github.com/microsoft/autogen) is in maintenance mode.** Its README states it "will not receive new features or enhancements and is community managed going forward," and recommends existing users migrate via the official AutoGen-to-Agent-Framework guide. Existing AutoGen apps keep working, and [Langfuse's AutoGen integration](/integrations/frameworks/autogen) remains available.
+- **[Semantic Kernel](https://github.com/microsoft/semantic-kernel) still ships releases** and remains a solid library for embedding AI "skills" into .NET applications, but Microsoft's agent investment now flows into Agent Framework, which provides a Semantic Kernel migration guide. Langfuse's [Semantic Kernel integration](/integrations/frameworks/semantic-kernel) continues to work.
 
 <Frame fullWidth>
   ![Microsoft Agent Framework trace visualization in
@@ -185,75 +189,136 @@ _[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz0
 
 [How to trace Microsoft Agent Framework with Langfuse →](/integrations/frameworks/microsoft-agent-framework)
 
-If you're in the Microsoft ecosystem and want a framework that complements AutoGen and Semantic Kernel with a more general-purpose agent runtime, the Microsoft Agent Framework offers a flexible foundation for building production-grade agents.
+If you are in the Microsoft ecosystem, or you need first-class .NET support with Azure integration, Microsoft Agent Framework is now the default choice, and the framework AutoGen and Semantic Kernel teams point new projects toward.
 
-## Comparison Table
+## Agno
 
-| **Framework**                                                                      | **Core Paradigm**                    | **Primary Strength**                                              | **Best For**                                                                                        |
-| ---------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **[LangGraph](https://www.langchain.com/langgraph)**                               | Graph-based workflow of prompts      | Explicit DAG control, branching, debugging                        | Complex multi-step tasks with branching, advanced error handling                                    |
-| **[OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)**            | High-level OpenAI toolchain          | Integrated tools such as web and file search                      | Teams relying on OpenAI's ecosystem who want official support & specialized features                |
-| **[Google ADK](https://github.com/google/adk-python)**                             | Multi-agent orchestration toolkit    | Built-in session management, Gemini-native                        | Teams in Google's ecosystem building multi-agent applications                                       |
-| **[Smolagents](https://huggingface.co/docs/smolagents/en/index)**                  | Code-centric minimal agent loop      | Simple setup, direct code execution                               | Quick automation tasks without heavy orchestration overhead                                         |
-| **[CrewAI](https://www.crewai.com/)**                                              | Multi-agent collaboration (crews)    | Parallel role-based workflows, memory                             | Complex tasks requiring multiple specialists working together                                       |
-| **[AutoGen](https://microsoft.github.io/autogen/stable/)**                         | Asynchronous multi-agent chat        | Live conversations, event-driven                                  | Scenarios needing real-time concurrency, multiple LLM "voices" interacting                          |
-| **[Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/overview/)** | Skill-based, enterprise integrations | Multi-language, enterprise compliance                             | Enterprise settings, .NET ecosystems, or large orgs needing robust skill orchestration              |
-| **[Strands Agents](https://strandsagents.com)**                                    | Model-agnostic agent toolkit         | Runs anywhere; multi-model via LiteLLM; strong OTEL observability | Teams needing provider-flexible agents (Bedrock, Anthropic, OpenAI, Ollama) with production tracing |
-| **[Pydantic AI](https://ai.pydantic.dev/)**                                        | Type-safe Python agent framework     | Strong type safety & FastAPI-style DX                             | Python developers wanting structured, validated agent logic                                         |
-| **[Agno](https://docs.agno.com/)**                                                 | Managed agent platform + SDK         | Speed, multi-provider, optional hosted platform                   | Teams wanting a fast agent SDK with optional managed deployment                                     |
-| **[Mastra](https://mastra.ai)**                                                    | TypeScript-first agent framework     | Native TS/JS, workflows, RAG, OpenTelemetry                       | JavaScript/TypeScript teams building agents with RAG and tool calling                               |
-| **[Microsoft Agent Framework](https://github.com/microsoft/agent-framework)**      | General-purpose agent runtime        | Multi-provider, OpenTelemetry, Azure integration                  | Microsoft ecosystem teams wanting a flexible agent foundation                                       |
+[Agno](https://github.com/agno-agi/agno) is a framework and runtime for building agent platforms while keeping ownership of your infrastructure and data. It combines three layers: a Python SDK for building agents, the AgentOS runtime for executing them, and a control plane for management. Agents get sessions, memory, and knowledge stored in your own database, plus more than 100 pre-built tool integrations, human-approval pauses, and built-in OpenTelemetry tracing. Now on 2.x, it targets teams that want to go from local development to a self-hosted, multi-tenant deployment quickly.
 
-As you can see there are very different approaches to these agent frameworks. Graph-based solutions like LangGraph give you precise control, while conversation-based solutions like AutoGen give you natural, flexible dialogues. Role-based orchestration from CrewAI can tackle complex tasks through a "cast" of specialized agents, whereas Smolagents is ideal for minimal code-driven patterns. Semantic Kernel is positioned in the enterprise space. The OpenAI Agents SDK appeals to users already in the OpenAI stack, while Google ADK brings multi-agent orchestration to Gemini-powered apps. Strands Agents is model-agnostic with optional deep AWS integrations, and Pydantic AI is tailored for type-safe Python environments. Agno offers a fast agent SDK with an optional managed platform, Mastra caters to TypeScript-first teams, and the Microsoft Agent Framework provides a flexible general-purpose runtime that complements AutoGen and Semantic Kernel.
+<Frame fullWidth>
+  ![Agno Agents trace visualization in
+  Langfuse](/images/cookbook/integration-agno-agents/agno-agents-openlit.png)
+</Frame>
+_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/080130871f53145aecf7c29d5dfb6e4c?timestamp=2025-06-11T14:01:32.598Z&display=details)_
 
-## When to Use Each Framework
+[How to trace Agno agents with Langfuse →](/integrations/frameworks/agno-agents)
 
-Rather than prescribing a specific tool, it's more important to focus on the high-level variables that should guide your decision:
+If you want a clean agent API plus an out-of-the-box runtime with production endpoints, Agno strikes a good balance between developer experience and operational convenience.
 
-- **Task Complexity and Workflow Structure:**  
-  Determine whether your task is simple or requires complex, multi-step reasoning. Complex workflows may benefit from explicit orchestration (like a graph-based or skill-based approach), whereas simpler tasks might be well served by a lightweight, code-centric solution.
+## Smolagents
 
-- **Collaboration and Multi-Agents:**  
-  Check if your project needs multiple agents with distinct roles interacting in a coordinated way. Multi-agent collaboration might require an architecture that supports asynchronous conversations and role delegation.
+Hugging Face's [smolagents](https://github.com/huggingface/smolagents) takes a radically simple, code-centric approach: its core logic is roughly 1,000 lines of code, and its signature `CodeAgent` writes its actions as executable Python instead of JSON tool calls. It is model-agnostic (local Transformers or Ollama models, plus 100+ providers via LiteLLM) and supports sandboxed execution through E2B, Modal, or Docker. Release cadence has slowed compared to the frameworks above, but the project remains maintained as of July 2026.
 
-- **Integrations:**  
-  Consider the environments and systems your agents need to interact with. Some frameworks provide easier integration for tool calling, while others are designed for rapid prototyping and minimal setup.
+<Frame fullWidth>
+  ![Smolagents Example trace in
+  Langfuse](/images/cookbook/integration-smolagents/smolagent_example_trace.png)
+</Frame>
 
-- **Performance and Scalability**  
-  Think about the performance demands of your application. High concurrency and real-time interactions may necessitate an event-driven architecture. Observability tools become crucial here, allowing you to trace agent behavior and optimize performance over time.
+_[Example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/ce5160f9bfd5a6cd63b07d2bfcec6f54?timestamp=2025-02-11T09%3A25%3A45.163Z&display=details)_
 
-Below's a Mermaid flowchart outlining some of the key decision. However, please note that this is not an exhaustive list and framework abilities might overlap (e.g. OpenAI Agents SDK can be used for multi-agent workflows).
+[How to trace smolagents with Langfuse →](/integrations/frameworks/smolagents)
+
+If you value fast setup and want to watch your agent generate and run Python code on the fly, smolagents provides a neat, minimal solution.
+
+## If you would rather not write code
+
+Several low-code and no-code tools now ship agent capabilities and can be a better fit for automation-heavy teams: [n8n](/integrations/no-code/n8n) for workflow automation with AI agent nodes, [Langflow](/integrations/no-code/langflow) and [Flowise](/integrations/no-code/flowise) for visual agent building, and [Dify](/integrations/no-code/dify) for LLM app development. They trade flexibility for speed, and all of them can send traces to Langfuse, so you keep the same observability whether the agent was coded or clicked together.
+
+## Comparison table
+
+| **Framework**                                                                 | **Language**         | **Core paradigm**                     | **Primary strength**                                | **Best for**                                                         |
+| ----------------------------------------------------------------------------- | -------------------- | ------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------- |
+| **[LangGraph](https://www.langchain.com/langgraph)**                          | Python, JS/TS        | Graph-based stateful workflows        | Explicit control, durable execution, ecosystem      | Complex multi-step tasks with branching and error handling           |
+| **[DeepAgents](https://github.com/langchain-ai/deepagents)**                  | Python, JS/TS        | Opinionated harness on LangGraph      | Subagents, filesystem memory, skills out of the box | Deep-agent architectures without building the harness yourself       |
+| **[OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)**       | Python (JS separate) | Lightweight multi-agent primitives    | Handoffs, guardrails, sessions, built-in tracing    | Teams in the OpenAI ecosystem wanting official, minimal abstractions |
+| **[Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python)** | Python, TS           | Claude Code harness as a library      | Production-tested loop, hooks, in-process MCP tools | Claude-based agents needing file, shell, and permission handling     |
+| **[Google ADK](https://github.com/google/adk-python)**                        | Python               | Workflow runtime + Task API           | Multi-agent delegation, Gemini-native               | Teams in Google's ecosystem building multi-agent applications        |
+| **[Pydantic AI](https://ai.pydantic.dev/)**                                   | Python               | Type-safe agent framework             | Validation, durable execution, OTel built in        | Python developers wanting structured, testable agent logic           |
+| **[CrewAI](https://www.crewai.com/)**                                         | Python               | Role-based crews + event-driven flows | Approachable multi-agent collaboration              | Tasks requiring multiple specialists inside controlled workflows     |
+| **[Strands Agents](https://strandsagents.com)**                               | Python, TS           | Model-driven agent loop               | Multi-provider, OTel tracing, AWS depth             | Provider-flexible agents with production tracing, especially on AWS  |
+| **[Mastra](https://mastra.ai)**                                               | TypeScript           | Full-stack TS agent framework         | Workflows, RAG, evals, 40+ model providers          | JS/TS teams wanting one framework for agents and workflows           |
+| **[Vercel AI SDK](https://ai-sdk.dev)**                                       | TypeScript           | LLM primitives + agent classes        | ToolLoopAgent, durable WorkflowAgent, UI streaming  | Product teams adding agents to Next.js/Node apps                     |
+| **[Microsoft Agent Framework](https://github.com/microsoft/agent-framework)** | Python, .NET/C#      | Graph-based workflows, middleware     | Successor to AutoGen/SK, OTel, Azure integration    | Microsoft ecosystem teams and .NET shops                             |
+| **[Agno](https://docs.agno.com/)**                                            | Python               | SDK + AgentOS runtime                 | Self-hosted runtime with API, memory, and tracing   | Teams wanting an agent platform on their own infrastructure          |
+| **[Smolagents](https://huggingface.co/docs/smolagents/en/index)**             | Python               | Minimal code-writing agent loop       | Tiny core, agents act via generated code            | Quick automation tasks without orchestration overhead                |
+
+As the table shows, the approaches differ fundamentally. Graph-based solutions like LangGraph and Microsoft Agent Framework give you precise control, model-driven loops like Strands and the OpenAI Agents SDK trade some control for simplicity, and CrewAI's role-based orchestration tackles complex tasks through a cast of specialized agents. Pydantic AI is tailored for type-safe Python environments, while Mastra and the Vercel AI SDK serve the TypeScript world. The Claude Agent SDK and DeepAgents both package the "deep agent" harness pattern, one around Claude Code and one around LangGraph.
+
+## Framework versus framework: common head-to-head decisions
+
+These are the comparisons engineering teams search for and ask about most. Each verdict is based on the frameworks' documented capabilities as of July 2026, not on benchmarks.
+
+### Pydantic AI vs. LangGraph [#pydantic-ai-vs-langgraph]
+
+Choose Pydantic AI when your priority is type-safe, validated agent logic with minimal ceremony; choose LangGraph when your priority is explicit orchestration of long-running, multi-actor workflows. Pydantic AI gives you dependency injection, typed outputs, and durable execution with much less code, which suits single agents and small agent systems embedded in Python services. LangGraph's node-and-edge model costs more upfront structure but pays off when you need branching, checkpointed state, human-in-the-loop interrupts, and replayable execution across many cooperating agents. Both are Python-first, instrument well via OpenTelemetry, and [trace natively to Langfuse](/integrations/frameworks/pydantic-ai).
+
+### Strands Agents vs. LangGraph (and LangChain) [#strands-agents-vs-langgraph]
+
+Strands and LangGraph sit at opposite ends of the control spectrum: Strands is model-driven (define a model, tools, and a prompt, and let the loop run), while LangGraph is workflow-driven (define the graph and let the model act inside it). Choose Strands for faster iteration, first-class AWS and Bedrock support, and built-in OpenTelemetry tracing with less orchestration code. Choose LangGraph when the process itself must be auditable and deterministic, or when you want LangChain's larger ecosystem of integrations around the agent. Compared to plain LangChain, Strands covers the agent loop that LangChain delegates to LangGraph, so the practical comparison is usually Strands vs. LangGraph rather than Strands vs. LangChain.
+
+### Mastra vs. LangChain [#mastra-vs-langchain]
+
+For TypeScript-native teams, Mastra is the more cohesive choice: agents, graph-based workflows, RAG, memory, and evals ship in one TypeScript-first package rather than as a JS port of Python-first designs. LangChain (with LangGraph.js) counters with a substantially larger ecosystem of integrations, more battle-tested production patterns, and better transferability if part of your stack is Python. Choose Mastra if your whole product lives in the JS/TS world and you value integrated workflows and dev tooling; choose LangChain/LangGraph if you need its ecosystem breadth or run mixed Python and TypeScript teams.
+
+### Microsoft Agent Framework vs. LangGraph [#microsoft-agent-framework-vs-langgraph]
+
+Both are graph-based orchestration frameworks, so the decision is mostly ecosystem fit. Microsoft Agent Framework is the natural choice for .NET shops and Azure-centric teams: it is the only major agent framework with first-class C# support, ships OpenTelemetry integration by default, and offers hosted deployment via Microsoft Foundry. LangGraph is the natural choice for Python and JavaScript teams: it is more widely adopted, has a deeper third-party integration catalog through LangChain, and its durable-execution and memory features are more mature. If you are migrating off AutoGen or Semantic Kernel, Agent Framework is the path Microsoft documents and supports.
+
+## When to use each framework
+
+Rather than prescribing a specific tool, it helps to focus on the variables that should guide your decision:
+
+- **Task complexity and workflow structure** determine how much orchestration you need. Complex workflows benefit from explicit graph-based control (LangGraph, Google ADK, Microsoft Agent Framework), whereas simpler tasks are well served by a model-driven loop (Strands, OpenAI Agents SDK, Smolagents).
+- **Language and stack** narrow the field quickly. TypeScript teams choose between Mastra and the Vercel AI SDK; .NET teams have one serious option in Microsoft Agent Framework; Python teams have the widest choice.
+- **Ecosystem commitments** matter more than they did a year ago, since every major model provider now ships its own framework. Staying aligned with your provider (Claude Agent SDK, OpenAI Agents SDK, Google ADK, Strands on AWS) reduces integration friction, while provider-neutral frameworks preserve optionality.
+- **Collaboration and multi-agent needs** favor frameworks with first-class delegation: CrewAI for role-based crews, DeepAgents for planner-plus-subagents, ADK's Task API, and Agent Framework's handoff and group patterns.
+- **Performance and scalability** demands, such as durable long-running executions, favor LangGraph, Pydantic AI, or the Vercel AI SDK's WorkflowAgent. Observability becomes crucial here, allowing you to trace agent behavior and optimize over time.
+
+The flowchart below outlines some key decisions. It is not exhaustive, and framework abilities overlap (for example, most single-agent frameworks can also run multi-agent setups).
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{"Do you need\nmultiple agents?"}
-    B -->|Yes| C{"Preferred multi-agent style?"}
-    B -->|No| D{"Single-agent approach?"}
-
-    %% SINGLE-AGENT BRANCH
-    D -->|"Code-gen agent (lightweight)"| M["SmolAgents\n(Small code approach)"]
-    D -->|"OpenAI models"| N["OpenAI Agents SDK"]
-    D -->|"Gemini models"| P["Google ADK"]
-    D -->|"Provider-flexible agent SDK"| Y["Strands Agents\n(Model-agnostic)"]
-    D -->|"Type-safe Python"| Z["Pydantic AI"]
-    D -->|"TypeScript-first"| T["Mastra\n(TS agent framework)"]
-
-    %% MULTI-AGENT BRANCH
-    F -->|Graph-based & fine-grained control| G["LangGraph\n(DAG of nodes)"]
-    F -->|Role-based, collaborative crew| H["CrewAI\n(Multi-role synergy)"]
-    F -->|Provider-flexible with OTEL| Y
-    F -->|"Google ecosystem"| P
-
-    C -->|"Conversation-based (chat & tool calls)"| E["AutoGen (Microsoft)"]
-    C -->|"Planner-based (multi-step task)"| X["Semantic Kernel (Microsoft)"]
-    C -->|Structured flows, DAG, or roles| F{"Workflow approach"}
-
+    A[Start] --> L{"Primary language?"}
+    L -->|".NET / C#"| MA["Microsoft Agent Framework"]
+    L -->|"TypeScript"| T{"Full framework or add to existing app?"}
+    T -->|"Full framework"| M["Mastra"]
+    T -->|"Add agents to Next.js/Node app"| V["Vercel AI SDK"]
+    L -->|"Python"| B{"Need explicit graph control?"}
+    B -->|"Yes"| G["LangGraph (or Google ADK / Microsoft Agent Framework)"]
+    B -->|"Deep-agent harness out of the box"| DA["DeepAgents or Claude Agent SDK"]
+    B -->|"No, model-driven loop"| S{"Ecosystem preference?"}
+    S -->|"AWS"| ST["Strands Agents"]
+    S -->|"OpenAI"| O["OpenAI Agents SDK"]
+    S -->|"Anthropic"| C["Claude Agent SDK"]
+    S -->|"Google"| AD["Google ADK"]
+    S -->|"None, type safety first"| P["Pydantic AI"]
+    S -->|"Role-based multi-agent"| CR["CrewAI"]
 ```
 
-## Why Agent Tracing and Observability Matter
+## Why agent tracing and observability matter
 
 Agent frameworks involve a lot of moving parts. Each agent can call external APIs, retrieve data, or make decisions that branch into new sub-tasks. Keeping track of what happened, why it happened, and how it happened is vital, especially in production.
 
-Observability tools like [Langfuse](/) let you capture, visualize, and analyze agent "traces" so you can see each prompt, response, and tool call in a structured timeline. This insight makes debugging far simpler and helps you refine prompts, measure performance, and ensure your AI behaves as expected.
+Observability tools like [Langfuse](/) let you capture, visualize, and analyze agent traces so you can see each prompt, response, and tool call in a structured timeline. Nearly every framework in this post emits OpenTelemetry-based traces, and Langfuse ingests them through native integrations linked in each section above. This insight makes debugging far simpler and helps you refine prompts, measure performance, and ensure your AI behaves as expected. If you'd like to go deeper on evaluating agents, see our guide on [AI agent observability and evaluation](/blog/2024-07-ai-agent-observability-with-langfuse).
 
-If you'd like to learn more about evaluating AI agents, check out [this guide](/integrations/frameworks/openai-agents)
+## FAQ
+
+### Which AI agent framework is best?
+
+There is no single best framework; the right choice depends on your language, ecosystem, and control requirements. LangGraph is the most common default for complex Python workflows, Pydantic AI for type-safe Python services, Mastra and the Vercel AI SDK for TypeScript, and the provider SDKs (OpenAI Agents SDK, Claude Agent SDK, Google ADK, Strands Agents) when you are committed to one model ecosystem.
+
+### Is AutoGen still maintained?
+
+AutoGen is in maintenance mode as of late 2025: it receives bug fixes and security patches but no new features, and it is community managed going forward. Microsoft recommends the Microsoft Agent Framework as its successor and publishes an official migration guide. Existing AutoGen applications continue to work.
+
+### Which agent framework should TypeScript teams use?
+
+Mastra and the Vercel AI SDK are the two leading TypeScript options, and LangGraph.js is a solid third. Mastra suits teams that want a complete framework with workflows, RAG, and evals; the Vercel AI SDK suits teams adding agent loops to existing Next.js or Node applications. Strands Agents and the Claude Agent SDK also ship TypeScript SDKs.
+
+### Do I need an agent framework at all?
+
+Not always. A single-model tool loop can be written in under a hundred lines with a provider SDK, and for simple use cases that is a fine start. Frameworks earn their place when you need durable state, retries, multi-agent delegation, human-in-the-loop steps, and consistent tracing, the parts that are tedious and error-prone to rebuild yourself.
+
+### How do I compare agent frameworks for my own use case?
+
+Build the same small task in your top two candidates and trace both. Because most frameworks in this post support OpenTelemetry, you can send traces from both prototypes to [Langfuse](/docs/observability/overview), compare cost, latency, and failure modes side by side, and then commit to the framework whose traces you would rather debug for the next year.

--- a/content/blog/2025-03-19-ai-agent-comparison.mdx
+++ b/content/blog/2025-03-19-ai-agent-comparison.mdx
@@ -28,15 +28,6 @@ If you want the short answer before the details:
 - **Strands Agents**, the **OpenAI Agents SDK**, the **Claude Agent SDK**, **Google ADK**, and **Microsoft Agent Framework** are the natural picks if you are committed to the AWS, OpenAI, Anthropic, Google, or Microsoft ecosystems respectively.
 - **CrewAI** is the most approachable way to build role-based multi-agent teams.
 
-## What changed in the agent framework landscape since early 2025
-
-The market consolidated around a smaller set of actively developed frameworks, and a few facts are worth knowing before you commit (all verified July 2026):
-
-- **AutoGen is in maintenance mode.** Microsoft's README states that AutoGen "will not receive new features or enhancements" and directs new users to [Microsoft Agent Framework](https://github.com/microsoft/agent-framework), which it calls the enterprise-ready successor. The last AutoGen release shipped in September 2025.
-- **Microsoft Agent Framework reached 1.x** and consolidates the ideas from AutoGen and Semantic Kernel into one Python and .NET framework with built-in OpenTelemetry support.
-- **The big frameworks stabilized.** LangGraph, CrewAI, Strands Agents, and Mastra all reached 1.x; Pydantic AI and Google ADK are on 2.x. The pre-1.0 churn that defined 2024 and early 2025 is largely over.
-- **Coding-agent SDKs became general-purpose agent frameworks.** The Claude Agent SDK exposes the same harness that powers Claude Code for arbitrary agent applications, and the Vercel AI SDK added first-class agent abstractions.
-
 ## LangGraph
 
 [LangGraph](https://github.com/langchain-ai/langgraph) extends the well-known [LangChain](https://github.com/langchain-ai/langchain) ecosystem with a graph-based architecture that treats agent steps like nodes in a directed graph. Each node handles a prompt or sub-task, and edges control data flow and transitions. This is helpful for complex, multi-step tasks where you need precise control over branching and error handling. Since reaching 1.0, LangGraph has focused on production concerns: durable execution that resumes agents exactly where they left off after a failure, human-in-the-loop interrupts, and short-term plus long-term memory. It is available in Python and JavaScript and is used in production by companies including Klarna, Replit, and Elastic (per the project README, July 2026).
@@ -222,7 +213,7 @@ If you value fast setup and want to watch your agent generate and run Python cod
 
 ## If you would rather not write code
 
-Several low-code and no-code tools now ship agent capabilities and can be a better fit for automation-heavy teams: [n8n](/integrations/no-code/n8n) for workflow automation with AI agent nodes, [Langflow](/integrations/no-code/langflow) and [Flowise](/integrations/no-code/flowise) for visual agent building, and [Dify](/integrations/no-code/dify) for LLM app development. They trade flexibility for speed, and all of them can send traces to Langfuse, so you keep the same observability whether the agent was coded or clicked together.
+Several low-code and no-code tools now ship agent capabilities and can be a better fit for automation-heavy teams: [LibreChat](https://www.librechat.ai/) for workflow automation with AI agent nodes, [Langflow](/integrations/no-code/langflow) and [Flowise](/integrations/no-code/flowise) for visual agent building, and [Dify](/integrations/no-code/dify) for LLM app development. They trade flexibility for speed, and all of them can send traces to Langfuse, so you keep the same observability whether the agent was coded or clicked together.
 
 ## Comparison table
 

--- a/content/resources/engineering/ai-agent-evaluation.mdx
+++ b/content/resources/engineering/ai-agent-evaluation.mdx
@@ -1,0 +1,188 @@
+---
+title: "AI agent evaluation: trajectory, tool calls, and task completion"
+description: "AI agent evaluation explained: how to measure trajectory, tool use, task completion, and multi-turn quality, with offline and online evaluation patterns."
+tags: [guide, evaluation]
+---
+
+# AI agent evaluation
+
+AI agent evaluation is the practice of measuring whether an agent accomplishes its task, and whether it gets there in an acceptable way. Unlike a single LLM call, an agent produces a multi-step execution: it plans, calls tools, reacts to tool results, and often spans several conversation turns. Evaluating only the final answer misses most of what can go wrong.
+
+**TL;DR:** Evaluate agents on four dimensions: trajectory (the path of steps the agent took), tool use (whether it called the right tools with the right arguments), task completion (whether the user's goal was met), and multi-turn quality (whether performance holds across a conversation). Run offline evaluations on datasets before shipping changes and online evaluations on sampled production traffic after. Use deterministic code checks for anything decidable, LLM-as-a-judge for semantic judgments, and human annotation to calibrate both. This guide covers each dimension with worked patterns in Langfuse.
+
+<Callout type="info">
+New to evaluation as a discipline? [Langfuse Academy](/academy) is a free, open explanation of the AI engineering lifecycle: tracing, monitoring, datasets, experiments, and evaluation, and how the pieces fit together. The [evaluation module](/academy/evaluate) covers the fundamentals this guide builds on.
+</Callout>
+
+## What AI agent evaluation measures
+
+Agent quality decomposes into four dimensions, and mature evaluation setups measure all of them rather than a single "overall quality" number. A single aggregate score tells you an agent got worse; a per-dimension score tells you where.
+
+| Dimension       | Question it answers                               | Typical metrics                                                                                 |
+| --------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Trajectory      | Did the agent take a sensible path to the result? | Step count, unnecessary tool calls, loops and retries, required steps present, correct ordering |
+| Tool use        | Did it call the right tools correctly?            | Correct tool selected, argument validity, tool error rate, recovery after failed calls          |
+| Task completion | Did the user get what they asked for?             | Goal achievement (with or without ground truth), answer correctness, resolution rate            |
+| Multi-turn      | Does quality hold across a conversation?          | Context retention across turns, goal drift, turns-to-resolution, per-session outcome            |
+
+The dimensions fail independently. An agent can complete the task with a wasteful trajectory (twelve tool calls where two suffice, which shows up as latency and cost), and an agent can execute a clean trajectory and still miss the goal because the final synthesis was wrong. Tool-use errors are often invisible in the final answer: the agent recovers, but the retry burned tokens and time you are paying for.
+
+## How agent evaluation differs from LLM evaluation
+
+Standard LLM evaluation scores an input-output pair: one prompt, one completion, one judgment. That model breaks for agents in three ways.
+
+**1.** The unit of evaluation is a trace, not a completion. An agent run is a tree of observations (LLM calls, tool executions, retrievals), and different quality questions attach to different nodes. Tool-argument checks belong on tool-call observations, and task completion belongs on the root of the trace.
+
+**2.** Intermediate steps carry independent failure modes. Retrieval can return the wrong documents, a tool can be called with malformed arguments, and a loop can repeat the same failing call. None of these are visible if you only score final text.
+
+**3.** Many agents are conversational, so the session, not the trace, is the unit users experience. A chatbot can produce five individually reasonable turns that collectively fail to resolve the user's issue.
+
+For the input-output methodology that still applies to the LLM calls inside an agent, see our roadmap for [evaluating LLM applications](/blog/2025-11-12-evals). This guide covers what is specific to agents.
+
+## Offline vs. online agent evaluation
+
+Offline evaluation runs your agent against a fixed dataset before you ship; online evaluation scores sampled production traffic after. You need both, because they catch different failures.
+
+|              | Offline (experiments)                           | Online (production evaluators)                             |
+| ------------ | ----------------------------------------------- | ---------------------------------------------------------- |
+| When it runs | Before a change ships, on demand or in CI       | Continuously on live traffic                               |
+| Data         | Curated dataset, often with expected outputs    | Real user inputs, no ground truth                          |
+| Catches      | Regressions from prompt, model, or tool changes | Drift, novel inputs, real-world tool failures              |
+| Cost profile | Bounded by dataset size                         | Controlled by sampling rate                                |
+| In Langfuse  | Datasets and experiments, gated in CI           | Evaluators on live observations, with filters and sampling |
+
+The standard loop: collect failing production traces, turn them into dataset items, reproduce the failure in an experiment, fix it, and keep the item as a permanent regression test. Langfuse supports the whole loop because production [traces](/docs/observability/data-model) and experiment runs share the same data model and the same scores.
+
+## Choosing an evaluation method
+
+Three method families cover agent evaluation, and the right choice depends on whether the check is decidable by code, requires reading, or requires domain expertise.
+
+| Method           | Use for                         | Cost and latency                   | Agent examples                                                                                          |
+| ---------------- | ------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Code evaluators  | Deterministic, objective checks | Free per run, milliseconds         | Required tool was called, arguments parse against a schema, step budget respected, output is valid JSON |
+| LLM-as-a-judge   | Semantic judgment at scale      | Model cost per evaluation, seconds | Task completion without ground truth, reasoning quality, groundedness of the final answer               |
+| Human annotation | Ground truth and calibration    | Expert time                        | Labeling ambiguous trajectories, building the reference set that judges are calibrated against          |
+
+These are layers, not alternatives. A practical setup runs cheap code checks on every sampled trace, an LLM judge on the subset where semantic judgment matters, and routes disagreements or low-confidence cases to [annotation queues](/docs/evaluation/evaluation-methods/annotation-queues) for human review. Human labels then recalibrate the judge, which keeps the automated layer honest.
+
+In Langfuse, all three methods produce [scores](/docs/evaluation/scores/overview) with one of four data types: numeric for continuous measures like step count, boolean for pass/fail checks like "used required tool", categorical for labels like `resolved` / `escalated` / `abandoned`, and text for free-form reviewer notes. Scores attach to traces, observations, sessions, or experiment runs, so every dimension of agent quality lands in one queryable system.
+
+## Evaluating tool calls
+
+Tool-call evaluation asserts that the agent selected the right tool, passed valid arguments, and handled the result. As of July 2026, Langfuse exposes recorded tool calls to both code and LLM-as-a-judge evaluators as a structured field, so you assert on them directly instead of parsing raw observation input.
+
+In a [code evaluator](/docs/evaluation/evaluation-methods/code-evaluators), each call on the target observation carries `id`, `name`, `arguments`, `type`, and `index`, with valid JSON arguments parsed:
+
+```python
+def evaluate(ctx):
+    tool_calls = ctx.observation.tool_calls
+    used_search = any(tc.name == "search" for tc in tool_calls)
+    return EvaluationResult(scores=[
+        Score(name="used_search_tool", value=used_search, data_type="BOOLEAN"),
+        Score(name="tool_call_count", value=len(tool_calls), data_type="NUMERIC"),
+    ])
+```
+
+The same contract exists in TypeScript via `ctx.observation.toolCalls`. Code evaluators run inside Langfuse on live production observations or on experiment outputs, execute standard-library code without network egress, and can return several scores per run, so one evaluator can cover tool selection, argument validity, and call-count budget together. They are also available in self-hosted deployments.
+
+For semantic questions about tool use, such as whether the chosen tool was appropriate for the user's request, map the **Tool Calls** variable in an LLM-as-a-judge evaluator. A JSONPath selector like `$[*].name` passes only tool names to the judge; mapping the full array includes arguments.
+
+Two related patterns: in experiments, a tool-call assertion makes a good regression test ("given this input, the agent must call `search`"), and in production, a boolean tool-call score is a good alerting signal because it is free to compute on every sampled trace. Ten more paste-ready checks, including a trajectory budget evaluator, are in our [code evaluator examples](/resources/engineering/code-evaluator-examples).
+
+## Judging task completion
+
+Task completion asks whether the agent achieved the user's goal, and it usually needs an LLM judge because "achieved the goal" is a semantic judgment over the whole run. The judge needs the overall input and final output, not an intermediate step.
+
+In Langfuse, [LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators run at the observation level, which is the recommended target as of July 2026 (trace-level judge evaluators are legacy). The pattern for whole-run judgments is to target the root observation of the agent, the span that records the overall request and final response, and map its input and output into the judge prompt. If your instrumentation does not yet write a summary of the run onto the root observation, add that first; the evaluator sees the observation it targets, not its children.
+
+Concretely:
+
+1. Filter the evaluator to the root observation by name or type, optionally narrowed by trace attributes such as tags or user ID.
+2. Map `{{input}}` and `{{output}}` from the root observation's fields, and preview the populated prompt against matched data from the last 24 hours before activating.
+3. Set a sampling rate to control judge cost in production, and choose a score type: boolean for "task completed, yes or no", numeric for degrees of completion, categorical for outcome labels.
+
+For common dimensions you can skip prompt writing: Langfuse ships a catalog of managed evaluators, built with partners such as Ragas, covering dimensions like hallucination, context relevance, toxicity, and helpfulness. For experiments with ground truth, map the dataset item's expected output as the judge's reference. Evaluators and their rules can also be created via the public API, which is useful for version-controlling your evaluation setup, though those endpoints are still marked unstable as of July 2026.
+
+## Scoring trajectories
+
+Trajectory evaluation checks the path, not the destination: which steps ran, in what order, and at what cost. It splits into a quantitative and a qualitative half.
+
+The quantitative half is code-evaluator territory. Step counts, loop detection, required-step presence, and budget checks are all decidable, and the structured tool-call field plus observation metadata give evaluators the raw material. A trajectory score like `within_step_budget` on every sampled production trace turns "the agent has gotten slower and more expensive" from an anecdote into a dashboard line.
+
+The qualitative half is reading trajectories, and that is faster with a visual. The Langfuse [agent graph view](/docs/observability/features/agent-graphs) renders a trace as a graph in two modes (in beta as of July 2026): **Aggregated** collapses repeated steps into single nodes with counters, so `retrieve_docs (3/3)` and a cycle edge reveal the agent's shape and its loops at a glance, while **Expanded** unrolls every call into a DAG in execution order for walking through one specific run. Aggregated mode is the fast way to spot pathological trajectories during error analysis; Expanded mode is the fast way to pin down exactly where one went wrong.
+
+When you find a bad trajectory, codify it: add the input to a dataset, and write the property that was violated ("must not call the payment tool twice") as a code evaluator that runs in every future experiment.
+
+## Evaluating multi-turn conversations
+
+Multi-turn evaluation scores the conversation, not the individual request, because users experience sessions. In Langfuse, every trace can carry a session ID, and scores attach directly to sessions, so conversation-level judgments live at the level they describe.
+
+Session-level scores can be created three ways:
+
+- Domain experts review whole conversations in annotation queues, which support sessions as well as traces and observations, and assign scores such as `resolution` or `conversation_quality` (keyboard-shortcut workflows make high-volume review practical).
+- Your application or evaluation pipeline writes session scores [via the SDK or API](/docs/evaluation/evaluation-methods/scores-via-sdk) by passing only a `session_id`, for example an end-of-conversation judge that reads the full transcript and scores goal completion and context retention.
+- Reviewers score a session manually in the UI while inspecting it.
+
+A useful division of labor: evaluate per-turn quality with observation-level evaluators (each turn's correctness and tool use), and evaluate conversation outcomes with session scores (resolved or not, turns-to-resolution as a numeric score, abandonment as a categorical one). Boolean and categorical session scores are filterable across the Langfuse UI, so "show me all unresolved sessions from the last week" is a table filter, and those sessions feed straight into annotation queues or datasets. For a deeper treatment of judge strategies across turns, see [evaluating multi-turn conversations](/blog/2025-10-09-evaluating-multi-turn-conversations).
+
+## Gating agent changes in CI
+
+Agent changes ship safely when an experiment must pass before merge, the same way tests gate code. Prompt edits, model swaps, and tool-schema changes all alter agent behavior in ways type checkers cannot see, so the regression suite is a dataset plus evaluators.
+
+With the Langfuse [experiments CI/CD integration](/docs/evaluation/experiments/experiments-ci-cd), a GitHub Actions step runs your experiment script against a dataset, posts the result on the pull request, and fails the workflow when a score misses your threshold:
+
+```yaml
+- uses: langfuse/experiment-action@v1.0.0
+  with:
+    langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+    langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
+    langfuse_base_url: https://cloud.langfuse.com
+    experiment_path: experiments/support-agent-gate
+    dataset_name: support-agent-regression-set
+    github_token: ${{ github.token }}
+```
+
+The experiment script uses the SDK's experiment runner (`run_experiment` in Python, `experiment.run` in JS/TS) with item-level evaluators for per-case checks and run-level evaluators for aggregates, and raises a `RegressionError` when a threshold is violated. Pinning a `dataset_version` makes the gate reproducible. The action requires Python SDK v4.6.0+ or JS SDK v5.3.0+.
+
+Experiment results are also accessible programmatically: the public API exposes `GET /api/public/experiments` and `GET /api/public/experiment-items`, and the Langfuse MCP server exposes them as `listExperiments` and `listExperimentItems` tools, so custom pipelines and coding agents can fetch scores and act on regressions without the UI. We used this dataset-experiment loop on ourselves to iterate on an agent skill; the write-up on [evaluating AI agent skills](/blog/2026-02-26-evaluate-ai-agent-skills) is a worked end-to-end example.
+
+## Learn the fundamentals in Langfuse Academy
+
+Agent evaluation sits inside a larger loop: trace production behavior, monitor it, build datasets from real failures, experiment against them, and evaluate the results. [Langfuse Academy](/academy) explains that loop end to end, free and open, with a module per step:
+
+- [The AI engineering loop](/academy/ai-engineering-loop) explains how the steps connect and why the loop matters more than any single tool.
+- [Tracing](/academy/tracing) and [monitoring](/academy/monitoring) cover the visibility an agent evaluation setup depends on.
+- [Datasets](/academy/datasets) and [experiments](/academy/experiments) cover turning production failures into regression tests.
+- [Evaluation](/academy/evaluate) covers how evaluation typically evolves, from manual review to failure-mode definitions to automated evaluators.
+
+If your team is aligning on vocabulary before building an agent evaluation practice, start there; this guide is the agent-specific layer on top.
+
+## FAQ
+
+### What is AI agent evaluation? [#what-is-ai-agent-evaluation]
+
+AI agent evaluation is the practice of measuring the quality of autonomous, multi-step LLM systems across four dimensions: trajectory (the path of steps), tool use (correct tool selection and arguments), task completion (whether the user's goal was met), and multi-turn quality (whether performance holds across a conversation). It differs from standard LLM evaluation because the unit of evaluation is a trace or session rather than a single input-output pair.
+
+### What metrics should I use to evaluate an AI agent? [#agent-evaluation-metrics]
+
+Start with one metric per dimension: a boolean task-completion judgment on the root of each run, a tool-selection correctness check on tool-call observations, a numeric step count with a budget threshold for trajectory efficiency, and a session-level resolution score for conversational agents. Add cost and latency per run, which tracing gives you without extra evaluators. Expand only when a metric has caught a real regression; unused metrics are noise.
+
+### How do you evaluate agent tool calls? [#tool-call-evaluation]
+
+Assert on the recorded tool calls of the observation rather than parsing model output. In Langfuse, code and LLM-as-a-judge evaluators access tool calls as a structured field with `name`, `arguments`, `type`, `id`, and `index`, so a code evaluator can check that a required tool was called or that arguments match a schema, and a judge can rate whether the chosen tool fit the request. Deterministic checks belong in code; appropriateness judgments belong with a judge.
+
+### How do you evaluate an agent without ground truth? [#evaluate-without-ground-truth]
+
+Use reference-free methods: LLM-as-a-judge with a rubric (does the final answer address the stated goal, is it grounded in the tool results the agent retrieved), deterministic property checks that need no reference (valid output format, required tool called, step budget respected), and human annotation on a sample to calibrate the judge. Managed evaluators for dimensions like hallucination judge outputs against the context provided in the trace rather than against an expected answer. Ground truth is only required for exact-match style checks in experiments.
+
+### What is the difference between trace-level and observation-level evaluation? [#trace-vs-observation-evals]
+
+Observation-level evaluators score one operation inside a trace (an LLM call, a tool execution, a retrieval), which makes them fast and precise; in Langfuse they are the recommended target, and trace-level judge evaluators are legacy. To evaluate a whole agent run, target the root observation that records the overall input and final output, and make sure your instrumentation writes the run's summary onto it, because an evaluator sees only the observation it targets.
+
+### How do you evaluate multi-turn conversations? [#multi-turn-evaluation]
+
+Score at two levels: per-turn evaluators for the quality of individual responses, and session-level scores for conversation outcomes such as resolution, goal drift, and turns-to-resolution. In Langfuse, traces share a session ID, scores attach directly to sessions via the UI, SDK, or annotation queues, and boolean or categorical session scores are filterable, so failed conversations can be pulled into review queues or datasets.
+
+### Should agent evaluations run in CI? [#agent-evals-in-ci]
+
+Yes, for any change that alters agent behavior: prompts, models, tool schemas, and orchestration logic. Run an experiment against a versioned dataset of regression cases and fail the pipeline when scores miss a threshold, exactly like a test suite. Keep the CI dataset small enough to run on every pull request (tens to low hundreds of items) and run larger sweeps on a schedule or before releases.

--- a/content/resources/engineering/chatbot-intent-analytics.mdx
+++ b/content/resources/engineering/chatbot-intent-analytics.mdx
@@ -244,13 +244,6 @@ classification either as an offline batch job over the trace API or as an LLM-as
 evaluator on live traffic. The intent distribution, its trend over time, and quality metrics
 per intent then come from dashboard widgets over the score data.
 
-### Can I chart JSON or text scores in Langfuse dashboards? [#json-text-scores]
-
-No. As of July 2026, only numeric, categorical, and boolean scores can be aggregated and
-charted in dashboards and score analytics; free-form text scores are excluded because they
-cannot be meaningfully aggregated. Store each field you want to chart as its own numeric,
-categorical, or boolean score instead of writing one JSON string.
-
 ### Should I store intent labels as tags or scores? [#tags-vs-scores]
 
 Use scores when you classify conversations after the fact, which is the usual case for

--- a/content/resources/engineering/chatbot-intent-analytics.mdx
+++ b/content/resources/engineering/chatbot-intent-analytics.mdx
@@ -1,0 +1,275 @@
+---
+title: "Chatbot analytics: analyzing what users ask your AI chatbot"
+description: "Four working patterns for chatbot analytics on LLM traces: offline intent classification, LLM-as-a-judge detection, score dashboards, and agent-driven analysis."
+tags: [guide, evaluation]
+---
+
+# Chatbot analytics: analyzing what users ask your AI chatbot
+
+Once an AI chatbot is in production, the questions shift from "does it work" to "what are
+users actually asking, and how well do we handle it". Answering that requires conversation
+content, not click events, which is why chatbot intent analytics is built on LLM traces.
+
+**TL;DR:** Classify every conversation into intents and write the labels back to Langfuse as
+categorical scores, either from an offline batch job or with a built-in LLM-as-a-judge
+evaluator running on live traffic. Numeric, categorical, and boolean scores chart natively in
+custom dashboards and score analytics; free-form text scores do not, so store anything you
+want to chart as one of the three chartable types. For open-ended questions like "what new
+topics appeared this week", point a reasoning model at your traces via the Langfuse MCP
+server or API.
+
+## Why chatbot analytics needs trace data
+
+Product analytics tools tell you how many sessions happened and where users dropped off. They
+do not tell you what users asked, what the model answered, or whether the answer was any
+good, because the conversation content never reaches them. Intent analytics needs three
+things that live in an LLM observability platform:
+
+1. **The full conversation content.** Each trace in Langfuse carries the user input, the
+   model output, and every intermediate step (retrieval, tool calls). This is the raw
+   material any intent classification runs on.
+2. **Conversation grouping.** Multi-turn chats are grouped into
+   [sessions](/docs/observability/features/sessions), so you can analyze a whole conversation
+   rather than isolated messages.
+3. **A place to put the labels.** Langfuse scores attach classification results (intent,
+   out-of-scope flags, quality ratings) to the exact trace or session they describe. That is
+   what makes the results filterable and chartable later, next to cost, latency, and user
+   feedback for the same conversations.
+
+The four patterns below build on each other, but each works standalone.
+
+## Pattern 1: offline intent classification over traces
+
+The most common setup is a scheduled batch job: fetch yesterday's chatbot traces via the API,
+classify each user message with a small LLM, and write the label back as a **categorical
+score**. Scores are the right write-back object here because they can be added long after the
+trace was created and they aggregate natively in dashboards.
+
+The script below is complete and runnable; adjust the trace name and input extraction to your
+application's trace structure.
+
+```python
+import os
+from datetime import datetime, timedelta, timezone
+
+from langfuse import get_client
+from openai import OpenAI
+
+# Authenticates via LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_BASE_URL
+langfuse = get_client()
+openai_client = OpenAI()  # uses OPENAI_API_KEY
+
+INTENTS = [
+    "order_status",
+    "returns_and_refunds",
+    "product_question",
+    "account_issue",
+    "pricing_and_plans",
+    "other",
+]
+
+
+def classify_intent(user_message: str) -> str:
+    response = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Classify the user message into exactly one of these intents: "
+                    + ", ".join(INTENTS)
+                    + ". Respond with the intent label only."
+                ),
+            },
+            {"role": "user", "content": user_message},
+        ],
+    )
+    label = response.choices[0].message.content.strip()
+    return label if label in INTENTS else "other"
+
+
+# Classify all chatbot traces from the last 24 hours
+to_ts = datetime.now(timezone.utc)
+from_ts = to_ts - timedelta(days=1)
+
+page = 1
+while True:
+    traces = langfuse.api.trace.list(
+        name="chat-turn",  # the trace name your chatbot uses
+        from_timestamp=from_ts,
+        to_timestamp=to_ts,
+        page=page,
+        limit=50,
+    )
+    if not traces.data:
+        break
+    for trace in traces.data:
+        # Adjust extraction to your trace input structure
+        message = (
+            trace.input.get("message")
+            if isinstance(trace.input, dict)
+            else str(trace.input or "")
+        )
+        if not message:
+            continue
+        langfuse.create_score(
+            trace_id=trace.id,
+            name="intent",
+            value=classify_intent(message),
+            data_type="CATEGORICAL",
+            score_id=f"intent-{trace.id}",  # idempotency key, same-day reruns overwrite
+        )
+    page += 1
+
+langfuse.flush()
+```
+
+Three details worth getting right:
+
+- **Use a stable `score_id`.** A deterministic id like `intent-{trace_id}` makes a rerun (for
+  example with an improved classifier) overwrite the existing score instead of duplicating it.
+  Overwriting requires the id, the name, and the score's date to match, so a rerun on a later
+  day adds a second score rather than replacing the first.
+- **Score sessions for conversation-level intents.** If one conversation spans many traces,
+  pass `session_id` instead of `trace_id` to `create_score` and classify the whole
+  conversation once.
+- **Start with a fixed label set.** A predefined taxonomy keeps charts stable week over week.
+  When you do not know the intents yet, run an embedding-and-clustering pass first; the
+  [intent classification cookbook](/guides/cookbook/example_intent_classification_pipeline)
+  shows both a supervised classifier and unsupervised clustering with LLM-generated cluster
+  labels over Langfuse traces.
+
+## Pattern 2: LLM-as-a-judge for intent and out-of-scope detection
+
+If you would rather not run your own pipeline, Langfuse's built-in
+[LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) do the same
+classification on live production traffic, managed inside Langfuse. You write a judge prompt
+with `{{input}}` and `{{output}}` variables, pick a score type, and Langfuse runs it on new
+traffic automatically.
+
+Two evaluator setups cover the common chatbot asks:
+
+- **Intent classification** is a custom evaluator with a **categorical** score type: define
+  the allowed categories (the same taxonomy as in pattern 1) and Langfuse enforces that the
+  judge output maps to one of them. Enable "Allow multiple matches" if a message can carry
+  two intents.
+- **Unexpected-request detection** is a custom evaluator with a **boolean** score type, with
+  a rubric like "return true if the user request falls outside the assistant's documented
+  scope". The judge's reasoning is stored alongside the score, so a spike in out-of-scope
+  flags comes with explanations you can read.
+
+Operationally: evaluators support a sampling percentage (classifying 10 percent of traffic is
+usually enough for distribution monitoring and cuts judge cost by 10x), and running them on
+observations rather than whole traces is the recommended, faster path. Filter to the final
+response observation of your chatbot so you classify one message per turn, not every internal
+step.
+
+## Pattern 3: dashboards on intent and quality scores
+
+Score write-back pays off in the charts. In [custom
+dashboards](/docs/metrics/features/custom-dashboards), a widget on the categorical scores
+data source grouped by score value plots intent volume per category over time, and a boolean
+`out_of_scope` score becomes a rate line. Widgets on other data sources support score
+filters, so a cost or latency widget can be narrowed to the conversations matching a score.
+The Scores section also has a zero-config analytics tab with distribution and trend charts
+per score, plus agreement metrics when you want to compare two scores (for example your
+offline classifier against an LLM judge on the same traces).
+
+Be deliberate about score types, because they decide what can be charted. As of July 2026:
+
+| Score type    | Example value           | Charts in dashboards and score analytics |
+| ------------- | ----------------------- | ---------------------------------------- |
+| `NUMERIC`     | `0.87`                  | Yes                                      |
+| `CATEGORICAL` | `"returns_and_refunds"` | Yes                                      |
+| `BOOLEAN`     | `1` (true)              | Yes                                      |
+| `TEXT`        | free-form string        | No                                       |
+
+Text scores (free-form strings up to 500 characters) are for qualitative notes; they cannot
+be meaningfully aggregated, so they are not supported in score analytics, experiments, or
+LLM-as-a-judge. The practical consequence: if your classifier returns a structured JSON
+result, do not store the blob as one text score. Split it into separate scores, for example a
+categorical `intent`, a boolean `out_of_scope`, and a numeric `classification_confidence`,
+and each one becomes chartable on its own.
+
+## Pattern 4: ad-hoc analysis with a reasoning model
+
+Classification pipelines answer questions you defined in advance. For the open-ended ones
+("what new complaint themes appeared after the pricing change", "summarize what users
+struggled with this week"), give a capable model direct access to your trace data and ask in
+natural language. Langfuse ships a native [MCP
+server](/docs/api-and-data-platform/features/mcp-server) at
+`https://cloud.langfuse.com/api/public/mcp` (and `/api/public/mcp` on self-hosted
+deployments) that AI assistants and agents connect to with a project-scoped API key; for
+coding agents that can run CLI tools, the Langfuse agent skill is the recommended setup.
+
+```bash
+# Register the Langfuse MCP server in Claude Code (EU region)
+claude mcp add --transport http langfuse https://cloud.langfuse.com/api/public/mcp \
+    --header "Authorization: Basic {base64 of pk-lf-...:sk-lf-...}"
+```
+
+Prompts that work well against chatbot traces: "fetch the last 50 conversations flagged
+out_of_scope and group them into themes", or "compare what users asked before and after
+Monday's deploy". A reasoning model reads a sample of conversations and reports patterns in
+minutes, which is the exploratory step that precedes adding a new label to your taxonomy.
+
+The honest constraint: an agent reads what fits in its context window, so this pattern
+samples rather than counts. Use it for discovery and hypothesis generation, then promote
+recurring findings into a pattern 1 or pattern 2 classifier for exact, chartable numbers.
+
+## From intent data to a better chatbot
+
+Intent analytics is only worth the setup if it changes the product. The three follow-ups we
+see teams actually ship:
+
+1. **Answer the top intents before the chatbot has to.** The intent distribution is a ranked
+   list of what users want; the largest clusters are candidates for FAQ pages, documentation,
+   or a dedicated flow that does the job better than free-form chat.
+2. **Fix prompts where a specific intent underperforms.** Filter traces to one intent with
+   negative user feedback or a failing judge score, read the conversations, and adjust the
+   system prompt or retrieval for that case. Segmented scores turn "the bot feels worse" into
+   "returns_and_refunds satisfaction dropped this week".
+3. **Turn bad conversations into test cases.** Add failing traces to a
+   [dataset](/docs/evaluation/experiments/datasets) and run experiments against it before
+   shipping prompt changes, so the conversations that failed once become the regression suite
+   that keeps them from failing again.
+
+## FAQ
+
+### How do I analyze what users ask my AI chatbot? [#analyze-user-questions]
+
+Trace every conversation in an LLM observability platform, then classify each user message
+into intents and store the labels as categorical scores on the traces. Run the
+classification either as an offline batch job over the trace API or as an LLM-as-a-judge
+evaluator on live traffic. The intent distribution, its trend over time, and quality metrics
+per intent then come from dashboard widgets over the score data.
+
+### Can I chart JSON or text scores in Langfuse dashboards? [#json-text-scores]
+
+No. As of July 2026, only numeric, categorical, and boolean scores can be aggregated and
+charted in dashboards and score analytics; free-form text scores are excluded because they
+cannot be meaningfully aggregated. Store each field you want to chart as its own numeric,
+categorical, or boolean score instead of writing one JSON string.
+
+### Should I store intent labels as tags or scores? [#tags-vs-scores]
+
+Use scores when you classify conversations after the fact, which is the usual case for
+intent analytics: scores can be attached to existing traces at any time, carry a data type,
+and aggregate in dashboards and score analytics. Tags are set during tracing and suit
+attributes you already know at request time, such as the app feature that triggered the
+conversation.
+
+### Do I need to classify every conversation? [#classification-sampling]
+
+No. For monitoring the intent distribution and out-of-scope rate, a 10 to 25 percent sample
+is typically representative and proportionally cheaper; LLM-as-a-judge evaluators have a
+built-in sampling percentage for exactly this. Classify everything only when you need
+per-conversation follow-up, such as routing every out-of-scope request to a review queue.
+
+### What is the difference between chatbot analytics and product analytics? [#chatbot-vs-product-analytics]
+
+Product analytics measures user behavior around the chatbot: sessions, retention, funnels,
+drop-off. Chatbot analytics on traces measures the conversations themselves: what users
+asked, what the model did, what it cost, and whether the answer was good, often combined with
+[user feedback](/docs/observability/features/user-feedback) captured in the chat UI. Most
+teams run both and connect them through shared user and session identifiers.

--- a/content/resources/engineering/langfuse-vs-datadog.mdx
+++ b/content/resources/engineering/langfuse-vs-datadog.mdx
@@ -1,6 +1,6 @@
 ---
 title: Langfuse vs. Datadog for LLM Observability & Agent Tracing
-description: Compare Langfuse and Datadog LLM Observability: tracing, evals, prompt management, pricing, self-hosting, and how teams run both together via OpenTelemetry.
+description: "Compare Langfuse and Datadog LLM Observability: tracing, evals, prompt management, pricing, self-hosting, and how teams run both together via OpenTelemetry."
 tags: [comparison]
 ---
 

--- a/content/resources/engineering/langfuse-vs-datadog.mdx
+++ b/content/resources/engineering/langfuse-vs-datadog.mdx
@@ -1,0 +1,152 @@
+---
+title: Langfuse vs. Datadog for LLM Observability & Agent Tracing
+description: Compare Langfuse and Datadog LLM Observability: tracing, evals, prompt management, pricing, self-hosting, and how teams run both together via OpenTelemetry.
+tags: [comparison]
+---
+
+# Langfuse vs. Datadog
+
+This guide outlines the key differences between **[Langfuse](/)** and **[Datadog LLM Observability](https://docs.datadoghq.com/llm_observability/)** (labeled Agent Observability in Datadog's docs as of July 2026) to help engineering teams choose the right LLM observability setup.
+
+**TL;DR:**
+
+- **Choose Langfuse** if you want an open-source (MIT) platform you can fully self-host, with LLM tracing, evaluations, runtime prompt management, and datasets/experiments in one purpose-built tool, and unit-based pricing that starts at $29/month.
+- **Choose Datadog** if your organization already runs on Datadog APM and you primarily need LLM traces correlated with the rest of your infrastructure, logs, and user sessions inside an existing enterprise agreement.
+- **Many teams run both**: Datadog for application and infrastructure monitoring, Langfuse for LLM engineering workflows, fed from the same OpenTelemetry instrumentation. See [Using Langfuse and Datadog Together](#coexistence).
+
+## Langfuse and Datadog at a Glance
+
+| Dimension                   | Langfuse                                              | Datadog LLM Observability                                                          |
+| --------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Source model**            | Open source (MIT)                                     | Proprietary SaaS                                                                   |
+| **Self-hosting**            | Yes, first-class                                      | No                                                                                 |
+| **LLM & agent tracing**     | Yes                                                   | Yes                                                                                |
+| **Evaluations**             | LLM-as-a-judge, code evaluators, human annotation     | LLM-as-a-judge templates, custom judges, external evals via API, annotation queues |
+| **Prompt management**       | Runtime serving with versions, labels, and caching    | Prompt Tracking (observability of prompt versions; no runtime serving)             |
+| **Datasets & experiments**  | Yes                                                   | Yes                                                                                |
+| **Playground**              | Yes                                                   | Yes                                                                                |
+| **OpenTelemetry**           | OTel-native SDKs + OTLP endpoint                      | OTLP ingestion (GenAI semantic conventions 1.37+)                                  |
+| **First-party SDKs**        | Python, JS/TS (OTel-native); other languages via OTel | Python, Node.js, Java                                                              |
+| **APM / infra correlation** | LLM-focused; runs alongside any APM via OTel          | Native correlation with Datadog APM, logs, and RUM                                 |
+| **Entry price**             | Free (50k units/mo); Core $29/mo                      | Free (40k LLM spans/mo); Pro $160/mo billed annually                               |
+
+## Open Source & Distribution
+
+Langfuse is open source (MIT) and [self-hosting](/self-hosting) is a first-class deployment option with the same codebase as Langfuse Cloud. Datadog is a proprietary SaaS platform; its products, including LLM Observability, run on Datadog-hosted regional sites and store data on Datadog's infrastructure ([source](https://docs.datadoghq.com/getting_started/site/), checked 2026-07).
+
+| Feature              | Langfuse                                                                                                                                                                            | Datadog                                                                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Model**            | **[Open Source](https://github.com/langfuse/langfuse)** (MIT License)                                                                                                               | **Proprietary SaaS** (Closed Source)                                                                                         |
+| **GitHub Stars**     | [![Langfuse GitHub stars](https://img.shields.io/github/stars/langfuse/langfuse?style=for-the-badge&label=%20&labelColor=black&color=orange)](https://github.com/langfuse/langfuse) | N/A                                                                                                                          |
+| **Self-Hosting**     | **First-Class Citizen**: Docker Compose, Kubernetes (Helm), and Terraform templates for AWS, Azure, and GCP.                                                                        | **Not available**: The platform runs only as Datadog-hosted SaaS (the Datadog Agent runs locally, data does not stay local). |
+| **Data Sovereignty** | **High**: Can run fully air-gapped in your own VPC or on-premises.                                                                                                                  | **Regional choice**: Nine hosted sites (US, EU, Japan, Australia, UK, US-gov); data resides with Datadog.                    |
+
+If self-hosting or air-gapped deployment is a hard requirement, this section already decides the comparison: Datadog does not offer a self-hosted platform (checked 2026-07).
+
+## LLM & Agent Tracing
+
+Both platforms capture hierarchical traces of LLM applications and agents, including token usage, latency, errors, and cost. The difference is scope and surrounding context: Langfuse is [purpose-built for LLM observability](/docs/observability/overview) and covers 100+ frameworks and model providers, while Datadog embeds LLM traces into its general observability platform and correlates them with APM services, logs, and real user sessions.
+
+| Feature                  | Langfuse                                                                                    | Datadog                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SDKs**                 | **Python and JS/TS**, built natively on OpenTelemetry.                                      | **Python, Node.js, and Java**, with automatic and manual instrumentation ([source](https://docs.datadoghq.com/llm_observability/instrumentation/sdk/)). |
+| **Auto-instrumentation** | 100+ integrations, including OpenAI, LangChain, LlamaIndex, Vercel AI SDK, LiteLLM, CrewAI. | Integrations include OpenAI, Anthropic, LangChain, AWS Bedrock, Gemini, Vertex AI, CrewAI, and Strands Agents.                                          |
+| **Other languages**      | Java, Go, and any OTel-capable stack via the OTLP endpoint.                                 | HTTP API for non-SDK languages.                                                                                                                         |
+| **Platform context**     | Sessions, users, environments, releases, agent graph views.                                 | Correlation with Datadog APM, infrastructure metrics, logs, and RUM sessions.                                                                           |
+
+## Evaluation
+
+Both platforms ship a working evaluation loop; the implementations differ in where evaluations run and how far they extend. [Langfuse evaluations](/docs/evaluation/overview) include managed LLM-as-a-judge evaluators, code-based evaluators, custom scores via SDK/API, human annotation queues, and dataset experiments, all of which also run in self-hosted deployments. Datadog provides LLM-as-a-judge templates (including Hallucination, Failure to Answer, Toxicity, Prompt Injection, Sentiment, Topic Relevancy, Goal Completeness, Tool Selection, and Tool Argument Correctness), custom LLM-as-a-judge evaluators defined in natural language, external evaluations submitted via API, and annotation queues ([source](https://docs.datadoghq.com/llm_observability/evaluations/), checked 2026-07).
+
+| Feature                   | Langfuse                                                            | Datadog                                                                  |
+| ------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **LLM-as-a-judge**        | Managed evaluators on any traced data, incl. tool-call evaluators.  | Template and custom judge evaluators.                                    |
+| **Code-based evaluators** | Deterministic evaluators run natively.                              | External evaluations via API or third-party frameworks (e.g., DeepEval). |
+| **Human review**          | Annotation queues.                                                  | Annotation queues.                                                       |
+| **Datasets/experiments**  | Datasets, experiments, and prompt experiments via UI, SDK, and API. | Datasets and experiments with Playground integration.                    |
+| **Where evals run**       | Cloud or your own infrastructure (self-hosted).                     | Datadog's SaaS platform.                                                 |
+
+## Prompt Management
+
+This is the largest functional gap between the two products. [Langfuse prompt management](/docs/prompt-management/overview) is a runtime system: prompts are versioned in Langfuse, deployed via release labels, fetched by your application through cached SDK calls, and linked to the traces and evaluation scores they produce. Prompt fetching is unlimited on all plans, including the free tier.
+
+Datadog offers Prompt Tracking, which links prompt templates and versions that are defined in your code to LLM spans for version history, diffs, and trace filtering. Applications do not fetch prompts from Datadog at runtime; it is an observability feature, not a prompt deployment system ([source](https://docs.datadoghq.com/llm_observability/monitoring/prompt_tracking/), checked 2026-07).
+
+If you want to update or roll back prompts without a code deploy, run A/B tests across prompt versions, or hand prompt iteration to non-engineers, Langfuse covers that workflow and Datadog does not.
+
+## Pricing
+
+The billing models are structurally different, so read the units carefully before comparing numbers. Langfuse bills [units](/docs/administration/billable-units), where one unit is a trace, an observation, or a score. Datadog bills only LLM inference spans; tool, workflow, agent, embedding, and retrieval spans are free ([source](https://www.datadoghq.com/pricing/list/), checked 2026-07). A single agent request can therefore produce a different billable count on each platform, and the fairest comparison is to model your own traffic on both.
+
+| Feature              | Langfuse                                                                   | Datadog LLM Observability                                                            |
+| -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Free tier**        | 50k units/mo, 30 days data access. Self-hosted OSS: unlimited, free (MIT). | 40k LLM spans/mo, 15-day retention, full feature access.                             |
+| **Paid entry**       | **Core: $29/mo** (100k units included).                                    | **Pro: $160/mo billed annually** ($200 month-to-month) for the first 100k LLM spans. |
+| **Additional usage** | $8 per 100k units, decreasing to $6 per 100k at volume.                    | $3.50 per 10k additional LLM spans (annual billing).                                 |
+| **Retention**        | Core: 90 days. Pro ($199/mo): 3 years.                                     | 15 days included; extensions to 30/60/90 days cost $1.50/$3.00/$4.00 per 10k spans.  |
+| **Enterprise**       | [$2,499/mo](/pricing), incl. audit logs, SCIM, SLAs.                       | Custom, typically part of a broader Datadog agreement.                               |
+
+Two practical notes. First, Datadog's free and Pro tiers include full feature access, which is a low barrier for teams already inside the Datadog ecosystem. Second, Datadog's 15-day default retention is short for LLM engineering workflows like building evaluation datasets from historical production traces; extended retention is a paid add-on, while Langfuse Core includes 90 days and Pro includes 3 years.
+
+## When Datadog Is the Better Fit
+
+An honest comparison names the cases where the other tool wins:
+
+- **Your organization already standardizes on Datadog.** If APM, logs, and dashboards live in Datadog, adding LLM spans to the same pane means one vendor, one bill, one access-control model, and no new procurement cycle.
+- **Cross-stack correlation is the primary requirement.** Datadog links LLM traces to the services, hosts, and real user sessions underneath them. Langfuse focuses on the LLM application layer and does not aim to replace an APM.
+- **You need a first-party Java SDK.** Datadog ships one; Langfuse covers Java through OpenTelemetry rather than a dedicated SDK.
+- **Ops-led monitoring is the main use case.** If the goal is alerting on latency, error rates, and token spend within an existing on-call workflow, Datadog's monitors and incident tooling are already where your team works.
+
+Conversely, teams that need self-hosting, runtime prompt management, evaluation workflows on their own infrastructure, or an open-source stack will not find those in Datadog (checked 2026-07).
+
+## Using Langfuse and Datadog Together [#coexistence]
+
+Choosing Langfuse rarely means dropping Datadog. The most common production setup we see keeps Datadog for application and infrastructure monitoring and adds Langfuse for LLM engineering: deep trace inspection, evaluations, prompt management, and dataset curation. Because the [Langfuse SDKs are OTel-native](/integrations/native/opentelemetry), both backends can be fed from one instrumentation layer by attaching two span processors to a shared `TracerProvider`:
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from langfuse.opentelemetry import LangfuseSpanProcessor
+
+provider = TracerProvider()
+
+# Langfuse receives LLM and GenAI spans (default filter)
+provider.add_span_processor(LangfuseSpanProcessor())
+
+# Datadog (or any APM) receives everything via your existing OTLP endpoint
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
+)
+
+trace.set_tracer_provider(provider)
+```
+
+The Langfuse span processor filters for LLM-relevant spans by default, so your APM keeps the full application picture while Langfuse stays focused on the GenAI layer. Datadog also accepts OpenTelemetry GenAI spans directly (semantic conventions 1.37+ over OTLP), so a collector-based fan-out to both backends works as well. Configuration details, isolated-provider setups, and troubleshooting for this pattern are covered in [using Langfuse with an existing OpenTelemetry setup](/faq/all/existing-otel-setup).
+
+## FAQ
+
+### Is Langfuse an alternative to Datadog LLM Observability? [#langfuse-datadog-alternative]
+
+Yes, for the LLM application layer. Langfuse covers tracing, evaluations, prompt management, and datasets/experiments, and adds self-hosting and an MIT open-source license that Datadog does not offer. Langfuse is not an APM, so it complements rather than replaces Datadog's infrastructure and application monitoring.
+
+### Can I self-host Datadog LLM Observability? [#self-host-datadog]
+
+No. Datadog runs as a hosted SaaS across nine regional sites, and telemetry data is stored on Datadog's infrastructure (checked July 2026). Langfuse is open source (MIT) and can be [self-hosted](/self-hosting) with Docker Compose, Kubernetes, or Terraform templates, including air-gapped deployments.
+
+### How much does Datadog LLM Observability cost? [#datadog-llm-observability-pricing]
+
+As of July 2026, Datadog offers a free tier with 40k LLM spans per month and 15-day retention, and a Pro plan at $160/month (billed annually) covering the first 100k LLM spans, with additional spans at $3.50 per 10k. Only LLM inference spans are billed; tool, workflow, and retrieval spans are free. Extended retention to 30, 60, or 90 days is a paid add-on.
+
+### Can I use Langfuse and Datadog at the same time? [#langfuse-and-datadog-together]
+
+Yes, and this is a common setup. Both products consume OpenTelemetry traces, so one instrumentation layer can feed Datadog for APM and Langfuse for LLM engineering, either via two span processors in your application or a collector-based fan-out. See [using Langfuse with an existing OpenTelemetry setup](/faq/all/existing-otel-setup) for working configurations.
+
+### Does Datadog support OpenTelemetry for LLM traces? [#datadog-opentelemetry]
+
+Yes. Datadog ingests OpenTelemetry traces that follow the GenAI semantic conventions version 1.37 or later over OTLP HTTP, and supports OpenLLMetry v0.47+; OpenInference is not supported (checked July 2026). Langfuse SDKs are built natively on OpenTelemetry, and Langfuse additionally accepts OTLP traces from OpenLLMetry, OpenLIT, and other instrumentation libraries on its `/api/public/otel` endpoint.
+
+<Callout type="info">
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.
+</Callout>

--- a/content/resources/engineering/langfuse-vs-datadog.mdx
+++ b/content/resources/engineering/langfuse-vs-datadog.mdx
@@ -11,24 +11,22 @@ This guide outlines the key differences between **[Langfuse](/)** and **[Datadog
 **TL;DR:**
 
 - **Choose Langfuse** if you want an open-source (MIT) platform you can fully self-host, with LLM tracing, evaluations, runtime prompt management, and datasets/experiments in one purpose-built tool, and unit-based pricing that starts at $29/month.
-- **Choose Datadog** if your organization already runs on Datadog APM and you primarily need LLM traces correlated with the rest of your infrastructure, logs, and user sessions inside an existing enterprise agreement.
-- **Many teams run both**: Datadog for application and infrastructure monitoring, Langfuse for LLM engineering workflows, fed from the same OpenTelemetry instrumentation. See [Using Langfuse and Datadog Together](#coexistence).
+- **Choose Datadog** if your organization already runs on Datadog APM and you primarily need LLM logs correlated with the rest of your infrastructure.
+- **Many teams run both**: Datadog for application and infrastructure monitoring, Langfuse for LLM evaluation workflows, fed from the same OpenTelemetry instrumentation. See [Using Langfuse and Datadog Together](#coexistence).
 
 ## Langfuse and Datadog at a Glance
 
-| Dimension                   | Langfuse                                              | Datadog LLM Observability                                                          |
-| --------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Source model**            | Open source (MIT)                                     | Proprietary SaaS                                                                   |
-| **Self-hosting**            | Yes, first-class                                      | No                                                                                 |
-| **LLM & agent tracing**     | Yes                                                   | Yes                                                                                |
-| **Evaluations**             | LLM-as-a-judge, code evaluators, human annotation     | LLM-as-a-judge templates, custom judges, external evals via API, annotation queues |
-| **Prompt management**       | Runtime serving with versions, labels, and caching    | Prompt Tracking (observability of prompt versions; no runtime serving)             |
-| **Datasets & experiments**  | Yes                                                   | Yes                                                                                |
-| **Playground**              | Yes                                                   | Yes                                                                                |
-| **OpenTelemetry**           | OTel-native SDKs + OTLP endpoint                      | OTLP ingestion (GenAI semantic conventions 1.37+)                                  |
-| **First-party SDKs**        | Python, JS/TS (OTel-native); other languages via OTel | Python, Node.js, Java                                                              |
-| **APM / infra correlation** | LLM-focused; runs alongside any APM via OTel          | Native correlation with Datadog APM, logs, and RUM                                 |
-| **Entry price**             | Free (50k units/mo); Core $29/mo                      | Free (40k LLM spans/mo); Pro $160/mo billed annually                               |
+| Dimension                  | Langfuse                                              | Datadog LLM Observability                                 |
+| -------------------------- | ----------------------------------------------------- | --------------------------------------------------------- |
+| **Self-hosting**           | Yes, first-class, Open source (MIT)                   | Proprietary SaaS                                          |
+| **LLM & agent tracing**    | Yes                                                   | Yes                                                       |
+| **Evaluations**            | LLM-as-a-judge, code evaluators, human annotation     | LLM-as-a-judge, external evals via API, annotation queues |
+| **Prompt management**      | Runtime serving with versions, labels, and caching    | Prompt tracking only                                      |
+| **Datasets & experiments** | Yes                                                   | Yes                                                       |
+| **Playground**             | Yes                                                   | Yes                                                       |
+| **OpenTelemetry**          | OTel-native SDKs + OTLP endpoint                      | OTLP ingestion (GenAI semantic conventions 1.37+)         |
+| **First-party SDKs**       | Python, JS/TS (OTel-native); other languages via OTel | Python, Node.js, Java                                     |
+| **Entry price**            | Free (50k units/mo); Core $29/mo                      | Free (40k LLM spans/mo); Pro $160/mo billed annually      |
 
 ## Open Source & Distribution
 
@@ -56,15 +54,15 @@ Both platforms capture hierarchical traces of LLM applications and agents, inclu
 
 ## Evaluation
 
-Both platforms ship a working evaluation loop; the implementations differ in where evaluations run and how far they extend. [Langfuse evaluations](/docs/evaluation/overview) include managed LLM-as-a-judge evaluators, code-based evaluators, custom scores via SDK/API, human annotation queues, and dataset experiments, all of which also run in self-hosted deployments. Datadog provides LLM-as-a-judge templates (including Hallucination, Failure to Answer, Toxicity, Prompt Injection, Sentiment, Topic Relevancy, Goal Completeness, Tool Selection, and Tool Argument Correctness), custom LLM-as-a-judge evaluators defined in natural language, external evaluations submitted via API, and annotation queues ([source](https://docs.datadoghq.com/llm_observability/evaluations/), checked 2026-07).
+Both platforms ship a working evaluation loop; the implementations differ in where evaluations run and how far they extend. [Langfuse evaluations](/docs/evaluation/overview) include managed LLM-as-a-judge evaluators, code-based evaluators, custom scores via SDK/API, human annotation queues, and dataset experiments, all of which also run in self-hosted deployments. Datadog provides LLM-as-a-judge templates (including Hallucination, Failure to Answer, Toxicity and Prompt Injection), custom LLM-as-a-judge evaluators defined in natural language, external evaluations submitted via API, and annotation queues ([source](https://docs.datadoghq.com/llm_observability/evaluations/), checked 2026-07).
 
-| Feature                   | Langfuse                                                            | Datadog                                                                  |
-| ------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| **LLM-as-a-judge**        | Managed evaluators on any traced data, incl. tool-call evaluators.  | Template and custom judge evaluators.                                    |
-| **Code-based evaluators** | Deterministic evaluators run natively.                              | External evaluations via API or third-party frameworks (e.g., DeepEval). |
-| **Human review**          | Annotation queues.                                                  | Annotation queues.                                                       |
-| **Datasets/experiments**  | Datasets, experiments, and prompt experiments via UI, SDK, and API. | Datasets and experiments with Playground integration.                    |
-| **Where evals run**       | Cloud or your own infrastructure (self-hosted).                     | Datadog's SaaS platform.                                                 |
+| Feature                   | Langfuse                                                            | Datadog                                                      |
+| ------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **LLM-as-a-judge**        | Managed evaluators on any traced data, incl. tool-call evaluators.  | Template and custom judge evaluators.                        |
+| **Code-based evaluators** | Deterministic evaluators run natively.                              | External via API or third-party frameworks (e.g., DeepEval). |
+| **Human review**          | Annotation queues.                                                  | Annotation queues.                                           |
+| **Datasets/experiments**  | Datasets, experiments, and prompt experiments via UI, SDK, and API. | Datasets and experiments with Playground integration.        |
+| **Where evals run**       | Cloud or your own infrastructure (self-hosted).                     | Datadog's SaaS platform.                                     |
 
 ## Prompt Management
 
@@ -87,17 +85,6 @@ The billing models are structurally different, so read the units carefully befor
 | **Enterprise**       | [$2,499/mo](/pricing), incl. audit logs, SCIM, SLAs.                       | Custom, typically part of a broader Datadog agreement.                               |
 
 Two practical notes. First, Datadog's free and Pro tiers include full feature access, which is a low barrier for teams already inside the Datadog ecosystem. Second, Datadog's 15-day default retention is short for LLM engineering workflows like building evaluation datasets from historical production traces; extended retention is a paid add-on, while Langfuse Core includes 90 days and Pro includes 3 years.
-
-## When Datadog Is the Better Fit
-
-An honest comparison names the cases where the other tool wins:
-
-- **Your organization already standardizes on Datadog.** If APM, logs, and dashboards live in Datadog, adding LLM spans to the same pane means one vendor, one bill, one access-control model, and no new procurement cycle.
-- **Cross-stack correlation is the primary requirement.** Datadog links LLM traces to the services, hosts, and real user sessions underneath them. Langfuse focuses on the LLM application layer and does not aim to replace an APM.
-- **You need a first-party Java SDK.** Datadog ships one; Langfuse covers Java through OpenTelemetry rather than a dedicated SDK.
-- **Ops-led monitoring is the main use case.** If the goal is alerting on latency, error rates, and token spend within an existing on-call workflow, Datadog's monitors and incident tooling are already where your team works.
-
-Conversely, teams that need self-hosting, runtime prompt management, evaluation workflows on their own infrastructure, or an open-source stack will not find those in Datadog (checked 2026-07).
 
 ## Using Langfuse and Datadog Together [#coexistence]
 
@@ -142,10 +129,6 @@ As of July 2026, Datadog offers a free tier with 40k LLM spans per month and 15-
 ### Can I use Langfuse and Datadog at the same time? [#langfuse-and-datadog-together]
 
 Yes, and this is a common setup. Both products consume OpenTelemetry traces, so one instrumentation layer can feed Datadog for APM and Langfuse for LLM engineering, either via two span processors in your application or a collector-based fan-out. See [using Langfuse with an existing OpenTelemetry setup](/faq/all/existing-otel-setup) for working configurations.
-
-### Does Datadog support OpenTelemetry for LLM traces? [#datadog-opentelemetry]
-
-Yes. Datadog ingests OpenTelemetry traces that follow the GenAI semantic conventions version 1.37 or later over OTLP HTTP, and supports OpenLLMetry v0.47+; OpenInference is not supported (checked July 2026). Langfuse SDKs are built natively on OpenTelemetry, and Langfuse additionally accepts OTLP traces from OpenLLMetry, OpenLIT, and other instrumentation libraries on its `/api/public/otel` endpoint.
 
 <Callout type="info">
   This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.

--- a/content/resources/engineering/langsmith-alternative.mdx
+++ b/content/resources/engineering/langsmith-alternative.mdx
@@ -1,90 +1,157 @@
 ---
 title: LangSmith Alternative? Langfuse vs. LangSmith for LLM Observability
-description: Langfuse is an open-source alternative to LangSmith. This article compares Langfuse and LangSmith for LLM observability, analytics, evaluations, testing, and annotation.
+description: Langfuse is the open-source LangSmith alternative. Updated July 2026 comparison of open source, self-hosting, storage architecture, evals, alerting, and pricing.
 tags: [comparison, integration]
 ---
 
 # Langfuse vs. LangSmith
 
-This guide outlines the key differences between **[Langfuse](/)** and **[LangSmith](https://www.langchain.com/langsmith)** to help engineering teams choose the right LLM observability platform.
+This guide outlines the key differences between **[Langfuse](/)** and **[LangSmith](https://www.langchain.com/langsmith)** to help engineering teams choose the right LLM observability platform. All LangSmith facts were checked against public LangChain sources in July 2026.
 
 **TL;DR:**
 
-- **Choose Langfuse** if you prioritize Open Source (MIT), data sovereignty (full self-hosting), a framework-agnostic approach (works with any stack), and transparent unit-based pricing.
-- **Choose LangSmith** if you are an "All-in-LangChain" shop requiring a managed SaaS solution that offers deep, native integration for deploying LangChain and LangGraph agents.
+- **Choose Langfuse** if you prioritize open source (MIT), data sovereignty (full self-hosting on an open storage stack), a framework-agnostic approach built on OpenTelemetry, and transparent unit-based pricing.
+- **Choose LangSmith** if you are an all-in LangChain/LangGraph shop that wants a managed SaaS covering observability, evals, and agent deployment infrastructure in one closed platform.
 
-## Open Source & Distribution
+## Open source and distribution
 
-Langfuse is open source (MIT) and self-hosting is a first-class citizen. LangSmith is a proprietary, closed-source SaaS tool; while it offers a self-hosted option, it requires an Enterprise license.
+Langfuse is open source (MIT) and self-hosting is a first-class deployment mode. LangSmith is a proprietary, closed-source platform: its client SDKs are open source, but the backend, UI, and storage layer are not, and self-hosting is an Enterprise-exclusive add-on.
 
-| Feature              | Langfuse                                                                                                                                                                            | LangSmith                                                                         |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Model**            | **[Open Source](https://github.com/langfuse/langfuse)** (MIT License)                                                                                                               | **Proprietary SaaS** (Closed Source)                                              |
-| **GitHub Stars**     | [![Langfuse GitHub stars](https://img.shields.io/github/stars/langfuse/langfuse?style=for-the-badge&label=%20&labelColor=black&color=orange)](https://github.com/langfuse/langfuse) | N/A                                                                               |
-| **Self-Hosting**     | **First-Class Citizen**: Full feature parity with Cloud.                                                                                                                            | **Enterprise Only**: Requires a sales contract and license key.                   |
-| **Data Sovereignty** | **High**: Can run fully air-gapped on own VPC without vendor contact.                                                                                                               | **Medium**: "Hybrid" deployment available for Enterprise; SaaS defaults to Cloud. |
+| Feature              | Langfuse                                                                                                                                                                            | LangSmith                                                                                                              |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Model**            | **[Open Source](https://github.com/langfuse/langfuse)** (MIT License)                                                                                                               | **Proprietary SaaS**: platform closed source; [client SDKs](https://github.com/langchain-ai/langsmith-sdk) open source |
+| **GitHub Stars**     | [![Langfuse GitHub stars](https://img.shields.io/github/stars/langfuse/langfuse?style=for-the-badge&label=%20&labelColor=black&color=orange)](https://github.com/langfuse/langfuse) | N/A (platform not on GitHub)                                                                                           |
+| **Self-Hosting**     | **First-class**: full feature parity with Cloud, from Docker Compose to Kubernetes/Helm.                                                                                            | **Enterprise only**: add-on requiring a sales contract; not available on Developer or Plus plans.                      |
+| **Data Sovereignty** | **High**: can run fully air-gapped in your own VPC without vendor contact.                                                                                                          | **Medium**: hybrid/self-hosted deployment for Enterprise; SaaS defaults to LangChain's cloud.                          |
 
-## Scalability & Performance
+## Scale and storage architecture [#storage-architecture]
 
-Both platforms utilize ClickHouse for high-scale analytics. Langfuse is [part of ClickHouse](https://langfuse.com/blog/joining-clickhouse) and works closely with the core database team to ensure highest performance and reliability.
+Both platforms were built for high-volume trace data, and both re-architected their storage layers as agent traces grew into thousands of spans with large payloads. They made different choices: LangChain built a proprietary database, and Langfuse invested in its data model on top of an open-source one.
 
-| Feature       | Langfuse                                                                                                      | LangSmith                                                           |
-| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| **Backend**   | **[ClickHouse](https://clickhouse.com/)** ([acquired Langfuse](https://langfuse.com/blog/joining-clickhouse)) | **ClickHouse**                                                      |
-| **Ingestion** | **Async Queue**: Decoupled Redis queue + generic workers for reliability.                                     | **Queue-Based**: Stateless backend designed for horizontal scaling. |
+In May 2026, LangChain announced [SmithDB](https://www.langchain.com/blog/introducing-smithdb), a purpose-built trace database written in Rust on Apache DataFusion and the Vortex file format, with trace data on object storage and stateless ingestion and query services. LangChain reports that SmithDB serves LangSmith's US Cloud ingestion and tracing queries and makes core experiences up to 15x faster. As of the May 2026 announcement, SmithDB for self-hosted LangSmith was in early access, so self-hosted deployments do not yet run the same storage engine as their cloud.
 
-## Integrations
+Langfuse stores traces in [ClickHouse](https://clickhouse.com/), the open-source columnar database (Apache 2.0). Langfuse is [part of ClickHouse](/blog/joining-clickhouse) and works directly with the database's core team. Rather than building a new engine, Langfuse redesigned its data model: since March 2026, every LLM call, tool execution, and agent step is written once to a single wide, immutable observations table, which eliminates joins and read-time deduplication. The engineering details and benchmarks are public in [Simplifying Langfuse for Scale](/blog/2026-03-10-simplify-langfuse-for-scale):
 
-LangSmith's primary strength is its vertical integration with the LangChain framework. Langfuse positions itself as an open and framework-agnostic platform built on [OpenTelemetry](https://opentelemetry.io/docs/) standards.
+- **1.** Initial table loads for large data volumes dropped from seconds to tens of milliseconds, and dashboard load times for large projects improved by at least 10x on longer time ranges.
+- **2.** The redesign carried a 19x year-over-year growth in processed data and a migration of petabytes of historic traces, done in collaboration with ClickHouse engineers, including a fix contributed upstream to ClickHouse itself.
+- **3.** Token-based full-text search across observation inputs and outputs runs directly on ClickHouse.
+- **4.** Compute and storage are decoupled: Langfuse's web and worker containers are stateless, and ClickHouse supports [object-storage-backed deployments that separate compute from storage](https://clickhouse.com/docs/guides/separation-storage-compute), the same architectural property SmithDB cites.
 
-| Feature        | Langfuse                                                                                           | LangSmith                                                                                     |
-| -------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **Standard**   | **[OpenTelemetry Native](/docs/observability/overview)**: SDKs built on OpenTelemetry.             | **Supported**: Supports OTel ingestion; features optimized for native SDK.                    |
-| **Frameworks** | Integrations with **100+ frameworks** and model providers (OpenAI, Vercel AI SDK, LangChain, etc.) | **Ecosystem Focused**: Deepest support for LangChain/LangGraph; others via wrappers and OTel. |
+A proprietary purpose-built store is a defensible engineering choice for a closed SaaS. The difference shows up when you operate the platform yourself: with Langfuse, the storage layer is a widely deployed database you can run, inspect, and query with SQL, operational expertise for it is hireable, and the same engine backs Langfuse Cloud and self-hosted deployments today.
+
+| Feature                      | Langfuse                                                                                                           | LangSmith                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| **Storage engine**           | **ClickHouse**: open source (Apache 2.0), operable and queryable by you.                                           | **SmithDB**: proprietary (Rust, DataFusion, Vortex), operated by LangChain. |
+| **Cloud/self-hosted parity** | Same engine and data model in Cloud and self-hosted.                                                               | SmithDB on US Cloud; self-hosted early access as of May 2026.               |
+| **Full-text search**         | [Yes](/docs/observability/features/full-text-search), on ClickHouse.                                               | Yes, via SmithDB.                                                           |
+| **Ingestion**                | Async queue (Redis) with stateless workers; ~60% of Cloud observations arrived via OpenTelemetry as of March 2026. | Stateless ingestion services over object storage.                           |
+
+## Integrations and framework coverage
+
+Both platforms now accept OpenTelemetry traces and instrument non-LangChain applications. The difference is degree: Langfuse's own SDKs are built on OpenTelemetry, while LangSmith's deepest, zero-setup integration remains LangChain and LangGraph, with OTel ingestion alongside its native SDK.
+
+| Feature        | Langfuse                                                                                                                         | LangSmith                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SDKs**       | [Python SDK v4 and JS/TS SDK v5](/docs/observability/sdk/overview), both built on OpenTelemetry; other languages via plain OTel. | Python and JS/TS SDKs; [OTel ingestion](https://docs.langchain.com/langsmith/trace-with-opentelemetry) supported (OTLP endpoint, OpenLLMetry conventions). |
+| **Frameworks** | Integrations with 100+ frameworks and model providers (OpenAI, Anthropic, Vercel AI SDK, LangChain, LlamaIndex, LiteLLM, etc.).  | Deepest support for LangChain/LangGraph (env-var setup); other frameworks via SDK wrappers and OTel.                                                       |
+| **Lock-in**    | Instrumentation is standard OTel; spans can be exported to any OTel-compatible backend.                                          | Native SDK is LangSmith-specific; OTel path reduces lock-in for ingestion.                                                                                 |
+
+## Evaluation and experiments
+
+Both platforms cover offline and online evaluation. Langfuse runs LLM-as-a-judge and deterministic code evaluators inside the platform and gates CI/CD pipelines on experiment results; LangSmith pairs its evals with dataset tooling and, since May 2026, LangSmith Engine for automated failure clustering.
+
+| Feature              | Langfuse                                                                                                                                                                            | LangSmith                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **LLM-as-a-judge**   | [Managed judges](/docs/evaluation/evaluation-methods/llm-as-a-judge) on observations, traces, and experiments; numeric, categorical, and boolean scores.                            | Managed and custom judges on runs and datasets.                                            |
+| **Code evaluators**  | [Deterministic Python/TypeScript evaluators](/docs/evaluation/evaluation-methods/code-evaluators) run in-platform, including self-hosted; structured access to recorded tool calls. | Inline Python custom code evaluators run in-platform on sampled runs (no internet access). |
+| **Experiments**      | Versioned dataset experiments with a [CI/CD GitHub Action](/docs/evaluation/experiments/experiments-ci-cd) that fails PRs on score regressions.                                     | Dataset experiments with comparison views; CI via SDK scripting.                           |
+| **Agent evaluation** | Tool-call fields exposed directly to evaluators (check names, arguments, order).                                                                                                    | Trajectory and tool-use evals; LangSmith Engine clusters production failures into issues.  |
+
+## Monitoring and alerting [#monitoring-alerting]
+
+Both platforms ship threshold-based alerting on production metrics as of July 2026.
+
+Langfuse [Monitors](/docs/metrics/features/monitors) watch metrics over observations and scores (for example average cost per trace, p95 latency, or an evaluation score), support separate warning and alert thresholds plus no-data handling, and route notifications to Slack, webhooks, or GitHub Actions workflows. Monitors are available on Langfuse Cloud.
+
+LangSmith [Alerts](https://docs.langchain.com/langsmith/alerts) fire on error rate, run latency, feedback score, or cost over 5- or 15-minute aggregation windows and route to PagerDuty, Dynatrace, or any webhook. Alerts are configured per project.
+
+| Feature          | Langfuse Monitors                                              | LangSmith Alerts                                     |
+| ---------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| **Metrics**      | Any observation or score metric with filters and aggregations. | Error rate, latency, feedback score, cost.           |
+| **Thresholds**   | Alert plus optional warning severity; no-data handling modes.  | Threshold over a 5- or 15-minute aggregation window. |
+| **Destinations** | Slack, webhooks, GitHub Actions.                               | PagerDuty, Dynatrace, webhooks.                      |
+| **Scope**        | Langfuse Cloud; configured per project.                        | Configured per project.                              |
 
 ## Pricing
 
-The economic models differ significantly. Langfuse charges based on the depth of data (Units), while LangSmith charges based on the volume of root executions (Traces).
+The economic models differ. Langfuse charges for the depth of ingested data (units), while LangSmith charges per seat plus per root execution (traces), with retention priced into the trace rate. Numbers below are as of July 2026.
 
-| Feature       | Langfuse                                                                                        | LangSmith                                                                              |
-| ------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| **Model**     | **[Unit-Based](/docs/administration/billable-units)**: 1 Unit = 1 Trace, Observation, or Score. | **Trace-Based**: Charges per root run (internal steps included).                       |
-| **Free Tier** | 50,000 units/mo                                                                                 | 5,000 traces/mo.                                                                       |
-| **Plans**     | [Free, Core ($29/mo), Pro ($199/mo), Enterprise](/pricing).                                     | [Developer (Free), Plus ($39/seat/mo), Enterprise](https://www.langchain.com/pricing). |
+| Feature         | Langfuse                                                                                                      | LangSmith                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Model**       | **[Unit-based](/docs/administration/billable-units)**: 1 unit = 1 trace, observation, or score. No seat fees. | **Seat + trace-based**: per-seat subscription plus per-trace charges.                                   |
+| **Free tier**   | 50,000 units/month (Hobby plan, 2 users).                                                                     | 5,000 base traces/month (Developer plan, 1 seat, 14-day retention).                                     |
+| **Paid plans**  | [Core $29/mo, Pro $199/mo, Enterprise](/pricing); 100k units included, then $8/100k units (volume discounts). | [Plus $39/seat/mo](https://www.langchain.com/pricing) with 10k base traces included; Enterprise custom. |
+| **Usage rate**  | $8 per 100k units after included volume, independent of retention plan.                                       | $2.50 per 1k base traces (14-day retention); $5.00 per 1k extended traces (400-day retention).          |
+| **Self-hosted** | Free (MIT, all core features); Enterprise Edition license optional.                                           | Enterprise contract required.                                                                           |
 
-## Open Platform & Extensibility
+## Open platform and extensibility
 
-Langfuse is API-first, allowing teams to treat observability data as their own. LangSmith focuses on extending the LangChain ecosystem via the Hub.
+Langfuse is API-first, so teams can treat observability data as their own. LangSmith exposes APIs for traces and datasets within its managed platform.
 
-| Feature         | Langfuse                                                                                                                           | LangSmith                                                   |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| **API Access**  | **API first**: Full CRUD for Traces, Spans, Scores, and platform features.                                                         | **Read/Write**: API available to query traces and datasets. |
-| **Data Export** | **[Blob Storage Export](/docs/api-and-data-platform/features/export-to-blob-storage)**: Automated dumps to S3/GCP (JSONL/Parquet). | **Bulk Export**: Available on paid plans.                   |
+| Feature         | Langfuse                                                                                                                           | LangSmith                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **API access**  | **API-first**: full CRUD for traces, observations, scores, prompts, and platform features; v2 high-scale query APIs.               | **Read/write**: API to query traces and manage datasets. |
+| **Data export** | **[Blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage)**: automated dumps to S3/GCS (JSONL/Parquet). | **Bulk export**: available on paid plans.                |
 
-## Enterprise Security
+## Enterprise security
 
-Both platforms are enterprise-ready with major certifications. Langfuse offers ISO 27001 in addition to SOC 2, and allows for easier air-gapped compliance via open-source self-hosting.
+Both platforms are enterprise-ready with major certifications. Langfuse adds ISO 27001 to SOC 2 Type II and offers a fully air-gapped compliance path through open-source self-hosting.
 
 | Feature            | Langfuse                                                                                                                   | LangSmith                                                                       |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| **Certifications** | [SOC 2 Type II, ISO 27001](/security), GDPR, HIPAA-ready region.                                                           | [SOC 2 Type II, GDPR, HIPAA](https://docs.langchain.com/langsmith/pricing-faq). |
-| **Adoption**       | Trusted by **19 of Fortune 50** & 63 of Fortune 500.                                                                       | Wide adoption among LangChain enterprise users.                                 |
+| **Certifications** | [SOC 2 Type II, ISO 27001](/security), GDPR; dedicated HIPAA-ready region.                                                 | [SOC 2 Type II, GDPR, HIPAA](https://docs.langchain.com/langsmith/regions-faq). |
+| **Data regions**   | EU, US, and Japan cloud regions plus a separate HIPAA region; any region via self-hosting.                                 | US and EU cloud regions; other regions via Enterprise self-hosting.             |
+| **Adoption**       | Trusted by **19 of Fortune 50** and 63 of Fortune 500.                                                                     | Wide adoption among LangChain enterprise users.                                 |
 | **Governance**     | [SSO](/docs/administration/authentication-and-sso), [RBAC](/docs/administration/rbac) available in Teams/Enterprise plans. | SSO, RBAC available in Enterprise plans.                                        |
 
-## Feature Highlights
+## Feature highlights
 
 **Langfuse:**
 
-- **[Model Agnosticism](/docs/integrations/overview):** Works equally well with OpenAI SDK, LiteLLM, LlamaIndex, or raw HTTP calls.
-- **[Prompt Management](/docs/prompt-management/overview):** Agnostic playground that doesn't lock you into a specific framework's syntax.
-- **[Evaluations](/docs/evaluation/overview):** "LLM-as-a-judge" evaluators that run on your own infrastructure or via the managed service.
-- **[ClickHouse Native](/blog/2024-12-langfuse-v3-infrastructure-evolution):** Unrestricted access to raw data via SQL (in self-hosted) for custom analytics.
+- **[Agent graph views](/docs/observability/features/agent-graphs)** render a trace as a graph of steps, with an aggregated overview mode and an expanded as-it-ran mode for multi-agent debugging.
+- **[Prompt management](/docs/prompt-management/overview)** provides versioning, deployment labels, and a playground without tying you to one framework's syntax.
+- **[Evaluations](/docs/evaluation/overview)** combine LLM-as-a-judge, in-platform code evaluators, and human annotation, with experiment gates in CI/CD.
+- **[ClickHouse-native analytics](/blog/2026-03-10-simplify-langfuse-for-scale)** give unrestricted raw SQL access to your data when self-hosting.
 
 **LangSmith:**
 
-- **[LangGraph Deployment](https://www.langchain.com/langsmith/deployment):** A specialized runtime to deploy LangGraph agents as APIs (DevOps capabilities).
-- **Zero-Setup Tracing:** Automatic instrumentation for LangChain applications via environment variables.
-- **[The Hub](https://smith.langchain.com/hub):** Access to a community repository of prompts.
+- **[LangSmith Deployment](https://www.langchain.com/langsmith/deployment)** runs LangGraph agents as managed, durable APIs, complemented by Managed Deep Agents since May 2026.
+- **Zero-setup tracing** instruments LangChain applications through environment variables alone.
+- **Interrupt 2026 additions** include LangSmith Engine (automated failure clustering with proposed fixes), Context Hub (versioned agent instructions), and an LLM Gateway.
+
+## Which should you choose
+
+Choose **Langfuse** if you need to self-host with full feature parity, run a mixed or non-LangChain stack on OpenTelemetry, want your observability data in an open database you can query directly, or prefer usage-based pricing without seat fees.
+
+Choose **LangSmith** if your team builds primarily on LangChain and LangGraph, wants tracing enabled by environment variables alone, and values a single managed vendor for observability plus agent deployment infrastructure, with self-hosting reserved for Enterprise contracts.
+
+## FAQ [#faq]
+
+### Is LangSmith free? [#is-langsmith-free]
+
+LangSmith has a free Developer plan with one seat and 5,000 base traces per month at 14-day retention (as of July 2026). Beyond that, base traces cost $2.50 per 1,000, extended 400-day retention traces cost $5.00 per 1,000, and the Plus plan is $39 per seat per month. It is free to start but not free software: the platform is proprietary and self-hosting requires an Enterprise contract. Langfuse's free tier includes 50,000 units per month, and the MIT-licensed open-source version is free to self-host without feature gates.
+
+### Is LangSmith open source? [#is-langsmith-open-source]
+
+No. The LangSmith platform (backend, UI, and storage layer, including SmithDB) is closed source. The LangChain and LangGraph frameworks and the LangSmith client SDKs are open source under MIT, which is a common point of confusion. Langfuse is open source end to end: the full platform is MIT-licensed and [self-hostable](/self-hosting).
+
+### Does LangSmith require LangChain? [#does-langsmith-require-langchain]
+
+No. LangSmith traces applications built without LangChain through its SDKs and accepts OpenTelemetry traces via an OTLP endpoint (as of July 2026). Its lowest-friction path remains LangChain/LangGraph, where tracing activates via environment variables. Langfuse is likewise framework-agnostic, with SDKs built on OpenTelemetry and integrations for 100+ frameworks and model providers.
+
+### What is SmithDB? [#what-is-smithdb]
+
+SmithDB is LangSmith's proprietary trace database, announced in May 2026 and written in Rust on Apache DataFusion and the Vortex file format, with trace data on object storage. LangChain reports it makes core LangSmith experiences up to 15x faster; at announcement, self-hosted availability was early access only. Langfuse achieves its scale characteristics on open-source ClickHouse with an observations-first immutable data model, so cloud and self-hosted deployments run the same engine.
 
 <Callout type="info">
   This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.

--- a/content/resources/engineering/llm-evaluation-strategy.mdx
+++ b/content/resources/engineering/llm-evaluation-strategy.mdx
@@ -1,0 +1,191 @@
+---
+title: How to build an LLM evaluation strategy
+description: "How to build an LLM evaluation strategy: quality dimensions from failure modes, evaluator selection, CI release gates, production monitoring, and human review."
+tags: [guide, evaluation]
+---
+
+# How to build an LLM evaluation strategy
+
+Most LLM evaluation content explains methods: what a judge prompt looks like, how to compute similarity, when exact match is enough. Rolling evaluation out across a team is a different problem. Someone has to decide which dimensions of quality matter for this application, which method measures each one, what score blocks a release, and what evidence exists when leadership asks how you know the system works. This guide covers that rollout, step by step, with Langfuse as the worked example.
+
+**TL;DR:** An LLM evaluation strategy assigns every quality dimension you care about to the cheapest method that measures it reliably, then wires those measurements into the points where decisions happen: experiments before merging, gates in CI, sampled evaluators on production traffic, and a human review loop for the judgments automation cannot make. Build it in six steps: derive dimensions from observed failure modes, pick a method per dimension, establish an offline baseline with datasets and experiments, gate changes in CI, monitor production with sampled evaluators and alerts, and close the loop by turning production failures into new test cases.
+
+## Why teams need a strategy, not just evaluators
+
+An evaluator without a decision attached produces a number nobody acts on. Teams that "have evals" but cannot say what happens when a score drops have monitoring, not a strategy. A strategy specifies, for every quality dimension:
+
+1. **What** is measured, defined precisely enough that two people would score the same trace the same way.
+2. **How** it is measured: deterministic code, a model judge, or a human reviewer.
+3. **When** it is measured: in experiments before release, on production traffic, or both.
+4. **What happens** when the measurement crosses a threshold: the release is blocked, an alert fires, or a reviewer gets the trace.
+
+This mapping is also the artifact you show people who do not read traces. Engineering leadership wants to know whether the next release regresses quality, and teams operating under regulatory obligations need to show who checked what. "We run a hallucination judge" answers neither; a documented dimension-to-method-to-threshold mapping answers both. The [evaluation core concepts](/docs/evaluation/core-concepts) page covers the underlying building blocks; the rest of this guide is about assembling them.
+
+## Step 1: Define quality dimensions from real failure modes
+
+Derive dimensions from traces, not from a metric catalog. Generic metrics like "coherence" produce scores that never change and never trigger action. Instead, read 50 to 100 real interactions from production or a pilot and write down what actually went wrong. Each recurring failure becomes a candidate dimension:
+
+- The assistant answered a question it should have escalated, which becomes a boolean `out_of_scope_handled` score.
+- The answer omitted a required disclaimer, which becomes a boolean `disclosure_present` score.
+- The response contradicted the retrieved documents, which becomes a numeric `faithfulness` score.
+- The agent called the wrong tool or looped, which becomes trajectory checks like `used_required_tool` and `within_step_budget`.
+
+Resist compound dimensions. A single 1-to-5 "compliance" score hides exactly the information a reviewer needs, so split it into sub-scores, one per named criterion: whether the answer stayed inside the advice boundary, whether required disclosures appeared, whether the tone fit the audience. In Langfuse, each sub-score is its own score config (boolean, categorical, or numeric), and because automated evaluators and human annotators write to the same score configs, their results stay comparable on one timeline.
+
+Start with three to five dimensions. Every dimension you define creates evaluators to maintain and thresholds to argue about, and a short list you act on beats a long list you ignore.
+
+## Step 2: Choose an evaluation method per dimension
+
+Use the cheapest method that measures the dimension reliably: code where the check is decidable, an LLM judge where the check requires reading, and humans where the check requires domain accountability or produces ground truth.
+
+| Method           | Right for                                                                              | Cost and latency             | Consistency                                      |
+| ---------------- | -------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------ |
+| Code evaluators  | Format validation, policy patterns, numeric tolerance, trajectory and tool-call checks | No LLM cost, milliseconds    | Deterministic, same verdict every time           |
+| LLM-as-a-judge   | Faithfulness, helpfulness, tone, reasoning quality                                     | Per-call LLM cost, seconds   | Consistent with a good rubric, not deterministic |
+| Human annotation | Ground truth, judge calibration, domain and compliance sign-off                        | Reviewer time, hours to days | Authoritative, varies between reviewers          |
+
+The strongest setups chain the three: a free deterministic screen runs on everything, the judge runs on what the screen flags plus a sample of the rest, and humans review where the judge is uncertain or the stakes are high. Our [code evaluator examples](/resources/engineering/code-evaluator-examples) page has ten paste-ready deterministic checks to start from. For agent applications, evaluators can read recorded tool calls through a dedicated structured field (available since July 2026), so trajectory dimensions like "did the agent call search before answering" are decidable in code rather than requiring a judge.
+
+## Step 3: Build the offline foundation: datasets, experiments, and CI gates
+
+Before improving anything, establish what current quality is. That takes three pieces:
+
+1. **A dataset that represents reality.** Build it from real traces, not invented examples: in Langfuse you can add any production observation to a [dataset](/docs/evaluation/experiments/datasets) directly from the UI, including batch selection from the observations table. Add hand-written edge cases for the failures you fear but have not seen yet. Expected outputs can come from domain experts correcting real outputs.
+2. **Experiments as the comparison mechanism.** An experiment runs your application against the dataset and applies your evaluators to every output. The first run against your current version is the baseline; every prompt change, model swap, and retrieval tweak afterwards is a comparison against it, not a matter of opinion.
+3. **A gate in CI.** Once experiments exist, run them on every release so a quality regression fails the build the same way a broken unit test does.
+
+For GitHub, the [experiments in CI/CD](/docs/evaluation/experiments/experiments-ci-cd) setup uses `langfuse/experiment-action`: it loads the dataset (optionally pinned to a version for reproducible runs), executes your experiment script, posts the scores as a PR comment, and fails the job when your script raises `RegressionError`:
+
+```python
+from langfuse import Evaluation, RegressionError, RunnerContext
+
+THRESHOLD = 0.95
+
+
+def answer_support_question(item, **kwargs):
+    ...  # call your application with the dataset item
+
+
+def exact_match(*, output, expected_output, **kwargs):
+    passed = output.strip() == (expected_output or "").strip()
+    return Evaluation(name="exact_match", value=1.0 if passed else 0.0)
+
+
+def avg_accuracy(*, item_results, **kwargs):
+    scores = [
+        e.value
+        for r in item_results
+        for e in r.evaluations
+        if e.name == "exact_match" and isinstance(e.value, (int, float))
+    ]
+    return Evaluation(name="avg_accuracy", value=sum(scores) / len(scores) if scores else 0.0)
+
+
+def experiment(context: RunnerContext):
+    result = context.run_experiment(
+        name="PR gate: support agent",
+        task=answer_support_question,
+        evaluators=[exact_match],
+        run_evaluators=[avg_accuracy],
+    )
+    accuracy = next(
+        (e.value for e in result.run_evaluations if e.name == "avg_accuracy"),
+        None,
+    )
+    if not isinstance(accuracy, (int, float)) or accuracy < THRESHOLD:
+        raise RegressionError(
+            result=result,
+            metric="avg_accuracy",
+            value=float(accuracy) if isinstance(accuracy, (int, float)) else 0.0,
+            threshold=THRESHOLD,
+        )
+    return result
+```
+
+On other CI systems, the same experiment runner works inside Pytest or Vitest, with threshold assertions failing the test suite. Keep the gate dataset small enough to run on every PR (tens to low hundreds of items) and reserve the full regression set for release branches.
+
+## Step 4: Monitor production with sampled evaluators and alerts
+
+Offline evaluation only covers inputs you thought to test, and production traffic will not match your dataset's distribution for long. The online half of the strategy runs evaluators on live traffic:
+
+- **Sampled judges on live observations.** [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) run on production observations matching your filters, with a sampling percentage to control cost. Sampling 5 to 10 percent of traffic is usually enough to see quality trends without paying to judge everything.
+- **Routing evaluators by intent.** Different conversation types deserve different rubrics: an evaluator that scores product advice makes no sense on a billing question. Classify intent in your application, write it to the trace as a tag or metadata, and create one evaluator per intent with a matching filter. Each evaluator then judges only the traffic its rubric was written for.
+- **Alerts on score thresholds.** [Monitors](/docs/metrics/features/monitors) (on Langfuse Cloud) evaluate numeric or categorical score metrics against warning and alert thresholds over a time window, and route breaches to Slack, webhooks, or a GitHub Actions trigger. A falling faithfulness average pages someone before users complain.
+
+One boundary to respect: online evaluator scores are produced asynchronously, after the response has shipped. They are for detecting regressions, routing traces to review, and building datasets, not for blocking a bad answer in flight. If a check must change behavior at request time, it belongs in your application code as a guardrail, and that guardrail's decisions then get evaluated like everything else.
+
+## Step 5: Run the human review loop
+
+Automated scores tell you the trend; humans define what "good" means and catch what rubrics miss. [Annotation queues](/docs/evaluation/evaluation-methods/annotation-queues) make this a workflow instead of screen-sharing: you define which score configs a queue uses, assign reviewers, and route traces, observations, or whole sessions into it for structured scoring.
+
+Four practices make the loop work in a team setting:
+
+- **Human and automated scores share score configs.** Because annotators write to the same score dimensions as your judges, you can put both on one chart, spot where they disagree, and use the human scores as the calibration reference.
+- **Different reviewer groups get different queues.** Engineers can triage flagged traces in one queue while domain or compliance reviewers score the same traffic in a separate queue against their own sub-score criteria. Assignment, score configs, and progress are per queue, so each group sees only the review job meant for them.
+- **Reviewers capture corrections, not just scores.** A reviewer who marks an output wrong can also record what the output should have been via [corrections](/docs/observability/features/corrections). Corrected outputs are exactly the expected outputs your datasets need.
+- **Scoring works retroactively.** Reviewers can annotate historical traces at any time, and automated evaluators can backfill scores over historical observations from the traces table. A criterion you defined this week can still be measured against last quarter's traffic.
+
+The question every team eventually asks is when human review can be reduced in favor of automated thresholds. The mechanism is calibration: have humans and the judge score the same items, measure agreement per dimension, and iterate on the rubric until agreement is stable. Where the judge has earned trust, shift humans from reviewing everything to reviewing judge-flagged items, disagreement cases, and a random sample that verifies the judge itself has not drifted. How much residual human coverage your obligations require is a policy decision for your organization; the strategy's job is to make the trade-off measurable instead of rhetorical.
+
+## Step 6: Close the loop from production failures to the next release
+
+Measurement only pays off when it changes the application. The loop that connects the previous steps:
+
+1. A production trace fails: a score crosses a threshold, an alert fires, or a reviewer flags it.
+2. The trace goes into a dataset, with a corrected expected output where a reviewer supplied one. Your regression set now contains this failure forever.
+3. You iterate on the prompt (or retrieval, or tool definitions) and run an experiment against the updated dataset, comparing the candidate to the current baseline.
+4. If the experiment wins, you promote the change. For prompts managed in Langfuse, promotion means moving the `production` label to the new version; [protected labels](/docs/prompt-management/features/prompt-version-control) restrict who can move it, so an experiment result plus an authorized approver becomes your promotion gate. (Label protection requires the Teams add-on, an Enterprise plan, or self-hosted EE.)
+5. The CI gate from step 3 keeps the fix from silently regressing later.
+
+Each pass through the loop grows the dataset, tightens the evaluators, and makes the next incident shorter. If your team is new to the underlying features, [Langfuse Academy](/academy) walks through this loop end to end, from tracing through datasets and experiments to production monitoring.
+
+## What the strategy produces as evidence in regulated environments
+
+Teams under financial-conduct, consumer-protection, or similar obligations need to demonstrate, not assert, that AI features are quality-controlled. The strategy above produces that evidence as a side effect when four properties hold:
+
+- **Everything is versioned.** Prompts are versioned with labeled deployments, datasets are versioned, and every experiment records which prompt version ran against which dataset version and what it scored. "What was live in March and how did we know it was safe" becomes a lookup, not an archaeology project.
+- **Gates are deterministic where possible.** A code evaluator returns the same verdict on the same input every time, so a release blocked (or passed) by a threshold is a reproducible fact. Deterministic gates are much easier to defend than "the judge felt differently that day."
+- **Every score has an author.** Scores record their source: which evaluator, which pipeline, or which human reviewer. Compliance sub-scores from a named reviewer on a specific trace are per-criterion evidence, which is stronger than a bare approval. On Enterprise plans and self-hosted EE, [audit logs](/docs/administration/audit-logs) additionally record who changed evaluators, prompts, and configuration, with before and after state.
+- **Review coverage is measurable.** Because human review runs through queues with defined score configs, you can state what percentage of traffic was reviewed, by whom, against which criteria, and how reviewer scores tracked automated ones.
+
+Which artifacts your specific regulator expects is a question for your compliance team, not for an engineering guide. The engineering job is to make sure the artifacts exist by construction, so that answering the question does not require a manual evidence-gathering scramble.
+
+## If you already run an in-house evaluation loop
+
+Many teams arrive with a homegrown setup: scripts that score outputs, or an application that critiques and retries its own answers. Keep what works. External evaluation pipelines can [write scores to Langfuse via the SDK](/docs/evaluation/evaluation-methods/scores-via-sdk), so an in-house evaluator coexists with platform-managed ones and its results land on the same traces.
+
+What a platform adds on top of a working loop is mostly organizational:
+
+- **Shared visibility.** Scores live next to the traces they judge, where engineers, product, and reviewers all look, instead of in a notebook one person owns.
+- **Datasets built from production without glue code.** Turning a failed trace into a regression test is a UI action rather than an export script.
+- **Gates maintained as configuration.** CI experiment gates, sampling rates, and thresholds are declared and versioned rather than living in bespoke scripts that decay.
+- **Review tooling you do not have to build.** Annotation queues, reviewer assignment, and score configs replace the internal labeling tool that nobody wants to maintain.
+- **An audit trail.** Score history, versioned prompts and datasets, and (on Enterprise) audit logs exist without extra work.
+
+One distinction worth drawing: a self-repair loop inside the application, where the model critiques and retries its own output, is a runtime behavior, not an evaluation strategy. It changes individual answers, but it cannot tell you whether quality is trending up, whether the retry step actually helps, or what to show a reviewer. You still need external measurement of the system, self-repair included.
+
+## FAQ
+
+### How many quality dimensions should an evaluation strategy start with? [#how-many-dimensions]
+
+Start with three to five, each derived from a failure mode you have observed in real traces. Every dimension carries ongoing cost: an evaluator to maintain, a threshold to defend, and alerts to triage. Expand the list when a new failure mode appears in production, not preemptively.
+
+### Can multiple people review and score the same trace? [#multiple-reviewers]
+
+Yes. Annotation queues in Langfuse support assigning multiple reviewers, and the same traces can be routed to separate queues with different score configs, for example an engineering triage queue and a compliance review queue with its own sub-score criteria. Each score records who created it, so parallel reviews stay attributable.
+
+### Can we score traces retroactively? [#retroactive-scoring]
+
+Yes, in two ways. Humans can annotate any historical trace, observation, or session at any time, and automated evaluators can backfill scores over historical observations by selecting them in the traces table and running an evaluation on the selection (this requires the evaluator's Fast Mode setting). This means a newly defined criterion can be measured against past traffic instead of starting from zero.
+
+### When can automated thresholds replace human review? [#automated-thresholds]
+
+After calibration, and usually partially rather than completely. Have humans and your LLM judge score the same items, measure agreement per dimension, and refine the rubric until agreement is stable. Then reduce human coverage to judge-flagged items, disagreements, and a verification sample; how much residual review you keep for high-stakes flows is a policy decision your measurements should inform.
+
+### How do we evaluate multi-turn conversations rather than single responses? [#multi-turn]
+
+Scores in Langfuse can attach to sessions, not just traces and observations, and annotation queues accept sessions, so human reviewers can score a whole conversation. For automated judges, target an observation that records the full conversation context you want judged, since evaluators read the data present on their target.
+
+### What is the difference between offline and online evaluation? [#offline-vs-online]
+
+Offline evaluation runs your application against a fixed dataset in experiments, before changes ship, and is where baselines and CI gates live. Online evaluation scores live production traffic, sampled to control cost, and is where drift, regressions, and unexpected inputs surface. A complete strategy needs both, connected by datasets that grow from production failures.

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -6,12 +6,17 @@
     "best-phoenix-arize-alternatives",
     "best-galileo-ai-alternatives",
     "best-braintrustdata-alternatives",
+    "langfuse-vs-datadog",
     "migrate-from-helicone",
+    "migrate-from-braintrust",
     "migrate-from-phoenix",
     "llm-gateway",
     "coding-agent-tracing",
     "opentelemetry-languages",
     "pii-masking-llm-applications",
-    "code-evaluator-examples"
+    "code-evaluator-examples",
+    "ai-agent-evaluation",
+    "llm-evaluation-strategy",
+    "chatbot-intent-analytics"
   ]
 }

--- a/content/resources/engineering/migrate-from-braintrust.mdx
+++ b/content/resources/engineering/migrate-from-braintrust.mdx
@@ -1,0 +1,365 @@
+---
+title: Migrate from Braintrust to Langfuse
+description: "Step-by-step guide to migrate from Braintrust to Langfuse: swap SDK instrumentation, export datasets via API, keep autoevals scorers, and re-run experiments."
+tags: [migration, guide]
+---
+
+# Migrate from Braintrust to Langfuse
+
+This guide walks through migrating LLM observability and evaluation from
+[Braintrust](https://www.braintrust.dev) to [Langfuse](/): instrumentation first, then
+datasets, experiments, prompts, and online scoring.
+
+**TL;DR:** Braintrust and Langfuse share the same core concepts (projects, logs/traces,
+datasets, experiments, scorers), so this is a re-pointing exercise rather than a redesign.
+Instrumentation is a wrapper swap: `wrap_openai` becomes Langfuse's OpenAI drop-in and
+`@traced` becomes `@observe`. Datasets export through Braintrust's REST API or SDK and import
+via the Langfuse SDK. Your autoevals scorers run in Langfuse experiments without a rewrite,
+because Langfuse integrates the autoevals library directly. Historical logs usually stay
+behind; experiments re-run against the migrated datasets.
+
+## Why teams migrate
+
+Teams tend to evaluate a Braintrust-to-Langfuse move for a few recurring reasons:
+
+- **Open source and full self-hosting.** Langfuse's core is MIT-licensed open source, and
+  [self-hosting](/self-hosting) runs the entire stack (UI, API, and data) in your own
+  infrastructure. Braintrust's self-hosted option is a hybrid model: you deploy the data
+  plane into your own AWS or Azure account via Terraform while Braintrust hosts the control
+  plane (web app and metadata), as described in their
+  [architecture docs](https://www.braintrust.dev/docs/reference/platform/architecture)
+  (as of July 2026). The hybrid model keeps your event data in your environment, but a fully
+  self-contained or air-gapped deployment is only possible with software you can run
+  end-to-end.
+- **Billing that follows request counts.** Langfuse Cloud bills on counted units (traces,
+  observations, scores) with [public pricing](/pricing) starting free at 50k units per month.
+  Braintrust bills primarily on processed data, measured in GB ingested across logs,
+  experiments, and datasets, with paid plans starting at $249 per month
+  ([Braintrust pricing](https://www.braintrust.dev/pricing), as of July 2026). Byte-based
+  billing scales with payload size rather than request count, which matters if your traces
+  carry large contexts or attachments.
+- **Ingestion-level sampling.** Langfuse SDKs include a built-in
+  [sample rate](/docs/observability/features/sampling) (`LANGFUSE_SAMPLE_RATE`) that keeps a
+  configurable fraction of traces at the source, a direct dial for controlling volume and
+  cost on high-traffic applications.
+
+Braintrust remains a polished platform with a tight evaluation loop, a capable playground,
+and a managed hybrid deployment, and if it serves your team well there is no urgency to
+move. This guide is for teams that have decided to consolidate on Langfuse. For a
+feature-by-feature comparison, see [Langfuse vs. Braintrust](/resources/engineering/best-braintrustdata-alternatives).
+
+## Concept mapping
+
+Braintrust and Langfuse map almost one-to-one, which keeps the mental migration small:
+
+| Braintrust                                | Langfuse                                                                                                                                      | Notes                                                      |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Project                                   | Project                                                                                                                                       | Langfuse adds organizations above projects                 |
+| Logs (production traces and spans)        | [Traces / observations](/docs/observability/data-model)                                                                                       | Hierarchical span trees in both                            |
+| Experiments                               | [Experiments / dataset runs](/docs/evaluation/experiments/experiments-via-sdk)                                                                | Runs linked to dataset items and scores                    |
+| Datasets                                  | [Datasets](/docs/evaluation/experiments/datasets)                                                                                             | `input` / `expected` / `metadata` in both                  |
+| Scorers (autoevals, LLM-as-a-judge, code) | [LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) + [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) | autoevals scorers work directly in Langfuse experiments    |
+| Human review                              | [Annotation queues](/docs/evaluation/evaluation-methods/annotation-queues)                                                                    | Structured human scoring on traces                         |
+| Playgrounds                               | [Playground](/docs/prompt-management/features/playground)                                                                                     | Iterate on prompts against real traces                     |
+| Prompts                                   | [Prompt management](/docs/prompt-management)                                                                                                  | Versions and deployment labels via SDK                     |
+| Gateway (formerly AI proxy)               | Not needed; pair with a gateway like [LiteLLM](/integrations/gateways/litellm) if you want one                                                | Langfuse observes asynchronously, outside the request path |
+| BTQL                                      | [Metrics API](/docs/metrics/features/metrics-api) and [custom dashboards](/docs/metrics/features/custom-dashboards)                           | Aggregated metrics via REST API and in-UI dashboards       |
+
+One architectural difference is worth knowing before you start: Braintrust's optional
+[gateway](https://www.braintrust.dev/docs/deploy/gateway) (which replaced its deprecated AI
+proxy) sits in the request path between your app and the model providers. Langfuse never
+proxies your LLM calls. The SDKs batch and send telemetry asynchronously, so a Langfuse
+outage cannot add latency to or drop your production traffic.
+
+## Step 1: Switch instrumentation
+
+Both platforms instrument the same way: wrap your model client, decorate your functions. The
+migration is a package swap.
+
+### Python
+
+```python
+# Before (Braintrust)
+from braintrust import init_logger, traced, wrap_openai
+from openai import OpenAI
+
+logger = init_logger(project="my-app")
+client = wrap_openai(OpenAI())
+
+@traced
+def answer(question: str) -> str:
+    response = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": question}]
+    )
+    return response.choices[0].message.content
+```
+
+```python
+# After (Langfuse)
+from langfuse import observe
+from langfuse.openai import OpenAI  # drop-in replacement, traces every call
+
+client = OpenAI()
+
+@observe()
+def answer(question: str) -> str:
+    response = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": question}]
+    )
+    return response.choices[0].message.content
+```
+
+Configuration moves from `BRAINTRUST_API_KEY` to Langfuse's key pair
+(`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`). There is no
+`init_logger` equivalent to call: the project is determined by the API keys. Nesting works
+the same way as in Braintrust: `@observe` on outer functions produces the trace hierarchy,
+and the wrapped OpenAI client attaches generations to the active span.
+
+### TypeScript
+
+The Langfuse JS/TS SDK is built on OpenTelemetry, so setup registers a span processor once,
+then wraps clients and functions like Braintrust does:
+
+```typescript
+// Before (Braintrust)
+import { initLogger, wrapOpenAI, wrapTraced } from "braintrust";
+import OpenAI from "openai";
+
+const logger = initLogger({ projectName: "my-app" });
+const client = wrapOpenAI(new OpenAI());
+
+const answer = wrapTraced(async function answer(question: string) {
+  const response = await client.chat.completions.create({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: question }],
+  });
+  return response.choices[0].message.content;
+});
+```
+
+```typescript
+// After (Langfuse)
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { observe } from "@langfuse/tracing";
+import { observeOpenAI } from "@langfuse/openai";
+import OpenAI from "openai";
+
+const sdk = new NodeSDK({ spanProcessors: [new LangfuseSpanProcessor()] });
+sdk.start();
+
+const client = observeOpenAI(new OpenAI());
+
+const answer = observe(
+  async function answer(question: string) {
+    const response = await client.chat.completions.create({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: question }],
+    });
+    return response.choices[0].message.content;
+  },
+  { name: "answer" },
+);
+```
+
+Both SDKs cover the same ground beyond OpenAI: Langfuse has
+[native integrations](/integrations) for Anthropic, LangChain, the Vercel AI SDK, LiteLLM,
+Pydantic AI, and 100+ other frameworks and providers, so wrapper-based instrumentation
+(`wrap_anthropic`, `wrap_litellm`, and friends) has a direct counterpart.
+
+### If you instrumented via OpenTelemetry
+
+If you used Braintrust's OTel integration (`braintrust[otel]` in Python or
+`@braintrust/otel` in JS) or exported spans from an OTel collector, you do not need to touch
+instrumentation at all. Point the OTLP exporter at
+[Langfuse's endpoint](/integrations/native/opentelemetry) instead:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"  # EU region
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
+```
+
+`AUTH_STRING` is your base64-encoded project keys
+(`echo -n "pk-lf-...:sk-lf-..." | base64`). Langfuse accepts OTLP over HTTP in protobuf and
+JSON encodings (no gRPC). Running both exporters in parallel during a validation window is a
+common way to de-risk the cutover.
+
+While you are configuring the SDK, decide on a
+[sample rate](/docs/observability/features/sampling). `LANGFUSE_SAMPLE_RATE=0.1` keeps 10% of
+traces, which is often enough for monitoring high-volume endpoints while cutting ingestion
+cost proportionally. The default is 1.0 (keep everything).
+
+## Step 2: Export and recreate datasets
+
+Braintrust datasets export cleanly through its API or SDK, and the record shapes map
+directly onto Langfuse dataset items:
+
+| Braintrust field | Langfuse field                                                |
+| ---------------- | ------------------------------------------------------------- |
+| `input`          | `input`                                                       |
+| `expected`       | `expected_output`                                             |
+| `metadata`       | `metadata`                                                    |
+| `tags`           | `metadata` (no dedicated column; keep them as a metadata key) |
+
+A common migration path is a short script that iterates each Braintrust dataset and inserts
+the rows into Langfuse:
+
+```python
+from braintrust import init_dataset
+from langfuse import get_client
+
+langfuse = get_client()
+langfuse.create_dataset(name="golden-set")
+
+# init_dataset fetches an existing dataset; iterating yields all records
+for row in init_dataset(project="my-app", name="golden-set"):
+    langfuse.create_dataset_item(
+        dataset_name="golden-set",
+        input=row["input"],
+        expected_output=row.get("expected"),
+        metadata={**(row.get("metadata") or {}), "tags": row.get("tags")},
+    )
+```
+
+If you prefer working against the REST API (for example, from a language without a
+Braintrust SDK), the export endpoints are `GET /v1/dataset` to list datasets and
+`GET /v1/dataset/{dataset_id}/fetch` to page through records with a cursor, authenticated
+via `Authorization: Bearer <api key>` against `https://api.braintrust.dev` (per Braintrust's
+[OpenAPI spec](https://github.com/braintrustdata/braintrust-openapi), as of July 2026). The
+fetch endpoint also accepts a `version` parameter if you need a snapshot of a dataset as of
+a past point in time.
+
+Langfuse [datasets](/docs/evaluation/experiments/datasets) support folders, JSON schema
+validation on `input` and `expectedOutput`, and media attachments, so structure that lived
+in Braintrust conventions can usually become explicit during the import.
+
+## Step 3: Re-run experiments and keep your autoevals scorers
+
+Braintrust experiments are defined with `Eval(name, data, task, scores)` and run via the
+`braintrust eval` CLI. The Langfuse equivalent is the
+[experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk): a plain script
+that loops your task over a dataset and applies evaluators, with concurrency, tracing, and
+error isolation handled for you.
+
+The scorers you wrote with [autoevals](https://github.com/braintrustdata/autoevals) carry
+over as-is. Langfuse ships a converter that makes any autoevals scorer a Langfuse evaluator:
+
+```python
+# Before (Braintrust)
+from braintrust import Eval
+from autoevals.llm import Factuality
+
+Eval(
+    "my-app",
+    data=load_examples,
+    task=answer,
+    scores=[Factuality],
+)
+```
+
+```python
+# After (Langfuse): same scorer, no rewrite
+from langfuse import get_client
+from langfuse.experiment import create_evaluator_from_autoevals
+from autoevals.llm import Factuality
+
+langfuse = get_client()
+dataset = langfuse.get_dataset("golden-set")
+
+def task(*, item, **kwargs):
+    return answer(item.input)  # your existing application logic
+
+result = dataset.run_experiment(
+    name="post-migration-baseline",
+    task=task,
+    evaluators=[create_evaluator_from_autoevals(Factuality())],
+)
+print(result.format())
+```
+
+The TypeScript SDK provides the same bridge via `createEvaluatorFromAutoevals` from
+`@langfuse/client`. Two differences to note when porting:
+
+- **Task signature.** Braintrust tasks receive the raw `input`; Langfuse tasks receive the
+  full dataset `item` (with `item.input`, `item.expected_output`, `item.metadata`).
+- **Runner.** There is no dedicated CLI; experiments are ordinary Python/TS scripts, which
+  makes them straightforward to [run in CI/CD](/docs/evaluation/experiments/experiments-ci-cd)
+  as regression gates.
+
+Historical Braintrust experiment results are best kept as an archived reference rather than
+imported: scores are cheap to regenerate against the migrated datasets, and score
+comparability across tools is shaky anyway. Re-run your latest baseline experiment in
+Langfuse right after the dataset import so future runs have an anchor.
+
+## Step 4: Recreate prompts, online scorers, and review workflows
+
+- **Prompts.** Export prompt definitions via Braintrust's `GET /v1/prompt` endpoint and
+  recreate them in [Langfuse prompt management](/docs/prompt-management), using labels
+  (e.g. `production`, `staging`) for deployment targeting. Application code then fetches
+  prompts by name and label and compiles variables at runtime.
+- **Online scorers.** Braintrust's online scoring (scorers sampled over production logs)
+  maps to Langfuse [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)
+  and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) running
+  continuously on incoming traces, with their own sampling and filter controls.
+- **Human review.** Rubrics from Braintrust's human review map to score configs on Langfuse
+  [annotation queues](/docs/evaluation/evaluation-methods/annotation-queues): numeric,
+  categorical, and boolean scores plus comments, assigned to reviewers as a queue.
+
+## Step 5: Decide what to do with historical logs
+
+Most teams cut over fresh: old logs stay queryable in Braintrust for their retention window,
+and Langfuse becomes the system of record from cutover day. If you need selected history
+(for example, traces referenced in open incidents), Braintrust's
+`GET /v1/project_logs/{project_id}/fetch` endpoint exports log events, and the Langfuse
+ingestion API can backfill them. Bulk-importing everything is rarely worth it: stale traces
+have low value, and the effort is better spent validating the new pipeline.
+
+## Validation checklist
+
+- [ ] Traces arrive in Langfuse with the expected hierarchy, timing, and token/cost data
+- [ ] User and session attribution works (`user_id`, `session_id` set where Braintrust used metadata)
+- [ ] Sample rate configured deliberately (default keeps 100% of traces)
+- [ ] Datasets migrated with item counts matching the source
+- [ ] Baseline experiment re-run in Langfuse with autoevals scorers producing scores
+- [ ] Prompts resolve by name and label from application code
+- [ ] Online evaluators scoring a sample of production traces
+- [ ] Team access set up (org/project roles, SSO if applicable)
+- [ ] Braintrust exporter removed, or the parallel-running window has an end date
+
+## FAQ
+
+### Can I keep my autoevals scorers? [#keep-autoevals]
+
+Yes. autoevals is an Apache-2.0 open-source library, and Langfuse's experiment SDKs include
+converters (`create_evaluator_from_autoevals` in Python, `createEvaluatorFromAutoevals` in
+TypeScript) that run autoevals scorers unchanged inside Langfuse experiments. Custom scorers
+written as plain functions port directly as Langfuse evaluators.
+
+### Do I have to migrate historical logs? [#historical-logs]
+
+No, and most teams do not. Old logs remain in Braintrust for their retention window while
+Langfuse records everything from cutover day. Selective backfill is possible via
+Braintrust's project-logs fetch endpoint and the Langfuse ingestion API, but it is usually
+only worth doing for traces you actively reference.
+
+### Does Langfuse have an LLM gateway or proxy like Braintrust? [#gateway]
+
+No, by design. Langfuse SDKs send telemetry asynchronously outside the request path, so
+observability cannot add latency or become a point of failure for model calls. If you want
+gateway features such as routing, caching, or failover, Langfuse integrates with dedicated
+gateways like [LiteLLM](/integrations/gateways/litellm) and receives traces from them.
+
+### How do I control ingestion volume and cost in Langfuse? [#sampling]
+
+Set a [sample rate](/docs/observability/features/sampling) in the SDK
+(`LANGFUSE_SAMPLE_RATE=0.1` keeps 10% of traces) to cap volume at the source. Because
+Langfuse bills on counted units rather than bytes of processed data, cost scales with how
+many traces you keep, not with payload size.
+
+### Is Langfuse open source where Braintrust is not? [#open-source]
+
+Langfuse's core platform is MIT-licensed and fully self-hostable, including the UI and
+storage layer. Braintrust's SDKs are Apache-2.0 open source, but the platform itself is
+proprietary; its self-hosted option is a hybrid deployment where the data plane runs in your
+cloud account and Braintrust hosts the control plane (as of July 2026). Check both models
+against your compliance requirements, particularly if you need air-gapped operation.


### PR DESCRIPTION
## What

Five new pages under `/resources/engineering` (registered in `meta.json`) and three refreshes, from the internal GEO content pipeline (evidence and briefs in `langfuse/internal-geo`, plan run 2026-07-13).

### New pages

1. **`langfuse-vs-datadog`** — head-to-head vs Datadog LLM Observability (1.1K/mo US searches, no coverage until now). Includes an honest "when Datadog is the better fit" section and an OTel fan-out coexistence pattern.
2. **`ai-agent-evaluation`** — pillar guide (trajectory, tool use, task completion, multi-turn); reflects current features incl. tool-call access in evaluators (07-10) and links Langfuse Academy.
3. **`migrate-from-braintrust`** — migration guide per the `migrate-from-helicone`/`migrate-from-phoenix` precedent: concept mapping, SDK before/after (Py + TS), dataset export path, validation checklist.
4. **`llm-evaluation-strategy`** — how to roll out an eval strategy (methods per failure mode, CI gates, human review loop, regulated-environment evidence).
5. **`chatbot-intent-analytics`** — four worked patterns for intent analytics on traces; states precisely which score types chart natively.

### Refreshes

6. **`langsmith-alternative`** — full fact re-verification: new "Scale and storage architecture" section (factual SmithDB treatment + Langfuse's public ClickHouse story), Monitors/alerting section, evaluation/experiments section, July-2026 pricing both sides, anchored FAQ (`#is-langsmith-free`, `#is-langsmith-open-source`, `#does-langsmith-require-langchain`, `#what-is-smithdb`).
7. **blog `2025-03-19-ai-agent-comparison`** — 2026 framework landscape: added Claude Agent SDK, Vercel AI SDK 7, DeepAgents; AutoGen/Semantic Kernel folded into Microsoft Agent Framework section (AutoGen maintenance mode, sourced); per-pair verdict sections for the vs-queries the post ranks for; versions pinned from PyPI/npm on 2026-07-13.
8. **blog `2024-07-ai-agent-observability-with-langfuse`** — answer-first definition, agent graph modes (07-13), tool-call monitoring/evals, long-trace debugging, multi-agent trace assembly, voice agents; framework matrix updated.

## Reviewer attention — competitor claims

Each draft's brief in `langfuse/internal-geo` carries a per-claim verification table (URL + checked 2026-07-13). Highest-value spot-checks:

- **Datadog**: pricing (free 40k LLM spans/15-day retention; Pro $160/mo annual first 100k spans; $3.50/10k additional), "only LLM inference spans billed", "prompt tracking is observability-only, no runtime prompt fetching", OTel semconv/OpenLLMetry support. Datadog is mid-rename to "Agent Observability" — numbers could move.
- **LangSmith**: pricing tiers, SmithDB claims (quoted as their claims), Alerts capabilities, self-hosting Enterprise-only. Note: langchain.com was unreachable from the drafting environment's egress proxy; claims were verified via search-quoted live pages — please spot-check the primary URLs.
- **Braintrust**: hybrid deployment model (data plane in customer cloud, hosted control plane), Gateway replacing the deprecated AI proxy, SDK/API shapes (verified against their published SDK source and OpenAPI spec). braintrust.dev had the same proxy limitation; free-tier numbers were deliberately left out of the page.
- **Frameworks**: AutoGen maintenance-mode statement (GitHub README banner) underpins the biggest structural change to the comparison post.

Checks run locally: `check-h1-headings` pass, `pnpm run format:check` pass, internal links in all changed files resolve against `content/` (the agent-observability post links `/resources/engineering/ai-agent-evaluation`, added in this same PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds five new engineering resource pages (`langfuse-vs-datadog`, `ai-agent-evaluation`, `migrate-from-braintrust`, `llm-evaluation-strategy`, `chatbot-intent-analytics`) and refreshes three existing pieces of content (LangSmith comparison, AI agent comparison blog, AI agent observability blog). All five new pages are registered in `meta.json`. The content is sourced from an internal GEO pipeline with per-claim verification against live URLs on 2026-07-13.

- All internal links resolve to existing pages (including cross-references between newly added pages like the `ai-agent-evaluation` page referenced from the refreshed agent observability blog).
- API references in code snippets (`get_client()`, `dataset.run_experiment()`, `create_evaluator_from_autoevals`, `@langfuse/otel`, `@langfuse/tracing`, `@langfuse/openai`) are consistent with patterns used in the existing cookbook guides and official SDK docs.
- Competitive pricing claims (Datadog, LangSmith, Braintrust) include source URLs and a checked date, and the PR description notes which sections were impossible to verify via direct HTTP egress.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only PR; no runtime logic changes. All new pages register cleanly in meta.json and all internal cross-references resolve to existing files.

All SDK imports, function names, and internal links were verified against existing cookbook guides and official docs — no broken references found. The only callouts are a slightly misleading "no rewrite" comment in the Braintrust migration snippet (the scorer instantiation convention changes) and a pinned action version that diverges from the placeholder convention in the canonical CI/CD doc. Both are cosmetic; neither would produce broken behavior for readers following the guides.

The `migrate-from-braintrust.mdx` Step 3 autoevals snippet and the `ai-agent-evaluation.mdx` GitHub Action YAML are worth a second read to confirm the wording is clear enough for the target audience.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: New Content + Refreshes] --> B[5 New Engineering Pages]
    A --> C[3 Refreshed Content Pages]

    B --> B1[langfuse-vs-datadog.mdx\nComparison + OTel coexistence pattern]
    B --> B2[ai-agent-evaluation.mdx\nTrajectory · Tool use · Task · Multi-turn]
    B --> B3[migrate-from-braintrust.mdx\nSDK swap · Dataset export · Autoevals bridge]
    B --> B4[llm-evaluation-strategy.mdx\n6-step rollout: CI gates + human review loop]
    B --> B5[chatbot-intent-analytics.mdx\n4 patterns: batch · judge · dashboard · MCP]

    C --> C1[langsmith-alternative.mdx\nSmithDB section · Monitoring · July-2026 pricing]
    C --> C2[blog: ai-agent-comparison.mdx\nClaude SDK · DeepAgents · Vercel AI SDK 7]
    C --> C3[blog: ai-agent-observability.mdx\nGraph modes · Tool-call analytics · Voice agents]

    B1 --> M[meta.json registration]
    B2 --> M
    B3 --> M
    B4 --> M
    B5 --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR: New Content + Refreshes] --> B[5 New Engineering Pages]
    A --> C[3 Refreshed Content Pages]

    B --> B1[langfuse-vs-datadog.mdx\nComparison + OTel coexistence pattern]
    B --> B2[ai-agent-evaluation.mdx\nTrajectory · Tool use · Task · Multi-turn]
    B --> B3[migrate-from-braintrust.mdx\nSDK swap · Dataset export · Autoevals bridge]
    B --> B4[llm-evaluation-strategy.mdx\n6-step rollout: CI gates + human review loop]
    B --> B5[chatbot-intent-analytics.mdx\n4 patterns: batch · judge · dashboard · MCP]

    C --> C1[langsmith-alternative.mdx\nSmithDB section · Monitoring · July-2026 pricing]
    C --> C2[blog: ai-agent-comparison.mdx\nClaude SDK · DeepAgents · Vercel AI SDK 7]
    C --> C3[blog: ai-agent-observability.mdx\nGraph modes · Tool-call analytics · Voice agents]

    B1 --> M[meta.json registration]
    B2 --> M
    B3 --> M
    B4 --> M
    B5 --> M
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/resources/engineering/migrate-from-braintrust.mdx:260-264
The comment "same scorer, no rewrite" is accurate in spirit — the underlying scorer logic is unchanged — but the call site does require a small change: Braintrust's `scores` list takes an uninstantiated class reference (`Factuality`), while `create_evaluator_from_autoevals` wraps an instance (`Factuality()`). Readers following this snippet will still get a `TypeError` if they miss the `()` without the comment pointing it out. The task-signature difference is already called out just below; adding a note for the scorer here keeps the "before vs. after" fully accurate.

```suggestion
```python
# After (Langfuse): same scorer, minimal changes at the call site
# Note: pass an *instance* (Factuality()) rather than the class (Factuality)
from langfuse import get_client
from langfuse.experiment import create_evaluator_from_autoevals
from autoevals.llm import Factuality
```

### Issue 2 of 2
content/resources/engineering/ai-agent-evaluation.mdx:135
**Pinned action version may fall behind**

The YAML pins `langfuse/experiment-action@v1.0.0`, while the primary `experiments-ci-cd.mdx` doc uses `@<release tag>` as a placeholder to encourage users to check for the latest version. A reader copying this snippet will stay on v1.0.0 indefinitely. Consider using `@v1` (floating major-version tag) or adding a note to check the GitHub releases page, matching the convention in the authoritative docs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add 5 engineering resources pages, refre..."](https://github.com/langfuse/langfuse-docs/commit/dd0558c5c9b308eb73c2dfe2d645a413c66ad9b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44444020)</sub>

<!-- /greptile_comment -->