### PR TITLE
Restore original dates on the two refreshed agent blog posts

### DIFF
--- a/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
+++ b/content/blog/2024-07-ai-agent-observability-with-langfuse.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Agent Observability, Tracing & Evaluation with Langfuse"
-date: 2026/07/15
+date: 2025/03/16
 description: "Trace, monitor, evaluate, and test AI agents in production. Learn what agent observability is and how to use Langfuse with LangGraph, OpenAI Agents SDK, Claude Agent SDK, CrewAI, Pydantic AI, Vercel AI SDK, and more."
 ogImage: /images/blog/ai-agent-observability/ai-agent-observability.png
 tag: agents, guide, evaluation

--- a/content/blog/2025-03-19-ai-agent-comparison.mdx
+++ b/content/blog/2025-03-19-ai-agent-comparison.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Comparing Open-Source AI Agent Frameworks"
-date: 2026/07/13
+date: 2025/03/19
 description: Compare the leading open-source AI agent frameworks in 2026, including LangGraph, OpenAI Agents SDK, Claude Agent SDK, Google ADK, Pydantic AI, CrewAI, Strands Agents, Mastra, Vercel AI SDK, and Microsoft Agent Framework. Learn when to use each and how to trace agent behavior with Langfuse.
 ogImage: /images/blog/2025-03-19-ai-agent-comparison/agent-comparison.png
 tag: agents, guide


### PR DESCRIPTION
## What

Reverts the frontmatter `date` fields that the content refreshes in #3305 bumped to July 2026, restoring the pre-refresh values:

- `content/blog/2025-03-19-ai-agent-comparison.mdx`: `2026/07/13` → `2025/03/19`
- `content/blog/2024-07-ai-agent-observability-with-langfuse.mdx`: `2026/07/15` → `2025/03/16`

Content is unchanged — dates only. Both values match each post's frontmatter as of the commit before #3305 (`6c47aa3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the `date` frontmatter field in two blog post MDX files that were accidentally bumped to July 2026 by a content-refresh PR (#3305), restoring the original 2025 publication dates.

- `2024-07-ai-agent-observability-with-langfuse.mdx`: date reverted from `2026/07/15` → `2025/03/16`
- `2025-03-19-ai-agent-comparison.mdx`: date reverted from `2026/07/13` → `2025/03/19`
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is two one-line frontmatter date corrections with no content modifications.

Both changes are single-field frontmatter reversions that restore the originally intended publication dates. No logic, content, or configuration is touched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR3305 as PR #3305 (content refresh)
    participant Frontmatter as Blog Frontmatter
    participant PR3306 as PR #3306 (this PR)

    PR3305->>Frontmatter: Set date to 2026/07/15 (agent-observability)
    PR3305->>Frontmatter: Set date to 2026/07/13 (agent-comparison)
    PR3306->>Frontmatter: Revert date to 2025/03/16 (agent-observability)
    PR3306->>Frontmatter: Revert date to 2025/03/19 (agent-comparison)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR3305 as PR #3305 (content refresh)
    participant Frontmatter as Blog Frontmatter
    participant PR3306 as PR #3306 (this PR)

    PR3305->>Frontmatter: Set date to 2026/07/15 (agent-observability)
    PR3305->>Frontmatter: Set date to 2026/07/13 (agent-comparison)
    PR3306->>Frontmatter: Revert date to 2025/03/16 (agent-observability)
    PR3306->>Frontmatter: Revert date to 2025/03/19 (agent-comparison)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Restore original frontmatter dates on tw..."](https://github.com/langfuse/langfuse-docs/commit/b210bc0b4ab770b2a25ee2abce16673f689590a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44515058)</sub>

<!-- /greptile_comment -->