### PR TITLE
docs: clarify observation types, trace nesting, and input/output rendering

### DIFF
--- a/components-mdx/observation-types-list.mdx
+++ b/components-mdx/observation-types-list.mdx
@@ -20,11 +20,13 @@ generations of AI models incl. prompts, [token usage and costs](/docs/observabil
 - <Bot size={16} className="text-purple-600 inline mr-1" /> `agent` decides on the
 application flow and can for example use tools with the guidance of a LLM.
 - <Wrench size={16} className="text-orange-600 inline mr-1" /> `tool` represents
-a tool call, for example to a weather API.
+a single action that does something, such as a function or API call (for example a
+weather API).
 - <Link size={16} className="text-pink-600 inline mr-1" /> `chain` is a link between
 different application steps, like passing context from a retriever to a LLM call.
 - <Search size={16} className="text-teal-600 inline mr-1" /> `retriever` represents
-data retrieval steps, such as a call to a vector store or a database.
+a data-retrieval step that only looks something up rather than changing state, such
+as a call to a vector store, database, or other knowledge source.
 - <WandSparkles size={16} className="text-indigo-600 inline mr-1" /> `evaluator`
 represents functions that assess relevance/correctness/helpfulness of a LLM's outputs.
 - <Layers3 size={16} className="text-amber-600 inline mr-1" /> `embedding` is a call

--- a/content/docs/observability/best-practices.mdx
+++ b/content/docs/observability/best-practices.mdx
@@ -56,6 +56,12 @@ For example
 
 Framework integrations typically set these types automatically. If you're instrumenting manually, you can set them via the `as_type` parameter (Python) or `asType` (JS/TS). See the [observation types docs](/docs/observability/features/observation-types) for a full list.
 
+### Is it nested correctly?
+
+A tool call should nest under the `generation` that decided to make it, rather than sitting next to it as a flat sibling, so the tree shows which action came from which decision.
+
+Framework integrations usually get this right automatically. If you're instrumenting manually, see [nesting observations](/docs/observability/sdk/instrumentation#nesting-observations).
+
 ### Is there noise you don't need?
 
 Not every observation in the tree is useful for understanding what your application did. HTTP spans, database queries, and framework internals often add clutter without giving you meaningful insight. If you see observations like these polluting your trace tree, you can [filter them out](/faq/all/unwanted-http-database-spans).
@@ -101,6 +107,12 @@ Typical input/output for `GENERATION` observations:
 - For a chatbot: the user message (input) and the assistant response (output).
 - For a RAG pipeline: the user query and the generated answer.
 - For a classification task: the text being classified and the predicted label.
+
+<Callout type="info">
+
+Most inputs/outputs can be rendered as a readable, role-labeled conversation rather than a raw JSON blob. If yours show up as raw JSON, you can take a look at the formatting: it should be a list of messages in the standard OpenAI format (each with a `role` and `content`), and it renders tool calls as cards only when they sit in an assistant message's `tool_calls` array with each call's `arguments` given as a JSON-encoded string (for example `"{\"location\": \"Paris\"}"`).
+
+</Callout>
 
 If your input and output fields are showing up empty unintentionally, see [why are the input and output of my trace empty?](/faq/all/empty-trace-input-and-output)
 

--- a/content/docs/observability/best-practices.mdx
+++ b/content/docs/observability/best-practices.mdx
@@ -58,7 +58,7 @@ Framework integrations typically set these types automatically. If you're instru
 
 ### Is it nested correctly?
 
-A tool call should nest under the `generation` that decided to make it, rather than sitting next to it as a flat sibling, so the tree shows which action came from which decision.
+A tool call should nest under the `agent` or `span` that orchestrates the step, as a sibling of the `generation` that requested it, so the tree shows which step each action belongs to instead of leaving tool calls dangling at the trace root.
 
 Framework integrations usually get this right automatically. If you're instrumenting manually, see [nesting observations](/docs/observability/sdk/instrumentation#nesting-observations).
 

--- a/content/docs/observability/sdk/troubleshooting-and-faq.mdx
+++ b/content/docs/observability/sdk/troubleshooting-and-faq.mdx
@@ -26,6 +26,7 @@ If you cannot find your issue below, try [Ask AI](/docs/ask-ai), open a [GitHub 
 - Prefer context managers (`with langfuse.start_as_current_observation(...)`) to maintain OTEL context.
 - If using manual spans (`langfuse.start_observation()`), always call `.end()`.
 - In async code, rely on Langfuse helpers to avoid losing context across `await` boundaries.
+- If an observation references a parent that Langfuse never received, it is shown at the trace root instead of under its intended parent. This can happen when the parent was filtered out, dropped, or never sent, so make sure every referenced parent observation is actually exported.
 
 ## LangChain/OpenAI integration issues
 


### PR DESCRIPTION
Sharpens the `tool` vs. `retriever` definitions on the observation types list so the distinction (an action vs. a read-only lookup) is clear. Adds an "Is it nested correctly?" check and an info callout on input/output rendering to the trace best-practices page. Documents in the SDK troubleshooting FAQ that an observation referencing a parent Langfuse never received is shown at the trace root. Content was adapted this skill PR: https://github.com/langfuse/skills/pull/62.