### PR TITLE
feat (sample project: Add QA chatbot experiment flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ node_modules
 .vercel
 node-compile-cache
 
-.env.local
-.env
-.env*.local
+.env*
+!.env.template
+!.env.example
 
 # next sitemap
 public/robots.txt

--- a/components/qaChatbot/README.md
+++ b/components/qaChatbot/README.md
@@ -1,0 +1,170 @@
+# QA chatbot experiments
+
+This folder contains the local scripts for seeding QA chatbot datasets and running Langfuse experiments against the production-managed chatbot prompt.
+
+Run commands from the repository root:
+
+```bash
+cd /Users/annabellschafer/langfuse-docs
+```
+
+## Folder layout
+
+```text
+components/qaChatbot/
+  datasets/      Dataset seed scripts.
+  evaluators/    Product evaluator setup scripts.
+  experiments/   Experiment runners.
+  shared/        Shared Langfuse config and message helpers.
+```
+
+The live chatbot component files remain in the root of this folder.
+
+## Environment files
+
+Use one env file per Langfuse project:
+
+```text
+components/qaChatbot/.env_sample_project
+components/qaChatbot/.env_eu
+components/qaChatbot/.env_us
+components/qaChatbot/.env_jp
+```
+
+Each env file must provide a Langfuse base URL, public key, and secret key. The scripts accept either generic names like `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, or the region-specific names already used in these files.
+
+Default workflow: try changes in `.env_sample_project` first, note the result, then roll out to other regions only after explicit instruction.
+
+## Add a cloud region
+
+For experiment scripts, adding a new region usually does not require code changes. Create a new env file with generic Langfuse keys:
+
+```bash
+cp components/qaChatbot/.env_sample_project components/qaChatbot/.env_new_region
+```
+
+```bash
+LANGFUSE_BASE_URL=https://new-region.cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+```
+
+Seed both datasets:
+
+```bash
+pnpm qa-chatbot:seed-general -- components/qaChatbot/.env_new_region
+pnpm qa-chatbot:seed-sdk-grounding -- components/qaChatbot/.env_new_region
+```
+
+Create missing product evaluators and experiment rules:
+
+```bash
+pnpm qa-chatbot:general-experiment -- components/qaChatbot/.env_new_region --setup-product-evaluators-only
+pnpm qa-chatbot:setup-sdk-grounding-evaluators -- components/qaChatbot/.env_new_region
+```
+
+Run a first smoke experiment:
+
+```bash
+pnpm qa-chatbot:general-experiment -- components/qaChatbot/.env_new_region --models gpt-4.1
+pnpm qa-chatbot:sdk-grounding-experiment -- components/qaChatbot/.env_new_region --models gpt-4o-mini
+```
+
+No code changes are needed for one-off seeding and experiments when the new env file uses the generic `LANGFUSE_*` names above.
+
+## Seed datasets
+
+Seed the general QA dataset:
+
+```bash
+pnpm qa-chatbot:seed-general -- components/qaChatbot/.env_sample_project
+```
+
+Seed the SDK integration docs-grounding dataset:
+
+```bash
+pnpm qa-chatbot:seed-sdk-grounding -- components/qaChatbot/.env_sample_project
+```
+
+The seed scripts upsert datasets and stable item IDs, so rerunning them updates existing datasets instead of creating duplicates.
+
+## Run experiments
+
+Run the general QA chatbot experiment:
+
+```bash
+pnpm qa-chatbot:general-experiment -- components/qaChatbot/.env_sample_project
+```
+
+Run the SDK integration docs-grounding experiment:
+
+```bash
+pnpm qa-chatbot:sdk-grounding-experiment -- components/qaChatbot/.env_sample_project
+```
+
+Pass models as a comma-separated list:
+
+```bash
+pnpm qa-chatbot:sdk-grounding-experiment -- components/qaChatbot/.env_sample_project \
+  --models gpt-5,gpt-5.6-terra,gpt-5.6-sol
+```
+
+Compare prompt labels:
+
+```bash
+pnpm qa-chatbot:general-experiment -- components/qaChatbot/.env_sample_project \
+  --models gpt-4.1 \
+  --prompt-labels production,candidate-v3
+```
+
+Compare prompt versions:
+
+```bash
+pnpm qa-chatbot:general-experiment -- components/qaChatbot/.env_sample_project \
+  --models gpt-4.1 \
+  --prompt-versions 1,2
+```
+
+## Common options
+
+Both experiment runners support:
+
+```text
+--env-file <path>
+--dataset-name <name>
+--models <model-a,model-b>
+--prompt-labels <label-a,label-b>
+--prompt-versions <version-a,version-b>
+--run-series <name>
+--max-concurrency <number>
+--mcp-url <url>
+```
+
+The general QA runner also supports:
+
+```text
+--setup-product-evaluators-only
+--skip-product-evaluators
+```
+
+`--setup-product-evaluators-only` creates or updates the Langfuse product LLM-as-a-judge evaluators without running dataset items.
+
+Set up SDK integration docs-grounding product evaluators and rules:
+
+```bash
+pnpm qa-chatbot:setup-sdk-grounding-evaluators -- components/qaChatbot/.env_sample_project
+```
+
+## Package scripts
+
+```bash
+pnpm qa-chatbot:seed-general
+pnpm qa-chatbot:seed-sdk-grounding
+pnpm qa-chatbot:setup-sdk-grounding-evaluators
+pnpm qa-chatbot:general-experiment
+pnpm qa-chatbot:sdk-grounding-experiment
+```
+
+## Shared config
+
+[shared/flow_config.ts](./shared/flow_config.ts) contains the managed prompt name and message normalization helpers used by the experiment runners.

--- a/components/qaChatbot/datasets/seed_general_qa_chatbot_dataset.ts
+++ b/components/qaChatbot/datasets/seed_general_qa_chatbot_dataset.ts
@@ -1,0 +1,716 @@
+type Behavior = "answer" | "ask_follow_up" | "defer_question";
+type Category = "typical_case" | "should_defer";
+type Source = "production_trace" | "synthetic_defer";
+type SeedMessage = { role: "user" | "assistant"; content: string };
+
+type SeedItem = {
+  id: string;
+  question: string;
+  messages?: SeedMessage[];
+  sampleReply: string;
+  behavior: Behavior;
+  keywords: [string, string, string];
+  category: Category;
+  source: Source;
+  topic: string;
+  language?: string;
+  sourceTraceId?: string;
+  sourceObservationId?: string;
+};
+
+const DATASET_NAME = "general QA chatbot";
+const SCHEMA_VERSION = "general_qa_chatbot_v1";
+
+const inputSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  additionalProperties: false,
+  required: ["messages"],
+  properties: {
+    messages: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["role", "content"],
+        properties: {
+          role: {
+            type: "string",
+            enum: ["system", "user", "assistant", "tool"],
+          },
+          content: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const expectedOutputSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  additionalProperties: false,
+  required: ["sample_reply", "general_behavior", "keyword_overlap"],
+  properties: {
+    sample_reply: { type: "string", minLength: 1 },
+    general_behavior: {
+      type: "string",
+      enum: ["answer", "ask_follow_up", "defer_question"],
+    },
+    keyword_overlap: {
+      type: "array",
+      minItems: 3,
+      maxItems: 3,
+      items: { type: "string", minLength: 1 },
+    },
+  },
+};
+
+const items: SeedItem[] = [
+  {
+    id: "general-qa-chatbot-v1-01-use-cases",
+    question: "What can I use Langfuse for?",
+    sampleReply:
+      "Langfuse helps teams observe, debug, evaluate, and improve LLM applications. Start with tracing to capture requests, prompts, tool calls, cost, and latency; then add prompt management, datasets, experiments, scores, and dashboards for production monitoring and iteration.",
+    behavior: "answer",
+    keywords: ["tracing", "evaluations", "prompt management"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "overview",
+    sourceTraceId: "0888d0b775b68df51a3412cef9d7c72c",
+    sourceObservationId: "a001b4da986441f6",
+  },
+  {
+    id: "general-qa-chatbot-v1-02-tracing",
+    question: "how does tracing work",
+    sampleReply:
+      "A trace represents one end-to-end request or workflow. Inside it, observations capture the individual steps such as spans, generations, tool calls, retrievers, and events. Use traces to inspect inputs, outputs, latency, token usage, cost, metadata, and where failures happen.",
+    behavior: "answer",
+    keywords: ["trace", "observations", "latency"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "tracing",
+    sourceTraceId: "9d43da490e4946ad11fc3505e38457f8",
+    sourceObservationId: "a9cd35c5e35e97b7",
+  },
+  {
+    id: "general-qa-chatbot-v1-03-overview",
+    question: "What is langfuse",
+    sampleReply:
+      "Langfuse is an open-source AI engineering platform for LLM applications. It combines observability, prompt management, evaluations, datasets, experiments, metrics, and dashboards so teams can debug production behavior and improve quality over time.",
+    behavior: "answer",
+    keywords: ["open-source", "observability", "evaluations"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "overview",
+    sourceTraceId: "8965d17135ad3f762b3ce72fa162237f",
+    sourceObservationId: "1d35c81aff9c85e3",
+  },
+  {
+    id: "general-qa-chatbot-v1-04-korean-get-started",
+    question: "langfuse는 어떻게 써야해?",
+    sampleReply:
+      "Langfuse는 LLM 앱을 추적하고 평가하고 개선하는 데 사용합니다. 먼저 프로젝트를 만들고 SDK 키를 설정한 뒤 Python 또는 JavaScript SDK로 첫 trace를 보내세요. 그 다음 prompt management, datasets, evaluators, dashboards를 추가해 운영 품질을 모니터링할 수 있습니다.",
+    behavior: "answer",
+    keywords: ["trace", "SDK", "evaluators"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "getting-started",
+    language: "ko",
+    sourceTraceId: "98b40ebc40d2c0713ff673cf08cfc4ef",
+    sourceObservationId: "04451a8381227922",
+  },
+  {
+    id: "general-qa-chatbot-v1-05-architecture-azure",
+    question:
+      "Tell me more about the Postgres and Clickhouse use and Azure compatibility",
+    messages: [
+      { role: "user", content: "What is the Langfuse architecture?" },
+      {
+        role: "assistant",
+        content:
+          "At a high level, Langfuse has an application/API layer, workers, Postgres for transactional data, ClickHouse for analytics, and supporting infrastructure such as queues and object storage.",
+      },
+      {
+        role: "user",
+        content:
+          "Tell me more about the Postgres and Clickhouse use and Azure compatibility",
+      },
+    ],
+    sampleReply:
+      "Langfuse uses Postgres for transactional application data and ClickHouse for high-volume analytical trace, observation, score, and metric data. For Azure deployments, use compatible managed Postgres and ClickHouse options or self-host the services, and verify storage, networking, and authentication settings against the self-hosting docs.",
+    behavior: "answer",
+    keywords: ["Postgres", "ClickHouse", "Azure"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "self-hosting",
+    sourceTraceId: "087814ea5a42c7b5efd10f7b0e5d1377",
+    sourceObservationId: "53e0a229a02b1ded",
+  },
+  {
+    id: "general-qa-chatbot-v1-06-architecture",
+    question: "What is the Langfuse architecture?",
+    sampleReply:
+      "At a high level, Langfuse consists of the application/API layer, ingestion and background workers, Postgres for transactional data, ClickHouse for analytics, object storage for blob exports or media, and optional observability infrastructure. For self-hosting, explain the components and point to the deployment docs for the exact version.",
+    behavior: "answer",
+    keywords: ["application", "Postgres", "ClickHouse"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "architecture",
+    sourceTraceId: "bc9b4cbacdda24b09dd26bd9ea960575",
+    sourceObservationId: "a95e2b75d5ce3535",
+  },
+  {
+    id: "general-qa-chatbot-v1-07-start-tracing",
+    question: "How do I get started with tracing?",
+    sampleReply:
+      "Create a Langfuse project, install the SDK or framework integration for your stack, set the public and secret keys, instrument one request, then inspect the trace in the UI. Start with one important production path before adding richer metadata, sessions, users, scores, and dashboards.",
+    behavior: "answer",
+    keywords: ["project", "SDK", "trace"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "tracing",
+    sourceTraceId: "3c28e14ae5d820f04e2ddf2fe5171a9d",
+    sourceObservationId: "361b7512037c86a2",
+  },
+  {
+    id: "general-qa-chatbot-v1-08-python-prompt-linking",
+    question: "How do I link my prompts to my traces? My code is in python",
+    sampleReply:
+      "In Python, fetch the managed prompt from Langfuse, compile it with your variables, pass it to your model call, and attach the prompt object or prompt metadata to the generation so the trace links back to the prompt version. Keep the prompt name and version visible in trace metadata for comparisons.",
+    behavior: "answer",
+    keywords: ["Python", "managed prompt", "generation"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "prompt-management",
+    sourceTraceId: "8d7015fefcb6e969efab193cc40ae5ae",
+    sourceObservationId: "656961cdbdbe7495",
+  },
+  {
+    id: "general-qa-chatbot-v1-09-python-install",
+    question: "Hello, how can I install Langfuse library in Python?",
+    sampleReply:
+      "Install the Python SDK with pip install langfuse, set LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_HOST, then initialize the client or use the relevant integration for your framework. After sending a test trace, verify it in the Langfuse project.",
+    behavior: "answer",
+    keywords: ["pip install", "Python SDK", "environment variables"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "sdk",
+    sourceTraceId: "1bed1accd93cec9537f205ea1f9befe2",
+    sourceObservationId: "44e4ac672274a4ac",
+  },
+  {
+    id: "general-qa-chatbot-v1-10-langgraph",
+    question: "how to use langfuse with langgraph",
+    sampleReply:
+      "Use the Langfuse LangChain CallbackHandler with LangGraph. Pass the handler in the graph invoke or stream config so Langfuse captures graph steps, LLM calls, tool calls, metadata, and the final answer in one trace.",
+    behavior: "answer",
+    keywords: ["LangGraph", "CallbackHandler", "trace"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    sourceTraceId: "040801ce2406c35d9fe8ed7f1f229549",
+    sourceObservationId: "e79811a435d4bb08",
+  },
+  {
+    id: "general-qa-chatbot-v1-11-langchain",
+    question: "does langfuse work with langchain",
+    sampleReply:
+      "Yes. Langfuse integrates with LangChain through a callback handler that records chains, LLM calls, tools, retrievers, inputs, outputs, latency, tokens, and cost. Add the handler to your LangChain invocation config and include user, session, and release metadata when useful.",
+    behavior: "answer",
+    keywords: ["LangChain", "callback handler", "metadata"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    sourceTraceId: "1a464aa74eef4a2b36be00c40dff7ceb",
+    sourceObservationId: "46c63bb7bb972a70",
+  },
+  {
+    id: "general-qa-chatbot-v1-12-italian-agent-test-set",
+    question:
+      "ma come posso usare lanfuse per creare dei test set per i miei agenti multistates?",
+    messages: [
+      { role: "user", content: "cosa posso chiederti?" },
+      {
+        role: "assistant",
+        content:
+          "Posso aiutarti con Langfuse: tracing, SDK e integrazioni, prompt management, dataset, esperimenti, valutazioni, dashboard e self-hosting.",
+      },
+      {
+        role: "user",
+        content:
+          "ma come posso usare lanfuse per creare dei test set per i miei agenti multistates?",
+      },
+    ],
+    sampleReply:
+      "Puoi creare un dataset Langfuse con input realistici, output attesi e metadati sullo stato o sul percorso dell'agente. Poi esegui esperimenti sugli agenti multi-step, salva i risultati come dataset runs e valuta risposta finale, trajectory, tool calls e regressioni con evaluator automatici o review umana.",
+    behavior: "answer",
+    keywords: ["dataset", "agent", "experiments"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "datasets",
+    language: "it",
+    sourceTraceId: "4438d380d910a9c3dba0368d9146ef27",
+    sourceObservationId: "95d51892ca2a2d42",
+  },
+  {
+    id: "general-qa-chatbot-v1-13-chinese-overview",
+    question: "请简介以下langfuse，以及它的功能",
+    sampleReply:
+      "Langfuse 是一个开源 AI 工程平台，用于观测、调试、评估和改进 LLM 应用。它支持 tracing、prompt management、datasets、experiments、scores、annotation queues、dashboards，以及 Python/JavaScript SDK 和多种框架集成。",
+    behavior: "answer",
+    keywords: ["tracing", "prompt management", "datasets"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "overview",
+    language: "zh",
+    sourceTraceId: "6e6b5d9b08a78dc2c0a4134cae9098cd",
+    sourceObservationId: "8f4a32149261c3c3",
+  },
+  {
+    id: "general-qa-chatbot-v1-14-code-example",
+    question: "Give me code example.",
+    messages: [
+      { role: "user", content: "What can I use Langfuse for?" },
+      {
+        role: "assistant",
+        content:
+          "Langfuse helps with LLM observability, tracing, prompt management, evaluations, datasets, experiments, metrics, and dashboards.",
+      },
+      { role: "user", content: "Give me code example." },
+    ],
+    sampleReply:
+      "Continue from the previous Langfuse overview and provide a minimal default Python first-trace example. Include installation, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST or LANGFUSE_BASE_URL, one traced span or generation, and a note to flush or verify the trace in Langfuse.",
+    behavior: "answer",
+    keywords: ["Python", "environment variables", "trace"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "sdk",
+    sourceTraceId: "65a168fc6d50d71db9488363f087d649",
+    sourceObservationId: "c94676eaeb92b915",
+  },
+  {
+    id: "general-qa-chatbot-v1-15-langgraph-case",
+    question: "How do i integrate with Langgraph",
+    sampleReply:
+      "For LangGraph, use the Langfuse LangChain callback and pass it in the graph invocation config. Show the minimal Python wiring, mention environment variables, and explain that Langfuse will capture graph nodes, model calls, tool calls, and final output in one trace.",
+    behavior: "answer",
+    keywords: ["LangGraph", "callback", "Python"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    sourceTraceId: "5e99ab85b19155c9232ca198ee1462f9",
+    sourceObservationId: "25de09cc31b30654",
+  },
+  {
+    id: "general-qa-chatbot-v1-16-java",
+    question: "what is langfuse and how it's used in java",
+    messages: [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content:
+          "Hi! How can I help with Langfuse today: setup, SDK integration, tracing, evaluations, or self-hosting?",
+      },
+      { role: "user", content: "what is langfuse and how it's used in java" },
+    ],
+    sampleReply:
+      "Langfuse is an open-source platform for tracing, evaluating, and improving LLM applications. For Java, explain the available integration path such as OpenTelemetry or API-based ingestion, then show how to send traces with the right host and API keys and where to inspect them.",
+    behavior: "answer",
+    keywords: ["Java", "OpenTelemetry", "traces"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    sourceTraceId: "1c71ba319198e166fd30f6e1ebf81d0e",
+    sourceObservationId: "77006eb06195ebb6",
+  },
+  {
+    id: "general-qa-chatbot-v1-17-why-langfuse",
+    question: "Why langfuse?",
+    sampleReply:
+      "Langfuse is useful when you need a shared system for LLM observability, prompt management, evaluations, datasets, experiments, and monitoring. Emphasize debugging production behavior, measuring quality and cost, preventing regressions, and supporting open-source or self-hosted deployments.",
+    behavior: "answer",
+    keywords: ["observability", "quality", "self-hosted"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "overview",
+    sourceTraceId: "8a1d0acfb2eab15f86441d7d5a2f94dd",
+    sourceObservationId: "5234df5d0af5b8f3",
+  },
+  {
+    id: "general-qa-chatbot-v1-18-django",
+    question: "integra con django?",
+    sampleReply:
+      "Si. Per Django puoi usare l'SDK Python di Langfuse o un'integrazione compatibile con LangChain/OpenTelemetry. Spiega come impostare le chiavi, creare o propagare una trace per richiesta, aggiungere metadata come user/session, e verificare i risultati nella UI.",
+    behavior: "answer",
+    keywords: ["Django", "Python SDK", "trace"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    language: "it",
+    sourceTraceId: "326d6fc27e4b05e49cd1df4517a934d5",
+    sourceObservationId: "65e425c77e7452a8",
+  },
+  {
+    id: "general-qa-chatbot-v1-19-bedrock-agentcore",
+    question: "How do i integrate with Amazon Bedrock agentcore",
+    sampleReply:
+      "Use Langfuse with Amazon Bedrock AgentCore through the documented integration path, typically OpenTelemetry or the relevant framework integration. Give the minimal setup steps, include API key and host configuration, and explain how traces, spans, tool calls, latency, and cost should appear in Langfuse.",
+    behavior: "answer",
+    keywords: ["Amazon Bedrock", "AgentCore", "OpenTelemetry"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "integrations",
+    sourceTraceId: "ba982e3f7828a67982370a81c558a07e",
+    sourceObservationId: "8871ca9203baa236",
+  },
+  {
+    id: "general-qa-chatbot-v1-20-params-clarification",
+    question: "Test what params look like",
+    sampleReply:
+      "Ask which parameters the user wants to inspect: model parameters on generations, prompt variables, trace or observation metadata, SDK initialization options, or API request fields. Offer to show a small example once they choose the parameter type.",
+    behavior: "ask_follow_up",
+    keywords: ["parameters", "generation", "metadata"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "clarification",
+    sourceTraceId: "8a830d70a0228b9d7717febb9c0e6a96",
+    sourceObservationId: "4986271e73298b80",
+  },
+  {
+    id: "general-qa-chatbot-v1-21-user-says-not-work",
+    question: "No does not work",
+    messages: [
+      {
+        role: "user",
+        content: "How do I link my prompts to my traces? My code is in python",
+      },
+      {
+        role: "assistant",
+        content:
+          "Fetch the managed prompt in Python, use it in the model call, and attach the prompt object to the generation so the trace links back to the prompt version.",
+      },
+      { role: "user", content: "No does not work" },
+    ],
+    sampleReply:
+      "Acknowledge that the previous prompt-linking guidance failed and stay on that task. Give a concrete Python alternative such as passing the prompt object to a generation or updating the current generation with the prompt, then ask for the exact error or code snippet if it still does not work.",
+    behavior: "answer",
+    keywords: ["prompt", "generation", "error"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "troubleshooting",
+    sourceTraceId: "657de9df37fdfebd19a050966d133286",
+    sourceObservationId: "0b39a62ac05e83e4",
+  },
+  {
+    id: "general-qa-chatbot-v1-22-user-disagrees",
+    question: "no thats not true",
+    messages: [
+      { role: "user", content: "What can I use Langfuse for?" },
+      {
+        role: "assistant",
+        content:
+          "Langfuse is an open-source AI engineering platform for observability and tracing, prompt management, evaluation and experiments, metrics, and dashboards.",
+      },
+      { role: "user", content: "no thats not true" },
+    ],
+    sampleReply:
+      "Apologize briefly, ask what part is incorrect, and request the relevant context or link. The assistant should avoid doubling down and should offer to correct the answer once the user identifies the mismatch.",
+    behavior: "ask_follow_up",
+    keywords: ["incorrect", "context", "correct"],
+    category: "typical_case",
+    source: "production_trace",
+    topic: "feedback",
+    sourceTraceId: "1aba00a20e37deffa288416c2405c311",
+    sourceObservationId: "e4377f8ba4ad7769",
+  },
+  {
+    id: "general-qa-chatbot-v1-23-weather",
+    question: "今天天气星期几",
+    sampleReply:
+      "礼貌说明这里不能提供实时天气预报，并询问用户是否想了解 Langfuse 相关问题。不要编造天气信息；如果只是在问日期或星期，可以说明需要明确问题范围。",
+    behavior: "defer_question",
+    keywords: ["天气", "Langfuse", "无法提供"],
+    category: "should_defer",
+    source: "production_trace",
+    topic: "out-of-scope",
+    language: "zh",
+    sourceTraceId: "d2697c51be222f10261f5decd610ccc5",
+    sourceObservationId: "ec520b1e0efaa9d5",
+  },
+  {
+    id: "general-qa-chatbot-v1-24-medical-advice",
+    question: "I have chest pain. Tell me what medicine to take.",
+    sampleReply:
+      "I cannot provide medical advice or recommend medicine. If this is urgent, contact emergency services or a qualified medical professional. If you are building a healthcare AI assistant, I can help you design Langfuse tracing, evaluation, and review workflows for safety-sensitive behavior.",
+    behavior: "defer_question",
+    keywords: ["medical advice", "emergency", "Langfuse"],
+    category: "should_defer",
+    source: "synthetic_defer",
+    topic: "out-of-scope",
+  },
+  {
+    id: "general-qa-chatbot-v1-25-financial-advice",
+    question: "What stock should I buy today to double my money?",
+    sampleReply:
+      "I cannot give financial advice or stock picks. If you are building an investment assistant, I can help explain how to use Langfuse to trace responses, capture risk-related feedback, and evaluate refusal or escalation behavior.",
+    behavior: "defer_question",
+    keywords: ["financial advice", "stock picks", "Langfuse"],
+    category: "should_defer",
+    source: "synthetic_defer",
+    topic: "out-of-scope",
+  },
+];
+
+function parseEnv(content: string): Record<string, string> {
+  return Object.fromEntries(
+    content
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const index = line.indexOf("=");
+        const key = line.slice(0, index);
+        const value = line.slice(index + 1).replace(/^['"]|['"]$/g, "");
+        return [key, value];
+      }),
+  );
+}
+
+function getFirstEnvValue(env: Record<string, string>, keys: string[]) {
+  return keys.map((key) => env[key]).find(Boolean);
+}
+
+function getRegionKeyFromEnvFile(envFile: string) {
+  const lower = envFile.toLowerCase();
+  if (lower.includes("_eu") || lower.includes("-eu")) return "EU";
+  if (lower.includes("_us") || lower.includes("-us")) return "US";
+  if (lower.includes("_jp") || lower.includes("-jp") || lower.includes("japan"))
+    return "JP";
+  return undefined;
+}
+
+function makeInput(item: SeedItem) {
+  return {
+    messages: item.messages ?? [{ role: "user", content: item.question }],
+  };
+}
+
+function makeExpectedOutput(item: SeedItem) {
+  return {
+    sample_reply: item.sampleReply,
+    general_behavior: item.behavior,
+    keyword_overlap: item.keywords,
+  };
+}
+
+async function mcpCall<T>(
+  baseUrl: string,
+  authHeader: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${baseUrl}/api/public/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: authHeader,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Math.floor(Math.random() * 1_000_000_000),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  const text = await response.text();
+  const eventPayloads = Array.from(text.matchAll(/^data: (.*)$/gm))
+    .map((match) => match[1])
+    .filter((payload) => payload && payload !== "[DONE]");
+  const payload = JSON.parse(eventPayloads[0] ?? text);
+  if (payload.error) {
+    throw new Error(JSON.stringify(payload.error));
+  }
+  const resultText = payload.result?.content?.find(
+    (entry: { type?: string }) => entry.type === "text",
+  )?.text;
+  return JSON.parse(resultText);
+}
+
+async function main() {
+  const envFile = process.argv[2] ?? ".env_sample_project";
+  const fs = await import("node:fs/promises");
+  const env = parseEnv(await fs.readFile(envFile, "utf8"));
+  const regionKey = getRegionKeyFromEnvFile(envFile);
+  const baseUrl = getFirstEnvValue(env, [
+    "LANGFUSE_BASE_URL",
+    "LANGFUSE_HOST",
+    ...(regionKey
+      ? [
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_BASE_URL`,
+          `${regionKey}_LANGFUSE_BASE_URL`,
+        ]
+      : []),
+  ])?.replace(/\/$/, "");
+  const publicKey = getFirstEnvValue(env, [
+    "LANGFUSE_PUBLIC_KEY",
+    ...(regionKey
+      ? [
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_PUBLIC_KEY`,
+          `${regionKey}_LANGFUSE_PUBLIC_KEY`,
+        ]
+      : []),
+  ]);
+  const secretKey = getFirstEnvValue(env, [
+    "LANGFUSE_SECRET_KEY",
+    ...(regionKey
+      ? [
+          `${regionKey}_LANGFUSE_SECRET_KEY`,
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_SECRET_KEY`,
+        ]
+      : []),
+  ]);
+
+  if (!baseUrl || !publicKey || !secretKey) {
+    throw new Error(
+      `Missing LANGFUSE_BASE_URL, LANGFUSE_PUBLIC_KEY, or LANGFUSE_SECRET_KEY in ${envFile}`,
+    );
+  }
+
+  const authHeader = `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`;
+  const listed = await mcpCall<{
+    data: Array<{ id: string; name: string; url?: string }>;
+  }>(baseUrl, authHeader, "listDatasets", {
+    name: DATASET_NAME,
+    page: 1,
+    limit: 10,
+  });
+  const existingDataset = listed.data.find(
+    (dataset) => dataset.name === DATASET_NAME,
+  );
+
+  const dataset = await mcpCall<{ id: string; url?: string }>(
+    baseUrl,
+    authHeader,
+    "upsertDataset",
+    {
+      ...(existingDataset ? { id: existingDataset.id } : {}),
+      name: DATASET_NAME,
+      description:
+        "General Langfuse QA chatbot dataset with production-derived typical questions and explicit defer cases.",
+      metadata: {
+        owner: "qa-chatbot",
+        schema_version: SCHEMA_VERSION,
+        item_count: items.length,
+        multi_turn_item_count: items.filter((item) => item.messages).length,
+        typical_case_count: items.filter(
+          (item) => item.category === "typical_case",
+        ).length,
+        should_defer_count: items.filter(
+          (item) => item.category === "should_defer",
+        ).length,
+        source: "sample project seed",
+      },
+      inputSchema,
+      expectedOutputSchema,
+    },
+  );
+
+  const datasetId = dataset.id ?? existingDataset?.id;
+  if (!datasetId) throw new Error("Langfuse did not return a dataset id.");
+
+  let sourceLinkFallbacks = 0;
+
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    const basePayload = {
+      datasetId,
+      id: item.id,
+      input: makeInput(item),
+      expectedOutput: makeExpectedOutput(item),
+      metadata: {
+        category: item.category,
+        source: item.source,
+        topic: item.topic,
+        language: item.language ?? "en",
+        input_context: item.messages ? "multi_turn" : "single_turn",
+        schema_version: SCHEMA_VERSION,
+        general_behavior: item.behavior,
+        item_number: index + 1,
+        ...(item.sourceTraceId ? { source_trace_id: item.sourceTraceId } : {}),
+        ...(item.sourceObservationId
+          ? { source_observation_id: item.sourceObservationId }
+          : {}),
+      },
+      status: "ACTIVE",
+    };
+
+    const linkedPayload = {
+      ...basePayload,
+      ...(item.sourceTraceId ? { sourceTraceId: item.sourceTraceId } : {}),
+      ...(item.sourceObservationId
+        ? { sourceObservationId: item.sourceObservationId }
+        : {}),
+    };
+
+    try {
+      await mcpCall(baseUrl, authHeader, "upsertDatasetItem", linkedPayload);
+    } catch (error) {
+      if (!item.sourceTraceId && !item.sourceObservationId) throw error;
+      await mcpCall(baseUrl, authHeader, "upsertDatasetItem", basePayload);
+      sourceLinkFallbacks += 1;
+    }
+  }
+
+  const readBackDataset = await mcpCall<{
+    inputSchema?: unknown;
+    expectedOutputSchema?: unknown;
+  }>(baseUrl, authHeader, "getDataset", { datasetId });
+  const itemList = await mcpCall<{
+    data: Array<{
+      id: string;
+      status?: string;
+      metadata?: { category?: string };
+    }>;
+    meta?: { totalItems?: number };
+  }>(baseUrl, authHeader, "listDatasetItems", {
+    datasetId,
+    page: 1,
+    limit: 100,
+  });
+  const activeItems = itemList.data.filter(
+    (item) => item.status !== "ARCHIVED",
+  );
+  const counts = activeItems.reduce<Record<string, number>>((acc, item) => {
+    const category = item.metadata?.category ?? "unknown";
+    acc[category] = (acc[category] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(
+    JSON.stringify(
+      {
+        datasetName: DATASET_NAME,
+        datasetId,
+        url: dataset.url ?? existingDataset?.url,
+        activeItems: activeItems.length,
+        counts,
+        hasInputSchema: Boolean(readBackDataset.inputSchema),
+        hasExpectedOutputSchema: Boolean(readBackDataset.expectedOutputSchema),
+        sourceLinkFallbacks,
+        schemaVersion: SCHEMA_VERSION,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+export {};

--- a/components/qaChatbot/datasets/seed_sdk_integration_grounding_dataset.ts
+++ b/components/qaChatbot/datasets/seed_sdk_integration_grounding_dataset.ts
@@ -1,0 +1,531 @@
+type IntegrationType = "sdk" | "model_provider" | "framework" | "gateway";
+type Ecosystem = "python" | "js_ts" | "provider" | "framework" | "gateway";
+
+type SeedItem = {
+  id: string;
+  question: string;
+  integration: string;
+  integrationType: IntegrationType;
+  ecosystem: Ecosystem;
+  docsUrls: string[];
+  docsPaths: string[];
+  requiresVersionOrPackage: boolean;
+  focus: string[];
+};
+
+const DATASET_NAME = "SDK integration docs grounding";
+const SCHEMA_VERSION = "sdk_integration_grounding_v1";
+
+const evaluationCriteria = [
+  "grounded_in_langfuse_docs",
+  "docs_links_required",
+  "version_or_package_details_required",
+  "avoid_training_data_only_claims",
+];
+
+const inputSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  additionalProperties: false,
+  required: ["messages"],
+  properties: {
+    messages: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["role", "content"],
+        properties: {
+          role: {
+            type: "string",
+            enum: ["system", "user", "assistant", "tool"],
+          },
+          content: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const items: SeedItem[] = [
+  {
+    id: "sdk-integration-grounding-v1-01-python-sdk-v4",
+    question:
+      "What is the current recommended way to instrument a Python app with Langfuse tracing, and which SDK version/package should I install?",
+    integration: "python-sdk",
+    integrationType: "sdk",
+    ecosystem: "python",
+    docsUrls: [
+      "https://langfuse.com/docs/observability/sdk/overview",
+      "https://langfuse.com/docs/observability/sdk/instrumentation",
+      "https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4",
+    ],
+    docsPaths: [
+      "/docs/observability/sdk/overview",
+      "/docs/observability/sdk/instrumentation",
+      "/docs/observability/sdk/upgrade-path/python-v3-to-v4",
+    ],
+    requiresVersionOrPackage: true,
+    focus: [
+      "Python SDK v4",
+      "pip install langfuse",
+      "OpenTelemetry-based instrumentation",
+    ],
+  },
+  {
+    id: "sdk-integration-grounding-v1-02-js-ts-sdk-v5",
+    question:
+      "How do I set up Langfuse tracing in a Node or TypeScript app with the current JS/TS SDK, including package names and initialization?",
+    integration: "js-ts-sdk",
+    integrationType: "sdk",
+    ecosystem: "js_ts",
+    docsUrls: [
+      "https://langfuse.com/docs/observability/sdk/overview",
+      "https://langfuse.com/docs/observability/sdk/instrumentation",
+      "https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5",
+    ],
+    docsPaths: [
+      "/docs/observability/sdk/overview",
+      "/docs/observability/sdk/instrumentation",
+      "/docs/observability/sdk/upgrade-path/js-v4-to-v5",
+    ],
+    requiresVersionOrPackage: true,
+    focus: ["JS/TS SDK v5", "@langfuse/tracing", "@langfuse/otel"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-03-openai-python",
+    question:
+      "How do I trace OpenAI Python SDK calls with Langfuse using the drop-in replacement, and what OpenAI SDK version compatibility should I mention?",
+    integration: "openai-python",
+    integrationType: "model_provider",
+    ecosystem: "python",
+    docsUrls: ["https://langfuse.com/integrations/model-providers/openai-py"],
+    docsPaths: ["/integrations/model-providers/openai-py"],
+    requiresVersionOrPackage: true,
+    focus: [
+      "drop-in import change",
+      "OpenAI SDK compatibility",
+      "streaming support",
+    ],
+  },
+  {
+    id: "sdk-integration-grounding-v1-04-openai-js",
+    question:
+      "How do I trace the OpenAI JS/TS SDK with Langfuse using observeOpenAI, and what packages and docs should the answer cite?",
+    integration: "openai-js",
+    integrationType: "model_provider",
+    ecosystem: "js_ts",
+    docsUrls: ["https://langfuse.com/integrations/model-providers/openai-js"],
+    docsPaths: ["/integrations/model-providers/openai-js"],
+    requiresVersionOrPackage: true,
+    focus: ["observeOpenAI", "OpenAI JS/TS SDK", "Langfuse tracing packages"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-05-anthropic-python",
+    question:
+      "What is the documented way to trace Anthropic Claude calls with Langfuse in Python, including the OpenTelemetry option and required packages?",
+    integration: "anthropic-python",
+    integrationType: "model_provider",
+    ecosystem: "python",
+    docsUrls: ["https://langfuse.com/integrations/model-providers/anthropic"],
+    docsPaths: ["/integrations/model-providers/anthropic"],
+    requiresVersionOrPackage: true,
+    focus: [
+      "AnthropicInstrumentor",
+      "OpenTelemetry instrumentation",
+      "OpenAI-compatible endpoint alternative",
+    ],
+  },
+  {
+    id: "sdk-integration-grounding-v1-06-anthropic-js",
+    question:
+      "How should I trace Anthropic JS/TS SDK calls with Langfuse, and what setup details should be grounded in the Langfuse docs?",
+    integration: "anthropic-js",
+    integrationType: "model_provider",
+    ecosystem: "js_ts",
+    docsUrls: [
+      "https://langfuse.com/integrations/model-providers/anthropic-js",
+    ],
+    docsPaths: ["/integrations/model-providers/anthropic-js"],
+    requiresVersionOrPackage: true,
+    focus: ["Anthropic JS/TS SDK", "OpenTelemetry", "Langfuse setup"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-07-langchain-langgraph",
+    question:
+      "What is the recommended Langfuse setup for LangChain or LangGraph, including callback handler package details for Python and JS/TS?",
+    integration: "langchain-langgraph",
+    integrationType: "framework",
+    ecosystem: "framework",
+    docsUrls: ["https://langfuse.com/integrations/frameworks/langchain"],
+    docsPaths: ["/integrations/frameworks/langchain"],
+    requiresVersionOrPackage: true,
+    focus: [
+      "LangChain callback handler",
+      "LangGraph tracing",
+      "Python and JS/TS packages",
+    ],
+  },
+  {
+    id: "sdk-integration-grounding-v1-08-llamaindex",
+    question:
+      "How do I trace a LlamaIndex application or workflow with Langfuse, and which integration docs and package setup should the answer rely on?",
+    integration: "llamaindex",
+    integrationType: "framework",
+    ecosystem: "python",
+    docsUrls: [
+      "https://langfuse.com/integrations/frameworks/llamaindex",
+      "https://langfuse.com/integrations/frameworks/llamaindex-workflows",
+    ],
+    docsPaths: [
+      "/integrations/frameworks/llamaindex",
+      "/integrations/frameworks/llamaindex-workflows",
+    ],
+    requiresVersionOrPackage: true,
+    focus: ["LlamaIndex instrumentation", "workflows", "package setup"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-09-vercel-ai-sdk",
+    question:
+      "How do I trace a Vercel AI SDK app with Langfuse, including OpenTelemetry setup, required package names, and links to the correct docs?",
+    integration: "vercel-ai-sdk",
+    integrationType: "framework",
+    ecosystem: "js_ts",
+    docsUrls: ["https://langfuse.com/integrations/frameworks/vercel-ai-sdk"],
+    docsPaths: ["/integrations/frameworks/vercel-ai-sdk"],
+    requiresVersionOrPackage: true,
+    focus: ["Vercel AI SDK", "OpenTelemetry", "Langfuse exporter setup"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-10-litellm-proxy",
+    question:
+      "What is the Langfuse integration path for LiteLLM Proxy, and how is it different from using the LiteLLM SDK directly?",
+    integration: "litellm-proxy",
+    integrationType: "gateway",
+    ecosystem: "gateway",
+    docsUrls: [
+      "https://langfuse.com/integrations/gateways/litellm",
+      "https://langfuse.com/integrations/frameworks/litellm-sdk",
+    ],
+    docsPaths: [
+      "/integrations/gateways/litellm",
+      "/integrations/frameworks/litellm-sdk",
+    ],
+    requiresVersionOrPackage: true,
+    focus: ["LiteLLM Proxy", "LiteLLM SDK", "Langfuse callback/config"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-11-amazon-bedrock",
+    question:
+      "How do I monitor Amazon Bedrock calls with Langfuse, and when should I use the Bedrock SDK integration versus OpenTelemetry-based tracing?",
+    integration: "amazon-bedrock",
+    integrationType: "model_provider",
+    ecosystem: "provider",
+    docsUrls: [
+      "https://langfuse.com/integrations/model-providers/amazon-bedrock",
+      "https://langfuse.com/integrations/frameworks/amazon-agentcore",
+    ],
+    docsPaths: [
+      "/integrations/model-providers/amazon-bedrock",
+      "/integrations/frameworks/amazon-agentcore",
+    ],
+    requiresVersionOrPackage: true,
+    focus: ["Amazon Bedrock SDK", "AgentCore", "OpenTelemetry"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-12-google-gemini-vertex",
+    question:
+      "How do I trace Google Gemini or Vertex AI usage with Langfuse, and what provider-specific setup details should be included from the docs?",
+    integration: "google-gemini-vertex-ai",
+    integrationType: "model_provider",
+    ecosystem: "provider",
+    docsUrls: [
+      "https://langfuse.com/integrations/model-providers/google-gemini",
+      "https://langfuse.com/integrations/model-providers/google-vertex-ai",
+    ],
+    docsPaths: [
+      "/integrations/model-providers/google-gemini",
+      "/integrations/model-providers/google-vertex-ai",
+    ],
+    requiresVersionOrPackage: true,
+    focus: ["Google GenAI SDK", "Vertex AI", "provider-specific setup"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-13-openai-agents",
+    question:
+      "How do I trace an OpenAI Agents SDK workflow with Langfuse, and which OpenInference or OpenTelemetry instrumentation details should be cited?",
+    integration: "openai-agents",
+    integrationType: "framework",
+    ecosystem: "python",
+    docsUrls: ["https://langfuse.com/integrations/frameworks/openai-agents"],
+    docsPaths: ["/integrations/frameworks/openai-agents"],
+    requiresVersionOrPackage: true,
+    focus: [
+      "OpenAI Agents SDK",
+      "OpenInference instrumentation",
+      "OpenTelemetry",
+    ],
+  },
+  {
+    id: "sdk-integration-grounding-v1-14-crewai",
+    question:
+      "How do I instrument a CrewAI app with Langfuse, and which OpenTelemetry or OpenLIT setup steps should the answer include?",
+    integration: "crewai",
+    integrationType: "framework",
+    ecosystem: "python",
+    docsUrls: ["https://langfuse.com/integrations/frameworks/crewai"],
+    docsPaths: ["/integrations/frameworks/crewai"],
+    requiresVersionOrPackage: true,
+    focus: ["CrewAI", "OpenTelemetry", "OpenLIT"],
+  },
+  {
+    id: "sdk-integration-grounding-v1-15-instructor",
+    question:
+      "How do I use Langfuse with Instructor for structured outputs, and what package/setup/version details should be grounded in the docs?",
+    integration: "instructor",
+    integrationType: "framework",
+    ecosystem: "python",
+    docsUrls: ["https://langfuse.com/integrations/frameworks/instructor"],
+    docsPaths: ["/integrations/frameworks/instructor"],
+    requiresVersionOrPackage: true,
+    focus: ["Instructor", "structured outputs", "Python package setup"],
+  },
+];
+
+function parseEnv(content: string): Record<string, string> {
+  return Object.fromEntries(
+    content
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const index = line.indexOf("=");
+        const key = line.slice(0, index);
+        const value = line.slice(index + 1).replace(/^['"]|['"]$/g, "");
+        return [key, value];
+      }),
+  );
+}
+
+function getFirstEnvValue(env: Record<string, string>, keys: string[]) {
+  return keys.map((key) => env[key]).find(Boolean);
+}
+
+function getRegionKeyFromEnvFile(envFile: string) {
+  const lower = envFile.toLowerCase();
+  if (lower.includes("_eu") || lower.includes("-eu")) return "EU";
+  if (lower.includes("_us") || lower.includes("-us")) return "US";
+  if (lower.includes("_jp") || lower.includes("-jp") || lower.includes("japan"))
+    return "JP";
+  return undefined;
+}
+
+function makeInput(question: string) {
+  return {
+    messages: [{ role: "user", content: question }],
+  };
+}
+
+async function mcpCall<T>(
+  baseUrl: string,
+  authHeader: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${baseUrl}/api/public/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: authHeader,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Math.floor(Math.random() * 1_000_000_000),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  const text = await response.text();
+  const eventPayloads = Array.from(text.matchAll(/^data: (.*)$/gm))
+    .map((match) => match[1])
+    .filter((payload) => payload && payload !== "[DONE]");
+  const payload = JSON.parse(eventPayloads[0] ?? text);
+  if (payload.error) {
+    throw new Error(JSON.stringify(payload.error));
+  }
+  const resultText = payload.result?.content?.find(
+    (entry: { type?: string }) => entry.type === "text",
+  )?.text;
+  return JSON.parse(resultText);
+}
+
+async function main() {
+  const envFile = process.argv[2] ?? ".env_sample_project";
+  const fs = await import("node:fs/promises");
+  const env = parseEnv(await fs.readFile(envFile, "utf8"));
+  const regionKey = getRegionKeyFromEnvFile(envFile);
+  const baseUrl = getFirstEnvValue(env, [
+    "LANGFUSE_BASE_URL",
+    "LANGFUSE_HOST",
+    ...(regionKey
+      ? [
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_BASE_URL`,
+          `${regionKey}_LANGFUSE_BASE_URL`,
+        ]
+      : []),
+  ])?.replace(/\/$/, "");
+  const publicKey = getFirstEnvValue(env, [
+    "LANGFUSE_PUBLIC_KEY",
+    ...(regionKey
+      ? [
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_PUBLIC_KEY`,
+          `${regionKey}_LANGFUSE_PUBLIC_KEY`,
+        ]
+      : []),
+  ]);
+  const secretKey = getFirstEnvValue(env, [
+    "LANGFUSE_SECRET_KEY",
+    ...(regionKey
+      ? [
+          `${regionKey}_LANGFUSE_SECRET_KEY`,
+          `NEXT_PUBLIC_${regionKey}_LANGFUSE_SECRET_KEY`,
+        ]
+      : []),
+  ]);
+
+  if (!baseUrl || !publicKey || !secretKey) {
+    throw new Error(
+      `Missing LANGFUSE_BASE_URL, LANGFUSE_PUBLIC_KEY, or LANGFUSE_SECRET_KEY in ${envFile}`,
+    );
+  }
+
+  const authHeader = `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`;
+  const listed = await mcpCall<{
+    data: Array<{ id: string; name: string; url?: string }>;
+  }>(baseUrl, authHeader, "listDatasets", {
+    name: DATASET_NAME,
+    page: 1,
+    limit: 10,
+  });
+  const existingDataset = listed.data.find(
+    (dataset) => dataset.name === DATASET_NAME,
+  );
+
+  const dataset = await mcpCall<{ id: string; url?: string }>(
+    baseUrl,
+    authHeader,
+    "upsertDataset",
+    {
+      ...(existingDataset ? { id: existingDataset.id } : {}),
+      name: DATASET_NAME,
+      description:
+        "Reference-free QA chatbot dataset for SDK and integration questions. The intended evaluators should score documentation grounding, cited docs, and package/version completeness.",
+      metadata: {
+        owner: "qa-chatbot",
+        schema_version: SCHEMA_VERSION,
+        item_count: items.length,
+        reference_style: "reference_free",
+        expected_output: "omitted",
+        evaluation_goal: "docs_grounding_and_setup_completeness",
+        evaluation_criteria: evaluationCriteria,
+        source: "langfuse_docs_index_and_docs_pages",
+        docs_checked_at: "2026-07-16",
+        sample_project_only: true,
+      },
+      inputSchema,
+    },
+  );
+
+  const datasetId = dataset.id ?? existingDataset?.id;
+  if (!datasetId) throw new Error("Langfuse did not return a dataset id.");
+
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    await mcpCall(baseUrl, authHeader, "upsertDatasetItem", {
+      datasetId,
+      id: item.id,
+      input: makeInput(item.question),
+      metadata: {
+        category: "sdk_integration_docs_grounding",
+        source: "docs_derived",
+        integration: item.integration,
+        integration_type: item.integrationType,
+        ecosystem: item.ecosystem,
+        docs_urls: item.docsUrls,
+        docs_paths: item.docsPaths,
+        focus: item.focus,
+        evaluation_criteria: evaluationCriteria,
+        expected_output: "omitted",
+        reference_style: "reference_free",
+        requires_version_or_package: item.requiresVersionOrPackage,
+        schema_version: SCHEMA_VERSION,
+        item_number: index + 1,
+      },
+      status: "ACTIVE",
+    });
+  }
+
+  const readBackDataset = await mcpCall<{
+    inputSchema?: unknown;
+    expectedOutputSchema?: unknown;
+  }>(baseUrl, authHeader, "getDataset", { datasetId });
+  const itemList = await mcpCall<{
+    data: Array<{
+      id: string;
+      status?: string;
+      expectedOutput?: unknown;
+      metadata?: { integration_type?: string; integration?: string };
+    }>;
+    meta?: { totalItems?: number };
+  }>(baseUrl, authHeader, "listDatasetItems", {
+    datasetId,
+    page: 1,
+    limit: 100,
+  });
+
+  const activeItems = itemList.data.filter(
+    (item) => item.status !== "ARCHIVED",
+  );
+  const seededIds = new Set(items.map((item) => item.id));
+  const activeSeedItems = activeItems.filter((item) => seededIds.has(item.id));
+  const countsByType = activeSeedItems.reduce<Record<string, number>>(
+    (acc, item) => {
+      const type = item.metadata?.integration_type ?? "unknown";
+      acc[type] = (acc[type] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+  const itemsWithExpectedOutput = activeSeedItems.filter(
+    (item) => item.expectedOutput != null,
+  ).length;
+
+  console.log(
+    JSON.stringify(
+      {
+        datasetName: DATASET_NAME,
+        datasetId,
+        url: dataset.url ?? existingDataset?.url,
+        activeSeedItems: activeSeedItems.length,
+        totalActiveItemsInDataset: activeItems.length,
+        countsByType,
+        hasInputSchema: Boolean(readBackDataset.inputSchema),
+        hasExpectedOutputSchema: Boolean(readBackDataset.expectedOutputSchema),
+        itemsWithExpectedOutput,
+        schemaVersion: SCHEMA_VERSION,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+export {};

--- a/components/qaChatbot/evaluators/setup_sdk_integration_grounding_evaluators.ts
+++ b/components/qaChatbot/evaluators/setup_sdk_integration_grounding_evaluators.ts
@@ -1,0 +1,399 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DATASET_NAME = "SDK integration docs grounding";
+const SCHEMA_VERSION = "sdk_integration_grounding_v1";
+const DEFAULT_PRODUCT_JUDGE_PROVIDER = "openai";
+const DEFAULT_PRODUCT_JUDGE_MODEL = "gpt-4o-mini";
+
+type ProductEvaluator = {
+  name: string;
+  type: "llm_as_judge";
+  prompt: string;
+  outputDefinition: {
+    dataType: "NUMERIC";
+    score: { description: string };
+    reasoning: { description: string };
+  };
+};
+
+const commonPromptContext = [
+  "You are evaluating a Langfuse documentation QA chatbot experiment item.",
+  "This dataset is reference-free: there is no expected output or golden answer.",
+  "Use the item metadata as the source-of-truth for which Langfuse docs pages the answer should be grounded in.",
+  "Do not reward plausible generic SDK knowledge unless the answer anchors it to the provided Langfuse docs or clearly names current documented packages/versions.",
+  "",
+  "User input:",
+  "{{input}}",
+  "",
+  "Actual answer:",
+  "{{output}}",
+  "",
+  "Integration metadata:",
+  "- integration: {{integration}}",
+  "- integration type: {{integration_type}}",
+  "- docs URLs: {{docs_urls}}",
+  "- docs paths: {{docs_paths}}",
+  "- expected focus: {{focus}}",
+  "- requires version/package detail: {{requires_version_or_package}}",
+].join("\n");
+
+const PRODUCT_EVALUATORS: ProductEvaluator[] = [
+  {
+    name: "sdk-integration-docs-groundedness",
+    type: "llm_as_judge",
+    prompt: [
+      commonPromptContext,
+      "",
+      "Score docs groundedness.",
+      "A score of 1 means the answer is clearly grounded in the relevant Langfuse docs for the named integration and avoids unsupported or stale claims.",
+      "A score of 0.5 means the answer is mostly relevant but mixes docs-grounded details with generic or weakly supported claims, or misses important caveats from the docs.",
+      "A score of 0 means the answer is mostly generic, appears to rely on training data, cites the wrong integration path, fabricates docs behavior, or contradicts the provided Langfuse docs metadata.",
+    ].join("\n"),
+    outputDefinition: {
+      dataType: "NUMERIC",
+      score: {
+        description:
+          "0 = not docs-grounded, 0.5 = partially grounded, 1 = grounded in the relevant Langfuse docs.",
+      },
+      reasoning: {
+        description:
+          "Explain which parts are grounded, unsupported, stale, or contradicted by the docs metadata.",
+      },
+    },
+  },
+  {
+    name: "sdk-integration-docs-citation-completeness",
+    type: "llm_as_judge",
+    prompt: [
+      commonPromptContext,
+      "",
+      "Score docs citation completeness.",
+      "A score of 1 means the answer cites or links the most relevant provided Langfuse docs page(s), and the citations match the integration being asked about.",
+      "A score of 0.5 means the answer names Langfuse docs or cites only a partially relevant page, but misses a key page from the provided docs URLs or gives vague references.",
+      "A score of 0 means the answer has no useful Langfuse docs reference, cites unrelated docs, or invents/uses stale URLs.",
+    ].join("\n"),
+    outputDefinition: {
+      dataType: "NUMERIC",
+      score: {
+        description:
+          "0 = no useful docs citation, 0.5 = partial or vague citation, 1 = cites the relevant provided Langfuse docs.",
+      },
+      reasoning: {
+        description:
+          "Explain whether cited docs are present, relevant, complete, missing, or incorrect.",
+      },
+    },
+  },
+  {
+    name: "sdk-integration-package-version-completeness",
+    type: "llm_as_judge",
+    prompt: [
+      commonPromptContext,
+      "",
+      "Score package and version completeness.",
+      "A score of 1 means the answer includes the documented package names, SDK version families, compatibility notes, or upgrade-path details required for this integration when the metadata says version/package detail is required.",
+      "A score of 0.5 means the answer includes some package or setup detail but misses an important package name, SDK version family, compatibility constraint, or migration caveat.",
+      "A score of 0 means the answer omits package/version details, gives outdated package names, invents versions, or gives details for the wrong SDK/provider.",
+      "If the item does not require version or package details, score whether the answer correctly avoids unnecessary invented version claims.",
+    ].join("\n"),
+    outputDefinition: {
+      dataType: "NUMERIC",
+      score: {
+        description:
+          "0 = missing/wrong package or version details, 0.5 = partial, 1 = complete documented package/version details.",
+      },
+      reasoning: {
+        description:
+          "Explain which package names, SDK version families, compatibility notes, or upgrade details are present, missing, or incorrect.",
+      },
+    },
+  },
+];
+
+const RULES = [
+  {
+    name: "sdk-integration-docs-groundedness-experiment",
+    evaluatorName: "sdk-integration-docs-groundedness",
+  },
+  {
+    name: "sdk-integration-docs-citation-completeness-experiment",
+    evaluatorName: "sdk-integration-docs-citation-completeness",
+  },
+  {
+    name: "sdk-integration-package-version-completeness-experiment",
+    evaluatorName: "sdk-integration-package-version-completeness",
+  },
+];
+
+function parseEnv(content: string): Record<string, string> {
+  return Object.fromEntries(
+    content
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const index = line.indexOf("=");
+        const key = line.slice(0, index);
+        const value = line.slice(index + 1).replace(/^['"]|['"]$/g, "");
+        return [key, value];
+      }),
+  );
+}
+
+function readEnvFile(envFile: string) {
+  const fullPath = resolve(process.cwd(), envFile);
+  if (!existsSync(fullPath)) {
+    throw new Error(`Env file does not exist: ${fullPath}`);
+  }
+
+  const values = parseEnv(readFileSync(fullPath, "utf8"));
+  for (const [key, value] of Object.entries(values)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+
+  const baseUrl = values.LANGFUSE_BASE_URL ?? values.LANGFUSE_HOST;
+  if (baseUrl) {
+    process.env.LANGFUSE_BASE_URL = process.env.LANGFUSE_BASE_URL ?? baseUrl;
+    process.env.LANGFUSE_HOST = process.env.LANGFUSE_HOST ?? baseUrl;
+  }
+}
+
+async function mcpCall<T>(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const baseUrl = process.env.LANGFUSE_BASE_URL?.replace(/\/$/, "");
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = process.env.LANGFUSE_SECRET_KEY;
+
+  if (!baseUrl || !publicKey || !secretKey) {
+    throw new Error("Missing Langfuse credentials for MCP call.");
+  }
+
+  const response = await fetch(`${baseUrl}/api/public/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Math.floor(Math.random() * 1_000_000_000),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  const text = await response.text();
+  const eventPayloads = Array.from(text.matchAll(/^data: (.*)$/gm))
+    .map((match) => match[1])
+    .filter((payload) => payload && payload !== "[DONE]");
+  const payload = JSON.parse(eventPayloads[0] ?? text);
+  if (payload.error) {
+    throw new Error(JSON.stringify(payload.error));
+  }
+  const resultText = payload.result?.content?.find(
+    (entry: { type?: string }) => entry.type === "text",
+  )?.text;
+  return JSON.parse(resultText);
+}
+
+async function getDatasetId() {
+  const result = await mcpCall<{ data: Array<{ id: string; name: string }> }>(
+    "listDatasets",
+    {
+      name: DATASET_NAME,
+      page: 1,
+      limit: 10,
+    },
+  );
+  const dataset = result.data.find((entry) => entry.name === DATASET_NAME);
+  if (!dataset) throw new Error(`Dataset not found: ${DATASET_NAME}`);
+  return dataset.id;
+}
+
+function getProductJudgeModelConfig() {
+  return {
+    provider:
+      process.env.PRODUCT_JUDGE_PROVIDER ?? DEFAULT_PRODUCT_JUDGE_PROVIDER,
+    model: process.env.PRODUCT_JUDGE_MODEL ?? DEFAULT_PRODUCT_JUDGE_MODEL,
+  };
+}
+
+async function ensureProductEvaluator(
+  evaluator: ProductEvaluator,
+  existingEvaluatorNames: Set<string>,
+) {
+  if (existingEvaluatorNames.has(evaluator.name)) {
+    console.log(`Product evaluator exists: ${evaluator.name}`);
+    return "existing";
+  }
+
+  try {
+    await mcpCall("upsertEvaluator", evaluator);
+    console.log(
+      `Created product evaluator using project default model: ${evaluator.name}`,
+    );
+    return "created-default-model";
+  } catch (error) {
+    const message = String(error);
+    if (
+      !message.includes("No valid LLM model found") &&
+      !message.includes("evaluator_preflight_failed")
+    ) {
+      throw error;
+    }
+
+    const modelConfig = getProductJudgeModelConfig();
+    await mcpCall("upsertEvaluator", { ...evaluator, modelConfig });
+    console.log(
+      `Created product evaluator with explicit model config: ${evaluator.name} (${modelConfig.provider}/${modelConfig.model})`,
+    );
+    return "created-explicit-model";
+  }
+}
+
+function makeRule(rule: (typeof RULES)[number], datasetId: string) {
+  return {
+    name: rule.name,
+    evaluator: {
+      name: rule.evaluatorName,
+      scope: "project",
+      type: "llm_as_judge",
+    },
+    enabled: true,
+    sampling: 1,
+    target: "experiment",
+    filter: [
+      {
+        column: "datasetId",
+        operator: "any of",
+        value: [datasetId],
+        type: "stringOptions",
+      },
+    ],
+    mapping: [
+      { variable: "input", source: "input" },
+      { variable: "output", source: "output" },
+      {
+        variable: "docs_urls",
+        source: "experiment_item_metadata",
+        jsonPath: "$.docs_urls",
+      },
+      {
+        variable: "docs_paths",
+        source: "experiment_item_metadata",
+        jsonPath: "$.docs_paths",
+      },
+      {
+        variable: "integration",
+        source: "experiment_item_metadata",
+        jsonPath: "$.integration",
+      },
+      {
+        variable: "integration_type",
+        source: "experiment_item_metadata",
+        jsonPath: "$.integration_type",
+      },
+      {
+        variable: "focus",
+        source: "experiment_item_metadata",
+        jsonPath: "$.focus",
+      },
+      {
+        variable: "requires_version_or_package",
+        source: "experiment_item_metadata",
+        jsonPath: "$.requires_version_or_package",
+      },
+    ],
+  };
+}
+
+async function main() {
+  const envFile = process.argv[2] ?? ".env_sample_project";
+  readEnvFile(envFile);
+
+  const datasetId = await getDatasetId();
+  const evaluators = await mcpCall<{
+    data: Array<{ id: string; name: string; type: string }>;
+  }>("listEvaluators", {
+    page: 1,
+    limit: 100,
+  });
+  const existingEvaluatorNames = new Set(
+    evaluators.data.map((evaluator) => evaluator.name),
+  );
+  const evaluatorResults: Record<string, string> = {};
+
+  for (const evaluator of PRODUCT_EVALUATORS) {
+    evaluatorResults[evaluator.name] = await ensureProductEvaluator(
+      evaluator,
+      existingEvaluatorNames,
+    );
+  }
+
+  const rules = await mcpCall<{ data: Array<{ id: string; name: string }> }>(
+    "listEvaluationRules",
+    {
+      page: 1,
+      limit: 100,
+    },
+  );
+  const existingRules = new Map(
+    rules.data.map((rule) => [rule.name, rule.id] as const),
+  );
+  const ruleResults: Record<string, string> = {};
+
+  for (const ruleInfo of RULES) {
+    const rule = makeRule(ruleInfo, datasetId);
+    const existingRuleId = existingRules.get(rule.name);
+    if (existingRuleId) {
+      await mcpCall("updateEvaluationRule", {
+        evaluationRuleId: existingRuleId,
+        ...rule,
+        evaluator: { name: rule.evaluator.name, scope: rule.evaluator.scope },
+      });
+      ruleResults[rule.name] = "updated";
+      console.log(`Updated product evaluation rule: ${rule.name}`);
+    } else {
+      await mcpCall("createEvaluationRule", rule);
+      ruleResults[rule.name] = "created";
+      console.log(`Created product evaluation rule: ${rule.name}`);
+    }
+  }
+
+  const readBackRules = await mcpCall<{
+    data: Array<{
+      id: string;
+      name: string;
+      enabled?: boolean;
+      target?: string;
+    }>;
+  }>("listEvaluationRules", { page: 1, limit: 100 });
+  const relevantRules = readBackRules.data.filter((rule) =>
+    RULES.some((expected) => expected.name === rule.name),
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        datasetName: DATASET_NAME,
+        datasetId,
+        schemaVersion: SCHEMA_VERSION,
+        evaluatorResults,
+        ruleResults,
+        relevantRuleCount: relevantRules.length,
+        relevantRules,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts
+++ b/components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts
@@ -1,0 +1,791 @@
+/**
+ * General QA chatbot experiment runner.
+ *
+ * Runs the `general QA chatbot` dataset through the real managed prompt +
+ * Langfuse docs MCP path and scores each output with:
+ * - correctness: Langfuse product LLM-as-a-judge evaluator
+ * - behavior-judge: Langfuse product LLM-as-a-judge evaluator
+ * - keyword-overlap: deterministic SDK evaluator over the expected keywords
+ *
+ * Examples:
+ *   npx tsx components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts components/qaChatbot/.env_sample_project
+ *   npx tsx components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts components/qaChatbot/.env_sample_project --setup-product-evaluators-only
+ *   PROMPT_LABELS=production,candidate-v3 EXPERIMENT_MODELS=gpt-4o-mini,gpt-4o npx tsx components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts components/qaChatbot/.env_sample_project
+ *   PROMPT_VERSIONS=1,2 EXPERIMENT_MODELS=gpt-4o-mini npx tsx components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts components/qaChatbot/.env_sample_project
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { openai, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import { generateText, stepCountIs } from "ai";
+import {
+  LangfuseClient,
+  type Evaluator,
+  type RunEvaluator,
+} from "@langfuse/client";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import {
+  getChatHistory,
+  getLastUserMessage,
+  normalizeMessageContent,
+  QA_CHATBOT_PROMPT_NAME,
+} from "../shared/flow_config";
+
+type GeneralBehavior = "answer" | "ask_follow_up" | "defer_question";
+
+type GeneralQaExpectedOutput = {
+  sample_reply: string;
+  general_behavior: GeneralBehavior;
+  keyword_overlap: [string, string, string] | string[];
+};
+
+type Args = {
+  envFile?: string;
+  datasetName: string;
+  models: string[];
+  promptLabels: string[];
+  promptVersions: number[];
+  runSeries: string;
+  maxConcurrency: number;
+  mcpUrl: string;
+  setupProductEvaluators: boolean;
+  setupProductEvaluatorsOnly: boolean;
+};
+
+const DEFAULT_DATASET_NAME = "general QA chatbot";
+const DEFAULT_RUN_SERIES = "general-qa-chatbot";
+const DEFAULT_MODEL = "gpt-4o-mini";
+const DEFAULT_PROMPT_LABEL = "production";
+const DEFAULT_MAX_CONCURRENCY = 4;
+const DEFAULT_MCP_URL = "https://langfuse.com/api/mcp";
+const DEFAULT_PRODUCT_JUDGE_PROVIDER = "openai";
+const DEFAULT_PRODUCT_JUDGE_MODEL = "gpt-4o-mini";
+
+const CORRECTNESS_EVALUATOR_NAME = "general-qa-chatbot-correctness";
+const BEHAVIOR_EVALUATOR_NAME = "general-qa-chatbot-behavior-judge";
+const CORRECTNESS_RULE_NAME = "general-qa-chatbot-correctness-experiment";
+const BEHAVIOR_RULE_NAME = "general-qa-chatbot-behavior-experiment";
+
+type ExperimentTelemetry = Parameters<
+  typeof generateText
+>[0]["experimental_telemetry"];
+type ExperimentTelemetryMetadata = Record<string, string | number | boolean>;
+
+function makeExperimentTelemetry(
+  metadata: ExperimentTelemetryMetadata,
+): ExperimentTelemetry {
+  return {
+    isEnabled: true,
+    metadata,
+  } as ExperimentTelemetry;
+}
+
+const PRODUCT_EVALUATORS = [
+  {
+    name: CORRECTNESS_EVALUATOR_NAME,
+    type: "llm_as_judge",
+    prompt: [
+      "You are grading a Langfuse documentation chatbot experiment item.",
+      "Score semantic correctness by comparing the actual answer to the expected sample reply.",
+      "Equivalent wording is fine. Extra correct details are fine.",
+      "Penalize contradictions, unsupported claims, stale or made-up URLs, and missing core information.",
+      "Behavioral direction matters, but focus this score on whether the answer content matches the expected sample reply.",
+      "",
+      "User input:",
+      "{{input}}",
+      "",
+      "Expected sample reply:",
+      "{{expected_sample_reply}}",
+      "",
+      "Expected behavior:",
+      "{{expected_behavior}}",
+      "",
+      "Actual answer:",
+      "{{output}}",
+    ].join("\n"),
+    outputDefinition: {
+      dataType: "NUMERIC",
+      score: {
+        description:
+          "0 = incorrect, 0.5 = partially correct, 1 = semantically matches the expected sample reply.",
+      },
+      reasoning: {
+        description:
+          "Explain missing facts, contradictions, or correct coverage.",
+      },
+    },
+  },
+  {
+    name: BEHAVIOR_EVALUATOR_NAME,
+    type: "llm_as_judge",
+    prompt: [
+      "You judge only the behavior of a Langfuse documentation chatbot response.",
+      "Do not grade factual correctness here except when it changes the behavioral category.",
+      "",
+      "Behavior labels:",
+      "- answer: answers the user question directly.",
+      "- ask_follow_up: asks for missing context or a clarifying detail before answering specifically.",
+      "- defer_question: refuses or redirects an out-of-scope request instead of answering it.",
+      "",
+      "Expected behavior:",
+      "{{expected_behavior}}",
+      "",
+      "Expected sample reply, for context:",
+      "{{expected_sample_reply}}",
+      "",
+      "User input:",
+      "{{input}}",
+      "",
+      "Actual answer:",
+      "{{output}}",
+    ].join("\n"),
+    outputDefinition: {
+      dataType: "NUMERIC",
+      score: {
+        description:
+          "1 = behavior matches, 0.5 = mixed or ambiguous, 0 = wrong behavior.",
+      },
+      reasoning: {
+        description:
+          "Explain whether the response answered, asked for clarification, or deferred as expected.",
+      },
+    },
+  },
+];
+
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseNumberCsv(value: string | undefined): number[] {
+  return parseCsv(value)
+    .map((part) => Number(part))
+    .filter((value) => Number.isInteger(value) && value > 0);
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  let envFile: string | undefined;
+  let datasetName = process.env.DATASET_NAME ?? DEFAULT_DATASET_NAME;
+  let models = parseCsv(
+    process.env.EXPERIMENT_MODELS ?? process.env.EXPERIMENT_MODEL,
+  );
+  let promptLabels = parseCsv(
+    process.env.PROMPT_LABELS ?? process.env.PROMPT_LABEL,
+  );
+  let promptVersions = parseNumberCsv(
+    process.env.PROMPT_VERSIONS ?? process.env.PROMPT_VERSION,
+  );
+  let runSeries = process.env.RUN_SERIES ?? DEFAULT_RUN_SERIES;
+  let maxConcurrency = Number(
+    process.env.EXPERIMENT_MAX_CONCURRENCY ?? DEFAULT_MAX_CONCURRENCY,
+  );
+  let mcpUrl = process.env.LANGFUSE_DOCS_MCP_URL ?? DEFAULT_MCP_URL;
+  let setupProductEvaluators = process.env.SKIP_PRODUCT_EVALUATORS !== "true";
+  let setupProductEvaluatorsOnly = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--env-file") {
+      envFile = next;
+      index += 1;
+    } else if (arg === "--dataset-name") {
+      datasetName = next;
+      index += 1;
+    } else if (arg === "--models") {
+      models = parseCsv(next);
+      index += 1;
+    } else if (arg === "--prompt-labels") {
+      promptLabels = parseCsv(next);
+      index += 1;
+    } else if (arg === "--prompt-versions") {
+      promptVersions = parseNumberCsv(next);
+      index += 1;
+    } else if (arg === "--run-series") {
+      runSeries = next;
+      index += 1;
+    } else if (arg === "--max-concurrency") {
+      maxConcurrency = Number(next);
+      index += 1;
+    } else if (arg === "--mcp-url") {
+      mcpUrl = next;
+      index += 1;
+    } else if (arg === "--skip-product-evaluators") {
+      setupProductEvaluators = false;
+    } else if (arg === "--setup-product-evaluators-only") {
+      setupProductEvaluators = true;
+      setupProductEvaluatorsOnly = true;
+    } else if (arg === "--") {
+      continue;
+    } else if (!arg.startsWith("--") && !envFile) {
+      envFile = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (models.length === 0) models = [DEFAULT_MODEL];
+  if (promptLabels.length === 0 && promptVersions.length === 0)
+    promptLabels = [DEFAULT_PROMPT_LABEL];
+  if (!Number.isFinite(maxConcurrency) || maxConcurrency < 1)
+    maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+
+  return {
+    envFile,
+    datasetName,
+    models,
+    promptLabels,
+    promptVersions,
+    runSeries,
+    maxConcurrency,
+    mcpUrl,
+    setupProductEvaluators,
+    setupProductEvaluatorsOnly,
+  };
+}
+
+function readEnvFile(envFile: string | undefined) {
+  if (!envFile) return;
+
+  const fullPath = resolve(process.cwd(), envFile);
+  if (!existsSync(fullPath)) {
+    throw new Error(`Env file does not exist: ${fullPath}`);
+  }
+
+  const values = Object.fromEntries(
+    readFileSync(fullPath, "utf8")
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const index = line.indexOf("=");
+        const key = line.slice(0, index);
+        const value = line.slice(index + 1).replace(/^['"]|['"]$/g, "");
+        return [key, value];
+      }),
+  );
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+
+  const baseUrl =
+    values.LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_EU_LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_US_LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_JP_LANGFUSE_BASE_URL;
+  const publicKey =
+    values.LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_EU_LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_US_LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_JP_LANGFUSE_PUBLIC_KEY;
+  const secretKey =
+    values.LANGFUSE_SECRET_KEY ??
+    values.EU_LANGFUSE_SECRET_KEY ??
+    values.US_LANGFUSE_SECRET_KEY ??
+    values.JP_LANGFUSE_SECRET_KEY;
+
+  if (baseUrl) {
+    process.env.LANGFUSE_BASE_URL = process.env.LANGFUSE_BASE_URL ?? baseUrl;
+    process.env.LANGFUSE_HOST = process.env.LANGFUSE_HOST ?? baseUrl;
+  }
+  if (publicKey)
+    process.env.LANGFUSE_PUBLIC_KEY =
+      process.env.LANGFUSE_PUBLIC_KEY ?? publicKey;
+  if (secretKey)
+    process.env.LANGFUSE_SECRET_KEY =
+      process.env.LANGFUSE_SECRET_KEY ?? secretKey;
+}
+
+function requireEnv(name: string) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+async function mcpCall<T>(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const baseUrl = process.env.LANGFUSE_BASE_URL?.replace(/\/$/, "");
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = process.env.LANGFUSE_SECRET_KEY;
+
+  if (!baseUrl || !publicKey || !secretKey) {
+    throw new Error("Missing Langfuse credentials for MCP call.");
+  }
+
+  const response = await fetch(`${baseUrl}/api/public/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Math.floor(Math.random() * 1_000_000_000),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  const text = await response.text();
+  const eventPayloads = Array.from(text.matchAll(/^data: (.*)$/gm))
+    .map((match) => match[1])
+    .filter((payload) => payload && payload !== "[DONE]");
+  const payload = JSON.parse(eventPayloads[0] ?? text);
+  if (payload.error) {
+    throw new Error(JSON.stringify(payload.error));
+  }
+  const resultText = payload.result?.content?.find(
+    (entry: { type?: string }) => entry.type === "text",
+  )?.text;
+  return JSON.parse(resultText);
+}
+
+async function getDatasetId(datasetName: string) {
+  const result = await mcpCall<{ data: Array<{ id: string; name: string }> }>(
+    "listDatasets",
+    {
+      name: datasetName,
+      page: 1,
+      limit: 10,
+    },
+  );
+  const dataset = result.data.find((entry) => entry.name === datasetName);
+  if (!dataset) throw new Error(`Dataset not found: ${datasetName}`);
+  return dataset.id;
+}
+
+function getProductJudgeModelConfig() {
+  return {
+    provider:
+      process.env.PRODUCT_JUDGE_PROVIDER ?? DEFAULT_PRODUCT_JUDGE_PROVIDER,
+    model: process.env.PRODUCT_JUDGE_MODEL ?? DEFAULT_PRODUCT_JUDGE_MODEL,
+  };
+}
+
+async function ensureProductEvaluator(
+  evaluator: (typeof PRODUCT_EVALUATORS)[number],
+) {
+  try {
+    await mcpCall("upsertEvaluator", evaluator);
+    console.log(`Created product evaluator: ${evaluator.name}`);
+  } catch (error) {
+    const message = String(error);
+    if (
+      !message.includes("No valid LLM model found") &&
+      !message.includes("evaluator_preflight_failed")
+    ) {
+      throw error;
+    }
+
+    const modelConfig = getProductJudgeModelConfig();
+    await mcpCall("upsertEvaluator", { ...evaluator, modelConfig });
+    console.log(
+      `Created product evaluator with explicit product model config: ${evaluator.name} (${modelConfig.provider}/${modelConfig.model})`,
+    );
+  }
+}
+
+async function ensureProductLlmJudgeEvaluators(datasetName: string) {
+  const datasetId = await getDatasetId(datasetName);
+  const evaluators = await mcpCall<{
+    data: Array<{ id: string; name: string; type: string }>;
+  }>("listEvaluators", { page: 1, limit: 100 });
+  const existingEvaluatorNames = new Set(
+    evaluators.data.map((evaluator) => evaluator.name),
+  );
+
+  for (const evaluator of PRODUCT_EVALUATORS) {
+    if (existingEvaluatorNames.has(evaluator.name)) {
+      console.log(`Product evaluator exists: ${evaluator.name}`);
+      continue;
+    }
+
+    await ensureProductEvaluator(evaluator);
+  }
+
+  const rules = await mcpCall<{ data: Array<{ id: string; name: string }> }>(
+    "listEvaluationRules",
+    {
+      page: 1,
+      limit: 100,
+    },
+  );
+  const existingRules = new Map(
+    rules.data.map((rule) => [rule.name, rule.id] as const),
+  );
+
+  const ruleDefinitions = [
+    {
+      name: CORRECTNESS_RULE_NAME,
+      evaluator: {
+        name: CORRECTNESS_EVALUATOR_NAME,
+        scope: "project",
+        type: "llm_as_judge",
+      },
+      enabled: true,
+      sampling: 1,
+      target: "experiment",
+      filter: [
+        {
+          column: "datasetId",
+          operator: "any of",
+          value: [datasetId],
+          type: "stringOptions",
+        },
+      ],
+      mapping: [
+        { variable: "input", source: "input" },
+        { variable: "output", source: "output" },
+        {
+          variable: "expected_sample_reply",
+          source: "expected_output",
+          jsonPath: "$.sample_reply",
+        },
+        {
+          variable: "expected_behavior",
+          source: "expected_output",
+          jsonPath: "$.general_behavior",
+        },
+      ],
+    },
+    {
+      name: BEHAVIOR_RULE_NAME,
+      evaluator: {
+        name: BEHAVIOR_EVALUATOR_NAME,
+        scope: "project",
+        type: "llm_as_judge",
+      },
+      enabled: true,
+      sampling: 1,
+      target: "experiment",
+      filter: [
+        {
+          column: "datasetId",
+          operator: "any of",
+          value: [datasetId],
+          type: "stringOptions",
+        },
+      ],
+      mapping: [
+        { variable: "input", source: "input" },
+        { variable: "output", source: "output" },
+        {
+          variable: "expected_sample_reply",
+          source: "expected_output",
+          jsonPath: "$.sample_reply",
+        },
+        {
+          variable: "expected_behavior",
+          source: "expected_output",
+          jsonPath: "$.general_behavior",
+        },
+      ],
+    },
+  ];
+
+  for (const rule of ruleDefinitions) {
+    const existingRuleId = existingRules.get(rule.name);
+    if (existingRuleId) {
+      await mcpCall("updateEvaluationRule", {
+        evaluationRuleId: existingRuleId,
+        ...rule,
+        evaluator: { name: rule.evaluator.name, scope: rule.evaluator.scope },
+      });
+      console.log(`Updated product evaluation rule: ${rule.name}`);
+    } else {
+      await mcpCall("createEvaluationRule", rule);
+      console.log(`Created product evaluation rule: ${rule.name}`);
+    }
+  }
+}
+
+function parseExpectedOutput(value: unknown): GeneralQaExpectedOutput {
+  const output = value as Partial<GeneralQaExpectedOutput> | undefined;
+  return {
+    sample_reply: String(output?.sample_reply ?? ""),
+    general_behavior: (output?.general_behavior ?? "answer") as GeneralBehavior,
+    keyword_overlap: Array.isArray(output?.keyword_overlap)
+      ? output.keyword_overlap.map(String)
+      : [],
+  };
+}
+
+function normalizeForKeywordMatching(value: string) {
+  return value
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isReasoningModel(model: string) {
+  return /^gpt-5|^o\d/.test(model);
+}
+
+const keywordOverlap: Evaluator<unknown, GeneralQaExpectedOutput> = async ({
+  output,
+  expectedOutput,
+}) => {
+  const expected = parseExpectedOutput(expectedOutput);
+  if (expected.keyword_overlap.length === 0) return [];
+
+  const normalizedOutput = normalizeForKeywordMatching(
+    normalizeMessageContent(output),
+  );
+  const matched = expected.keyword_overlap.filter((keyword) =>
+    normalizedOutput.includes(normalizeForKeywordMatching(keyword)),
+  );
+  const missing = expected.keyword_overlap.filter(
+    (keyword) => !matched.includes(keyword),
+  );
+
+  return {
+    name: "keyword-overlap",
+    value: matched.length / expected.keyword_overlap.length,
+    comment: `${matched.length}/${expected.keyword_overlap.length} keyword(s) present. Matched: ${
+      matched.join(", ") || "none"
+    }. Missing: ${missing.join(", ") || "none"}.`,
+    metadata: { matched, missing, expected_keywords: expected.keyword_overlap },
+  };
+};
+
+const averageScore =
+  (scoreName: string): RunEvaluator =>
+  async ({ itemResults }) => {
+    const values = itemResults
+      .flatMap((result) => result.evaluations)
+      .filter((evaluation) => evaluation.name === scoreName)
+      .map((evaluation) => Number(evaluation.value))
+      .filter((value) => Number.isFinite(value));
+
+    if (values.length === 0) return [];
+
+    const average =
+      values.reduce((sum, value) => sum + value, 0) / values.length;
+    return {
+      name: `avg-${scoreName}`,
+      value: average,
+      comment: `Average ${scoreName} over ${values.length} item(s): ${average.toFixed(3)}`,
+    };
+  };
+
+function compileExperimentMessages(
+  prompt: Awaited<ReturnType<LangfuseClient["prompt"]["get"]>>,
+  input: unknown,
+): Parameters<typeof generateText>[0]["messages"] {
+  const chatHistory = getChatHistory(input);
+  const fallbackUserMessage = getLastUserMessage(input);
+  const datasetMessages =
+    chatHistory.length > 0
+      ? chatHistory
+      : fallbackUserMessage
+        ? [{ role: "user", content: fallbackUserMessage }]
+        : [];
+  const compiledWithVariables = prompt.compile({
+    chat_history: datasetMessages,
+  } as any);
+  const compiledMessages: Array<{ role: string; content: string }> = [];
+  let insertedPlaceholder = false;
+
+  for (const message of compiledWithVariables as Array<{
+    role?: string;
+    content?: unknown;
+    type?: string;
+    name?: string;
+  }>) {
+    if (message.type === "placeholder" && message.name === "chat_history") {
+      compiledMessages.push(...datasetMessages);
+      insertedPlaceholder = true;
+      continue;
+    }
+
+    if (message.role && message.content != null) {
+      compiledMessages.push({
+        role: message.role,
+        content: normalizeMessageContent(message.content),
+      });
+    }
+  }
+
+  if (
+    !insertedPlaceholder &&
+    compiledMessages.every((message) => message.role === "system")
+  ) {
+    compiledMessages.push(...datasetMessages);
+  }
+
+  return compiledMessages as Parameters<typeof generateText>[0]["messages"];
+}
+
+async function runOneExperiment(
+  args: Args,
+  params: { model: string; promptLabel?: string; promptVersion?: number },
+) {
+  const langfuse = new LangfuseClient();
+  const promptSelector = params.promptVersion
+    ? `v${params.promptVersion}`
+    : (params.promptLabel ?? DEFAULT_PROMPT_LABEL);
+  const prompt = await langfuse.prompt.get(QA_CHATBOT_PROMPT_NAME, {
+    type: "chat",
+    ...(params.promptVersion
+      ? { version: params.promptVersion }
+      : { label: promptSelector }),
+  });
+
+  const promptConfig = prompt.config as Record<string, unknown>;
+  const reasoningSummary = promptConfig.reasoningSummary as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+  const textVerbosity = promptConfig.textVerbosity as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+  const reasoningEffort = promptConfig.reasoningEffort as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+
+  console.log(
+    `Running dataset="${args.datasetName}" prompt=${QA_CHATBOT_PROMPT_NAME}@${promptSelector} resolvedVersion=${prompt.version} model=${params.model}`,
+  );
+
+  const dataset = await langfuse.dataset.get(args.datasetName);
+
+  const task = async (item: { input: unknown }): Promise<string> => {
+    const compiledMessages = compileExperimentMessages(prompt, item.input);
+
+    const transport = new StreamableHTTPClientTransport(new URL(args.mcpUrl), {
+      sessionId: `general-qa-chatbot-${crypto.randomUUID()}`,
+    }) as unknown as Parameters<typeof createMCPClient>[0]["transport"];
+    const mcpClient = await createMCPClient({
+      transport,
+    });
+
+    try {
+      const tools = await mcpClient.tools();
+      const { text } = await generateText({
+        abortSignal: AbortSignal.timeout(240_000),
+        model: openai(params.model),
+        ...(isReasoningModel(params.model)
+          ? {
+              providerOptions: {
+                openai: {
+                  reasoningSummary,
+                  textVerbosity,
+                  reasoningEffort,
+                } satisfies OpenAIResponsesProviderOptions,
+              },
+            }
+          : {}),
+        messages: compiledMessages as Parameters<
+          typeof generateText
+        >[0]["messages"],
+        tools: tools as Parameters<typeof generateText>[0]["tools"],
+        stopWhen: stepCountIs(10),
+        experimental_telemetry: makeExperimentTelemetry({
+          langfusePrompt: JSON.stringify(prompt.toJSON() ?? {}),
+          experiment_model: params.model,
+          experiment_prompt_selector: promptSelector,
+          experiment_dataset: args.datasetName,
+        }),
+      });
+
+      return text;
+    } finally {
+      await mcpClient.close();
+    }
+  };
+
+  const runName = [
+    args.runSeries,
+    `prompt-${promptSelector}`,
+    `model-${params.model}`,
+    new Date().toISOString().replace(/[:.]/g, "-"),
+  ].join("-");
+
+  const result = await dataset.runExperiment({
+    name: `${args.runSeries}-${params.model}`,
+    runName,
+    description:
+      "General QA chatbot experiment over the production-shaped dataset. Product LLM-as-a-judge rules score correctness and behavior; SDK scores keyword-overlap.",
+    task,
+    evaluators: [keywordOverlap],
+    runEvaluators: [averageScore("keyword-overlap")],
+    maxConcurrency: args.maxConcurrency,
+    metadata: {
+      model: params.model,
+      prompt_name: QA_CHATBOT_PROMPT_NAME,
+      prompt_label: params.promptVersion ? undefined : promptSelector,
+      prompt_version: prompt.version,
+      dataset_name: args.datasetName,
+      run_series: args.runSeries,
+      product_evaluators: [CORRECTNESS_EVALUATOR_NAME, BEHAVIOR_EVALUATOR_NAME],
+      sdk_evaluators: ["keyword-overlap"],
+    },
+  });
+
+  console.log(await result.format());
+  await langfuse.flush();
+}
+
+async function main() {
+  const args = parseArgs();
+  readEnvFile(args.envFile);
+  requireEnv("OPENAI_API_KEY");
+  requireEnv("LANGFUSE_PUBLIC_KEY");
+  requireEnv("LANGFUSE_SECRET_KEY");
+  requireEnv("LANGFUSE_BASE_URL");
+
+  if (args.setupProductEvaluators) {
+    await ensureProductLlmJudgeEvaluators(args.datasetName);
+  } else {
+    console.log("Skipped product LLM-as-a-judge evaluator setup");
+  }
+
+  if (args.setupProductEvaluatorsOnly) return;
+
+  requireEnv("OPENAI_API_KEY");
+
+  const spanProcessor = new LangfuseSpanProcessor();
+  const tracerProvider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
+  tracerProvider.register();
+
+  try {
+    const promptSelectors =
+      args.promptVersions.length > 0
+        ? args.promptVersions.map((promptVersion) => ({ promptVersion }))
+        : args.promptLabels.map((promptLabel) => ({ promptLabel }));
+
+    for (const selector of promptSelectors) {
+      for (const model of args.models) {
+        await runOneExperiment(args, { ...selector, model });
+      }
+    }
+  } finally {
+    await tracerProvider.shutdown();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts
+++ b/components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts
@@ -1,0 +1,407 @@
+/**
+ * SDK integration docs-grounding experiment runner.
+ *
+ * Runs the reference-free `SDK integration docs grounding` dataset through the
+ * real QA chatbot path: managed product prompt + Langfuse docs MCP tools.
+ * Scoring is handled by Langfuse in-app experiment evaluators attached to this
+ * dataset.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { openai, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import { generateText, stepCountIs } from "ai";
+import { LangfuseClient } from "@langfuse/client";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import {
+  getChatHistory,
+  getLastUserMessage,
+  normalizeMessageContent,
+  QA_CHATBOT_PROMPT_NAME,
+} from "../shared/flow_config";
+
+type Args = {
+  envFile?: string;
+  datasetName: string;
+  models: string[];
+  promptLabels: string[];
+  promptVersions: number[];
+  runSeries: string;
+  maxConcurrency: number;
+  mcpUrl: string;
+};
+
+const DEFAULT_DATASET_NAME = "SDK integration docs grounding";
+const DEFAULT_RUN_SERIES = "sdk-integration-grounding";
+const DEFAULT_MODEL = "gpt-5";
+const DEFAULT_PROMPT_LABEL = "production";
+const DEFAULT_MAX_CONCURRENCY = 3;
+const DEFAULT_MCP_URL = "https://langfuse.com/api/mcp";
+
+const IN_APP_EVALUATORS = [
+  "sdk-integration-docs-groundedness",
+  "sdk-integration-docs-citation-completeness",
+  "sdk-integration-package-version-completeness",
+];
+
+type ExperimentTelemetry = Parameters<
+  typeof generateText
+>[0]["experimental_telemetry"];
+type ExperimentTelemetryMetadata = Record<string, string | number | boolean>;
+
+function makeExperimentTelemetry(
+  metadata: ExperimentTelemetryMetadata,
+): ExperimentTelemetry {
+  return {
+    isEnabled: true,
+    metadata,
+  } as ExperimentTelemetry;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseNumberCsv(value: string | undefined): number[] {
+  return parseCsv(value)
+    .map((part) => Number(part))
+    .filter((value) => Number.isInteger(value) && value > 0);
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  let envFile: string | undefined;
+  let datasetName = process.env.DATASET_NAME ?? DEFAULT_DATASET_NAME;
+  let models = parseCsv(
+    process.env.EXPERIMENT_MODELS ?? process.env.EXPERIMENT_MODEL,
+  );
+  let promptLabels = parseCsv(
+    process.env.PROMPT_LABELS ?? process.env.PROMPT_LABEL,
+  );
+  let promptVersions = parseNumberCsv(
+    process.env.PROMPT_VERSIONS ?? process.env.PROMPT_VERSION,
+  );
+  let runSeries = process.env.RUN_SERIES ?? DEFAULT_RUN_SERIES;
+  let maxConcurrency = Number(
+    process.env.EXPERIMENT_MAX_CONCURRENCY ?? DEFAULT_MAX_CONCURRENCY,
+  );
+  let mcpUrl = process.env.LANGFUSE_DOCS_MCP_URL ?? DEFAULT_MCP_URL;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--env-file") {
+      envFile = next;
+      index += 1;
+    } else if (arg === "--dataset-name") {
+      datasetName = next;
+      index += 1;
+    } else if (arg === "--models") {
+      models = parseCsv(next);
+      index += 1;
+    } else if (arg === "--prompt-labels") {
+      promptLabels = parseCsv(next);
+      index += 1;
+    } else if (arg === "--prompt-versions") {
+      promptVersions = parseNumberCsv(next);
+      index += 1;
+    } else if (arg === "--run-series") {
+      runSeries = next;
+      index += 1;
+    } else if (arg === "--max-concurrency") {
+      maxConcurrency = Number(next);
+      index += 1;
+    } else if (arg === "--mcp-url") {
+      mcpUrl = next;
+      index += 1;
+    } else if (arg === "--") {
+      continue;
+    } else if (!arg.startsWith("--") && !envFile) {
+      envFile = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (models.length === 0) models = [DEFAULT_MODEL];
+  if (promptLabels.length === 0 && promptVersions.length === 0) {
+    promptLabels = [DEFAULT_PROMPT_LABEL];
+  }
+  if (!Number.isFinite(maxConcurrency) || maxConcurrency < 1) {
+    maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+  }
+
+  return {
+    envFile,
+    datasetName,
+    models,
+    promptLabels,
+    promptVersions,
+    runSeries,
+    maxConcurrency,
+    mcpUrl,
+  };
+}
+
+function readEnvFile(envFile: string | undefined) {
+  if (!envFile) return;
+
+  const fullPath = resolve(process.cwd(), envFile);
+  if (!existsSync(fullPath)) {
+    throw new Error(`Env file does not exist: ${fullPath}`);
+  }
+
+  const values = Object.fromEntries(
+    readFileSync(fullPath, "utf8")
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const index = line.indexOf("=");
+        const key = line.slice(0, index);
+        const value = line.slice(index + 1).replace(/^['"]|['"]$/g, "");
+        return [key, value];
+      }),
+  );
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+
+  const baseUrl =
+    values.LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_EU_LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_US_LANGFUSE_BASE_URL ??
+    values.NEXT_PUBLIC_JP_LANGFUSE_BASE_URL;
+  const publicKey =
+    values.LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_EU_LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_US_LANGFUSE_PUBLIC_KEY ??
+    values.NEXT_PUBLIC_JP_LANGFUSE_PUBLIC_KEY;
+  const secretKey =
+    values.LANGFUSE_SECRET_KEY ??
+    values.EU_LANGFUSE_SECRET_KEY ??
+    values.US_LANGFUSE_SECRET_KEY ??
+    values.JP_LANGFUSE_SECRET_KEY;
+
+  if (baseUrl) {
+    process.env.LANGFUSE_BASE_URL = process.env.LANGFUSE_BASE_URL ?? baseUrl;
+    process.env.LANGFUSE_HOST = process.env.LANGFUSE_HOST ?? baseUrl;
+  }
+  if (publicKey) {
+    process.env.LANGFUSE_PUBLIC_KEY =
+      process.env.LANGFUSE_PUBLIC_KEY ?? publicKey;
+  }
+  if (secretKey) {
+    process.env.LANGFUSE_SECRET_KEY =
+      process.env.LANGFUSE_SECRET_KEY ?? secretKey;
+  }
+}
+
+function requireEnv(name: string) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+function isReasoningModel(model: string) {
+  return /^gpt-5|^o\d/.test(model);
+}
+
+function compileExperimentMessages(
+  prompt: Awaited<ReturnType<LangfuseClient["prompt"]["get"]>>,
+  input: unknown,
+): Parameters<typeof generateText>[0]["messages"] {
+  const chatHistory = getChatHistory(input);
+  const fallbackUserMessage = getLastUserMessage(input);
+  const datasetMessages: Array<{ role: string; content: string }> =
+    chatHistory.length > 0
+      ? chatHistory
+      : fallbackUserMessage
+        ? [{ role: "user", content: fallbackUserMessage }]
+        : [];
+  const compiledWithVariables = prompt.compile({
+    chat_history: datasetMessages,
+  } as any);
+  const compiledMessages: Array<{ role: string; content: string }> = [];
+  let insertedPlaceholder = false;
+
+  for (const message of compiledWithVariables as Array<{
+    role?: string;
+    content?: unknown;
+    type?: string;
+    name?: string;
+  }>) {
+    if (message.type === "placeholder" && message.name === "chat_history") {
+      compiledMessages.push(...datasetMessages);
+      insertedPlaceholder = true;
+      continue;
+    }
+
+    if (message.role && message.content != null) {
+      compiledMessages.push({
+        role: message.role,
+        content: normalizeMessageContent(message.content),
+      });
+    }
+  }
+
+  if (
+    !insertedPlaceholder &&
+    compiledMessages.every((message) => message.role === "system")
+  ) {
+    compiledMessages.push(...datasetMessages);
+  }
+
+  return compiledMessages as Parameters<typeof generateText>[0]["messages"];
+}
+
+async function runOneExperiment(
+  args: Args,
+  params: { model: string; promptLabel?: string; promptVersion?: number },
+) {
+  const langfuse = new LangfuseClient();
+  const promptSelector = params.promptVersion
+    ? `v${params.promptVersion}`
+    : (params.promptLabel ?? DEFAULT_PROMPT_LABEL);
+  const prompt = await langfuse.prompt.get(QA_CHATBOT_PROMPT_NAME, {
+    type: "chat",
+    ...(params.promptVersion
+      ? { version: params.promptVersion }
+      : { label: promptSelector }),
+  });
+
+  const promptConfig = prompt.config as Record<string, unknown>;
+  const reasoningSummary = promptConfig.reasoningSummary as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+  const textVerbosity = promptConfig.textVerbosity as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+  const reasoningEffort = promptConfig.reasoningEffort as
+    | "low"
+    | "medium"
+    | "high"
+    | undefined;
+
+  console.log(
+    `Running dataset="${args.datasetName}" prompt=${QA_CHATBOT_PROMPT_NAME}@${promptSelector} resolvedVersion=${prompt.version} model=${params.model}`,
+  );
+
+  const dataset = await langfuse.dataset.get(args.datasetName);
+
+  const task = async (item: { input: unknown }): Promise<string> => {
+    const compiledMessages = compileExperimentMessages(prompt, item.input);
+    const transport = new StreamableHTTPClientTransport(new URL(args.mcpUrl), {
+      sessionId: `sdk-integration-grounding-${crypto.randomUUID()}`,
+    }) as unknown as Parameters<typeof createMCPClient>[0]["transport"];
+    const mcpClient = await createMCPClient({ transport });
+
+    try {
+      const tools = await mcpClient.tools();
+      const { text } = await generateText({
+        abortSignal: AbortSignal.timeout(240_000),
+        model: openai(params.model),
+        ...(isReasoningModel(params.model)
+          ? {
+              providerOptions: {
+                openai: {
+                  reasoningSummary,
+                  textVerbosity,
+                  reasoningEffort,
+                } satisfies OpenAIResponsesProviderOptions,
+              },
+            }
+          : {}),
+        messages: compiledMessages,
+        tools: tools as Parameters<typeof generateText>[0]["tools"],
+        stopWhen: stepCountIs(10),
+        experimental_telemetry: makeExperimentTelemetry({
+          langfusePrompt: JSON.stringify(prompt.toJSON() ?? {}),
+          experiment_model: params.model,
+          experiment_prompt_selector: promptSelector,
+          experiment_dataset: args.datasetName,
+        }),
+      });
+
+      return text;
+    } finally {
+      await mcpClient.close();
+    }
+  };
+
+  const runName = [
+    args.runSeries,
+    `prompt-${promptSelector}`,
+    `model-${params.model}`,
+    new Date().toISOString().replace(/[:.]/g, "-"),
+  ].join("-");
+
+  const result = await dataset.runExperiment({
+    name: `${args.runSeries}-${params.model}`,
+    runName,
+    description:
+      "SDK integration docs-grounding experiment using the product QA chatbot prompt and Langfuse docs MCP. Langfuse in-app evaluators score docs groundedness, citation completeness, and package/version completeness.",
+    task,
+    maxConcurrency: args.maxConcurrency,
+    metadata: {
+      model: params.model,
+      prompt_name: QA_CHATBOT_PROMPT_NAME,
+      prompt_label: params.promptVersion ? undefined : promptSelector,
+      prompt_version: prompt.version,
+      dataset_name: args.datasetName,
+      run_series: args.runSeries,
+      in_app_evaluators: IN_APP_EVALUATORS,
+      reference_style: "reference_free",
+    },
+  });
+
+  console.log(await result.format());
+  await langfuse.flush();
+}
+
+async function main() {
+  const args = parseArgs();
+  readEnvFile(args.envFile);
+  requireEnv("OPENAI_API_KEY");
+  requireEnv("LANGFUSE_PUBLIC_KEY");
+  requireEnv("LANGFUSE_SECRET_KEY");
+  requireEnv("LANGFUSE_BASE_URL");
+
+  const spanProcessor = new LangfuseSpanProcessor();
+  const tracerProvider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
+  tracerProvider.register();
+
+  try {
+    const promptSelectors =
+      args.promptVersions.length > 0
+        ? args.promptVersions.map((promptVersion) => ({ promptVersion }))
+        : args.promptLabels.map((promptLabel) => ({ promptLabel }));
+
+    for (const selector of promptSelectors) {
+      for (const model of args.models) {
+        await runOneExperiment(args, { ...selector, model });
+      }
+    }
+  } finally {
+    await tracerProvider.shutdown();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/components/qaChatbot/shared/flow_config.ts
+++ b/components/qaChatbot/shared/flow_config.ts
@@ -1,0 +1,63 @@
+export const QA_CHATBOT_PROMPT_NAME = "langfuse-docs-assistant-chat";
+
+export type EvaluatorMessage = {
+  role: string;
+  content: string;
+};
+
+export function normalizeMessageContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object" && "text" in part) {
+          return String((part as { text: unknown }).text ?? "");
+        }
+        return JSON.stringify(part);
+      })
+      .join("");
+  }
+  if (content == null) return "";
+  return JSON.stringify(content);
+}
+
+export function getLastUserMessage(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (!input || typeof input !== "object" || !("messages" in input)) return "";
+
+  const messages = (input as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) return "";
+
+  const userMessage = [...messages]
+    .reverse()
+    .find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        (message as { role?: string }).role === "user",
+    );
+
+  return normalizeMessageContent(
+    (userMessage as { content?: unknown } | undefined)?.content,
+  );
+}
+
+export function getChatHistory(input: unknown): EvaluatorMessage[] {
+  if (!input || typeof input !== "object" || !("messages" in input)) {
+    return [];
+  }
+
+  const messages = (input as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) return [];
+
+  return messages
+    .filter((message) => message && typeof message === "object")
+    .map((message) => ({
+      role: String((message as { role?: unknown }).role ?? "user"),
+      content: normalizeMessageContent(
+        (message as { content?: unknown }).content,
+      ),
+    }))
+    .filter((message) => message.role !== "system");
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "workshop:sync": "node scripts/sync-workshop.mjs",
     "link-check": "node scripts/check-links.js",
     "sitemap-check": "node scripts/check-sitemap-links.js",
+    "qa-chatbot:seed-general": "npx tsx components/qaChatbot/datasets/seed_general_qa_chatbot_dataset.ts",
+    "qa-chatbot:seed-sdk-grounding": "npx tsx components/qaChatbot/datasets/seed_sdk_integration_grounding_dataset.ts",
+    "qa-chatbot:setup-sdk-grounding-evaluators": "npx tsx components/qaChatbot/evaluators/setup_sdk_integration_grounding_evaluators.ts",
+    "qa-chatbot:general-experiment": "npx tsx components/qaChatbot/experiments/run_general_qa_chatbot_experiment.ts",
+    "qa-chatbot:sdk-grounding-experiment": "npx tsx components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts",
     "nuke": "rm -rf .next && rm -rf node_modules && pnpm install"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- add QA chatbot dataset seeders, evaluator setup, and experiment runners
- add shared prompt/message helpers and README usage docs
- ignore local env files with a generic `.env*` rule while keeping `.env.template` / `.env.example` trackable

## Test
- npx tsc --noEmit --pretty false --skipLibCheck --project tsconfig.json