### PR TITLE
docs: add user feedback loop guide and link it across eval docs

### DIFF
--- a/components/academy/FeedbackCaptureDiagram.tsx
+++ b/components/academy/FeedbackCaptureDiagram.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLayoutEffect, useRef } from "react";
+import { useId, useLayoutEffect, useRef } from "react";
 
 const INNER_W = 900;
 const INNER_H = 250;
@@ -53,6 +53,7 @@ export function FeedbackCaptureDiagram() {
   const row2Mid = ROW2_Y + BOX_H / 2;
   const attachX = LF_X + 26;
   const gapMid = (ROW1_Y + BOX_H + ROW2_Y) / 2;
+  const arrowId = `fc-arrow-${useId().replace(/:/g, "")}`;
 
   return (
     <figure
@@ -130,7 +131,7 @@ export function FeedbackCaptureDiagram() {
           >
             <defs>
               <marker
-                id="fc-arrow"
+                id={arrowId}
                 viewBox="0 0 10 10"
                 refX="8"
                 refY="5"
@@ -156,7 +157,7 @@ export function FeedbackCaptureDiagram() {
               y2={row1Mid}
               stroke="var(--line-cta)"
               strokeWidth="1.5"
-              markerEnd="url(#fc-arrow)"
+              markerEnd={`url(#${arrowId})`}
             />
             <line
               x1={BOX_W_APP + 6}
@@ -165,7 +166,7 @@ export function FeedbackCaptureDiagram() {
               y2={row2Mid}
               stroke="var(--line-cta)"
               strokeWidth="1.5"
-              markerEnd="url(#fc-arrow)"
+              markerEnd={`url(#${arrowId})`}
             />
             <line
               x1={attachX}
@@ -175,7 +176,7 @@ export function FeedbackCaptureDiagram() {
               stroke="var(--line-cta)"
               strokeWidth="1.5"
               strokeDasharray="4 4"
-              markerEnd="url(#fc-arrow)"
+              markerEnd={`url(#${arrowId})`}
             />
           </svg>
 

--- a/components/academy/FeedbackCaptureDiagram.tsx
+++ b/components/academy/FeedbackCaptureDiagram.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+
+const INNER_W = 900;
+const INNER_H = 250;
+
+const BOX_W_APP = 250;
+const BOX_W_LF = 250;
+const BOX_H = 60;
+const APP_X = 0;
+const LF_X = INNER_W - BOX_W_LF;
+const ROW1_Y = 30;
+const ROW2_Y = 160;
+
+function estimateInitialScale(): number {
+  if (typeof window === "undefined") return 0.7;
+  const vw = document.documentElement.clientWidth;
+  return Math.min(1, Math.max(0.3, (vw - 32) / INNER_W));
+}
+
+export function FeedbackCaptureDiagram() {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const estScale = estimateInitialScale();
+
+  useLayoutEffect(() => {
+    const wrap = wrapRef.current;
+    const inner = innerRef.current;
+    if (!wrap || !inner) return;
+
+    const fit = () => {
+      const scale = Math.min(1, wrap.clientWidth / INNER_W);
+      inner.style.transform = `scale(${scale})`;
+      wrap.style.height = `${INNER_H * scale}px`;
+    };
+
+    fit();
+    let rafId = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(fit);
+    });
+    ro.observe(wrap);
+
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  const row1Mid = ROW1_Y + BOX_H / 2;
+  const row2Mid = ROW2_Y + BOX_H / 2;
+  const attachX = LF_X + 26;
+  const gapMid = (ROW1_Y + BOX_H + ROW2_Y) / 2;
+
+  return (
+    <figure
+      className="feedback-capture not-prose"
+      aria-label="In your app, an agent execution is captured as a trace in Langfuse, and a user signal is captured as a score that is attached to that trace"
+    >
+      <div
+        ref={wrapRef}
+        suppressHydrationWarning
+        className="feedback-capture__wrap"
+        style={{ height: INNER_H * estScale }}
+      >
+        <div
+          ref={innerRef}
+          suppressHydrationWarning
+          className="feedback-capture__canvas"
+          style={{ transform: `scale(${estScale})` }}
+        >
+          <span
+            className="feedback-capture__col-label"
+            style={{ left: APP_X, top: 6, width: BOX_W_APP }}
+          >
+            In your app
+          </span>
+          <span
+            className="feedback-capture__col-label"
+            style={{ left: LF_X, top: 6, width: BOX_W_LF }}
+          >
+            In Langfuse
+          </span>
+
+          <article
+            className="feedback-capture__box corner-box-corners"
+            style={{
+              left: APP_X,
+              top: ROW1_Y,
+              width: BOX_W_APP,
+              height: BOX_H,
+            }}
+          >
+            <h3 className="feedback-capture__title">Agent execution</h3>
+          </article>
+
+          <article
+            className="feedback-capture__box corner-box-corners"
+            style={{
+              left: APP_X,
+              top: ROW2_Y,
+              width: BOX_W_APP,
+              height: BOX_H,
+            }}
+          >
+            <h3 className="feedback-capture__title">User signal</h3>
+          </article>
+
+          <article
+            className="feedback-capture__box corner-box-corners"
+            style={{ left: LF_X, top: ROW1_Y, width: BOX_W_LF, height: BOX_H }}
+          >
+            <h3 className="feedback-capture__title">Trace</h3>
+          </article>
+
+          <article
+            className="feedback-capture__box feedback-capture__box--score corner-box-corners"
+            style={{ left: LF_X, top: ROW2_Y, width: BOX_W_LF, height: BOX_H }}
+          >
+            <h3 className="feedback-capture__title">Score</h3>
+          </article>
+
+          <svg
+            className="feedback-capture__lines"
+            viewBox={`0 0 ${INNER_W} ${INNER_H}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <defs>
+              <marker
+                id="fc-arrow"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="7"
+                markerHeight="7"
+                orient="auto-start-reverse"
+              >
+                <path
+                  d="M 0 1 L 8 5 L 0 9"
+                  fill="none"
+                  stroke="var(--line-cta)"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </marker>
+            </defs>
+
+            <line
+              x1={BOX_W_APP + 6}
+              y1={row1Mid}
+              x2={LF_X - 8}
+              y2={row1Mid}
+              stroke="var(--line-cta)"
+              strokeWidth="1.5"
+              markerEnd="url(#fc-arrow)"
+            />
+            <line
+              x1={BOX_W_APP + 6}
+              y1={row2Mid}
+              x2={LF_X - 8}
+              y2={row2Mid}
+              stroke="var(--line-cta)"
+              strokeWidth="1.5"
+              markerEnd="url(#fc-arrow)"
+            />
+            <line
+              x1={attachX}
+              y1={ROW2_Y - 6}
+              x2={attachX}
+              y2={ROW1_Y + BOX_H + 8}
+              stroke="var(--line-cta)"
+              strokeWidth="1.5"
+              strokeDasharray="4 4"
+              markerEnd="url(#fc-arrow)"
+            />
+          </svg>
+
+          <span
+            className="feedback-capture__attach-label"
+            style={{ left: attachX + 14, top: gapMid - 8 }}
+          >
+            attached to the trace
+          </span>
+        </div>
+      </div>
+
+      <style>{`
+        .feedback-capture {
+          margin: 32px 0;
+          width: 100%;
+        }
+
+        .feedback-capture__wrap {
+          position: relative;
+          width: 100%;
+          overflow: hidden;
+        }
+
+        .feedback-capture__canvas {
+          position: relative;
+          width: ${INNER_W}px;
+          height: ${INNER_H}px;
+          transform-origin: top left;
+        }
+
+        .feedback-capture__col-label {
+          position: absolute;
+          font-family: var(--font-mono);
+          font-size: 12px;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: var(--text-disabled);
+        }
+
+        .feedback-capture__box {
+          position: absolute;
+          padding: 12px 16px;
+          background: var(--surface-bg);
+          border: 1px solid var(--line-structure);
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+
+        .feedback-capture__box--score {
+          background: color-mix(in oklab, var(--surface-cta-primary) 24%, var(--surface-bg));
+          border-style: dashed;
+        }
+
+        .feedback-capture__title {
+          font-family: var(--font-analog), serif;
+          font-weight: 500;
+          font-size: 20px;
+          line-height: 1.1;
+          letter-spacing: -0.005em;
+          color: var(--text-primary);
+          margin: 0;
+        }
+
+        .feedback-capture__lines {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          overflow: visible;
+          pointer-events: none;
+        }
+
+        .feedback-capture__attach-label {
+          position: absolute;
+          font-family: var(--font-mono);
+          font-size: 12px;
+          letter-spacing: 0.04em;
+          color: var(--text-secondary);
+          white-space: nowrap;
+        }
+      `}</style>
+    </figure>
+  );
+}

--- a/content/academy/monitoring/index.mdx
+++ b/content/academy/monitoring/index.mdx
@@ -65,6 +65,12 @@ Implicit:  extracted field manually edited before approval
 
 Both register as scores, so they feed into the same dashboards, trend charts, and signal rules as your other evaluation data. To figure out which feedback signals are worth turning into automated evaluators in the first place, see our deeper dive into [Error analysis](/academy/monitoring/error-analysis).
 
+<ManualGuideCallout
+  href="/guides/user-feedback-loop"
+  topic="user feedback loop"
+  lede="Choose the feedback signals that fit your application, capture them as scores on your traces, and act on what they surface."
+/>
+
 <Callout type="info">
 There are two types of automated evaluators to attach scores to traces:
 - LLM-as-a-judge (for quality signals or behavioral patterns like user disagreement)

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -947,9 +947,9 @@ To overwrite a score without fetching existing scores first, set a stable `id` a
 <ManualGuideList
   guides={[
     {
-      href: "/guides/cookbook/user-feedback",
+      href: "/guides/user-feedback-loop",
       topic: "Collecting user feedback",
-      lede: "Collect in-app feedback from your users on application quality or performance, captured in the frontend via our Browser SDK.",
+      lede: "Capture explicit and implicit user feedback as scores on your traces, including in-app ratings sent via our Browser SDK.",
     },
     {
       href: "/guides/cookbook/example_external_evaluation_pipelines",

--- a/content/docs/evaluation/overview.mdx
+++ b/content/docs/evaluation/overview.mdx
@@ -33,6 +33,7 @@ Once you have that context, use the table below to find the right feature page:
 | If you want to...                                   | Use this Langfuse feature                                                                                                                      |
 | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Review and rate traces manually                     | [Annotation Queues](/docs/evaluation/evaluation-methods/annotation-queues), [Scores via UI](/docs/evaluation/evaluation-methods/scores-via-ui) |
+| Collect feedback from your end users                | [User Feedback](/docs/observability/features/user-feedback)                                                                                    |
 | Leave open-ended notes on traces                    | [Text scores](/docs/evaluation/scores/overview#score-types), [Annotation Queues](/docs/evaluation/evaluation-methods/annotation-queues)        |
 | Track recurring failure categories                  | [Score configs](/faq/all/manage-score-configs), [scores](/docs/evaluation/scores/overview#score-types)                                         |
 | Build a reusable set of test cases                  | [Datasets](/docs/evaluation/experiments/datasets)                                                                                              |

--- a/content/docs/observability/features/user-feedback.mdx
+++ b/content/docs/observability/features/user-feedback.mdx
@@ -137,3 +137,7 @@ The [user-feedback example](https://github.com/langfuse/langfuse-examples/tree/m
 - OpenTelemetry tracing
 - Thumbs up/down with optional comments
 - Session tracking across conversations
+
+## Related
+
+For an end-to-end walkthrough, from choosing signals to acting on them, see the guide on [how to set up a user feedback loop](/guides/user-feedback-loop).

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -32,9 +32,16 @@ import {
   FileCode,
   Wand,
   Users,
+  ThumbsUp,
 } from "lucide-react";
 
 <TutorialCards>
+  <TutorialCard
+    title="Set Up a User Feedback Loop"
+    description="Capture explicit and implicit user feedback as scores on your traces, and use it to surface the responses worth reviewing."
+    href="/guides/user-feedback-loop"
+    icon={<ThumbsUp />}
+  />
   <TutorialCard
     title="Error Analysis"
     description="Review traces to classify issues like hallucinations, irrelevance, and formatting errors. Turn raw logs into actionable insights."

--- a/content/guides/user-feedback-loop.mdx
+++ b/content/guides/user-feedback-loop.mdx
@@ -1,0 +1,174 @@
+---
+title: How to set up a user feedback loop for your application
+sidebarTitle: User feedback loop
+description: Capture explicit and implicit user feedback as scores on your traces, surface the responses worth reviewing, and turn what you learn into datasets and automated evaluators.
+category: Evaluation
+---
+
+import { LoopDiagram } from "@/components/academy/LoopDiagram";
+import { FeedbackCaptureDiagram } from "@/components/academy/FeedbackCaptureDiagram";
+
+# How to set up a user feedback loop for your application
+
+Once traces are coming in, capturing user feedback is a great next step. Your users judge every response through what they click, edit, retry, or say. Capturing that on your traces gives you a quality signal grounded in real usage, where each score points at a trace you can open and learn from.
+
+<Callout type="info">
+  A lot of teams ask _"I have traces coming in, how do I now get started with evals?"_. Often, these teams are better off starting with user feedback first.
+</Callout>
+
+This feedback gathering step generally has a very high ROI, in the AI Engineering process. We often write about this process in the [Langfuse Academy](/academy), where we walk through the [AI engineering loop](/academy/ai-engineering-loop) in more detail. Gathering user feedback happens in the monitoring stage highlighted below.
+
+<LoopDiagram highlight="monitor" />
+
+## Prerequisites
+
+You already have traces coming into Langfuse. See [tracing](/docs/observability/get-started) if you have not set this up yet.
+
+## Walkthrough
+
+<Steps>
+
+### Choose your feedback signals [#choose-signals]
+
+Feedback comes in two forms. **Explicit feedback** is a rating the user gives on purpose, like a thumbs up or down or a star rating: unambiguous, but rare and skewed toward unhappy users. **Implicit feedback** is derived from what users do, like retrying a query or editing a draft: you have data on every trace, but needs interpretation.
+
+The best signals depend heavily on your use case. Some examples as inspiration:
+
+| Signal                                                | What it tells you                       | Typically captured via |
+| ----------------------------------------------------- | --------------------------------------- | ---------------------- |
+| Thumbs up or down on a response                       | Direct rating of that response          | Browser SDK            |
+| A user rephrasing the same question                   | The previous answer didn't land         | LLM-as-a-Judge         |
+| A user asking to speak to a human                     | The user stopped trusting the assistant | LLM-as-a-Judge         |
+| A response copied by the user                         | The output was good enough to reuse     | Browser SDK            |
+| A drafted reply edited before it is sent              | What was wrong or missing in the draft  | SDK / API              |
+| A copilot suggestion accepted or dismissed            | Whether the suggestion fit the context  | Browser SDK            |
+| An extracted field corrected in a review step         | Which field was extracted incorrectly   | SDK / API              |
+| A search query reformulated without clicking a result | The results missed the intent           | SDK / API              |
+| A recommended item skipped right after it starts      | The pick missed the user's taste        | SDK / API              |
+
+Tips:
+
+- signals combine well, no need to implement only one
+- capture free-form text wherever it fits (can be as a [comment on the score](/docs/evaluation/scores/data-model)), as much of this analysis is now done by agents, and they work better with more context
+- the [academy examples](/academy/examples) show how signals are chosen for a specific application and change over its lifecycle
+
+### Capture the signals as scores [#capture]
+
+Every signal ends up as a [score](/docs/evaluation/scores/data-model) on the trace that produced the output. A score has a name, a value with a data type (boolean, numeric, categorical or free text), and an optional `comment`. Evaluators also store their results as scores, so your user feedback can land in the same filters, dashboards, and analytics.
+
+<FeedbackCaptureDiagram />
+
+The route into that score depends on where the signal originates:
+
+<Tabs items={["Signal from UI", "App event from backend", "Via LLM-as-a-Judge"]}>
+<Tab>
+
+Ratings from your UI go straight from the browser using your public key:
+
+```typescript
+import { LangfuseBrowserClient } from "@langfuse/browser";
+
+const langfuse = new LangfuseBrowserClient({
+  publicKey: process.env.NEXT_PUBLIC_LANGFUSE_PUBLIC_KEY!,
+});
+
+// On a thumbs up / down click
+await langfuse.score({
+  traceId, // returned by your backend with the response
+  name: "response_rating", // one descriptive name per signal
+  value: 1, // 1 for thumbs up, 0 for thumbs down
+  dataType: "BOOLEAN",
+});
+```
+
+The [User Feedback](/docs/observability/features/user-feedback) page has the full setup for a Next.js chatbot, including how the frontend gets the trace ID.
+
+</Tab>
+<Tab>
+
+Events your app observes, like an accepted suggestion, an edited draft, or a closed ticket, are scored the moment they happen:
+
+<LangTabs items={["Python", "JS/TS"]}>
+<Tab>
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+# The user edited the drafted reply before sending it
+langfuse.create_score(
+    trace_id=trace_id,  # the trace that produced the draft
+    name="draft_edited",
+    value=1,
+    data_type="BOOLEAN",
+    comment=edit_diff,  # the edit itself, as context for later analysis
+)
+```
+
+</Tab>
+<Tab>
+
+```typescript
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+// The user edited the drafted reply before sending it
+await langfuse.score.create({
+  traceId, // the trace that produced the draft
+  name: "draft_edited",
+  value: 1,
+  dataType: "BOOLEAN",
+  comment: editDiff, // the edit itself, as context for later analysis
+});
+
+// Flush the scores in short-lived environments
+await langfuse.flush();
+```
+
+</Tab>
+</LangTabs>
+
+See [Scores via API/SDK](/docs/evaluation/evaluation-methods/scores-via-sdk) for score types, updating scores, and validating them against a score config.
+
+</Tab>
+<Tab>
+
+Signals that live in free text, like a user asking for a human or rephrasing a question, leave no event your code can catch. An [LLM-as-a-Judge evaluator](/docs/evaluation/evaluation-methods/llm-as-a-judge) on your production traces reads the conversation and writes the score, with no change to your application.
+
+</Tab>
+</Tabs>
+
+### Act on the feedback [#act]
+
+#### Monitor how quality is trending [#monitor-trends]
+
+[Score analytics](/docs/evaluation/scores/score-analytics) and [custom dashboards](/docs/metrics/features/custom-dashboards) chart how each signal moves over time. One caveat: not every signal is a clean quality metric, e.g. thumbs feedback skews toward unhappy users.
+
+#### Surface interesting traces [#surface-traces]
+
+Filter traces by score, for example `response_rating = 0`, to get a concrete list of traces to investigate. [Error analysis](/academy/monitoring/error-analysis) is a structured way to read and cluster them, and an [annotation queue](/docs/evaluation/evaluation-methods/annotation-queues) brings in more reviewers.
+
+#### Use it as input for structured improvement [#structured-improvement]
+
+Add the failing cases to a [dataset](/docs/evaluation/experiments/datasets), test a fix with an [experiment](/docs/evaluation/experiments/experiments-via-ui) before shipping, and turn a recurring failure mode into an [automated evaluator](/docs/evaluation/core-concepts#evaluation-methods) that scores every production trace from then on.
+
+**Much of this can also be handed to an agent**, see [Let an agent act on the feedback](#agents) below.
+
+</Steps>
+
+## Let an agent act on the feedback [#agents]
+
+Langfuse is built for agent access through the [Langfuse CLI](/docs/api-and-data-platform/features/cli), the [Agent Skill](/docs/api-and-data-platform/features/agent-skill), and the [MCP Server](/docs/api-and-data-platform/features/mcp-server): point one at your project and it can interpret and act on the behavior that gets surfaced via user feedback. An example task:
+
+```text
+Fetch the traces from the last 7 days with a response_rating score of 0.
+Read the comments and outputs, cluster the failures into categories,
+and propose a prompt change for the two biggest ones.
+```
+
+Some reading material as inspiration:
+
+- [Using Agent Skills to Automatically Improve your Prompts](/blog/2026-02-16-prompt-improvement-claude-skills)
+- [AI is eating the AI engineering loop](/blog/2026-06-09-ai-is-eating-ai-engineering)

--- a/content/guides/user-feedback-loop.mdx
+++ b/content/guides/user-feedback-loop.mdx
@@ -75,6 +75,7 @@ const langfuse = new LangfuseBrowserClient({
 // On a thumbs up / down click
 await langfuse.score({
   traceId, // returned by your backend with the response
+  id: `response_rating-${traceId}`, // stable id, so re-rating updates instead of duplicating
   name: "response_rating", // one descriptive name per signal
   value: 1, // 1 for thumbs up, 0 for thumbs down
   dataType: "BOOLEAN",

--- a/content/guides/user-feedback-loop.mdx
+++ b/content/guides/user-feedback-loop.mdx
@@ -30,7 +30,7 @@ You already have traces coming into Langfuse. See [tracing](/docs/observability/
 
 ### Choose your feedback signals [#choose-signals]
 
-Feedback comes in two forms. **Explicit feedback** is a rating the user gives on purpose, like a thumbs up or down or a star rating: unambiguous, but rare and skewed toward unhappy users. **Implicit feedback** is derived from what users do, like retrying a query or editing a draft: you have data on every trace, but needs interpretation.
+Feedback comes in two forms. **Explicit feedback** is a rating the user gives on purpose, like a thumbs up or down or a star rating: unambiguous, but rare and skewed toward unhappy users. **Implicit feedback** is derived from what users do, like retrying a query or editing a draft: you have data on every trace, but it needs interpretation.
 
 The best signals depend heavily on your use case. Some examples as inspiration:
 


### PR DESCRIPTION
Adds a new guide, **How to set up a user feedback loop for your application** (`/guides/user-feedback-loop`), and links it from the places people look when they ask "I have traces, how do I start with evals?".

Many teams asking for evals are best served by first capturing user feedback and attaching it to their traces. That path existed in scattered pieces but was not surfaced on the evaluation journey. This guide makes it a first-class path.

## The guide

Three steps plus a follow-up section:

1. **Choose your feedback signals** — explicit vs implicit, an inspiration table of signals by use case (with the typical capture route), and tips on combining signals and capturing free-form text for agent analysis.
2. **Capture the signals as scores** — a new `FeedbackCaptureDiagram` showing an agent execution captured as a trace and a user signal captured as a score attached to it, then three capture routes in tabs (frontend Browser SDK, backend SDK/API, LLM-as-a-Judge).
3. **Act on the feedback** — monitor quality trends, surface traces to investigate, use as input for structured improvement.
4. **Let an agent act on the feedback** — CLI / Agent Skill / MCP Server, with an example prompt and further reading.

## Linking changes

- **Evaluation Overview**: new routing-table row "Collect feedback from your end users" → User Feedback docs page.
- **Scores via API/SDK**: fixed the broken `/guides/cookbook/user-feedback` link in Related guides to point at the new guide.
- **Guides index**: new "Set Up a User Feedback Loop" tutorial card under Evaluation Tutorials.
- **Academy → Monitoring**: `ManualGuideCallout` referencing the guide.
- **User Feedback (Observability)**: guide reference in a new Related section.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new end-to-end guide for setting up a user feedback loop, a custom `FeedbackCaptureDiagram` React component, and threads links to the new guide from the evaluation overview, scores-via-sdk page, the guides index, the academy monitoring page, and the user feedback observability page.

- **New guide** (`/guides/user-feedback-loop`): three-step walkthrough (choose signals → capture as scores → act), with an inspiration table of signals, tabbed code examples for Browser SDK, backend SDK, and LLM-as-a-Judge, and an \"agent act on feedback\" section at the end.
- **New diagram component** (`FeedbackCaptureDiagram.tsx`): a CSS-scaled, SSR-safe SVG diagram illustrating the flow from \"Agent execution\" + \"User signal\" in-app to \"Trace\" + \"Score\" in Langfuse.
- **Link changes**: evaluation overview routing table, scores-via-sdk related guides (broken link fixed), guides index card, academy monitoring callout, and user-feedback observability related section all now point at the new guide.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are documentation and a new diagram component with no effect on existing behavior.

The broken link fix and new guide are well-structured and internally consistent. Two minor issues were found: the FeedbackCaptureDiagram uses a hard-coded global SVG marker ID that would conflict if the component appears more than once on a page, and the Browser SDK code example in the guide omits the stable id field shown in the reference docs, which could mislead developers into creating duplicate scores on repeated clicks.

components/academy/FeedbackCaptureDiagram.tsx (SVG marker ID) and content/guides/user-feedback-loop.mdx (Browser SDK score example missing id field).
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User Feedback Loop Guide"] --> B["Evaluation Overview"]
    A --> C["Scores via API/SDK"]
    A --> D["Guides Index"]
    A --> E["Academy Monitoring"]
    A --> F["User Feedback Observability"]
    G["Step 1: Choose Signals"] --> H["Step 2: Capture as Scores"]
    H --> I["Step 3: Act on Feedback"]
    I --> J["Let an agent act"]
    H -->|"renders"| K["FeedbackCaptureDiagram"]
    A --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User Feedback Loop Guide"] --> B["Evaluation Overview"]
    A --> C["Scores via API/SDK"]
    A --> D["Guides Index"]
    A --> E["Academy Monitoring"]
    A --> F["User Feedback Observability"]
    G["Step 1: Choose Signals"] --> H["Step 2: Capture as Scores"]
    H --> I["Step 3: Act on Feedback"]
    I --> J["Let an agent act"]
    H -->|"renders"| K["FeedbackCaptureDiagram"]
    A --> G
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
components/academy/FeedbackCaptureDiagram.tsx:133
**Non-unique SVG marker ID will conflict on duplicate instances**

`id="fc-arrow"` is a document-scoped DOM ID. If `FeedbackCaptureDiagram` is ever rendered more than once on the same page (e.g. embedded in a page that includes two guides, or reused in future content), the second `<marker>` definition will create a duplicate ID. Browsers resolve `url(#fc-arrow)` by the first match in document order, so the second instance's arrowheads may silently point to the wrong (or missing) marker. A page-unique identifier — e.g. a `useId`-based suffix or a module-level UUID — avoids the conflict.

### Issue 2 of 2
content/guides/user-feedback-loop.mdx:68-82
**Missing stable `id` allows duplicate scores on repeated clicks**

The Browser SDK score call omits the `id` field. Without it, every call creates a new score record rather than upserting, so a user who double-clicks a thumbs button will produce two scores on the same trace. The existing reference implementation in `user-feedback.mdx` shows the correct pattern: `id: \`user-feedback-${messageId}\``. Adding a stable, trace-scoped `id` here would make the guide's example consistent with the idempotent approach already documented in the SDK page.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add user feedback loop guide and l..."](https://github.com/langfuse/langfuse-docs/commit/1e6ac896964fd5c0ed29df15ca3c21a4e4a84d14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44635625)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->