### PR TITLE
Add 6 evaluation-focused engineering resources pages (metric recipes, regression testing, golden datasets, Promptfoo migration)

### DIFF
--- a/content/resources/engineering/answer-relevance-evaluation.mdx
+++ b/content/resources/engineering/answer-relevance-evaluation.mdx
@@ -149,14 +149,20 @@ print(result.format())
 
 Each item produces a trace with the task execution and two scores (`answer_relevance` and `refusal`); the run carries the aggregate `relevance_rate`. The judge's one-sentence reasoning lands in the score comment, which is what you read when auditing why an item failed.
 
-To make runs comparable over time, move the questions into a Langfuse-hosted dataset and run the same task and evaluators against it. Every execution then becomes a dataset run you can diff in the UI against previous prompt or model versions:
+To make runs comparable over time, move the questions into a Langfuse-hosted dataset and run the same evaluators against it. Every execution then becomes a dataset run you can diff in the UI against previous prompt or model versions. Note one difference: hosted dataset items are objects with an `input` attribute, not dicts, so the task reads `item.input` instead of `item["input"]`:
 
 ```python
 dataset = langfuse.get_dataset("support-questions")
 
+
+def answer_dataset_question(*, item, **kwargs):
+    """Same application task; hosted dataset items expose attributes, not dict keys."""
+    return answer_question(item={"input": item.input}, **kwargs)
+
+
 result = dataset.run_experiment(
     name="Answer relevance, prompt v2",
-    task=answer_question,
+    task=answer_dataset_question,
     evaluators=[answer_relevance],
     run_evaluators=[relevance_rate],
 )

--- a/content/resources/engineering/answer-relevance-evaluation.mdx
+++ b/content/resources/engineering/answer-relevance-evaluation.mdx
@@ -1,0 +1,195 @@
+---
+title: Answer relevance evaluation for LLM applications
+description: "Answer relevance evaluation for LLM apps: what the metric measures, judge prompt design, a runnable Langfuse experiment, and how Ragas answer relevancy fits."
+tags: [guide, evaluation]
+---
+
+# Answer relevance evaluation for LLM applications
+
+Answer relevance measures whether a generated answer addresses the question that was asked. It is one of the core quality metrics for question-answering systems, RAG pipelines, and support chatbots, because the most common failure in these applications is not a wrong fact but a non-answer: the model responds fluently to a related question, covers half of a two-part question, or deflects entirely. Relevance is judged from the question and the answer alone, so it can be computed without ground truth labels.
+
+**TL;DR:** Answer relevance evaluation checks question-answer fit, not factual correctness and not groundedness in retrieved context. Because it needs no reference answer, it works both in offline experiments and on live production traffic. The recipe below defines the metric boundary, walks through judge prompt design for the hard cases (partial answers and refusals), and implements it end to end as a Langfuse experiment with a binary LLM-as-a-judge evaluator, plus the online evaluator setup for production traces.
+
+## How answer relevance differs from faithfulness and hallucination detection
+
+Answer relevance answers exactly one question: does the response address what the user asked? A response can be perfectly relevant and factually wrong, and a response can be fully grounded in retrieved documents while ignoring the question. Evaluating these as one blended "quality" score hides which failure you have, so each dimension gets its own evaluator:
+
+| Question about the output                           | Metric                  | Recipe                                                                            |
+| --------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------------- |
+| Does it address the question that was asked?        | Answer relevance        | This page                                                                         |
+| Is it supported by the retrieved context?           | RAG faithfulness        | [RAG faithfulness evaluation](/resources/engineering/rag-faithfulness-evaluation) |
+| Does it assert facts that are false or unsupported? | Hallucination detection | [Hallucination detection](/resources/engineering/hallucination-detection)         |
+
+The three metrics fail independently in practice. A RAG system with a weak retriever produces faithful but irrelevant answers (it accurately summarizes the wrong documents). A strong model with no retrieval produces relevant but unfaithful answers. Scoring relevance separately tells you whether to fix the prompt and question handling, or the retrieval and grounding.
+
+## Answer relevance needs no ground truth
+
+Answer relevance is a reference-free metric. The judge compares the answer against the question, not against an expected output, so an evaluation dataset for it is just a list of questions. This has two practical consequences:
+
+1. You can start evaluating before anyone writes golden answers. A dump of real user questions is a complete relevance dataset.
+2. The same evaluator runs on production traffic, where ground truth never exists. Reference-based metrics like answer correctness are confined to curated test sets; relevance is not.
+
+The trade-off is scope: a reference-free judge cannot tell you the answer is right. Teams typically pair a relevance evaluator with a correctness evaluator on the labeled subset of their data and rely on relevance alone for the unlabeled rest.
+
+## Designing an answer relevance judge prompt
+
+Relevance requires reading comprehension, so the evaluator is an LLM-as-a-judge rather than a code check. Three design decisions determine whether the scores are useful.
+
+**Keep the judge on the question, not the quality.** Judges drift toward rating answers as "good" when they are long, confident, and well-formatted. The prompt must state that style, correctness, and completeness of explanation are out of scope, and that the only test is whether the specific question asked gets addressed. Answering a related but different question fails.
+
+**Decide explicitly how partial answers score.** For a multi-part question ("what is the refund policy, and does it differ for annual plans?"), an answer covering one part is the exact failure mode this metric exists to catch. The rubric below fails partial answers. If you prefer to track partial coverage, make it a separate categorical score rather than softening the relevance definition.
+
+**Score refusals honestly.** "I can't help with that" is not relevant to the question, and the judge should say so, even when refusing was the right behavior. Letting refusals pass as relevant silently inflates your metric as the model gets more cautious. The honest setup scores the refusal as not relevant and tracks refusals as their own score, so a rising refusal rate is visible instead of laundered through the relevance number.
+
+One more recommendation from [Langfuse Academy](/academy/evaluate): prefer binary pass/fail scores over 1-to-5 scales. A binary rubric forces a clear definition of what separates acceptable from unacceptable, while graded scales leave the difference between a 3 and a 4 to the judge's mood, which makes scores drift across evaluators and over time.
+
+## Run an answer relevance experiment with the Langfuse Python SDK
+
+The script below is self-contained: a task that answers questions, a binary relevance judge, a run-level aggregate, and a dataset of plain questions with no expected outputs. It uses the experiment runner in the Langfuse Python SDK (v4), which traces every task execution, runs evaluators concurrently, and records scores automatically. If your application already traces with Langfuse, this adds no new services and no new credentials: the experiment uses the same SDK and the same API keys as your tracing setup, against Langfuse Cloud or a self-hosted instance.
+
+```python
+# pip install langfuse openai
+# env: LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST, OPENAI_API_KEY
+
+import json
+
+import openai
+from langfuse import Evaluation, get_client
+from langfuse.openai import OpenAI  # drop-in wrapper, traces the task's model calls
+
+langfuse = get_client()
+task_client = OpenAI()          # application calls, traced into each experiment item
+judge_client = openai.OpenAI()  # judge calls, kept out of the application traces
+
+JUDGE_PROMPT = """You are evaluating whether an answer is relevant to the question asked.
+
+Question:
+{question}
+
+Answer:
+{answer}
+
+The answer is relevant only if it addresses the specific question asked. Apply these rules:
+- Answering a related but different question is not relevant.
+- Addressing only some parts of a multi-part question is not relevant.
+- A refusal, deflection, or "I don't know" is not relevant, even if refusing was appropriate.
+- Style, length, and factual correctness are out of scope; judge only question-answer fit.
+
+Respond in JSON: {{"relevant": true or false, "refusal": true or false, "reasoning": "one sentence"}}"""
+
+
+def answer_question(*, item, **kwargs):
+    """The application under test: answer a user question."""
+    response = task_client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {"role": "system", "content": "You are a support assistant for a SaaS product."},
+            {"role": "user", "content": item["input"]},
+        ],
+    )
+    return response.choices[0].message.content
+
+
+def answer_relevance(*, input, output, **kwargs):
+    """Binary LLM-as-a-judge for answer relevance. Reference-free: no expected output used."""
+    judgment = judge_client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {
+                "role": "user",
+                "content": JUDGE_PROMPT.format(question=input, answer=output),
+            }
+        ],
+        response_format={"type": "json_object"},
+        temperature=0,
+    )
+    verdict = json.loads(judgment.choices[0].message.content)
+    return [
+        Evaluation(
+            name="answer_relevance",
+            value=1.0 if verdict["relevant"] else 0.0,
+            comment=verdict["reasoning"],
+        ),
+        Evaluation(name="refusal", value=1.0 if verdict["refusal"] else 0.0),
+    ]
+
+
+def relevance_rate(*, item_results, **kwargs):
+    """Run-level aggregate: share of relevant answers across the dataset."""
+    values = [
+        e.value
+        for r in item_results
+        for e in r.evaluations
+        if e.name == "answer_relevance"
+    ]
+    return Evaluation(
+        name="relevance_rate",
+        value=sum(values) / len(values) if values else None,
+    )
+
+
+# A relevance dataset is just questions; no ground truth required.
+data = [
+    {"input": "How do I rotate an API key without downtime?"},
+    {"input": "What is the refund policy, and does it differ for annual plans?"},
+    {"input": "Can I export my usage data to CSV?"},
+    {"input": "Why was my account charged twice this month?"},
+]
+
+result = langfuse.run_experiment(
+    name="Answer relevance baseline",
+    description="Binary relevance judge over the support question set",
+    data=data,
+    task=answer_question,
+    evaluators=[answer_relevance],
+    run_evaluators=[relevance_rate],
+)
+print(result.format())
+```
+
+Each item produces a trace with the task execution and two scores (`answer_relevance` and `refusal`); the run carries the aggregate `relevance_rate`. The judge's one-sentence reasoning lands in the score comment, which is what you read when auditing why an item failed.
+
+To make runs comparable over time, move the questions into a Langfuse-hosted dataset and run the same task and evaluators against it. Every execution then becomes a dataset run you can diff in the UI against previous prompt or model versions:
+
+```python
+dataset = langfuse.get_dataset("support-questions")
+
+result = dataset.run_experiment(
+    name="Answer relevance, prompt v2",
+    task=answer_question,
+    evaluators=[answer_relevance],
+    run_evaluators=[relevance_rate],
+)
+```
+
+The full runner API, including concurrency control and async tasks, is documented in [experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk).
+
+## Evaluate answer relevance on production traces
+
+Because relevance is reference-free, the same rubric runs on live traffic. In Langfuse, this is an [LLM-as-a-judge evaluator](/docs/evaluation/evaluation-methods/llm-as-a-judge) that the platform executes for you, no SDK code involved: create a custom evaluator with the rubric above as the prompt and `{{question}}` and `{{answer}}` variables, map those variables to the input and output of the observations you want judged (with JSONPath for nested fields, and a live preview against your last 24 hours of data), and target live observations with a sampling percentage. Sampling 5 to 10 percent of traffic is usually enough to see the relevance trend without judging every request.
+
+Scores attach to the matched observations asynchronously, so this is a monitoring signal, not an in-flight guardrail. The payoff is the trend line: a relevance drop after a prompt change, a model swap, or a retriever regression shows up in the score timeline before it shows up in support tickets, and the flagged traces are the exact items to pull into your experiment dataset for the next offline iteration.
+
+## Ragas answer relevancy and Langfuse
+
+[Ragas](https://docs.ragas.io/) popularized this metric under the name `answer_relevancy` (class `ResponseRelevancy`), and its implementation is worth understanding even if you do not use the library. Instead of asking a judge directly, Ragas generates a few candidate questions from the answer (three by default) and scores the mean cosine similarity between their embeddings and the original question's embedding; evasive or noncommittal answers are forced to a score of 0. It is reference-free, like the judge approach above, and requires both an LLM and an embedding model. The embedding formulation yields a graded 0-to-1 signal and comes with prompts the Ragas project maintains; the direct binary judge is simpler to run, cheaper (no embedding calls), and gives you a rubric you can read and edit when scores look wrong.
+
+Both work with Langfuse. Ragas scores computed in your own pipeline can be pushed to Langfuse traces and experiments, and the managed evaluator catalog includes evaluators built with partners like Ragas. See the [Ragas integration](/integrations/frameworks/ragas) for the end-to-end setup.
+
+## FAQ
+
+### What is the difference between answer relevance and answer correctness? [#relevance-vs-correctness]
+
+Answer relevance checks whether the response addresses the question asked; answer correctness checks whether the response is factually right, usually by comparing against a reference answer. An answer can be fully relevant and wrong, or correct on the facts while answering a different question. Relevance is reference-free and runs anywhere, while correctness needs ground truth and is confined to labeled datasets.
+
+### Can you evaluate answer relevance without ground truth? [#no-ground-truth]
+
+Yes. Answer relevance is judged from the question and the answer alone, so no expected output is needed. This is why a plain list of real user questions is a complete relevance dataset, and why the same evaluator can run on production traces, where ground truth never exists.
+
+### How should refusals be scored in answer relevance evaluation? [#handling-refusals]
+
+Score refusals as not relevant, and record a separate refusal score so they stay distinguishable from ordinary failures. A refusal does not address the question, even when refusing is the correct behavior, and counting refusals as relevant hides growing model caution inside a flat metric. Ragas handles this the same way: noncommittal answers are scored 0.
+
+### Is answer relevance the same as Ragas answer relevancy? [#ragas-answer-relevancy]
+
+They measure the same property with different mechanics. Ragas `answer_relevancy` generates questions from the answer and scores embedding similarity to the original question, producing a graded 0-to-1 value; a direct LLM-as-a-judge reads the question-answer pair against a rubric, typically returning a binary verdict with reasoning. Both are reference-free, and both can write scores to Langfuse.

--- a/content/resources/engineering/golden-dataset-evaluation.mdx
+++ b/content/resources/engineering/golden-dataset-evaluation.mdx
@@ -1,0 +1,239 @@
+---
+title: "Golden dataset evaluation: build and maintain LLM test sets"
+description: "Golden dataset evaluation for LLM apps: build test sets from production traces, keep them fresh, and compare prompt versions over time with experiments."
+tags: [guide, evaluation]
+---
+
+# Golden dataset evaluation: build and maintain LLM test sets
+
+A golden dataset is the fixed set of test cases you run your LLM application against before every meaningful change. Building one is not hard; keeping it representative for six months while your prompts, models, and users all change is the part most teams get wrong. This guide covers what a good golden dataset looks like, how to build one from the data you already have, how to maintain it as production evolves, and how to use it to compare prompt versions over time. The concepts are tool-agnostic; the implementation uses Langfuse, where datasets, experiments, and traces live in one place.
+
+**TL;DR:** A golden dataset is a curated collection of inputs with reviewed reference outputs (or explicit pass criteria) that represents what your application must handle. Good ones are scoped to one component or behavior, sized for their job (tens of items for a fast PR gate, hundreds to a thousand for a full regression set), cover your known failure modes, and grow from production failures instead of staying frozen. Build it from real traces first, CSV imports and synthetic generation second. Maintain it with schema validation, deduplication, and item versioning. Compare prompt versions by running one experiment per version against the same pinned dataset version and reading score deltas against a designated baseline.
+
+## What a golden dataset is
+
+A golden dataset (also called a gold set or reference set) is a collection of test cases where each item records an input your application should handle and, usually, a reviewed definition of what a correct response looks like. "Golden" means the items are curated and trusted: someone with domain knowledge confirmed the expected output, or deliberately decided the item does not need one because a reference-free check (format, safety, tone) is the pass criterion.
+
+That trust is the entire value. When an experiment against the golden dataset shows a score drop, you want the conclusion to be "the change regressed quality," not "item 23 has a wrong label." An unreviewed pile of examples produces scores nobody acts on; a golden dataset produces scores that block or promote releases.
+
+Teams need one because informal spot-checking does not survive iteration. The first prompt tweak you eyeball; by the tenth, you cannot remember which earlier behavior you traded away. A fixed, trusted test set turns "does the new prompt feel better" into a measured comparison, and it is the prerequisite for everything downstream: regression testing in CI, model migration decisions, and honest before/after numbers for stakeholders.
+
+## What a good golden dataset looks like
+
+A good golden dataset mirrors what your system encounters in production and is scoped tightly enough that a failure points at a cause. Three properties matter most.
+
+**Scope: one dataset per component or behavior.** A dataset can target the end-to-end flow or a single step like retrieval, routing, or summarization, but it should not mix them. You will end up with several datasets, each answering one question. Langfuse supports folder-style names (`support-agent/golden`, `support-agent/adversarial`) to keep them organized.
+
+**Size: matched to the job, not maximized.** More items mean more coverage but slower, costlier runs. The [Langfuse Academy datasets module](/academy/datasets) suggests these working sizes:
+
+| Purpose                             | Typical size                                               |
+| ----------------------------------- | ---------------------------------------------------------- |
+| Exploring a single issue            | ~10 items                                                  |
+| Testing model capability boundaries | ~10 complex unsolved examples                              |
+| CI checks on larger changes         | 100 to 1000 items, covering the production distribution    |
+| Guardrail penetration testing       | Large and growing, add cases as they surface in production |
+
+For a gate that runs on every pull request, keep a subset of tens to low hundreds of items so the check stays fast, and reserve the full set for release branches or nightly runs.
+
+**Coverage of failure modes, not just happy paths.** Every failure mode you have observed in production deserves at least a few items: the ambiguous question, the multi-part request, the input in the wrong language, the prompt-injection attempt. A dataset of easy cases scores 95 percent forever and tells you nothing. A useful heuristic: if a class of input has ever caused an incident or a support ticket, it belongs in the dataset.
+
+Freshness is the property that decays silently. A golden dataset assembled in January describes January's traffic; by July, users ask different questions and your product has new features. Treat the dataset as an append-mostly log that tracks production (the maintenance section below covers how), and date your items in metadata so you can see at a glance how stale the set is.
+
+## Building a golden dataset in Langfuse
+
+Everything in this section is a UI action or an SDK call against data you already have. There is no separate evaluation service to deploy or keep in sync: datasets live in the same Langfuse project as your traces, the SDK calls run inside your existing codebase, and if you self-host Langfuse, nothing leaves your infrastructure. The [datasets documentation](/docs/evaluation/experiments/datasets) is the full feature reference; this section covers the workflow.
+
+### Start from production traces
+
+Real traffic beats invented examples, so start there. In the Langfuse UI, every trace and observation has an "+ Add to dataset" action, which is the right tool while you review failures one by one. For bulk collection, filter the observations table (by score, user feedback, tags, or any other column), select the rows, and use **Actions** → **Add to dataset**. A field-mapping step controls how observation data becomes a dataset item: use whole fields as-is, extract values with JSON path expressions, or build custom objects from multiple fields. Batch additions run in the background with partial success, so a few malformed rows do not block the rest.
+
+Programmatically, the same operation is one SDK call, and linking the source trace preserves the full execution context for anyone reviewing the item later:
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+langfuse.create_dataset_item(
+    dataset_name="support-agent/golden",
+    input={"question": "How do I cancel my subscription?"},
+    expected_output={"answer": "Go to Settings > Billing > Cancel plan. The plan stays active until the end of the billing period."},
+    source_trace_id="<trace_id>",
+    source_observation_id="<observation_id>",  # optional: link a specific span or generation
+)
+```
+
+The expected output typically starts as the model's actual production output, corrected by a domain expert. That review step is what makes the item golden rather than merely logged.
+
+### Import existing test cases via CSV
+
+If test cases already live in a spreadsheet, upload the CSV in the dataset UI. A header row is required; you then drag each column onto `input`, `expected output`, or `metadata`, and multiple columns dropped on the same field are combined into one structured JSON object. Unmapped columns are ignored. CSV import is for text and structured JSON items; use the item editor or SDK for items with media attachments.
+
+Dataset items can carry media attachments (images, audio, documents) in `input`, `expected_output`, and `metadata` as of June 2026, so vision and document workflows get golden datasets too. SDK-based experiments support these items with Python SDK 4.10.0+ and JS/TS `@langfuse/client` 5.6.0+; UI-based experiments do not support them yet.
+
+### Augment synthetically where real data is thin
+
+Synthetic generation fills coverage gaps that production has not exercised yet: paraphrases of known-hard inputs, edge cases for a feature that just launched, adversarial phrasings of the same intent. Generate variations with an LLM, then review them with the same rigor as real items, because unreviewed synthetic items dilute the trust that makes the dataset golden. The [synthetic datasets cookbook](/guides/cookbook/example_synthetic_datasets) has runnable pipelines for this. Keep the ratio in check: synthetic items should extend a production-grounded core, not replace it.
+
+### Enforce structure with dataset schemas
+
+Once several people and pipelines write to a dataset, malformed items creep in and break experiment runs at the worst time. Langfuse datasets accept optional JSON Schemas for `input` and `expected_output`; once set, every item is validated on creation, update, and CSV import, and invalid items are rejected with the exact validation error:
+
+```python
+langfuse.create_dataset(
+    name="support-agent/golden",
+    input_schema={
+        "type": "object",
+        "properties": {"question": {"type": "string"}},
+        "required": ["question"],
+    },
+    expected_output_schema={
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    },
+)
+```
+
+Define the schema on day one. Retrofitting one onto a thousand inconsistent items is a cleanup project; enforcing it from the start is free.
+
+## Maintaining a golden dataset
+
+A golden dataset is maintained the way a test suite is maintained: every escaped bug becomes a test, duplicates get merged, and obsolete cases get retired deliberately rather than silently.
+
+### Turn production failures into items as they occur
+
+The highest-value new items are the cases your application just failed. Wire the pipeline so that flagged production traces flow into the dataset while the failure is fresh: a reviewer working through an annotation queue can add the trace to a dataset directly, and a scheduled script can sweep for negative signals automatically. The script below collects yesterday's thumbs-down feedback into the golden dataset:
+
+```python
+from datetime import datetime, timedelta, timezone
+from langfuse import get_client
+
+langfuse = get_client()
+
+scores = langfuse.api.scores.get_many(
+    name="user-feedback",
+    from_timestamp=datetime.now(timezone.utc) - timedelta(days=1),
+    limit=100,
+)
+
+for score in scores.data:
+    if score.value == 0 and score.trace_id:  # thumbs-down
+        trace = langfuse.api.trace.get(score.trace_id)
+        langfuse.create_dataset_item(
+            dataset_name="support-agent/golden",
+            input=trace.input,
+            expected_output=None,  # a reviewer supplies the corrected answer
+            metadata={"source": "production-failure", "added": str(datetime.now(timezone.utc).date())},
+            source_trace_id=score.trace_id,
+        )
+```
+
+Items arriving this way are candidates, not yet golden: route them through expert review to fill in the corrected expected output before they count in experiments. A broader [LLM evaluation strategy](/resources/engineering/llm-evaluation-strategy) builds on this same loop, connecting production monitoring back to offline testing.
+
+### Deduplicate before items pile up
+
+Twenty near-identical phrasings of the same question overweight that case in every average score and slow every run. Deduplicate on intake: before adding an item, check whether the dataset already covers the same intent, either by exact-matching normalized inputs fetched via `langfuse.api.dataset_items.list` or by embedding similarity for paraphrases. When you find a cluster of near-duplicates, keep the hardest one or two variants and drop the rest. Dataset schemas help here too, since consistent structure makes duplicates easier to detect.
+
+### Version the dataset, and run experiments against pinned versions
+
+Langfuse datasets are versioned automatically: every addition, update, deletion, or archival of items creates a new version identified by timestamp, with item-level diffs. This solves the core bookkeeping problem of a living golden dataset, which is that scores from different dates are only comparable if you know which dataset state each run saw. Experiments record the dataset state they ran against, and you can fetch a dataset as of any timestamp to reproduce or extend old comparisons:
+
+```python
+from datetime import datetime, timezone
+from langfuse import get_client
+
+langfuse = get_client()
+
+# The dataset exactly as it was when the baseline experiment ran
+baseline_version = datetime(2026, 7, 1, 9, 0, 0, tzinfo=timezone.utc)
+dataset = langfuse.get_dataset("support-agent/golden", version=baseline_version)
+```
+
+Note that versioning applies to dataset items only; changing a dataset's schema does not create a new version.
+
+### Retire items deliberately
+
+Retire an item when the behavior it tests no longer exists (a removed feature, a deprecated flow) or when the expected output has become wrong (a policy change made the reference answer incorrect). Archive rather than delete: archived items drop out of future experiment runs, but stay in the version history, so historical runs remain interpretable.
+
+```python
+langfuse.create_dataset_item(
+    dataset_name="support-agent/golden",
+    id="<item_id>",
+    status="ARCHIVED",
+)
+```
+
+Do not retire an item just because your application keeps passing it. Passing items are doing their job, which is proving the behavior still holds. A reasonable cadence is a quarterly review pass over items older than six months, checking each against current product behavior.
+
+## Comparing prompt versions over time
+
+With a trusted dataset in place, comparing prompt versions becomes mechanical: run one [experiment](/docs/evaluation/experiments/experiments-via-sdk) per prompt version against the same dataset version, score each run with the same evaluators, and read the deltas.
+
+### Run one experiment per prompt version
+
+Fetch each prompt version from prompt management and run it through the SDK's experiment runner, which handles concurrency, tracing, and score attachment. Recording the prompt version in the run name and metadata makes runs identifiable in the UI months later:
+
+```python
+from langfuse import get_client, Evaluation
+from langfuse.openai import OpenAI
+
+langfuse = get_client()
+dataset = langfuse.get_dataset("support-agent/golden")
+
+def correctness(*, output, expected_output, **kwargs):
+    match = expected_output and expected_output["answer"].lower() in output.lower()
+    return Evaluation(name="correctness", value=1.0 if match else 0.0)
+
+for version in [7, 8]:
+    prompt = langfuse.get_prompt("support-agent", version=version)
+
+    def task(*, item, prompt=prompt, **kwargs):
+        compiled = prompt.compile(question=item.input["question"])
+        response = OpenAI().chat.completions.create(
+            model="gpt-4.1",
+            messages=[{"role": "user", "content": compiled}],
+        )
+        return response.choices[0].message.content
+
+    result = dataset.run_experiment(
+        name=f"support-agent prompt v{version}",
+        description=f"Prompt version {version} on the golden dataset",
+        task=task,
+        evaluators=[correctness],
+        metadata={"prompt_version": version},
+    )
+    print(result.format())
+```
+
+Because experiments run against the latest dataset version by default, pin a version (previous section) when a comparison spans days or weeks of dataset growth; otherwise the two runs are tested on different sets of items. If the change under test is prompt-only, you can skip the code entirely: [experiments via UI](/docs/evaluation/experiments/experiments-via-ui) run a selected prompt version against a dataset with a configured model and optional evaluators, directly from the dataset page.
+
+### Read the deltas against a baseline
+
+In the experiments table, select two runs and click **Compare**, then designate one (typically the current production version) as the baseline. The compare view matches rows by dataset item, so each row shows baseline and candidate output for the same input, with green and red deltas for scores, cost, and latency. The Charts tab summarizes the aggregate picture, which answers the first question: did quality move, and at what cost.
+
+The item-level table answers the second, more important question: what exactly got worse. Filter the columns to build a regression worklist, for example all items where the candidate's correctness dropped or cost rose more than 10 percent, then open each row's trace to see why. Two reading disciplines keep the deltas honest: verify that the evaluator's verdict matches actual output quality on a few spot-checked rows before trusting an aggregate, and treat a small aggregate delta composed of large offsetting item-level swings as a behavior change worth reading, not a wash.
+
+Over longer horizons, the experiments table on a dataset is the timeline: every run records its prompt version metadata, its scores, and its dataset version, so "how has quality developed across prompt versions 5 through 12" is answered by scanning one table.
+
+### Automate the comparison in CI
+
+Once the manual loop works, move it into CI so every pull request that touches a prompt runs the golden dataset automatically and fails on regression. Langfuse ships a GitHub Action (`langfuse/experiment-action`) that loads a dataset, optionally pinned to a version, runs your experiment script, posts scores as a PR comment, and fails the job on a raised regression. The full setup, including thresholds and non-GitHub CI systems, is covered in our [LLM regression testing guide](/resources/engineering/llm-regression-testing).
+
+## FAQ
+
+### How large should a golden dataset be? [#dataset-size]
+
+Large enough to cover your failure modes, small enough that you actually run it. Start with 20 to 50 reviewed items covering your most important behaviors, which already catches gross regressions. Grow toward 100 to 1000 items for a full regression set that mirrors the production distribution, and keep a subset of tens to low hundreds for per-PR CI gates. Coverage of distinct failure modes matters more than raw count: 100 diverse items beat 1000 near-duplicates.
+
+### Does every item need a ground-truth expected output? [#ground-truth]
+
+No. The expected output exists to serve reference-based evaluators (exact match, similarity, fact coverage), and it can be a literal answer, a gold reference response, or a list of criteria the output must satisfy. Items checked only by reference-free evaluators, such as format validity, safety, or tone, need no expected output at all. Many golden datasets mix both kinds, and a single item's expected output field can hold several reference types as JSON.
+
+### How do we detect and handle dataset drift? [#dataset-drift]
+
+Dataset drift means your golden dataset no longer resembles production traffic, so passing it stops predicting production quality. The clearest symptom is divergence between strong experiment scores and weakening production signals such as user feedback or online evaluator scores. Counter it structurally: continuously add sampled recent traces and fresh failures, record an `added` date in item metadata so you can measure the age distribution of the set, and retire items for behaviors that no longer exist. Dataset versioning keeps older comparisons valid while the set evolves.
+
+### Can we share a golden dataset across projects? [#share-across-projects]
+
+Datasets in Langfuse are scoped to a single project, and there is currently no built-in cross-project sharing (as of July 2026). To reuse a dataset elsewhere, export the items from the UI as CSV or JSON, or copy them programmatically via the SDK, recreating items with `create_dataset_item` in the target project. The [data migration cookbook](/guides/cookbook/example_data_migration) includes a complete script that copies datasets, items, and runs between projects while preserving item IDs.

