### PR TITLE
docs(opentelemetry): document experiment span propagation

### DIFF
--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -110,6 +110,99 @@ OpenTelemetry integration, you can use the convenience methods
 which handle attribute propagation automatically. These methods provide a
 simpler interface and are the recommended approach when using Langfuse SDKs.
 
+## Experiments: Propagating Experiment Context to All Spans
+
+An experiment contains one or more experiment items. Each item is one trace:
+it has a root span and may have child spans for model calls, tools, or other
+work. To make the item show up correctly in Langfuse, use three levels of
+attributes:
+
+| Level               | Attributes                                                                                                                                                               | Apply to                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| Experiment context  | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, and `langfuse.experiment.metadata.*` | Every span in every item trace |
+| Item context        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                           | Every span in one item trace   |
+| Root-only item data | `langfuse.experiment.item.expected_output` and `langfuse.experiment.item.metadata.*`                                                                                     | The item's root span only      |
+
+The root observation ID is the link between an item and its spans. On the root
+span, set `langfuse.experiment.item.root_observation_id` to that span's own
+OTel `spanId`. Propagate the same value to all child spans of the item.
+
+### Recommended: Use OpenTelemetry Baggage for Experiment Context
+
+Use the same Baggage plus `BaggageSpanProcessor` pattern as for trace
+attributes. Baggage carries experiment and item context; the processor copies
+it to each span as `langfuse.experiment.*` attributes.
+
+The experiment context must be **Baggage only**. Do not create one enclosing
+"experiment" span: each item needs to start a separate trace.
+
+```text
+configureBaggageToSpanAttributeProcessor()
+
+experimentAttributes = {
+  "langfuse.experiment.id": experiment.id,
+  "langfuse.experiment.name": experiment.name,
+  "langfuse.experiment.description": experiment.description,
+  "langfuse.experiment.dataset.id": experiment.datasetId, // optional
+  "langfuse.experiment.metadata.prompt_version": "v4",
+}
+experimentBaggage = baggageFromAttributes(experimentAttributes)
+
+for each item:
+  # Start a new trace, while preserving the experiment Baggage.
+  root = tracer.startSpan(
+    "experiment-item",
+    withBaggage(ROOT_CONTEXT, experimentBaggage),
+  )
+  rootId = root.spanContext().spanId
+
+  itemAttributes = {
+    "langfuse.experiment.item.id": item.id,
+    "langfuse.experiment.item.version": item.version, // optional
+    "langfuse.experiment.item.root_observation_id": rootId,
+  }
+
+  # The root already exists, so set its complete context explicitly.
+  root.setAttributes({
+    ...experimentAttributes,
+    ...itemAttributes,
+    "langfuse.experiment.item.expected_output": jsonEncode(item.expectedOutput),
+    "langfuse.experiment.item.metadata.country": item.metadata.country,
+  })
+
+  # Add item context before creating child spans.
+  itemBaggage = mergeBaggage(
+    experimentBaggage,
+    baggageFromAttributes(itemAttributes),
+  )
+  withContext(withActiveSpan(withBaggage(ROOT_CONTEXT, itemBaggage), root)):
+    runInstrumentedTask(item) # Child spans inherit both contexts.
+
+  root.end()
+```
+
+The root span must be created before the item context because its `spanId` is
+only available after creation. Set the root observation ID on the root directly,
+then add it to Baggage before any child span starts.
+
+Use one attribute per metadata value, for example
+`langfuse.experiment.metadata.prompt_version`. This is the preferred OTel form.
+For object or array expected outputs, send a JSON-encoded string.
+
+<Callout type="info">
+  **Scores:** Attach experiment-item scores to the root observation. When using
+  the Scores API, use the root span's `spanId` as the observation ID.
+</Callout>
+
+### Choose an Environment for Experiment Runs
+
+Experiment runs often deserve a separate environment such as `experiment` so
+they do not mix with production traffic. If the exporter only sends experiment
+runs, set `langfuse.environment=experiment` as a resource attribute. If the
+same exporter also sends production traffic, set and propagate
+`langfuse.environment` on the item root and its child spans instead. See
+[Environments](/docs/observability/features/environments) for details.
+
 ## Ingestion Options
 
 ### OpenTelemetry native Langfuse SDK v4

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -121,11 +121,11 @@ model calls, tool calls, and other work.
 To make experiment data show correctly in Langfuse, model three levels of
 context in this order:
 
-| Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                               |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, and `langfuse.experiment.metadata.*` |
-| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output`, and `langfuse.experiment.item.metadata.*`                       |
-| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                           |
+| Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, `langfuse.experiment.metadata.*`, and optional `langfuse.environment` |
+| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output`, and `langfuse.experiment.item.metadata.*`                                                        |
+| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                                                            |
 
 Configure a `BaggageSpanProcessor` as described in the [Baggage propagation
 pattern](#recommended-use-opentelemetry-baggage-for-propagation).
@@ -134,17 +134,18 @@ show how each level is represented.
 
 ### 1. Experiment Context: Baggage Shared by All Item Traces
 
-Create experiment Baggage once. Start every item root with this Baggage and no
-active parent span: each item must remain a separate trace. Do not create an
-enclosing "experiment" span.
+Create experiment Baggage once. Start every item execution with this Baggage
+and no active parent span: each execution must remain a separate trace. Do not
+create an enclosing "experiment" span.
 
 ```text
 experimentBaggage = baggageFromAttributes({
-  "langfuse.experiment.id": experiment.id,
-  "langfuse.experiment.name": experiment.name,
+  "langfuse.experiment.id": experiment.id, // unique per experiment
+  "langfuse.experiment.name": experiment.name, // unique per experiment
   "langfuse.experiment.description": experiment.description,
   "langfuse.experiment.dataset.id": experiment.datasetId, // optional
   "langfuse.experiment.metadata.prompt_version": "v4",
+  "langfuse.environment": "experiment", // optional: use a separate environment for experiment traffic
 })
 ```
 
@@ -177,8 +178,8 @@ for each item:
 
   root.setAttributes({
     ...itemAttributes,
-    "langfuse.experiment.item.expected_output": jsonEncode(item.expectedOutput),
-    "langfuse.experiment.item.metadata.country": item.metadata.country,
+    "langfuse.experiment.item.expected_output": jsonEncode(item.expectedOutput), // optional
+    "langfuse.experiment.item.metadata.country": item.metadata.country, // optional
   })
 ```
 
@@ -223,9 +224,10 @@ root.end()
 Experiment runs often deserve a separate environment such as `experiment` so
 they do not mix with production traffic. If the exporter only sends experiment
 runs, set `langfuse.environment=experiment` as a resource attribute. If the
-same exporter also sends production traffic, set and propagate
-`langfuse.environment` on the item root and its child spans instead. See
-[Environments](/docs/observability/features/environments) for details.
+same exporter also sends production traffic, add `langfuse.environment` to the
+experiment Baggage. This applies it to every item trace and span in the
+experiment. See [Environments](/docs/observability/features/environments) for
+details.
 
 ## Ingestion Options
 

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -112,10 +112,11 @@ simpler interface and are the recommended approach when using Langfuse SDKs.
 
 ## Experiments: Ingesting Experiment Spans
 
-An [experiment](/docs/evaluation/core-concepts#experiments) runs an
-application against a set of test items and evaluates the outputs. Represent
-each experiment item as one trace: a root span for the item execution and any
-child spans for model calls, tools, or other work.
+An [experiment](/docs/evaluation/core-concepts#experiments) runs your
+application against test data. Each input is an experiment item, optionally
+with an expected output. Each item corresponds to one trace that shows how your
+application produced the actual output from that input, with child spans for
+model calls, tool calls, and other work.
 
 To make experiment data show correctly in Langfuse, model three levels of
 context in this order:

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -110,46 +110,58 @@ OpenTelemetry integration, you can use the convenience methods
 which handle attribute propagation automatically. These methods provide a
 simpler interface and are the recommended approach when using Langfuse SDKs.
 
-## Experiments: Propagating Experiment Context to All Spans
+## Experiments: Ingesting Experiment Spans
 
-An experiment contains one or more experiment items. Each item is one trace:
-it has a root span and may have child spans for model calls, tools, or other
-work. To make the item show up correctly in Langfuse, use three levels of
-attributes:
+An [experiment](/docs/evaluation/core-concepts#experiments) runs an
+application against a set of test items and evaluates the outputs. Represent
+each experiment item as one trace: a root span for the item execution and any
+child spans for model calls, tools, or other work.
 
-| Level               | Attributes                                                                                                                                                               | Apply to                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| Experiment context  | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, and `langfuse.experiment.metadata.*` | Every span in every item trace |
-| Item context        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                           | Every span in one item trace   |
-| Root-only item data | `langfuse.experiment.item.expected_output` and `langfuse.experiment.item.metadata.*`                                                                                     | The item's root span only      |
+To make experiment data show correctly in Langfuse, model three levels of
+context in this order:
 
-The root observation ID is the link between an item and its spans. On the root
-span, set `langfuse.experiment.item.root_observation_id` to that span's own
-OTel `spanId`. Propagate the same value to all child spans of the item.
+| Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, and `langfuse.experiment.metadata.*` |
+| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output`, and `langfuse.experiment.item.metadata.*`                       |
+| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                           |
 
-### Recommended: Use OpenTelemetry Baggage for Experiment Context
+Configure a `BaggageSpanProcessor` as described in the [Baggage propagation
+pattern](#recommended-use-opentelemetry-baggage-for-propagation).
+It copies Baggage entries to each newly created span. The following sections
+show how each level is represented.
 
-Use the same Baggage plus `BaggageSpanProcessor` pattern as for trace
-attributes. Baggage carries experiment and item context; the processor copies
-it to each span as `langfuse.experiment.*` attributes.
+### 1. Experiment Context: Baggage Shared by All Item Traces
 
-The experiment context must be **Baggage only**. Do not create one enclosing
-"experiment" span: each item needs to start a separate trace.
+Create experiment Baggage once. Start every item root with this Baggage and no
+active parent span: each item must remain a separate trace. Do not create an
+enclosing "experiment" span.
 
 ```text
-configureBaggageToSpanAttributeProcessor()
-
-experimentAttributes = {
+experimentBaggage = baggageFromAttributes({
   "langfuse.experiment.id": experiment.id,
   "langfuse.experiment.name": experiment.name,
   "langfuse.experiment.description": experiment.description,
   "langfuse.experiment.dataset.id": experiment.datasetId, // optional
   "langfuse.experiment.metadata.prompt_version": "v4",
-}
-experimentBaggage = baggageFromAttributes(experimentAttributes)
+})
+```
 
+### 2. Experiment Item Root: One Trace Per Item
+
+An experiment item has an input, an expected output, and the actual output from
+your application. Its trace captures the execution that produces the actual
+output from that input. Langfuse expects exactly one trace per experiment item.
+
+Langfuse needs a clear root span to identify the item trace and its data. The
+root's `langfuse.observation.input` should be the experiment item input, and
+its `langfuse.observation.output` should be the actual output. Create the root
+with the experiment Baggage, then set the expected output and metadata directly
+on it. Its
+`langfuse.experiment.item.root_observation_id` must equal its own OTel `spanId`.
+
+```text
 for each item:
-  # Start a new trace, while preserving the experiment Baggage.
   root = tracer.startSpan(
     "experiment-item",
     withBaggage(ROOT_CONTEXT, experimentBaggage),
@@ -158,36 +170,42 @@ for each item:
 
   itemAttributes = {
     "langfuse.experiment.item.id": item.id,
-    "langfuse.experiment.item.version": item.version, // optional
+    "langfuse.experiment.item.version": item.version, // optional: Langfuse-managed datasets only
     "langfuse.experiment.item.root_observation_id": rootId,
   }
 
-  # The root already exists, so set its complete context explicitly.
   root.setAttributes({
-    ...experimentAttributes,
     ...itemAttributes,
     "langfuse.experiment.item.expected_output": jsonEncode(item.expectedOutput),
     "langfuse.experiment.item.metadata.country": item.metadata.country,
   })
-
-  # Add item context before creating child spans.
-  itemBaggage = mergeBaggage(
-    experimentBaggage,
-    baggageFromAttributes(itemAttributes),
-  )
-  withContext(withActiveSpan(withBaggage(ROOT_CONTEXT, itemBaggage), root)):
-    runInstrumentedTask(item) # Child spans inherit both contexts.
-
-  root.end()
 ```
 
-The root span must be created before the item context because its `spanId` is
-only available after creation. Set the root observation ID on the root directly,
-then add it to Baggage before any child span starts.
+To link a [Langfuse-managed dataset](/docs/evaluation/experiments/datasets),
+set the experiment dataset ID and dataset item ID. If you run a specific
+[dataset version](/docs/evaluation/experiments/datasets#versioning), set the
+item version as well. Fetch these IDs and the version from Langfuse so the link
+refers to the correct dataset, item, and version.
 
-Use one attribute per metadata value, for example
-`langfuse.experiment.metadata.prompt_version`. This is the preferred OTel form.
-For object or array expected outputs, send a JSON-encoded string.
+{/* TODO: Add a FAQ explaining how to link ingested experiment items to the correct Langfuse dataset version. */}
+
+### 3. Item Context: Baggage Shared Within One Item Trace
+
+Before starting child spans, add the item identity and root ID to Baggage. This
+lets Langfuse link model calls, tool calls, and other work to the experiment
+item.
+
+```text
+itemBaggage = mergeBaggage(
+  experimentBaggage,
+  baggageFromAttributes(itemAttributes),
+)
+
+withContext(withActiveSpan(withBaggage(ROOT_CONTEXT, itemBaggage), root)):
+  runInstrumentedTask(item)
+
+root.end()
+```
 
 <Callout type="info">
   **Scores:** Attach experiment-item scores to the root observation. When using

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -139,7 +139,7 @@ pattern](#recommended-use-opentelemetry-baggage-for-propagation).
 It copies Baggage entries to each newly created span. The following sections
 show how each level is represented.
 
-<Callout type="warning">
+<Callout type="info">
   **Baggage is sent to downstream services:** OpenTelemetry injects Baggage
   into outbound request headers. This is usually not relevant for experiment
   context, but do not add sensitive values to it.

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -75,7 +75,7 @@ observations rather than only at the trace level. If you want to reliably
 filter or aggregate by these attributes, they need to be present on each span
 in the trace, not only on the root span.
 
-### Recommended: Use OpenTelemetry Baggage for Propagation
+### Recommended: Use OpenTelemetry Baggage for Propagation [#recommended-use-opentelemetry-baggage-for-propagation]
 
 The recommended approach for propagating these attributes across all spans is
 to use [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/)
@@ -112,6 +112,13 @@ simpler interface and are the recommended approach when using Langfuse SDKs.
 
 ## Experiments: Ingesting Experiment Spans
 
+<Callout type="info">
+  **Using Python or TypeScript?** Use [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)
+  with the [Langfuse SDKs](/docs/observability/sdk/overview). They handle these
+  attributes automatically. This guide is for direct OpenTelemetry ingestion,
+  primarily when no Langfuse SDK is available for your language.
+</Callout>
+
 An [experiment](/docs/evaluation/core-concepts#experiments) runs your
 application against test data. Each input is an experiment item, optionally
 with an expected output. Each item corresponds to one trace that shows how your
@@ -131,6 +138,12 @@ Configure a `BaggageSpanProcessor` as described in the [Baggage propagation
 pattern](#recommended-use-opentelemetry-baggage-for-propagation).
 It copies Baggage entries to each newly created span. The following sections
 show how each level is represented.
+
+<Callout type="warning">
+  **Baggage is sent to downstream services:** OpenTelemetry injects Baggage
+  into outbound request headers. This is usually not relevant for experiment
+  context, but do not add sensitive values to it.
+</Callout>
 
 ### 1. Experiment Context: Baggage Shared by All Item Traces
 
@@ -161,6 +174,8 @@ its `langfuse.observation.output` should be the actual output. Create the root
 with the experiment Baggage, then set the expected output and metadata directly
 on it. Its
 `langfuse.experiment.item.root_observation_id` must equal its own OTel `spanId`.
+Prefer this span to also be the OTel trace root, with no parent span or Langfuse
+parent observation.
 
 ```text
 for each item:
@@ -171,7 +186,7 @@ for each item:
   rootId = root.spanContext().spanId
 
   itemAttributes = {
-    "langfuse.experiment.item.id": item.id,
+    "langfuse.experiment.item.id": item.id, // DatasetItem ID when linking a Langfuse-managed dataset
     "langfuse.experiment.item.version": item.version, // optional: Langfuse-managed datasets only
     "langfuse.experiment.item.root_observation_id": rootId,
   }
@@ -184,17 +199,16 @@ for each item:
 ```
 
 To link a [Langfuse-managed dataset](/docs/evaluation/experiments/datasets),
-set the experiment dataset ID and dataset item ID. If you run a specific
-[dataset version](/docs/evaluation/experiments/datasets#versioning), set the
-item version as well. Fetch these IDs and the version from Langfuse so the link
-refers to the correct dataset, item, and version.
+set the experiment dataset ID to `Dataset.id` and
+`langfuse.experiment.item.id` to the `DatasetItem.id` returned by Langfuse. If
+you fetch a
+[specific dataset version](/docs/evaluation/experiments/datasets#fetch-dataset-at-a-specific-version),
+set the item version to the same version timestamp.
 
 When using local data, you can also set the experiment dataset ID and item IDs
 as local correlation identifiers. Use stable IDs to correlate the same local
 dataset across repeated experiment runs. Do not set an item version for local
 data.
-
-{/* TODO: Add a FAQ explaining how to link ingested experiment items to the correct Langfuse dataset version. */}
 
 ### 3. Item Context: Baggage Shared Within One Item Trace
 
@@ -216,7 +230,9 @@ root.end()
 
 <Callout type="info">
   **Scores:** Attach experiment-item scores to the root observation. When using
-  the Scores API, use the root span's `spanId` as the observation ID.
+  the [Scores API](/docs/evaluation/evaluation-methods/scores-via-sdk#trace-or-observation-level-scores),
+  use the root span's `traceId` as `traceId` and its `spanId` as
+  `observationId`.
 </Callout>
 
 ### Choose an Environment for Experiment Runs

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -187,6 +187,11 @@ set the experiment dataset ID and dataset item ID. If you run a specific
 item version as well. Fetch these IDs and the version from Langfuse so the link
 refers to the correct dataset, item, and version.
 
+When using local data, you can also set the experiment dataset ID and item IDs
+as local correlation identifiers. Use stable IDs to correlate the same local
+dataset across repeated experiment runs. Do not set an item version for local
+data.
+
 {/* TODO: Add a FAQ explaining how to link ingested experiment items to the correct Langfuse dataset version. */}
 
 ### 3. Item Context: Baggage Shared Within One Item Trace


### PR DESCRIPTION
## Summary

- document the three scopes of direct OTLP experiment ingestion: experiment context, item context, and root-only item data
- show how to use OpenTelemetry Baggage and a Baggage span processor without joining all experiment items into one trace
- explain the root observation ID invariant, root-level scores, and an optional dedicated `experiment` environment

## Validation

- `git diff --check`
- `prettier --check content/integrations/native/opentelemetry.mdx`
- manually ingested a two-item OTLP payload against a local Langfuse server; the resulting experiment data was verified in the UI

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Experiments: Ingesting Experiment Spans" section to the OpenTelemetry integration docs, describing how to structure OTLP payloads so that Langfuse can ingest and synthesize experiment runs without using the Langfuse SDK directly.

- Introduces a three-level context model (experiment context via shared Baggage, item root via direct span attributes, item context via merged Baggage) with pseudocode walkthroughs for each level.
- Documents the `langfuse.experiment.item.root_observation_id` invariant, root-level score attachment, and an optional dedicated `experiment` environment for separating experiment traffic from production.
- A leftover `{/* TODO */}` comment acknowledges a gap in guidance for linking ingested items to Langfuse-managed dataset versions; the dual-purpose role of `langfuse.experiment.item.id` (local identifier vs. managed-dataset item UUID) is not explicitly distinguished in the prose, which could cause silent linkage failures for managed-dataset users.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code execution risk; the new section is well-structured and the author validated it against a local Langfuse instance.

The three-level model and pseudocode are internally consistent, and the cross-references resolve correctly. Two areas need attention before this is fully polished: the TODO comment openly flags an incomplete FAQ about dataset-version linking, and the attribute `langfuse.experiment.item.id` is used for both local identifiers and Langfuse-managed dataset item UUIDs without making that distinction explicit — a reader using a managed dataset who supplies their own local ID would silently break the dataset link.

content/integrations/native/opentelemetry.mdx — specifically the dataset linking prose (lines 186-195) and the TODO comment (line 197).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application
    participant OTel as OTel SDK + BaggageSpanProcessor
    participant Langfuse as Langfuse OTLP Endpoint

    Note over App: Build experimentBaggage once<br/>(experiment.id, name, description, dataset.id…)

    loop For each experiment item
        App->>OTel: "startSpan("experiment-item", ctx=withBaggage(ROOT_CONTEXT, experimentBaggage))"
        Note over OTel: BaggageSpanProcessor copies<br/>experimentBaggage → root span attrs
        App->>OTel: root.setAttributes(itemAttributes + expected_output + item metadata)
        Note over App: itemBaggage = merge(experimentBaggage, itemAttributes)<br/>incl. item.id, item.version, root_observation_id
        App->>OTel: withContext(withActiveSpan(withBaggage(ROOT_CONTEXT, itemBaggage), root))
        Note over OTel: Context: root is active span,<br/>itemBaggage in effect
        loop runInstrumentedTask — child spans
            OTel->>OTel: "startSpan (child)<br/>BaggageSpanProcessor copies<br/>itemBaggage → child attrs"
        end
        App->>OTel: root.end()
        OTel->>Langfuse: Export all spans for item trace (OTLP)
    end

    Note over Langfuse: Groups all item traces into one experiment<br/>via experiment.id present on every span
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application
    participant OTel as OTel SDK + BaggageSpanProcessor
    participant Langfuse as Langfuse OTLP Endpoint

    Note over App: Build experimentBaggage once<br/>(experiment.id, name, description, dataset.id…)

    loop For each experiment item
        App->>OTel: "startSpan("experiment-item", ctx=withBaggage(ROOT_CONTEXT, experimentBaggage))"
        Note over OTel: BaggageSpanProcessor copies<br/>experimentBaggage → root span attrs
        App->>OTel: root.setAttributes(itemAttributes + expected_output + item metadata)
        Note over App: itemBaggage = merge(experimentBaggage, itemAttributes)<br/>incl. item.id, item.version, root_observation_id
        App->>OTel: withContext(withActiveSpan(withBaggage(ROOT_CONTEXT, itemBaggage), root))
        Note over OTel: Context: root is active span,<br/>itemBaggage in effect
        loop runInstrumentedTask — child spans
            OTel->>OTel: "startSpan (child)<br/>BaggageSpanProcessor copies<br/>itemBaggage → child attrs"
        end
        App->>OTel: root.end()
        OTel->>Langfuse: Export all spans for item trace (OTLP)
    end

    Note over Langfuse: Groups all item traces into one experiment<br/>via experiment.id present on every span
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/integrations/native/opentelemetry.mdx:197
**Left-in TODO marks an acknowledged documentation gap.** The comment is invisible to readers, but the guidance it refers to — how to correctly link an ingested experiment item to a Langfuse-managed dataset version — is genuinely missing from this section. A user following the prose ("Fetch these IDs and the version from Langfuse") still has no concrete reference for which API call to make or how the `item.version` field must match the stored version. Either the FAQ should be added before this lands, or the gap should be tracked as an issue so the documentation doesn't ship incomplete.

### Issue 2 of 2
content/integrations/native/opentelemetry.mdx:173-184
**`langfuse.experiment.item.id` role is ambiguous for Langfuse-managed datasets.** The prose says "set the experiment dataset ID and dataset item ID," but the pseudocode only shows `langfuse.experiment.item.id` = `item.id` — it's not explicit that this field doubles as the Langfuse dataset item ID when using managed datasets. A reader working with a Langfuse-managed dataset could reasonably interpret `langfuse.experiment.item.id` as a locally-generated run identifier and use their own value, breaking the link to the dataset. Clarifying that `langfuse.experiment.item.id` must be set to the Langfuse dataset item's UUID (fetched from the API) when linking a managed dataset would prevent this misuse.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): clarify experiment co..."](https://github.com/langfuse/langfuse-docs/commit/9d6cbf903b370fb9c842d3db14133edb7daa69b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44769470)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->