### PR TITLE
chore: highlight code evaluators blog post instead of autoresearch

### DIFF
--- a/content/blog/2026-03-24-optimizing-ai-skill-with-autoresearch.mdx
+++ b/content/blog/2026-03-24-optimizing-ai-skill-with-autoresearch.mdx
@@ -5,7 +5,6 @@ description: "We applied Karpathy's autoresearch to optimize our Langfuse prompt
 tag: engineering
 ogImage: /images/blog/2026-03-24-optimizing-ai-skill-with-autoresearch/og.jpg
 author: Lotte
-highlight: true
 ---
 
 import { Details, Summary } from "@/components/Details";

--- a/content/blog/2026-06-22-code-evaluators-execution-model.mdx
+++ b/content/blog/2026-06-22-code-evaluators-execution-model.mdx
@@ -4,6 +4,7 @@ date: 2026/06/22
 description: "Code evaluators let you score traces with your own Python or TypeScript code. A look at the execution model behind them: the requirements, the options we rejected, and the security stance we adopted."
 tag: engineering
 author: Tobias
+highlight: true
 ---
 
 import { BlogHeader } from "@/components/blog/BlogHeader";


### PR DESCRIPTION
Marks Tobias's "Designing the runtime for Langfuse code evaluators" post as a highlighted blog post and removes the highlight from the "We Used Autoresearch on Our AI Skill" post. The blog Highlights section now features the code evaluators post, "The Rage Clicks of LLM apps," and "AI is eating the AI engineering loop."

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR swaps the highlighted blog post in the "Highlights" section: the `highlight: true` frontmatter flag is removed from the March 2026 autoresearch post and added to the June 2026 code evaluators post.

- Removes `highlight: true` from `2026-03-24-optimizing-ai-skill-with-autoresearch.mdx`, un-featuring that post.
- Adds `highlight: true` to `2026-06-22-code-evaluators-execution-model.mdx`, featuring the code evaluators execution model post alongside the two existing highlighted posts.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward frontmatter-only change with no logic or content modifications — safe to merge.

Both changes are single-line frontmatter edits that toggle a boolean `highlight` field. There is no logic, no imports, and no template changes involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Blog Highlights Section] --> B["'The Rage Clicks of LLM Apps'"]
    A --> C["'AI is Eating the AI Engineering Loop'"]
    A --> D["'Designing the Runtime for Langfuse Code Evaluators'<br/>(newly highlighted)"]
    E["'We Used Autoresearch on Our AI Skill'<br/>(highlight removed)"] -.->|was highlighted| A
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Blog Highlights Section] --> B["'The Rage Clicks of LLM Apps'"]
    A --> C["'AI is Eating the AI Engineering Loop'"]
    A --> D["'Designing the Runtime for Langfuse Code Evaluators'<br/>(newly highlighted)"]
    E["'We Used Autoresearch on Our AI Skill'<br/>(highlight removed)"] -.->|was highlighted| A
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: highlight code evaluators blog po..."](https://github.com/langfuse/langfuse-docs/commit/0d6b3afb7d6dce0635650d366d8f70a09ee383b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44633612)</sub>

<!-- /greptile_comment -->