--- a/content/resources/engineering/hallucination-detection.mdx
+++ b/content/resources/engineering/hallucination-detection.mdx
@@ -1,0 +1,189 @@
+---
+title: Hallucination detection for LLM apps
+description: "Hallucination detection for LLM apps: taxonomy, LLM-as-a-judge evaluators on production traces, offline experiments with references, and code pre-screens."
+tags: [guide, evaluation]
+---
+
+# Hallucination detection for LLM apps
+
+A hallucination is an output that asserts something false or unsupported: a fabricated citation, a confident wrong number, an API method that does not exist. Hallucination detection is the practice of scoring outputs for unsupported claims automatically, so that the failure shows up as a metric on a dashboard instead of a complaint from a user. This page covers what counts as a hallucination, the detection methods that work in practice, and how to design the judge that does the detecting, with Langfuse as the worked implementation.
+
+**TL;DR:** Production hallucination detection runs an LLM-as-a-judge evaluator on a sample of live traffic; the judge is reference-free, checking the output against the input and context recorded on the same observation, so no ground truth is required. Offline detection runs experiments against a dataset with reference answers before each release, where a judge can verify claims against known-correct outputs. Deterministic code pre-screens (missing citations, numbers absent from context) flag risk signals for free and route only flagged traces to the paid judge. Score verdicts as binary hallucinated/clean, with the failing claims listed in the score comment.
+
+## What counts as a hallucination
+
+A hallucination is a claim in the output that the available evidence does not support. Two distinctions determine how you detect it.
+
+**Intrinsic versus extrinsic.** An intrinsic hallucination contradicts the source material: the context says the limit is 100 requests per minute and the answer says 1,000. An extrinsic hallucination adds material the source does not contain: the answer cites a paper that was never retrieved, or invents a config flag. Extrinsic claims may even be true, but an application that promises grounded answers cannot verify them, so detection treats unsupported and false the same way.
+
+**Grounded-context versus open-domain.** The second axis is what evidence exists to check against:
+
+| Setting                                                  | Evidence available                           | Detection approach                                                                         |
+| -------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Grounded context (RAG, tool results, provided documents) | The context is recorded alongside the output | Compare output claims against the recorded context                                         |
+| Open-domain (model answers from its own knowledge)       | No context to compare against                | Judge with world knowledge, reference answers in offline tests, or self-consistency checks |
+
+Grounded-context detection is a comparison problem and by far the more tractable case: the evidence travels with the trace. Open-domain detection is harder, because there is nothing on the trace that proves the claim either way; offline reference datasets and judge world knowledge carry more of the load there.
+
+## Hallucination detection vs faithfulness vs relevance
+
+Three metrics get conflated under "the answer is wrong", and they fail independently, so they need separate evaluators.
+
+- **Hallucination detection** asks whether the output makes claims the evidence does not support. It applies to any LLM application, with or without retrieval.
+- **Faithfulness** is the grounded-context subcase applied to RAG: is every claim in the answer supported by the retrieved documents? [RAG faithfulness evaluation](/resources/engineering/rag-faithfulness-evaluation) covers that case in depth, including how to separate retrieval failures from generation failures.
+- **Answer relevance** asks whether the output addresses the question at all. An answer can be fully grounded and still off-topic, or perfectly on-topic and fabricated. [Answer relevance evaluation](/resources/engineering/answer-relevance-evaluation) covers that dimension.
+
+If your application is a RAG pipeline, the faithfulness page is the deeper treatment of your main hallucination risk. This page covers the general detection problem: the taxonomy, the production and offline wiring, and judge design that applies to all three metrics.
+
+## Three detection methods
+
+| Method                              | Needs references                     | Cost per check                | Where it runs                   |
+| ----------------------------------- | ------------------------------------ | ----------------------------- | ------------------------------- |
+| LLM-as-a-judge on production traces | No                                   | One judge-model call          | Live traffic, sampled           |
+| Judge in offline experiments        | Yes (dataset with reference answers) | One judge-model call per item | Before release, in CI or ad hoc |
+| Deterministic code pre-screens      | No                                   | None                          | Every trace                     |
+
+### Method 1: LLM-as-a-judge on production traces
+
+Langfuse ships a catalog of managed [LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators, built and maintained by Langfuse and partners like Ragas. Hallucination is one of the managed dimensions, alongside Context-Relevance, Toxicity, and Helpfulness, so no prompt writing is required to start. The Hallucination evaluator is reference-free: it judges the output against the input and context you map from the observation, which is exactly why it works on production traffic where no expected output exists.
+
+Setup, in order:
+
+1. On the Evaluators page, click `+ Set up Evaluator` and set a default judge model via an LLM Connection. The model must support structured output so verdicts parse reliably.
+2. Pick the managed Hallucination evaluator from the catalog (or define a custom prompt with `{{variables}}` if your domain needs a stricter rubric).
+3. Target live observations, the recommended production target. Filter to the observations worth judging, for example only final answer generations in traces tagged `customer-facing`, and set a sampling percentage. Judging 5 to 10 percent of traffic is usually enough to see the trend without paying to judge everything.
+4. Map your observation fields onto the evaluator's variables. Langfuse previews the populated judge prompt with real data from the last 24 hours, and JSONPath expressions handle nested fields.
+
+One mechanic matters for correctness: observation-level evaluators see only the data on the observation they target, not sibling or child observations. If the judge needs the retrieved context to check groundedness, your instrumentation must put that context on the target observation, or you target a root observation that records the overall input and output. Scores land asynchronously on the observation, and you can backfill historical traffic by enabling the evaluator's Fast Mode, selecting rows in the traces table, and running Actions → Evaluate.
+
+### Method 2: Offline detection with reference datasets
+
+Before a prompt or model change ships, run the candidate against a dataset whose items carry reference answers, and have a judge verify claims against the reference. This catches hallucination regressions where production monitoring would only catch them after users saw them. With the Python SDK, [experiments via the SDK](/docs/evaluation/experiments/experiments-via-sdk) wrap the loop: `run_experiment` executes your task per item, applies evaluators, and records the run in Langfuse for comparison.
+
+```python
+import json
+
+from langfuse import Evaluation, get_client
+from openai import OpenAI
+
+langfuse = get_client()
+judge_client = OpenAI()
+
+JUDGE_PROMPT = """Check the generated answer against the reference answer.
+
+Question: {question}
+Reference answer: {reference}
+Generated answer: {answer}
+
+List every factual claim in the generated answer that contradicts the reference
+or asserts something the reference does not support. If there are none, return
+an empty list. Reply as JSON: {{"unsupported_claims": [...], "hallucinated": <bool>}}"""
+
+
+def hallucination_judge(*, input, output, expected_output, **kwargs):
+    response = judge_client.chat.completions.create(
+        model="gpt-4.1",
+        response_format={"type": "json_object"},
+        messages=[
+            {
+                "role": "user",
+                "content": JUDGE_PROMPT.format(
+                    question=input, reference=expected_output, answer=output
+                ),
+            }
+        ],
+    )
+    verdict = json.loads(response.choices[0].message.content)
+    return Evaluation(
+        name="hallucinated",
+        value=1.0 if verdict["hallucinated"] else 0.0,
+        comment="; ".join(verdict["unsupported_claims"]) or None,
+    )
+
+
+def hallucination_rate(*, item_results, **kwargs):
+    values = [
+        e.value
+        for r in item_results
+        for e in r.evaluations
+        if e.name == "hallucinated"
+    ]
+    return Evaluation(
+        name="hallucination_rate",
+        value=sum(values) / len(values) if values else None,
+    )
+
+
+def my_task(*, item, **kwargs):
+    return answer_question(item.input)  # call your application here
+
+
+dataset = langfuse.get_dataset("qa-with-references")
+
+result = dataset.run_experiment(
+    name="Hallucination check",
+    description="Judge outputs against reference answers",
+    task=my_task,
+    evaluators=[hallucination_judge],
+    run_evaluators=[hallucination_rate],
+)
+print(result.format())
+```
+
+The judge returns the binary verdict as the score and the offending claims in the comment, so a failed item is debuggable from the run view without rereading the full output. The `hallucination_rate` run evaluator gives each experiment run a single comparable number, which is the value a CI gate would assert on. Build the dataset from production: any trace the production judge flags is a candidate item, with a corrected reference supplied during review.
+
+### Method 3: Deterministic pre-screens
+
+Some hallucination risk signals are decidable without a model. They are not hallucination detection by themselves, since no regex verifies semantics, but they are free, deterministic, and run on every trace, which makes them the right first layer. Two honest examples:
+
+- **Citation presence.** A grounded answer that cites none of the retrieved sources is a hallucination risk even when it reads well. The [code evaluator examples](/resources/engineering/code-evaluator-examples) page has a paste-ready version (example 4) plus nine other deterministic checks.
+- **Unsupported numbers.** A number in the answer that appears nowhere in the provided context is a specific, checkable risk flag. As a Langfuse code evaluator, authored in the UI and run on observations:
+
+```python
+import re
+
+def evaluate(ctx):
+    context = str((ctx.observation.metadata or {}).get("retrieved_context", ""))
+    answer = str(ctx.observation.output)
+    answer_nums = set(re.findall(r"-?\d+(?:\.\d+)?", answer.replace(",", "")))
+    context_nums = set(re.findall(r"-?\d+(?:\.\d+)?", context.replace(",", "")))
+    unsupported = answer_nums - context_nums
+    return EvaluationResult(scores=[
+        Score(name="unsupported_numbers", value=bool(unsupported), data_type="BOOLEAN",
+              comment=f"Not in context: {sorted(unsupported)}" if unsupported else None)
+    ])
+```
+
+Expect false positives (derived values, dates the model formatted differently), which is acceptable for a screen whose job is routing, not verdicts.
+
+## Designing the hallucination judge
+
+**Claim-level checking, answer-level verdicts.** A judge that scores the whole answer in one pass misses the single fabricated detail inside an otherwise correct response. Instruct the judge to enumerate the factual claims and check each one, as the prompt above does, then aggregate: the answer is hallucinated if any claim fails. The per-claim list goes into the score comment, which is what makes a flagged trace reviewable and what lets you calibrate the judge against human labels claim by claim.
+
+**Binary verdicts.** Score hallucination as pass/fail, not on a 1-to-5 scale. Binary scoring forces a precise definition of what separates acceptable from unacceptable, while graded scales leave every reader wondering what a 3 means; this is the standing recommendation in the [Langfuse Academy evaluation module](/academy/evaluate), and hallucination is the clearest case for it, because one fabricated claim is a failure regardless of how good the rest of the answer is.
+
+**Escalation, cheapest layer first.** Run the free code screens on all traffic. Run the judge on everything a screen flags, plus a sample of clean traffic to catch what patterns miss. Route judge-flagged traces in high-stakes flows to an [annotation queue](/docs/evaluation/evaluation-methods/annotation-queues), where human verdicts double as calibration data for the judge and as reference answers for the offline dataset. Each layer reduces the volume the next, more expensive layer has to handle.
+
+## Hallucination detection without new infrastructure
+
+Hallucination detection is often postponed because it sounds like another service to deploy and operate. If your application already sends traces to Langfuse, it is not: LLM-as-a-judge evaluators, code evaluators, datasets, and experiments run inside the same Langfuse deployment that receives the traces, so the setup above adds zero new services to your architecture. The only external call is the one Langfuse makes to your judge model through an LLM Connection, using the provider credentials you configure.
+
+The same holds off the cloud. Langfuse is open source and [self-hostable](/self-hosting), so the full detection loop, from trace ingestion through judge execution to score storage, can run on infrastructure your team controls. Teams with data-residency constraints run detection on the same self-hosted instance that does their tracing.
+
+## FAQ
+
+### What is the difference between hallucination detection and faithfulness evaluation? [#hallucination-vs-faithfulness]
+
+Faithfulness is the RAG-specific instance of hallucination detection: it checks whether every claim in the answer is supported by the retrieved context. Hallucination detection is the broader metric, covering open-domain answers with no retrieved context and fabrications that contradict the input rather than the documents. If your application is a RAG pipeline, faithfulness is the version of this metric you should implement first.
+
+### Can you detect hallucinations without ground truth? [#detection-without-ground-truth]
+
+Yes, with a reference-free judge. The managed Hallucination evaluator in Langfuse checks the output against the input and context recorded on the same observation, so it needs no expected output and runs on live production traffic. What reference-free detection cannot do is verify open-domain claims that no recorded evidence supports or contradicts; those need reference datasets in offline experiments, or a judge trusted for its world knowledge.
+
+### How reliable is an LLM judge at detecting hallucinations? [#judge-reliability]
+
+Reliable enough to trend on and to route with, not reliable enough to treat every verdict as truth. Judges perform best with a binary rubric and claim-level checking, and worst on subtle domain facts, where the judge can share blind spots with the model being judged (especially when both come from the same model family). Calibrate against human labels: route a sample of judge verdicts to an annotation queue, measure agreement, and tighten the rubric until agreement is stable.
+
+### Can hallucination detection block a bad answer before the user sees it? [#blocking-at-request-time]
+
+No. Evaluator scores are produced asynchronously, after the response has shipped, which makes them the right tool for detecting regressions, routing traces to review, and building regression datasets. A check that must stop an answer in flight is a guardrail and belongs in your application code at request time, and the guardrail's decisions should then be scored like any other output.

--- a/content/resources/engineering/llm-regression-testing.mdx
+++ b/content/resources/engineering/llm-regression-testing.mdx
@@ -61,7 +61,7 @@ def support_agent_task(*, item, **kwargs):
 
 def contains_answer(*, output, expected_output, **kwargs):
     """Code evaluator: deterministic, free, runs on every item."""
-    passed = bool(expected_output) and expected_output.lower() in output.lower()
+    passed = bool(expected_output) and expected_output.lower() in (output or "").lower()
     return Evaluation(name="contains_answer", value=1.0 if passed else 0.0)
 
 

--- a/content/resources/engineering/llm-regression-testing.mdx
+++ b/content/resources/engineering/llm-regression-testing.mdx
@@ -1,0 +1,264 @@
+---
+title: "LLM regression testing: fail CI before regressions ship"
+description: "Set up LLM regression testing that fails CI: golden datasets, experiment thresholds, RegressionError, and GitHub Actions via langfuse/experiment-action."
+tags: [guide, evaluation]
+---
+
+# LLM regression testing: fail CI before regressions ship
+
+A prompt tweak that fixes one complaint can quietly break ten other answers. LLM regression testing catches that break before it merges: every change to a prompt, model, or retrieval component runs against a fixed set of test cases, gets scored, and fails the CI pipeline when a score drops below a threshold. This guide shows the complete setup with Langfuse, from the gate script to the GitHub Actions workflow that blocks the pull request.
+
+**TL;DR:** An LLM regression test runs your application against a golden dataset, scores every output with evaluators (deterministic code checks plus an LLM judge), and raises `RegressionError` when an aggregate score misses your threshold. In GitHub Actions, `langfuse/experiment-action` runs that script against a Langfuse dataset, posts the scores as a pull request comment, and fails the job on regression. If you already trace with Langfuse, the gate needs no new services: the same SDK and the same API keys.
+
+## What is LLM regression testing?
+
+LLM regression testing is the practice of verifying that a change to an LLM application did not degrade output quality on inputs that used to work. Because LLM outputs are non-deterministic, the check is not an exact-match assertion but an evaluation: each output gets scored, and the test passes when scores meet a defined threshold. The unit under test is application behavior, not a function.
+
+A regression gate should run whenever any component that shapes outputs changes:
+
+- **Prompt edits**, including a new version of a prompt managed outside the codebase.
+- **Model swaps and provider model upgrades**, where the same prompt can behave differently.
+- **RAG and retrieval changes**, such as a new chunking strategy or embedding model.
+- **Tool and agent changes**, where a reworded tool description shifts an agent's behavior.
+
+This page covers the offline gate in depth. For where the gate sits inside a complete evaluation program, with quality dimensions, production monitoring, and human review, see the broader guide on [building an LLM evaluation strategy](/resources/engineering/llm-evaluation-strategy).
+
+## The minimal regression gate: golden dataset, experiment, threshold
+
+Three pieces make a regression gate:
+
+1. **A golden dataset** of representative inputs with expected outputs, stored as a Langfuse dataset so it is versioned and shared.
+2. **An experiment** that runs your application against every dataset item and scores the outputs with evaluators.
+3. **A threshold check** that raises `RegressionError` when an aggregate score is too low, which is what fails the pipeline.
+
+The script below is a complete gate using the Langfuse Python SDK (v4). It combines a deterministic code evaluator, which is free and gives the same verdict every run, with an LLM-as-a-judge evaluator for the quality dimension a string check cannot decide. The `experiment(context)` entry point is the contract for the GitHub Action in the next section: the `RunnerContext` initializes the Langfuse client, loads the dataset configured in the workflow, and attaches CI metadata (commit SHA, branch, job URL, actor) to the run.
+
+```python title="experiments/regression-gate.py"
+import json
+
+from langfuse import Evaluation, RegressionError, RunnerContext
+from langfuse.openai import OpenAI
+
+client = OpenAI()
+
+THRESHOLDS = {
+    "avg_contains_answer": 0.9,
+    "avg_faithfulness": 0.8,
+}
+
+
+def support_agent_task(*, item, **kwargs):
+    """Run the application under test on one dataset item."""
+    response = client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {"role": "system", "content": "Answer using only the provided context."},
+            {"role": "user", "content": item.input["question"]},
+        ],
+    )
+    return response.choices[0].message.content
+
+
+def contains_answer(*, output, expected_output, **kwargs):
+    """Code evaluator: deterministic, free, runs on every item."""
+    passed = bool(expected_output) and expected_output.lower() in output.lower()
+    return Evaluation(name="contains_answer", value=1.0 if passed else 0.0)
+
+
+def faithfulness_judge(*, input, output, expected_output, **kwargs):
+    """LLM-as-a-judge evaluator: returns a binary verdict with a reason."""
+    judgment = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Is the answer faithful to the reference? "
+                    'Respond with JSON: {"score": 0 or 1, "reason": "<one sentence>"}\n'
+                    f"Question: {input}\nReference: {expected_output}\nAnswer: {output}"
+                ),
+            }
+        ],
+        response_format={"type": "json_object"},
+    )
+    verdict = json.loads(judgment.choices[0].message.content)
+    return Evaluation(
+        name="faithfulness",
+        value=float(verdict["score"]),
+        comment=verdict["reason"],
+    )
+
+
+def average_of(score_name: str):
+    """Build a run-level evaluator that averages one item-level score."""
+
+    def run_evaluator(*, item_results, **kwargs):
+        values = [
+            evaluation.value
+            for result in item_results
+            for evaluation in result.evaluations
+            if evaluation.name == score_name
+            and isinstance(evaluation.value, (int, float))
+        ]
+        return Evaluation(
+            name=f"avg_{score_name}",
+            value=sum(values) / len(values) if values else 0.0,
+        )
+
+    return run_evaluator
+
+
+def experiment(context: RunnerContext):
+    result = context.run_experiment(
+        name="PR gate: support agent",
+        task=support_agent_task,
+        evaluators=[contains_answer, faithfulness_judge],
+        run_evaluators=[average_of("contains_answer"), average_of("faithfulness")],
+    )
+
+    scores = {e.name: e.value for e in result.run_evaluations}
+
+    for metric, threshold in THRESHOLDS.items():
+        value = scores.get(metric)
+        if not isinstance(value, (int, float)) or value < threshold:
+            raise RegressionError(
+                result=result,  # lets the action include scores in the PR comment
+                metric=metric,
+                value=float(value) if isinstance(value, (int, float)) else 0.0,
+                threshold=threshold,
+            )
+
+    return result
+```
+
+Replace `support_agent_task` with a call into your actual application. Everything else is reusable: the evaluators score whatever the task returns, and the threshold loop turns any run-level score into a gate. To run the same experiment outside CI, fetch the dataset and call `langfuse.get_dataset("support-agent-golden-set").run_experiment(...)` with the same task and evaluators.
+
+## Fail CI with GitHub Actions: langfuse/experiment-action
+
+[`langfuse/experiment-action`](https://github.com/langfuse/experiment-action) is the official GitHub Action for running Langfuse experiments in CI. Given the script above, it does four things:
+
+1. Loads the dataset named in the workflow, optionally pinned to a `dataset_version` timestamp for reproducible runs.
+2. Executes every experiment script found at `experiment_path` (a file, directory, or glob; Python, TypeScript, and JavaScript are supported).
+3. Posts or updates a pull request comment with pass/regression/error status per script, run-level scores, an item-level results table, and a link to the experiment in Langfuse.
+4. Fails the job when a script raises `RegressionError` (`should_fail_on_regression`, default `true`) or crashes (`should_fail_on_script_error`, default `true`).
+
+```yaml title=".github/workflows/llm-regression-tests.yml"
+name: LLM regression tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read # check out the repository
+  pull-requests: write # post the experiment result comment
+  actions: read # optional: link results to this job's logs
+
+jobs:
+  regression-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      # Pin to the latest release tag (v1.0.6 as of July 2026)
+      - uses: langfuse/experiment-action@v1.0.6
+        env:
+          # Provider keys for your task and judge; the experiment
+          # subprocess inherits the step environment.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          langfuse_base_url: https://cloud.langfuse.com # or your self-hosted URL
+          experiment_path: experiments/regression-gate.py
+          dataset_name: support-agent-golden-set
+          dataset_version: "2026-07-01T00:00:00Z" # optional: pin for reproducibility
+          github_token: ${{ github.token }} # enables the PR comment
+```
+
+The action installs the latest Langfuse SDK by default and requires Python SDK v4.6.0+ or JS SDK v5.3.0+; set `python_sdk_version` or `js_sdk_version` to pin a specific version, or `should_skip_sdk_installation: true` if you manage the environment yourself. A `result_json` output exposes the normalized results for downstream steps, for example a Slack notification or an artifact upload. The full input reference and the JS/TS variant of the gate script are in the [experiments in CI/CD documentation](/docs/evaluation/experiments/experiments-ci-cd).
+
+With `on: pull_request`, every PR that touches the application gets a scored verdict before review. Marking the job as a required status check in branch protection makes the gate binding: a regression cannot merge.
+
+## Run the gate in pytest or Vitest on other CI systems
+
+The GitHub Action is a convenience wrapper, not a requirement. On GitLab CI, Jenkins, CircleCI, or any other runner, the same `run_experiment` call works inside your existing test framework: run the experiment in a pytest or Vitest test, read the run-level score from `result.run_evaluations`, and assert it against the threshold. A failing assertion fails the suite, and the suite fails the pipeline. Our guide to [testing LLM applications](/blog/2025-10-21-testing-llm-applications) walks through the full pytest setup, including local datasets for gates that should not depend on any network fetch.
+
+## Prompt-version regression testing before label promotion
+
+Prompts managed in Langfuse are versioned, and deployment is controlled by labels: your application fetches the version tagged `production`, so promoting a new prompt version means moving that label. That structure gives prompt changes the same gate as code changes, without a redeploy:
+
+1. Save the candidate as a new prompt version and give it a `staging` label.
+2. Run the regression experiment with the candidate version against the golden dataset.
+3. Promote the `production` label only when the experiment clears the thresholds.
+
+The gate script changes in one place: the task fetches the candidate by label instead of hardcoding the prompt, and passes it to the generation so the run is linked to the exact prompt version.
+
+```python title="experiments/prompt-gate.py (task excerpt)"
+from langfuse import get_client
+from langfuse.openai import OpenAI
+
+langfuse = get_client()
+client = OpenAI()
+
+candidate = langfuse.get_prompt("support-agent", label="staging")
+
+
+def support_agent_task(*, item, **kwargs):
+    response = client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {"role": "system", "content": candidate.compile()},
+            {"role": "user", "content": item.input["question"]},
+        ],
+        langfuse_prompt=candidate,  # link this run to the exact prompt version
+    )
+    return response.choices[0].message.content
+```
+
+Linking pays off twice. The prompt's Metrics tab aggregates scores, latency, and cost per prompt version across all linked generations. And because the gate creates a dataset run per experiment, the comparison view puts the candidate's run next to the production version's run on the same dataset, item by item, before you decide.
+
+The promotion itself can be locked down. [Protected prompt labels](/docs/prompt-management/features/prompt-version-control) prevent `member` and `viewer` roles from moving or deleting a label like `production`; only project `admin` and `owner` roles can. A passing experiment plus an authorized approver moving the label becomes your promotion gate. Label protection is available on the Pro plan with the Teams add-on, on Enterprise, and in self-hosted Enterprise Edition.
+
+## Comparing regression runs over time
+
+Every gate run against a Langfuse dataset is recorded as a dataset run, so the history accumulates automatically. The experiment comparison view shows runs side by side: aggregate scores per run, per-item outputs, and which specific items regressed between two runs. When the PR comment says `avg_faithfulness` dropped from 0.86 to 0.71, the comparison view answers the follow-up question of which ten items broke and what the outputs looked like. CI metadata attached by the action (commit SHA, branch, actor) makes each run traceable to the change that produced it.
+
+The gate only covers inputs you thought to test, so pair it with an online complement. Sampled LLM-as-a-judge evaluators score a percentage of production traffic, and [monitors](/docs/metrics/features/monitors) (available on Langfuse Cloud) alert on those score metrics with warning and alert thresholds, routing breaches to Slack, webhooks, or a GitHub Actions trigger. The offline gate stops regressions you can reproduce; monitors catch the ones production finds for you.
+
+## Building the golden dataset the gate runs against
+
+The dataset determines what the gate can catch, and the strongest source is production: in Langfuse, any trace or observation can be added to a dataset directly from the UI, so every incident becomes a permanent regression test with one action. Add hand-written edge cases for failures you fear but have not seen, and source expected outputs from domain experts correcting real outputs rather than writing ideals from scratch. Keep the PR-gate dataset small enough to run on every pull request, tens to low hundreds of items, and reserve the full set for release branches. Our guide to [golden dataset evaluation](/resources/engineering/golden-dataset-evaluation) covers construction, sizing, and maintenance in depth.
+
+## How a Langfuse regression gate compares to Promptfoo
+
+[Promptfoo](https://github.com/promptfoo/promptfoo) is an MIT-licensed CLI and library for evaluating and red-teaming LLM apps, and a well-established way to run eval assertions in CI. It runs evaluations entirely locally, with test cases and graders defined in configuration files, and it needs no platform behind it (facts checked July 2026). For teams that want declarative prompt-and-model matrix testing with no external state, it is a reasonable default, and it can fetch Langfuse-managed prompts through the [Promptfoo integration](/integrations/other/promptfoo).
+
+The trade-off is where your evaluation data lives. With a config-file harness, datasets, scores, and history live in the repo and the CI logs, disconnected from production. If you already trace with Langfuse, the regression gate described on this page adds zero new services: it authenticates with the same public and secret key your tracing uses, runs against Langfuse Cloud or your self-hosted instance, and writes results where your production traces, datasets, and prompt versions already are. Failed production traces become dataset items without an export step, gate scores land on the prompt version that produced them, and the comparison view spans CI runs and manual experiments alike.
+
+Choose Promptfoo when you want a self-contained local harness and have no observability platform in the loop. Choose the Langfuse gate when Langfuse is already your source of truth for traces, datasets, or prompts, and you want regression testing wired into that same data instead of parallel to it.
+
+## FAQ
+
+### How many dataset items does a CI regression gate need? [#how-many-items]
+
+Enough to cover your known failure modes, and small enough to run on every pull request: tens to low hundreds of items is the practical range for a PR gate. Below roughly 20 items, one flaky output moves an average score by 5 percentage points or more, which makes thresholds noisy. Keep a larger full regression set for release branches or nightly runs, where latency and evaluation cost matter less.
+
+### How do I keep LLM judges from making CI flaky? [#flaky-judges]
+
+Make the judge as deterministic as you can: pin the judge model version, use a binary pass/fail verdict with an explicit rubric instead of a 1-to-10 scale, and request structured JSON output. Averaging over the whole dataset dampens single-item noise, and setting the threshold with a margin below your baseline (for example 0.8 when the baseline is 0.88) absorbs normal variance. For checks that must never flake, use deterministic code evaluators as the blocking gate and treat judge metrics as warnings until they prove stable.
+
+### How do I test a model upgrade before rolling it out? [#model-upgrades]
+
+Run the same regression experiment with the new model against the same golden dataset, ideally pinned to the same dataset version, and compare the runs in the experiment comparison view. Record the model name in the experiment metadata so runs stay attributable. This works for provider-forced upgrades too: when a model you depend on is deprecated, the gate tells you whether the replacement clears your thresholds before production does.
+
+### When should a regression block the merge instead of warning? [#block-vs-warn]
+
+Block on deterministic metrics with clear pass criteria, such as format validity, required-content checks, and safety patterns, plus any judge metric that has been stable across enough runs to trust. Warn on judge metrics you are still calibrating: run them in the experiment and post them to the PR comment, but keep them out of the `RegressionError` thresholds (or set `should_fail_on_regression: false` in a separate advisory workflow). Promote a metric from warning to blocking once its baseline has held steady and false alarms have stopped.
+
+### Can I migrate from Promptfoo to Langfuse regression gates? [#migrate-from-promptfoo]
+
+Yes. The concepts map directly: Promptfoo test cases become Langfuse dataset items, assertions become evaluator functions, and the CI invocation becomes `langfuse/experiment-action`. See the step-by-step guide to [migrating from Promptfoo](/resources/engineering/migrate-from-promptfoo) for the concept mapping and code before-and-after.

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -9,6 +9,7 @@
     "langfuse-vs-datadog",
     "migrate-from-helicone",
     "migrate-from-braintrust",
+    "migrate-from-promptfoo",
     "migrate-from-phoenix",
     "llm-gateway",
     "coding-agent-tracing",
@@ -17,6 +18,11 @@
     "code-evaluator-examples",
     "ai-agent-evaluation",
     "llm-evaluation-strategy",
+    "rag-faithfulness-evaluation",
+    "answer-relevance-evaluation",
+    "hallucination-detection",
+    "llm-regression-testing",
+    "golden-dataset-evaluation",
     "chatbot-intent-analytics"
   ]
 }

--- a/content/resources/engineering/migrate-from-promptfoo.mdx
+++ b/content/resources/engineering/migrate-from-promptfoo.mdx
@@ -1,0 +1,369 @@
+---
+title: Migrate a Promptfoo eval suite to Langfuse
+description: "Step-by-step guide to migrate a Promptfoo eval suite to Langfuse: turn tests into dataset items, port assertions to evaluators, and keep failing CI on regressions."
+tags: [migration, guide]
+---
+
+# Migrate a Promptfoo eval suite to Langfuse
+
+This guide walks through moving an existing [Promptfoo](https://www.promptfoo.dev) eval
+suite to [Langfuse](/) datasets and experiments: test cases first, then assertions, the
+prompt/provider matrix, and the CI gate.
+
+**TL;DR:** A promptfooconfig.yaml maps cleanly onto Langfuse concepts. `tests` and their
+`vars` become dataset items, deterministic assertions become code evaluators, model-graded
+assertions become LLM-as-a-judge evaluators, and `promptfoo eval` in CI becomes an
+experiment script that raises `RegressionError` inside the `langfuse/experiment-action`
+GitHub Action. What changes structurally: Promptfoo evals are declarative YAML runs whose
+results live in local files or a shared viewer, while Langfuse experiments are code that
+runs against datasets on a platform where your production traces, scores, and prompts
+already live. You can migrate incrementally and keep Promptfoo running side-by-side, and
+Promptfoo's red teaming has no Langfuse equivalent, so keep it for that.
+
+## Why teams migrate
+
+Promptfoo is a good CI harness for prompt testing: a declarative config, a broad assertion
+library, and a fast local loop with `promptfoo eval` and `promptfoo view`. Teams typically
+outgrow it in one specific way: eval results live apart from production. Promptfoo runs
+produce output files and a results viewer, with sharing to promptfoo.app or a self-hosted
+sharing server (as of July 2026, per the
+[Promptfoo sharing docs](https://www.promptfoo.dev/docs/usage/sharing/)). Production
+telemetry lives somewhere else entirely.
+
+Moving the suite into Langfuse changes that:
+
+- **Eval results land next to production traces.** Every experiment item execution creates
+  a full [trace](/docs/observability/data-model), so a failing test case is inspectable
+  with the same tooling you use for production incidents, and the same datasets can be
+  built from real production traces.
+- **Non-engineers can see and shape evals.** Datasets, experiment comparisons, and
+  [annotation queues](/docs/evaluation/evaluation-methods/annotation-queues) are in the
+  Langfuse UI, so product managers and domain experts review outputs and edit test cases
+  without checking out a repo.
+- **Judges run as managed platform evaluators.** Langfuse ships a catalog of
+  [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)
+  maintained with partners like Ragas (Hallucination, Context-Relevance, Toxicity,
+  Helpfulness), and the same judges score live production traffic, not only offline runs.
+- **The whole platform is self-hostable.** Both tools are MIT-licensed open source; the
+  difference is what you can run. [Self-hosting Langfuse](/self-hosting) gives you the full
+  platform (UI, API, storage) in your own infrastructure as the persistent system of record
+  for eval history.
+
+Be equally clear about what you give up. Promptfoo's declarative assertion catalog is broad
+(30+ types including `rouge-n`, `bleu`, `perplexity`, `latency`, and `cost`, all negatable
+and weightable); in Langfuse, deterministic checks are code you write as evaluator
+functions or [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators), with
+the [autoevals](https://github.com/braintrustdata/autoevals) library covering many
+model-graded and heuristic checks out of the box. The zero-code YAML workflow becomes a
+Python or TypeScript script. And Promptfoo's provider matrix, which expands
+`providers × prompts × tests` automatically, becomes a loop you write yourself. If the
+declarative harness is all you need and results-in-files is acceptable, Promptfoo remains a
+reasonable choice; this guide is for teams consolidating evals where their traces live.
+
+## Concept mapping
+
+| Promptfoo (promptfooconfig.yaml)                                            | Langfuse                                                                                                                                                                                    | Notes                                                               |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `tests` with `vars`                                                         | [Dataset items](/docs/evaluation/experiments/datasets) (`input`, `expected_output`, `metadata`)                                                                                             | One test case becomes one item                                      |
+| Assertion reference values (`value:` on `contains`, `factuality`, ...)      | `expected_output` on the dataset item                                                                                                                                                       | Per-item ground truth moves into the item                           |
+| Deterministic `assert` types (`contains`, `regex`, `is-json`, `javascript`) | Evaluator functions in the [experiment SDK](/docs/evaluation/experiments/experiments-via-sdk), or [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) authored in the UI | Checks become code instead of YAML types                            |
+| Model-graded `assert` types (`llm-rubric`, `factuality`, `context-*`)       | [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) or autoevals scorers via `create_evaluator_from_autoevals`                                                  | Managed judges also run on production traces                        |
+| `defaultTest`                                                               | `evaluators` passed to `run_experiment`                                                                                                                                                     | Experiment evaluators apply to every item by default                |
+| `prompts` (inline or `file://`)                                             | [Prompt management](/docs/prompt-management) with versions and labels                                                                                                                       | Promptfoo can also fetch these via `langfuse://` references         |
+| `providers` × `prompts` matrix                                              | One experiment run per variant on the same dataset                                                                                                                                          | Runs are compared side-by-side in the Langfuse UI                   |
+| `promptfoo eval` in CI (exit code `100` on failures)                        | Experiment script raising `RegressionError` + [langfuse/experiment-action](/docs/evaluation/experiments/experiments-ci-cd)                                                                  | Both fail the job and comment on the PR                             |
+| `outputPath`, `promptfoo view`, `promptfoo share`                           | Experiment runs persisted in Langfuse                                                                                                                                                       | History and comparisons live in the platform, no artifact shuffling |
+
+## The example suite
+
+The steps below migrate this small but representative config: two test cases, a
+deterministic assertion each, and a model-graded rubric applied to every test via
+`defaultTest`.
+
+```yaml
+# promptfooconfig.yaml (before)
+prompts:
+  - file://prompts/support-agent.txt
+providers:
+  - openai:gpt-4.1
+defaultTest:
+  assert:
+    - type: llm-rubric
+      value: "Is polite and offers a concrete next step"
+tests:
+  - vars:
+      question: "How do I reset my password?"
+    assert:
+      - type: icontains
+        value: "reset link"
+  - vars:
+      question: "What is your refund window?"
+    assert:
+      - type: icontains
+        value: "30 days"
+```
+
+All Langfuse snippets below use the Python SDK v4 (`pip install langfuse`); the JS/TS SDK
+(`@langfuse/client`) has equivalent APIs throughout.
+
+## Step 1: Turn tests into a dataset
+
+Each entry in `tests` becomes a dataset item. The `vars` map to `input`, and per-test
+reference values (here, the `icontains` string) move to `expected_output`:
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()  # reads LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_BASE_URL
+
+langfuse.create_dataset(name="support-agent-regression")
+
+test_cases = [
+    {"question": "How do I reset my password?", "must_contain": "reset link"},
+    {"question": "What is your refund window?", "must_contain": "30 days"},
+]
+
+for case in test_cases:
+    langfuse.create_dataset_item(
+        dataset_name="support-agent-regression",
+        input={"question": case["question"]},
+        expected_output=case["must_contain"],
+    )
+```
+
+Unlike YAML tests in a repo, [dataset items](/docs/evaluation/experiments/datasets) are
+editable in the UI, versioned, and can be created directly from interesting production
+traces, which is how regression suites usually grow after the migration.
+
+## Step 2: Port assertions to evaluators
+
+Evaluators are plain functions that receive the item's `input`, `output`, and
+`expected_output` and return an `Evaluation`. The `icontains` assertion becomes a few lines
+of Python, and the `llm-rubric` assertion becomes a judge function that calls a model. Like
+`defaultTest`, evaluators passed to an experiment apply to every item.
+
+```python
+from langfuse import Evaluation
+from langfuse.openai import OpenAI  # traced drop-in replacement
+
+def contains_expected(*, output, expected_output, **kwargs):
+    # replaces: type: icontains
+    passed = (expected_output or "").lower() in (output or "").lower()
+    return Evaluation(name="contains_expected", value=1.0 if passed else 0.0)
+
+RUBRIC = "Is polite and offers a concrete next step"
+
+def rubric_judge(*, input, output, **kwargs):
+    # replaces: type: llm-rubric
+    response = OpenAI().chat.completions.create(
+        model="gpt-4.1",
+        messages=[{
+            "role": "user",
+            "content": (
+                f"Grade this response against the rubric: {RUBRIC}\n\n"
+                f"Question: {input['question']}\n\nResponse: {output}\n\n"
+                'Reply "PASS" or "FAIL", then a one-sentence reason.'
+            ),
+        }],
+    )
+    verdict = response.choices[0].message.content or ""
+    return Evaluation(
+        name="rubric",
+        value=1.0 if verdict.strip().upper().startswith("PASS") else 0.0,
+        comment=verdict,
+    )
+```
+
+For Promptfoo's other model-graded assertions, you rarely need to write the judge yourself:
+
+- The [autoevals](https://github.com/braintrustdata/autoevals) library ships `Factuality`
+  (adapted from OpenAI's evals project, the same lineage as Promptfoo's `factuality`
+  assertion), `ClosedQA`, embedding similarity, and RAG metrics covering context precision,
+  recall, and faithfulness. Langfuse converts any of them into an evaluator with
+  `create_evaluator_from_autoevals` (see the
+  [experiment SDK docs](/docs/evaluation/experiments/experiments-via-sdk)).
+- Langfuse-managed [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)
+  are configured in the UI and executed by the platform against experiments or live
+  traffic, so judge prompts stop living in application code entirely.
+
+Deterministic checks you want non-engineers to see and reuse can also be authored directly
+in the Langfuse UI as [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators),
+which Langfuse executes on experiment observations.
+
+## Step 3: Run the experiment (and the provider matrix)
+
+The experiment runner loops your application over the dataset, traces every execution, and
+applies the evaluators. Where Promptfoo calls the provider for you, the Langfuse task
+function is your own code, which means the eval exercises your actual retrieval, tools, and
+glue logic rather than a bare model call.
+
+```python
+def support_agent_task(*, item, **kwargs):
+    return answer_question(item.input["question"])  # your application logic
+
+dataset = langfuse.get_dataset("support-agent-regression")
+
+result = dataset.run_experiment(
+    name="post-migration-baseline",
+    task=support_agent_task,
+    evaluators=[contains_expected, rubric_judge],
+)
+print(result.format())
+```
+
+Promptfoo's `providers` and `prompts` lists expand into a grid automatically. In Langfuse,
+you express a variant comparison as one experiment run per variant on the same dataset,
+typically looping over [prompt management](/docs/prompt-management) versions or labels:
+
+```python
+for label in ["production", "candidate"]:
+    prompt = langfuse.get_prompt("support-agent", label=label)
+
+    def task(*, item, prompt=prompt, **kwargs):
+        compiled = prompt.compile(question=item.input["question"])
+        response = OpenAI().chat.completions.create(
+            model=prompt.config.get("model", "gpt-4.1"),
+            messages=[{"role": "user", "content": compiled}],
+        )
+        return response.choices[0].message.content
+
+    dataset.run_experiment(
+        name=f"support-agent ({label})",
+        task=task,
+        evaluators=[contains_expected, rubric_judge],
+    )
+```
+
+The runs appear side-by-side in the dataset's experiment comparison view, which replaces
+`promptfoo view` as the place where variant results are compared, with the difference that
+every result links to a full trace.
+
+## Step 4: Keep failing CI on regressions
+
+`promptfoo eval` exits with code `100` when a test case fails (as of July 2026, per the
+[Promptfoo CLI docs](https://www.promptfoo.dev/docs/usage/command-line/)), and
+`promptfoo/promptfoo-action` posts a results link on pull requests. The Langfuse equivalent
+is the [langfuse/experiment-action](/docs/evaluation/experiments/experiments-ci-cd) GitHub
+Action: your experiment script raises `RegressionError` when a metric violates its
+threshold, the action fails the job, and it posts a PR comment with run-level scores, an
+item-level table, and a link to the experiment in Langfuse.
+
+```python
+# experiments/support-agent-gate.py
+# support_agent_task, contains_expected, and rubric_judge as defined in steps 2 and 3
+from langfuse import Evaluation, RegressionError, RunnerContext
+
+THRESHOLD = 0.9
+
+def pass_rate(*, item_results, **kwargs):
+    scores = [
+        e.value
+        for item in item_results
+        for e in item.evaluations
+        if e.name == "contains_expected"
+    ]
+    return Evaluation(name="pass_rate", value=sum(scores) / len(scores) if scores else 0.0)
+
+def experiment(context: RunnerContext):
+    result = context.run_experiment(
+        name="PR gate: support agent",
+        task=support_agent_task,
+        evaluators=[contains_expected, rubric_judge],
+        run_evaluators=[pass_rate],
+    )
+
+    rate = next(
+        (e.value for e in result.run_evaluations if e.name == "pass_rate"), None
+    )
+
+    if not isinstance(rate, (int, float)) or rate < THRESHOLD:
+        raise RegressionError(
+            result=result,
+            metric="pass_rate",
+            value=float(rate) if isinstance(rate, (int, float)) else 0.0,
+            threshold=THRESHOLD,
+        )
+
+    return result
+```
+
+```yaml
+# .github/workflows/eval-gate.yml (excerpt)
+- uses: langfuse/experiment-action@<release tag>
+  with:
+    langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+    langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
+    experiment_path: experiments/support-agent-gate
+    dataset_name: support-agent-regression
+    github_token: ${{ github.token }}
+```
+
+The action supports pinning a `dataset_version` for reproducible runs and exposes a
+normalized `result_json` output for downstream steps. For a deeper treatment of regression
+gates, thresholds, and flaky-judge handling, see our guide to
+[LLM regression testing](/resources/engineering/llm-regression-testing).
+
+## What you can keep running
+
+Migration does not have to be a cutover, and two Promptfoo workflows remain useful
+alongside Langfuse:
+
+- **Promptfoo evals against Langfuse-managed prompts.** Promptfoo natively resolves
+  `langfuse://prompt-name@production` references in its `prompts` list, so moving prompts
+  into Langfuse first lets both systems test the same source of truth during the
+  transition. The [Promptfoo integration page](/integrations/other/promptfoo) covers the
+  setup; this migration guide is the optional endpoint of that path.
+- **Red teaming.** Promptfoo's `redteam` and model-scanning capabilities target security
+  probing, which Langfuse does not do. Teams that migrate their quality evals commonly keep
+  Promptfoo in the toolchain for adversarial testing.
+
+Historical Promptfoo results are best archived rather than imported: scores are cheap to
+regenerate against the migrated dataset, and re-running your latest suite as a
+`post-migration-baseline` experiment gives future runs a clean anchor.
+
+## Validation checklist
+
+- [ ] Dataset item count matches the number of Promptfoo test cases (including any CSV-loaded tests)
+- [ ] Every assertion in the old config has a corresponding evaluator (code, autoevals, or managed judge)
+- [ ] Reference values (`contains` strings, factuality references) moved into `expected_output`
+- [ ] Baseline experiment run completed with all evaluators producing scores
+- [ ] Judge evaluator spot-checked against a handful of known-good and known-bad outputs
+- [ ] CI gate fails on a deliberately broken prompt (mirror of exit code `100` behavior)
+- [ ] PR comment from `langfuse/experiment-action` renders scores and links to the run
+- [ ] Team members who used `promptfoo view` have Langfuse project access
+- [ ] Decision recorded on what stays in Promptfoo (red teaming, side-by-side window end date)
+
+## FAQ
+
+### Can I keep running Promptfoo alongside Langfuse? [#keep-both-tools]
+
+Yes, and most teams do during the transition. Promptfoo can fetch prompts from Langfuse via
+`langfuse://` references, so both tools can evaluate the same prompt versions while you
+port test cases and assertions incrementally. Many teams also keep Promptfoo permanently
+for red teaming, which Langfuse does not replace.
+
+### Do Langfuse evaluators cover Promptfoo's assertion types? [#assertion-parity]
+
+Mostly, but not as a one-to-one catalog. Deterministic assertions (`contains`, `regex`,
+`is-json`, custom `javascript`/`python`) become short evaluator functions or UI-authored
+code evaluators. Model-graded assertions map to autoevals scorers (factuality, closed QA,
+similarity, RAG context metrics) or Langfuse-managed LLM-as-a-judge evaluators. Promptfoo's
+per-assertion `weight` and `threshold` scoring has no direct equivalent; compute composite
+scores in a run-level evaluator instead. Statistical metrics like `rouge-n` or `perplexity`
+need a library call inside an evaluator function.
+
+### Can Langfuse fail my CI pipeline the way `promptfoo eval` does? [#ci-parity]
+
+Yes. Where `promptfoo eval` exits with code `100` on failing test cases, a Langfuse
+experiment script raises `RegressionError` when a metric drops below your threshold, and
+the `langfuse/experiment-action` GitHub Action fails the job and posts a PR comment with
+scores and a link to the run. Outside GitHub Actions, the same experiment code runs as a
+pytest or Vitest suite with ordinary assertions.
+
+### How do non-engineers access results after migrating? [#team-access]
+
+Through the Langfuse UI, with org- and project-level roles. Experiment runs, score
+comparisons, and individual traces are browsable without touching the repo, and annotation
+queues let reviewers grade outputs in a structured workflow. This replaces the Promptfoo
+pattern of sharing viewer links or result files, and it applies equally on self-hosted
+Langfuse deployments.

--- a/content/resources/engineering/migrate-from-promptfoo.mdx
+++ b/content/resources/engineering/migrate-from-promptfoo.mdx
@@ -289,7 +289,7 @@ def experiment(context: RunnerContext):
 
 ```yaml
 # .github/workflows/eval-gate.yml (excerpt)
-- uses: langfuse/experiment-action@<release tag>
+- uses: langfuse/experiment-action@v1.0.6
   with:
     langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
     langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}

--- a/content/resources/engineering/rag-faithfulness-evaluation.mdx
+++ b/content/resources/engineering/rag-faithfulness-evaluation.mdx
@@ -1,0 +1,251 @@
+---
+title: "How to evaluate RAG faithfulness with LLM-as-a-judge"
+description: "RAG faithfulness evaluation explained: what the faithfulness metric measures, how to design an LLM-as-a-judge for it, and runnable Langfuse Python SDK code."
+tags: [guide, evaluation]
+---
+
+# How to evaluate RAG faithfulness with LLM-as-a-judge
+
+**TL;DR:** Faithfulness measures whether a RAG answer is grounded in the retrieved context: extract the factual claims the answer makes, check each claim against the retrieved documents, and score the share of supported claims. It is reference-free, so it needs no ground-truth answers, which makes it the RAG metric you can run on any dataset and on live traffic. This page defines the metric, shows how to design a faithfulness judge prompt, and implements it end to end with the Langfuse Python SDK: as an offline experiment with `run_experiment`, and as a managed LLM-as-a-judge evaluator on production traces.
+
+## What RAG faithfulness measures
+
+Faithfulness (also called groundedness) is the degree to which an answer is supported by the context that was retrieved for it. A faithful answer only states things the retrieved documents say or directly imply. An unfaithful answer mixes in claims from the model's parametric knowledge, or invents details outright, even when the prose reads well and the answer happens to be correct.
+
+The standard formulation, popularized by Ragas, is claim-based:
+
+```
+faithfulness = number of claims supported by the retrieved context / total claims in the answer
+```
+
+A score of 1.0 means every claim traces back to the context. A score of 0.5 means half the answer is unsupported. Because the comparison target is the retrieved context, not a ground-truth answer, faithfulness is a reference-free metric: you can compute it for any question, including ones nobody has written an expected answer for.
+
+Faithfulness is one of three metrics that get conflated in RAG evaluation, and they answer different questions:
+
+| Metric                  | Question it answers                                              | Compared against  |
+| ----------------------- | ---------------------------------------------------------------- | ----------------- |
+| Faithfulness            | Is every claim in the answer supported by the retrieved context? | Retrieved context |
+| Answer relevance        | Does the answer address the question that was asked?             | User question     |
+| Hallucination detection | Is the model fabricating content, inside or outside a RAG flow?  | Any source        |
+
+An answer can be perfectly faithful and useless: "our refund policy covers orders" is grounded in a refund document but does not answer "how long do I have to return this?". That failure belongs to [answer relevance evaluation](/resources/engineering/answer-relevance-evaluation). Faithfulness is also narrower than hallucination detection: it is the RAG-specific, context-bounded version of the problem, checked against documents you control rather than against world knowledge.
+
+## How faithfulness is measured
+
+Faithfulness requires reading comprehension, so it is measured with an LLM judge rather than string matching. Deterministic checks like citation presence or lexical overlap are useful pre-filters, but they cannot tell a paraphrase from a fabrication. The measurement pipeline, independent of tooling, has three steps:
+
+1. **Decompose the answer into claims.** Each atomic factual statement in the answer becomes one unit of evaluation. "Refunds take 5 business days and go to the original payment method" is two claims.
+2. **Verify each claim against the retrieved context.** The judge model receives the context and one or more claims, and decides per claim whether the context states or directly implies it. World knowledge does not count as support.
+3. **Aggregate.** The share of supported claims is the faithfulness score. The list of unsupported claims is the debugging payload: it tells you which sentence to fix and whether the failure is in generation (context contained the fact, model ignored it) or retrieval (context never contained it).
+
+To run this you need the three inputs on hand at evaluation time: the question, the generated answer, and the exact context that was retrieved for that answer. This is why faithfulness evaluation and tracing are naturally coupled. If your [LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) setup can see the retrieved documents next to the generation, faithfulness is a prompt away; if the context was thrown away after generation, there is nothing to verify against.
+
+## Designing a faithfulness judge prompt
+
+The judge prompt determines whether your faithfulness scores are trustworthy. Two design decisions matter most.
+
+**Claim extraction beats holistic judgment.** A holistic judge ("rate the faithfulness of this answer from 1 to 5") produces scores that drift between runs and hide what failed. A claim-extraction judge makes many small binary decisions instead: list the claims, label each one supported or unsupported. Each decision is easier for the judge model than a global rating, the aggregate score has a defined meaning (share of supported claims), and the unsupported-claim list localizes the failure for whoever reads the score comment.
+
+**Binary decisions beat graded scales.** Langfuse Academy's [evaluation module](/academy/evaluate) recommends binary pass/fail scores over 1-to-5 scales for evaluator design in general, because binary forces a definition of acceptable versus unacceptable while graded scales leave "what separates a 3 from a 4" undefined. Claim-level faithfulness gets you both properties: every judge decision is binary, and the numeric score comes from aggregation rather than from a rating the judge produces directly.
+
+Beyond those two decisions, the prompt rules that prevent the common failure modes:
+
+- **Define what counts as a claim.** Restrict extraction to factual statements. Hedges, questions back to the user, and statements of inability ("I could not find this in the documentation") are not claims and must not be penalized, otherwise the judge punishes exactly the honest behavior you want from a RAG system.
+- **Forbid outside knowledge explicitly.** Judges default to marking true statements as supported. State that a claim counts as supported only if the context says or directly implies it, even if the claim is true.
+- **Allow paraphrase.** Support does not require verbatim overlap. Without this rule the judge under-scores answers that correctly summarize the context.
+- **Demand structured output.** Have the judge return JSON with one entry per claim, and compute the score in code. Never ask the judge to do the arithmetic.
+- **Pin the judge's temperature to 0** so repeated evaluations of the same answer agree.
+
+## Run a faithfulness experiment with the Langfuse Python SDK
+
+The script below is self-contained: it creates a dataset of questions, runs a small RAG task against it, and scores every answer with a claim-extraction faithfulness judge using the Python SDK v4 experiment runner. The task returns both the answer and the contexts it used, so the evaluator receives everything it needs through the standard [experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk) contract. Replace the toy corpus and retrieval function with your vector store.
+
+```python
+# pip install langfuse openai
+import json
+
+from langfuse import Evaluation, get_client
+from langfuse.openai import OpenAI  # drop-in OpenAI client, traced automatically
+
+# Reads LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST from the environment
+langfuse = get_client()
+client = OpenAI()
+
+# --- A minimal corpus and retriever standing in for your vector store ---
+
+DOCUMENTS = [
+    "Orders can be refunded within 30 days of delivery. Refunds are issued to "
+    "the original payment method within 5 business days.",
+    "Standard shipping takes 3 to 5 business days within the EU. Express "
+    "shipping delivers within 24 hours for orders placed before 2pm.",
+    "All devices include a 2-year manufacturer warranty covering hardware "
+    "defects. Water damage is not covered by the warranty.",
+]
+
+def retrieve(question: str) -> list[str]:
+    words = question.lower().split()
+    ranked = sorted(DOCUMENTS, key=lambda d: -sum(w in d.lower() for w in words))
+    return ranked[:2]
+
+# --- One-time setup: create the dataset in Langfuse ---
+
+langfuse.create_dataset(name="rag-faithfulness-demo")
+for question in [
+    "How long do I have to return an order?",
+    "When does express shipping arrive?",
+    "Does the warranty cover water damage?",
+]:
+    langfuse.create_dataset_item(
+        dataset_name="rag-faithfulness-demo",
+        input={"question": question},
+        # No expected_output: faithfulness is reference-free
+    )
+
+# --- The RAG task under evaluation ---
+
+def rag_task(*, item, **kwargs):
+    question = item.input["question"]
+    contexts = retrieve(question)
+    context_block = "\n\n".join(contexts)
+    response = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": "Answer using only the provided context. If the "
+                "context is insufficient, say you do not know.",
+            },
+            {
+                "role": "user",
+                "content": f"Context:\n{context_block}\n\nQuestion: {question}",
+            },
+        ],
+    )
+    # Return the contexts alongside the answer so evaluators can verify against them
+    return {
+        "answer": response.choices[0].message.content,
+        "contexts": contexts,
+    }
+
+# --- The faithfulness judge ---
+
+JUDGE_PROMPT = """You are verifying whether an answer is faithful to its source context.
+
+Context:
+{context}
+
+Answer:
+{answer}
+
+Extract every factual claim the answer makes. Hedges, questions, and statements
+of inability ("I don't know") are not claims. For each claim, decide whether the
+context supports it. A claim is supported only if the context states or directly
+implies it; paraphrase counts, outside knowledge does not, even if the claim is true.
+
+Respond with JSON only, marking each claim as supported true or false:
+{{"claims": [{{"claim": "<claim text>", "supported": true}}]}}"""
+
+
+def faithfulness(*, input, output, **kwargs):
+    context = "\n\n".join(output["contexts"])
+    response = client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {
+                "role": "user",
+                "content": JUDGE_PROMPT.format(
+                    context=context, answer=output["answer"]
+                ),
+            }
+        ],
+        response_format={"type": "json_object"},
+        temperature=0,
+    )
+    claims = json.loads(response.choices[0].message.content)["claims"]
+    if not claims:
+        return Evaluation(
+            name="faithfulness", value=1.0, comment="No factual claims made"
+        )
+    unsupported = [c["claim"] for c in claims if not c["supported"]]
+    return Evaluation(
+        name="faithfulness",
+        value=1 - len(unsupported) / len(claims),
+        comment=(
+            f"Unsupported claims: {unsupported}"
+            if unsupported
+            else f"All {len(claims)} claims supported"
+        ),
+    )
+
+
+def avg_faithfulness(*, item_results, **kwargs):
+    values = [
+        e.value
+        for result in item_results
+        for e in result.evaluations
+        if e.name == "faithfulness" and isinstance(e.value, (int, float))
+    ]
+    return Evaluation(
+        name="avg_faithfulness",
+        value=sum(values) / len(values) if values else None,
+    )
+
+# --- Run the experiment ---
+
+dataset = langfuse.get_dataset("rag-faithfulness-demo")
+
+result = dataset.run_experiment(
+    name="Faithfulness baseline",
+    description="Claim-level faithfulness judge on the RAG demo dataset",
+    task=rag_task,
+    evaluators=[faithfulness],
+    run_evaluators=[avg_faithfulness],
+)
+
+print(result.format())
+```
+
+Every task execution is traced, item scores attach to the item's trace, and `avg_faithfulness` attaches to the dataset run, so consecutive runs are comparable in the Langfuse UI. From here the useful moves are comparing runs before and after a retrieval or prompt change, and turning the run-level average into a CI gate that fails a pull request when faithfulness regresses.
+
+## Score production traces with a managed LLM-as-a-judge evaluator
+
+Offline experiments cover the inputs you thought to test. The same faithfulness judgment can run on live traffic through Langfuse's managed LLM-as-a-judge evaluators, which execute server-side against production observations, without an evaluation job in your own infrastructure:
+
+1. **Instrument the context onto the target observation.** Observation-level evaluators read only the data on the observation they match; they do not load sibling observations from the trace. Record the retrieved documents on the generation (or root) observation, in its input or metadata, so the judge has something to verify against.
+2. **Create the evaluator.** On the Evaluators page, pick a managed evaluator from the catalog (maintained by Langfuse and partners including Ragas) or define a custom one with your own faithfulness prompt using `{{context}}`, `{{answer}}` style variables. The judge model is set through an LLM connection and must support structured output.
+3. **Target live observations and sample.** Filter to the observations that carry your RAG generations, then set a sampling percentage. Judging 5 to 10 percent of traffic is typically enough to see a faithfulness trend without paying to judge everything.
+4. **Map variables.** Map observation fields onto the prompt variables, with JSONPath expressions for nested data. Langfuse previews the populated judge prompt against your recent production data before you save.
+
+Scores land on the matched observations asynchronously, after the response has shipped. That makes online faithfulness scoring a monitoring and triage tool: alert when the average drops, route low-scoring traces to review, and add them to the experiment dataset above so the next release is tested against last week's failures. A check that must block an unfaithful answer before the user sees it belongs in your application as a guardrail, not in an evaluator.
+
+## Faithfulness evaluation without new infrastructure
+
+If Langfuse already traces your RAG pipeline, everything on this page runs against the deployment you have. The experiment runner is part of the same Python SDK that does the tracing, authenticates with the same API keys, and writes scores next to the traces and datasets you already accumulate. Managed evaluators run inside the same Langfuse instance. There is no separate evaluation service to deploy, no second vendor account, and no additional data pipeline to operate. Langfuse is open source and can be [self-hosted](/self-hosting), so judge inputs and scores can stay entirely within your infrastructure when data residency requires it.
+
+## Ragas faithfulness and when to use it
+
+[Ragas](https://docs.ragas.io/) is an established open-source library for RAG evaluation, and its faithfulness metric is a well-known reference implementation of the claim-decomposition approach described above. If your team already evaluates with Ragas, there is no need to rewrite those metrics: the [Ragas integration](/integrations/frameworks/ragas) shows how to run Ragas evaluations and attach the resulting scores to Langfuse traces, so Ragas faithfulness numbers land in the same score timeline as everything else.
+
+The native route on this page is the better fit when you want the judge prompt to be visible and editable in the same platform as your traces, when you want managed evaluators sampling production traffic without operating a separate evaluation job, or when faithfulness is one of several metrics (relevance, correctness, custom policy checks) that should share one dataset, one experiment run, and one score table. The two approaches also combine: Ragas offline during development, a managed judge online in production.
+
+## FAQ
+
+### What is the difference between RAG faithfulness and hallucination detection? [#faithfulness-vs-hallucination]
+
+Faithfulness is scoped to RAG: it checks the answer against the specific context retrieved for that request, and an answer that is true but unsupported by the context still fails. Hallucination detection is the broader failure class: fabricated content in any LLM output, with or without retrieval, checked against whatever source of truth applies. In a RAG system, a faithfulness score is usually the most actionable hallucination signal because the comparison target is documents you control. For the broader problem, see [hallucination detection](/resources/engineering/hallucination-detection).
+
+### Does faithfulness evaluation require ground-truth answers? [#reference-free-vs-ground-truth]
+
+No. Faithfulness compares the answer to the retrieved context, both of which exist for every request, so it is reference-free. This is why the dataset in the example above has no `expected_output` and why faithfulness can run on sampled production traffic. Reference-based metrics like answer correctness require a ground-truth answer per item and only run where you have labeled data; a complete RAG evaluation usually combines both kinds.
+
+### Which model should I use as the faithfulness judge? [#judge-model-choice]
+
+Use a model that is strong at instruction following and supports structured output, and prefer a stronger model than the one generating the answers, since claim verification against long contexts is a demanding reading task. Pin temperature to 0 for repeatability. Calibrate once by having a person label 20 to 50 answers and comparing against the judge's verdicts; if agreement is low, fix the rubric wording before swapping models, because rubric ambiguity is the more common cause.
+
+### Should faithfulness be a binary or a graded score? [#binary-vs-graded]
+
+Make the individual judge decisions binary and let the numeric score emerge from aggregation. Each claim is either supported by the context or it is not, and binary decisions are where LLM judges are most consistent. The aggregated share of supported claims gives you a 0-to-1 metric for dashboards and thresholds, without asking the judge to produce a graded rating whose steps are undefined.
+
+### Do I need Ragas to evaluate faithfulness? [#ragas-required]
+
+No. Faithfulness is a metric, not a library feature: any LLM judge with a claim-extraction prompt implements it, as the experiment code on this page does with the Langfuse SDK alone. Ragas provides a maintained implementation of that judge along with other RAG metrics, and its scores can be pushed into Langfuse through the integration. Choose based on where you want the judge to live: in your own prompt under version control, or in a library you import.


### PR DESCRIPTION
## What

Six new pages under `/resources/engineering` (registered in `meta.json`), from the internal GEO content pipeline. They target the metric- and workflow-vocabulary queries where eval-framework competitors currently own the results, with tool-agnostic intros and runnable Langfuse implementations:

**Metric recipes** (each: definition, runnable Python SDK v4 `run_experiment` + LLM-as-a-judge code, online managed-evaluator path, judge-design guidance per Langfuse Academy, anchored FAQ):
1. **`rag-faithfulness-evaluation`** — groundedness of answers in retrieved context
2. **`answer-relevance-evaluation`** — does the answer address the question (reference-free)
3. **`hallucination-detection`** — umbrella metric with taxonomy; managed Hallucination evaluator + offline judge + code-evaluator pre-screens

**Workflow pillars:**
4. **`llm-regression-testing`** — golden dataset → experiments → thresholds → `RegressionError` failing CI; features **langfuse/experiment-action** with a working workflow YAML (pinned v1.0.6, inputs verified against docs + repo)
5. **`golden-dataset-evaluation`** — building/maintaining golden datasets (schema enforcement, versioning, multi-modal), comparing prompt versions over time via compare-view baselines

**Bridge/migration:**
6. **`migrate-from-promptfoo`** — promptfooconfig.yaml → datasets/evaluators concept mapping, worked before/after, CI parity (exit-code semantics), honest concessions (red teaming stays in Promptfoo)

The six pages cross-link each other as a set — that's why they ship in one PR (link check would 404 individually).

## Reviewer attention

- **Promptfoo claims**: promptfoo.dev returned 403 through the drafting environment's egress proxy, so all claims were verified against the `promptfoo/promptfoo` GitHub docs source (`site/docs/**`, checked 2026-07-15) — please spot-check the live promptfoo.dev URLs listed in the internal brief, especially exit code 100 on failure and the sharing model.
- **Ragas mechanism** (answer-relevance page): verified from the ragas GitHub source (docs.ragas.io also proxy-blocked) — question-generation + embedding-similarity description worth a glance.
- **experiment-action pinned at v1.0.6** (released 2026-07-09) — re-check the latest tag if this sits unmerged for a while.
- **SDK shapes**: `run_experiment`, evaluator list-returns, `RegressionError`, dataset APIs all verified against current docs (one page confirmed the evaluator list-return contract against the installed Python SDK). The golden-dataset failure-sweep snippet uses v2-shaped scores API params — flagged for a quick run-through.
- Judge rubric choices (partial answers fail relevance; refusals scored separately) are editorial recommendations, softened where appropriate.

Checks run locally: single-H1 pass, `pnpm run format:check` pass, YAML frontmatter parsed for all six, internal links resolve within the PR.

From the internal GEO content pipeline (evidence and briefs in `langfuse/internal-geo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9eeJ64aD7eTMQmsSBUhYJ)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds six new documentation pages under `/resources/engineering` covering LLM evaluation topics — RAG faithfulness, answer relevance, hallucination detection, regression testing, golden dataset management, and a Promptfoo migration guide — all cross-linked and registered in `meta.json`.

- The metric recipe pages (faithfulness, relevance, hallucination) are technically accurate: evaluator signatures, return shapes, and edge-case handling (empty claims, refusals, zero-division guards) are consistent with the existing SDK patterns.
- The regression testing and golden dataset pages introduce working `run_experiment` / `RegressionError` workflows and a GitHub Actions integration pinned to `v1.0.6`, but the `contains_answer` evaluator omits a null guard on `output` that the corresponding evaluator in the migration guide correctly includes.
- The migration guide's Step 4 GitHub Actions snippet uses `langfuse/experiment-action@<release tag>` as a literal string, which is not a valid action reference and will fail any CI that copies it verbatim.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge after fixing the two concrete defects; the content is accurate and well-structured.

Two real defects exist in the newly added code: the @<release tag> placeholder in the migration guide will break CI for anyone who copies the YAML, and the missing null guard on output in the regression testing evaluator is inconsistent with the safer version provided in the same PR.

content/resources/engineering/migrate-from-promptfoo.mdx (Step 4 YAML snippet) and content/resources/engineering/llm-regression-testing.mdx (the contains_answer evaluator body)
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Production Traces] -->|Add to dataset| B[Golden Dataset]
    B -->|run_experiment| C[Experiment Run]
    C --> D[Task Function]
    D --> E[LLM Application]
    E --> F[Output]
    F --> G{Evaluators}
    G -->|contains_answer| H[Code Evaluator]
    G -->|faithfulness_judge| I[LLM-as-a-Judge]
    H --> J[Evaluation Scores]
    I --> J
    J -->|avg per run| K[Run-level Scores]
    K -->|compare vs THRESHOLDS| L{RegressionError?}
    L -->|score below threshold| M[CI Fails / PR blocked]
    L -->|all scores pass| N[CI Passes / PR allowed]
    M -->|experiment-action| O[PR Comment with score table]
    N -->|experiment-action| O
    B -->|online evaluators| P[Production Monitoring]
    P -->|flag low scores| A
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Production Traces] -->|Add to dataset| B[Golden Dataset]
    B -->|run_experiment| C[Experiment Run]
    C --> D[Task Function]
    D --> E[LLM Application]
    E --> F[Output]
    F --> G{Evaluators}
    G -->|contains_answer| H[Code Evaluator]
    G -->|faithfulness_judge| I[LLM-as-a-Judge]
    H --> J[Evaluation Scores]
    I --> J
    J -->|avg per run| K[Run-level Scores]
    K -->|compare vs THRESHOLDS| L{RegressionError?}
    L -->|score below threshold| M[CI Fails / PR blocked]
    L -->|all scores pass| N[CI Passes / PR allowed]
    M -->|experiment-action| O[PR Comment with score table]
    N -->|experiment-action| O
    B -->|online evaluators| P[Production Monitoring]
    P -->|flag low scores| A
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/resources/engineering/migrate-from-promptfoo.mdx:292
**Invalid action reference will break CI**

The GitHub Actions step uses `langfuse/experiment-action@<release tag>` as a literal string, which is not a valid action reference. Any team that copies this YAML as-is will get an immediate workflow failure with an "invalid ref" error. The companion `llm-regression-testing.mdx` page correctly pins this to `@v1.0.6` — that version should be used here too (or `@<release tag>` should be rendered as a template placeholder via a comment/note rather than appearing verbatim in the YAML block).

### Issue 2 of 2
content/resources/engineering/llm-regression-testing.mdx:64
**`output` is not null-guarded, unlike the equivalent evaluator in the migration guide**

If the task function raises an unhandled exception and `output` is `None`, `output.lower()` will throw an `AttributeError` that aborts the evaluator, causing the whole experiment item to be marked as errored. The corresponding evaluator in `migrate-from-promptfoo.mdx` correctly uses `(output or "").lower()` — readers copying both snippets will see inconsistent safety patterns.

```suggestion
    passed = bool(expected_output) and expected_output.lower() in (output or "").lower()
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add 6 evaluation-focused engineering res..."](https://github.com/langfuse/langfuse-docs/commit/63133d70a62f0482c9c7ef1b4dc37dca95775a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44795383)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->