### PR TITLE
fix: pass QA chatbot system prompt as instructions

### DIFF
--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -78,6 +78,13 @@ export const handler = async (req: Request) => {
       }));
 
       const compiledPrompt = prompt.compile({}, { chat_history: chatHistory });
+      const systemPrompt = compiledPrompt
+        .filter((message) => message.role === "system")
+        .map((message) => message.content)
+        .join("\n\n");
+      const modelMessages = compiledPrompt.filter(
+        (message) => message.role !== "system",
+      );
 
       const mcpClient = await startActiveObservation(
         "create-mcp-client",
@@ -103,7 +110,8 @@ export const handler = async (req: Request) => {
             reasoningEffort,
           } satisfies OpenAIResponsesProviderOptions,
         },
-        messages: compiledPrompt,
+        instructions: systemPrompt || undefined,
+        messages: modelMessages,
         tools: tools as Parameters<typeof streamText>[0]["tools"],
         stopWhen: stepCountIs(10),
         runtimeContext: {


### PR DESCRIPTION
## What changed

- Extract system-role messages from the compiled Langfuse chat prompt.
- Pass their content through AI SDK 7's `instructions` option.
- Keep only non-system messages in the `messages` array.

## Why

AI SDK 7 rejects system-role entries in `prompt` or `messages`. The QA chatbot passed the complete compiled Langfuse prompt through `messages`, causing `AI_InvalidPromptError` before generation started.

This preserves the managed system prompt while sending it through the API field expected by AI SDK 7.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run format:check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an `AI_InvalidPromptError` in the QA chatbot by separating system-role messages from chat messages before passing them to `streamText`. AI SDK 7 no longer accepts system-role entries inside the `messages` array, so the fix extracts them and forwards their content through the `instructions` parameter instead.

- **System prompt extraction**: `compiledPrompt` is split into system messages (joined with `\n\n` into `systemPrompt`) and all other messages (`modelMessages`), with `systemPrompt || undefined` guarding against an empty-string passthrough.
- **API alignment**: `streamText` now receives `instructions: systemPrompt | undefined` and `messages: modelMessages`, matching the field contract AI SDK 7 expects for the OpenAI Responses provider.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a targeted, narrowly-scoped fix that restores the chatbot to a working state under AI SDK 7 constraints.

The extraction logic is straightforward and the `|| undefined` guard correctly suppresses an empty string. The only latent concern is that `message.content` is consumed directly via `.join()` without checking whether it is a string or a content-array, but in practice Langfuse system messages are always plain strings and TypeScript did not surface a type mismatch.

No files require special attention; the single changed file is small and well-contained.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pass QA chatbot system prompt as in..."](https://github.com/langfuse/langfuse-docs/commit/41f60f98e92a6de94482168f579a2931e145c12d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44759246)</sub>

<!-- /greptile_comment -->