### PR TITLE
docs: clarify propagate_attributes scope, trace.list lightweight views, and ingestion lag

### DIFF
--- a/components/PropagationRestrictionsCallout.tsx
+++ b/components/PropagationRestrictionsCallout.tsx
@@ -71,8 +71,11 @@ export function PropagationRestrictionsCallout({
         )}
         <li>
           Call <strong>early in your trace</strong> to ensure all observations
-          are covered. This way you make sure that all Metrics in Langfuse are
-          accurate.
+          are covered. Only the <strong>currently active observation</strong>{" "}
+          and observations <strong>started while the context is active</strong>{" "}
+          receive the attributes — observations started earlier are not
+          retroactively updated. This way you make sure that all Metrics in
+          Langfuse are accurate.
         </li>
         <li>Invalid values are dropped with a warning</li>
       </ul>

--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -18,7 +18,7 @@ If you are new to Langfuse, we recommend familiarizing yourself with the [Langfu
 
 <Callout type="info">
 
-New data is typically available for querying within 15-30 seconds of ingestion, though processing times may vary at times. Please visit [status.langfuse.com](https://status.langfuse.com) if you encounter any issues.
+Ingestion is **asynchronous**: SDK `flush()` only guarantees delivery to the API, not read visibility. New data is typically available for querying within 15-30 seconds of ingestion, though processing times may vary — under heavy or parallel load, visibility can lag longer (there is no fixed SLA). Reading a trace immediately after writing it may return a 404. See [Handling ingestion lag](#ingestion-lag) for the recommended retry pattern, and visit [status.langfuse.com](https://status.langfuse.com) if you encounter persistent issues.
 
 </Callout>
 
@@ -71,6 +71,40 @@ observations = langfuse.api.observations.get_many(
 ```
 
 Use `trace_id` to retrieve the observations that belong to a single trace. Use `parent_observation_id` in the response to reconstruct an observation tree when needed.
+
+### Traces: `list` returns lightweight views [#traces-list-vs-get]
+
+`langfuse.api.trace.list(...)` returns **lightweight trace views**: the `observations` and `scores` fields contain only **IDs (strings)**, not full objects. Trace-level aggregates (`total_cost`, `latency`) are included, but per-observation usage and cost details are not. To get full observation objects, call `langfuse.api.trace.get(trace_id)` per trace (or prefer `observations.get_many(trace_id=...)` above).
+
+List-then-get pagination example for usage/cost aggregation:
+
+```python
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+usage_by_model = defaultdict(int)
+from_timestamp = datetime.now(timezone.utc) - timedelta(days=1)
+page = 1
+
+while True:
+    traces = langfuse.api.trace.list(
+        from_timestamp=from_timestamp,
+        page=page,
+        limit=50,
+    )
+    for trace_view in traces.data:
+        # trace_view.observations is a list of ID strings only
+        full_trace = langfuse.api.trace.get(trace_view.id)
+        for obs in full_trace.observations:  # full objects incl. usage/cost
+            if obs.usage_details:
+                model = obs.model or "unknown"
+                usage_by_model[model] += obs.usage_details.get("total", 0)
+    if page >= traces.meta.total_pages:
+        break
+    page += 1
+```
+
+If you only need trace-level totals, `trace.list` alone is enough (`trace_view.total_cost`, `trace_view.latency`) — no per-trace `get` required. For large-scale aggregation, prefer the [Metrics API v2](/docs/metrics/features/metrics-api#v2) over paginating row-level data.
 
 ### Metrics
 
@@ -216,6 +250,73 @@ Explore more entities via Intellisense on `langfuse.api`.
 
 </Tab>
 </LangTabs>
+
+## Handling ingestion lag (get-after-write) [#ingestion-lag]
+
+Trace ingestion is asynchronous. `flush()` in the SDKs guarantees that data was **delivered** to the Langfuse API, not that it is **readable** yet. Reading right after writing — e.g. `trace.get(trace_id)` after a flush, fetching a score you just created, or fetching dataset run items right after an experiment — may raise a 404 (`langfuse.api.NotFoundError` in Python) or return incomplete data until processing completes. Typical visibility is within 15-30 seconds; under heavy or parallel load it can take longer, and there is no fixed SLA.
+
+Instead of a fixed `time.sleep()`, use bounded retries with backoff:
+
+<LangTabs items={["Python SDK", "JS/TS SDK"]}>
+<Tab title="Python SDK">
+
+```python
+import time
+
+from langfuse import get_client
+from langfuse.api import NotFoundError
+
+langfuse = get_client()
+
+
+def get_trace_with_retry(trace_id: str, *, timeout: float = 60.0):
+    """Fetch a trace, retrying on 404 until ingestion completes."""
+    deadline = time.monotonic() + timeout
+    delay = 1.0
+    while True:
+        try:
+            return langfuse.api.trace.get(trace_id)
+        except NotFoundError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 10.0)  # exponential backoff, capped
+
+
+langfuse.flush()  # ensure delivery before polling
+trace = get_trace_with_retry(trace_id, timeout=60)
+```
+
+Note: a successful `trace.get` means the trace record exists — observations and scores of that trace may still be arriving. If you depend on completeness (e.g. counting observations or summing costs), additionally check that the expected observations are present before proceeding.
+
+</Tab>
+<Tab title="JS/TS SDK">
+
+```ts
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+async function getTraceWithRetry(traceId: string, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 1_000;
+  while (true) {
+    try {
+      return await langfuse.api.trace.get(traceId);
+    } catch (err: any) {
+      const is404 = err?.statusCode === 404;
+      if (!is404 || Date.now() >= deadline) throw err;
+      await new Promise((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 2, 10_000); // exponential backoff, capped
+    }
+  }
+}
+```
+
+</Tab>
+</LangTabs>
+
+The same pattern applies to any read-after-write on ingested entities: traces, observations, scores, and dataset run items. Entities created via synchronous endpoints (prompts, datasets, dataset items) are readable immediately and do not need retries.
 
 ## Related Resources
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -22,6 +22,12 @@ You can add scores via the Langfuse SDKs or API. Scores can take one of four dat
 
 If a score is ingested manually using a `trace_id` to link the score to a trace, it is not necessary to wait until the trace has been created. The score will show up in the scores table and will be linked to the trace once the trace with the same `trace_id` is created.
 
+<Callout type="info">
+
+Score ingestion is asynchronous. A score created via SDK is queued, sent on the next flush, and processed server-side — it is typically queryable via the API/UI within 15-30 seconds, potentially longer under load. If you fetch a score right after creating it, retry with bounded backoff. See [Handling ingestion lag](/docs/api-and-data-platform/features/query-via-sdk#ingestion-lag).
+
+</Callout>
+
 Here are examples by `Score` data types.
 
 For trace and observation scores, `trace_id`/`traceId` is required and `observation_id`/`observationId` is optional. If you attach a score to an observation, always provide both the observation ID and the corresponding trace ID.

--- a/content/docs/observability/features/sessions.mdx
+++ b/content/docs/observability/features/sessions.mdx
@@ -188,6 +188,15 @@ The [Flowise Integration](/docs/flowise) automatically maps the Flowise chatId t
 
 <PropagationRestrictionsCallout attributes={["sessionId"]} />
 
+## Scope and ordering of `sessionId` propagation [#scope-and-ordering]
+
+Propagation is forward-only and follows the active execution context:
+
+- **Covered**: the observation that is currently active when you enter the propagation context, and every observation started while the context is active (any nesting depth, any type).
+- **Not covered**: observations started before entering the context. In the Python SDK, a detached root created with `start_observation()` (which does not become the active span) stays unstamped if you enter `propagate_attributes` afterwards — start it inside the context, or use `start_as_current_observation` for the root and propagate within it.
+
+Where the value lands: each covered observation carries `session.id` in the exported OTel span data, and after ingestion `sessionId` surfaces as a **trace-level field**. When verifying programmatically, read it from the trace (`langfuse.api.trace.get(trace_id).session_id`) — observation objects returned by the public API do not expose a `session_id` field, so asserting on fetched child observations will always fail.
+
 ## Example
 
 Try this feature using the public [example project](/docs/demo).

--- a/content/docs/observability/features/users.mdx
+++ b/content/docs/observability/features/users.mdx
@@ -177,6 +177,15 @@ await startActiveObservation("langchain-call", async () => {
 
 <PropagationRestrictionsCallout attributes={["userId"]} />
 
+## Scope and ordering of `userId` propagation [#scope-and-ordering]
+
+Propagation is forward-only and follows the active execution context:
+
+- **Covered**: the observation that is currently active when you enter the propagation context, and every observation started while the context is active (any nesting depth, any type).
+- **Not covered**: observations started before entering the context. In the Python SDK, a detached root created with `start_observation()` (which does not become the active span) stays unstamped if you enter `propagate_attributes` afterwards — start it inside the context, or use `start_as_current_observation` for the root and propagate within it.
+
+Where the value lands: each covered observation carries `user.id` in the exported OTel span data, and after ingestion `userId` surfaces as a **trace-level field**. When verifying programmatically, read it from the trace (`langfuse.api.trace.get(trace_id).user_id`) — observation objects returned by the public API do not expose a `user_id` field, so asserting on fetched child observations will always fail.
+
 ## View all users
 
 The user list provides an overview of all users that have been tracked by Langfuse. It makes it simple to segment by overall token usage, number of traces, and user feedback.

--- a/content/docs/observability/sdk/instrumentation.mdx
+++ b/content/docs/observability/sdk/instrumentation.mdx
@@ -538,6 +538,8 @@ await startActiveObservation("user-workflow", async () => {
 </Tab>
 </LangTabs>
 
+**Scope**: propagation is forward-only. The attributes are applied to the observation that is currently active when the context is entered, and to every observation started while the context is active. Observations started earlier are not retroactively updated — in the Python SDK, a detached span from `start_observation()` (never the active span) stays unstamped if you enter `propagate_attributes` after starting it. After ingestion, `userId` and `sessionId` surface as trace-level fields (read them via `api.trace.get(trace_id)`); observation objects returned by the public API do not expose these fields. See [Sessions](/docs/observability/features/sessions#scope-and-ordering) and [Users](/docs/observability/features/users#scope-and-ordering) for details.
+
 <PropagationRestrictionsCallout attributes={[]} />
 
 ### Cross-service propagation


### PR DESCRIPTION
## What changed

Closes three documentation gaps that agent-behavior testing showed cause real debugging sessions. All claims were verified against the Python SDK source and unit tests (companion docstring PR in langfuse-python to follow).

### 1. `propagate_attributes` scope semantics
- **Sessions / Users**: new "Scope and ordering" sections — propagation is forward-only (currently active observation + observations started while the context is active); a detached Python `start_observation()` root started before entering the context stays unstamped. Documents where the values land: `sessionId`/`userId` are **trace-level fields** — verify via `api.trace.get(trace_id)`, since observation objects returned by the public API don't expose these fields (asserting on fetched children always fails).
- **Instrumentation page + shared `PropagationRestrictionsCallout`**: same scope rule stated where all propagation docs converge.

### 2. `trace.list` returns lightweight views
- **Query via SDKs**: new section documenting that `trace.list` items carry observation/score **IDs (strings)**, not full objects, while trace-level aggregates (`total_cost`, `latency`) are included. Adds a list-then-get pagination example for per-observation usage/cost aggregation, with pointers to `observations.get_many` and Metrics API v2 for scale.

### 3. Ingestion lag (get-after-write)
- **Query via SDKs**: existing 15-30s availability callout extended (ingestion is async, `flush()` guarantees delivery not read visibility, no fixed SLA, can lag longer under parallel load) plus a new "Handling ingestion lag" section with bounded retry-with-backoff snippets (Python `langfuse.api.NotFoundError` + JS/TS), including the trap that a successful `trace.get` doesn't imply all observations have arrived yet.
- **Scores via SDK**: short callout linking to the pattern.

## Reviewer notes

- SDK behavior verified in `langfuse-python`: the span processor stamps propagated attributes on **every** span started inside the context (not root-only); the confusion in the field comes from the API surface (observations carry no session/user fields) and detached roots.
- Python exception name is `langfuse.api.NotFoundError` — there is no `LangfuseNotFoundError` in the Python SDK.
- Ran `pnpm run format`; content-only changes plus one shared component tweak, no build config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes three documentation gaps in Langfuse's observability and SDK query docs: it clarifies the forward-only scope of `propagate_attributes`, explains that `trace.list` returns lightweight views (IDs, not full objects), and adds a bounded retry-with-backoff pattern for ingestion lag.

- **Propagation scope**: `PropagationRestrictionsCallout.tsx`, `sessions.mdx`, `users.mdx`, and `instrumentation.mdx` now consistently document that only the currently active observation and observations started while the context is active receive propagated attributes, plus the trace-level-field caveat for `sessionId`/`userId` verification.
- **`trace.list` lightweight views**: New Python-only section documenting ID-only `observations`/`scores` fields and a list-then-get pagination example; the JS/TS tab lacks an equivalent note.
- **Ingestion lag handling**: New `#ingestion-lag` section with bounded exponential-backoff retry snippets for both Python (`langfuse.api.NotFoundError`) and JS/TS, plus a short callout in `scores-via-sdk.mdx`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only changes with no build config or code logic touched; safe to merge with minor polish.

The propagation-scope additions and the ingestion-lag retry pattern are accurate and internally consistent across the six changed files. The only gaps found are: `trace_id` appears undefined in the Python retry usage snippet (a copy-paste hazard), and the `trace.list` lightweight-view behaviour is documented for Python only while the JS/TS tab is silent on it.

content/docs/api-and-data-platform/features/query-via-sdk.mdx — both the undefined `trace_id` in the usage example and the absent JS/TS lightweight-view note live here.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant SDK
    participant API
    participant Store

    App->>SDK: trace/observation created
    SDK->>API: flush() — delivers payload
    API-->>SDK: 202 Accepted
    Note over API,Store: async ingestion pipeline (15–30s typical)
    API->>Store: write to storage
    App->>SDK: trace.get(trace_id) [immediate]
    SDK->>API: "GET /trace/{id}"
    API-->>SDK: 404 NotFoundError
    Note over App,SDK: retry with exponential backoff
    App->>SDK: trace.get(trace_id) [after delay]
    SDK->>API: "GET /trace/{id}"
    API-->>SDK: 200 trace (may still be missing observations)
    Note over App: check observation completeness separately
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant SDK
    participant API
    participant Store

    App->>SDK: trace/observation created
    SDK->>API: flush() — delivers payload
    API-->>SDK: 202 Accepted
    Note over API,Store: async ingestion pipeline (15–30s typical)
    API->>Store: write to storage
    App->>SDK: trace.get(trace_id) [immediate]
    SDK->>API: "GET /trace/{id}"
    API-->>SDK: 404 NotFoundError
    Note over App,SDK: retry with exponential backoff
    App->>SDK: trace.get(trace_id) [after delay]
    SDK->>API: "GET /trace/{id}"
    API-->>SDK: 200 trace (may still be missing observations)
    Note over App: check observation completeness separately
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/docs/api-and-data-platform/features/query-via-sdk.mdx:286-287
**`trace_id` undefined in usage example**

The concluding call-site snippet uses `trace_id` as if it were already in scope, but the variable is never assigned anywhere in the snippet. Readers who copy these two lines verbatim will get a `NameError` at runtime. A short stub assignment or a `# replace with your trace ID` comment before the call would make the snippet self-contained.

### Issue 2 of 2
content/docs/api-and-data-platform/features/query-via-sdk.mdx:75-107
**Lightweight-view behaviour only documented for Python tab**

The new "Traces: `list` returns lightweight views" section — including the pagination example and the note about `total_cost`/`latency` versus per-observation fields — lives entirely inside the Python SDK tab. The JS/TS SDK tab does not mention that `trace.list` returns ID-only `observations`/`scores` fields, even though the same REST endpoint underlies both clients. Users working with `@langfuse/client` who hit this behaviour have no documentation pointer to guide them.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify propagate\_attributes scope..."](https://github.com/langfuse/langfuse-docs/commit/3fd5857e36eb141cd75d6ddaf3d65adea0893372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44811619)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->