### PR TITLE
docs(opentelemetry): clarify optional attributes for experiment context and item spans

### DIFF
--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -130,9 +130,9 @@ context in this order:
 
 | Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                                                                |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description`, optional `langfuse.experiment.dataset.id`, `langfuse.experiment.metadata.*`, and optional `langfuse.environment` |
-| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output`, and `langfuse.experiment.item.metadata.*`                                                        |
-| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, optional `langfuse.experiment.item.version`, and `langfuse.experiment.item.root_observation_id`                                                                            |
+| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description` (optional), `langfuse.experiment.dataset.id` (optional), `langfuse.experiment.metadata.*` (optional), `langfuse.environment` (optional) |
+| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output` (optional), `langfuse.experiment.item.metadata.*` (optional)                                                        |
+| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, `langfuse.experiment.item.root_observation_id`, `langfuse.experiment.item.version` (optional)                                                                            |
 
 Configure a `BaggageSpanProcessor` as described in the [Baggage propagation
 pattern](#recommended-use-opentelemetry-baggage-for-propagation).
@@ -155,10 +155,10 @@ create an enclosing "experiment" span.
 experimentBaggage = baggageFromAttributes({
   "langfuse.experiment.id": experiment.id, // unique per experiment
   "langfuse.experiment.name": experiment.name, // unique per experiment
-  "langfuse.experiment.description": experiment.description,
-  "langfuse.experiment.dataset.id": experiment.datasetId, // optional
-  "langfuse.experiment.metadata.prompt_version": "v4",
-  "langfuse.environment": "experiment", // optional: use a separate environment for experiment traffic
+  "langfuse.experiment.description": experiment.description, // optional
+  "langfuse.experiment.dataset.id": experiment.datasetId, // optional: Langfuse-managed datasets only
+  "langfuse.experiment.metadata.prompt_version": "v4", // optional
+  "langfuse.environment": "experiment", // optional: separate environment for experiment traffic
 })
 ```
 

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -128,11 +128,11 @@ model calls, tool calls, and other work.
 To make experiment data show correctly in Langfuse, model three levels of
 context in this order:
 
-| Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                                                                |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.description` (optional), `langfuse.experiment.dataset.id` (optional), `langfuse.experiment.metadata.*` (optional), `langfuse.environment` (optional) |
-| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output` (optional), `langfuse.experiment.item.metadata.*` (optional)                                                        |
-| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, `langfuse.experiment.item.root_observation_id`, `langfuse.experiment.item.version` (optional)                                                                            |
+| Level                | Purpose                                                                                                                    | How to apply it                      | Attributes                                                                                                                                                                                                           |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Experiment context   | Propagates the experiment's identity to every span in every item trace, so Langfuse can synthesize them as one experiment. | Baggage                              | `langfuse.experiment.id`, `langfuse.experiment.name`, `langfuse.experiment.dataset.id`, `langfuse.experiment.description` (optional), `langfuse.experiment.metadata.*` (optional), `langfuse.environment` (optional) |
+| Experiment item root | Identifies one item trace root and stores its input, expected output, and actual output.                                   | Attributes directly on the root span | `langfuse.observation.input`, `langfuse.observation.output`, `langfuse.experiment.item.expected_output` (optional), `langfuse.experiment.item.metadata.*` (optional)                                                 |
+| Item context         | Propagates one item's identity to the root and child spans in that item's trace.                                           | Root attributes, then Baggage        | `langfuse.experiment.item.id`, `langfuse.experiment.item.root_observation_id`, `langfuse.experiment.item.version` (optional)                                                                                         |
 
 Configure a `BaggageSpanProcessor` as described in the [Baggage propagation
 pattern](#recommended-use-opentelemetry-baggage-for-propagation).
@@ -155,8 +155,8 @@ create an enclosing "experiment" span.
 experimentBaggage = baggageFromAttributes({
   "langfuse.experiment.id": experiment.id, // unique per experiment
   "langfuse.experiment.name": experiment.name, // unique per experiment
+  "langfuse.experiment.dataset.id": experiment.datasetId, // recommended: Manage datasets in Langfuse
   "langfuse.experiment.description": experiment.description, // optional
-  "langfuse.experiment.dataset.id": experiment.datasetId, // optional: Langfuse-managed datasets only
   "langfuse.experiment.metadata.prompt_version": "v4", // optional
   "langfuse.environment": "experiment", // optional: separate environment for experiment traffic
 })


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the OpenTelemetry integration documentation to clarify which attributes are optional vs. required for experiment context, experiment item root spans, and item context spans.

- The table rows for all three span levels now annotate optional fields inline with `(optional)` rather than mixing "optional" as a prefix word, improving consistency and scannability.
- The item context row reorders attributes so required fields (`langfuse.experiment.item.id`, `langfuse.experiment.item.root_observation_id`) appear before the optional one (`langfuse.experiment.item.version`).
- The code snippet comments are updated to mark `description`, `metadata.*`, and `environment` as optional, and the `dataset.id` comment is clarified to note it applies to Langfuse-managed datasets only.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no functional code impact; safe to merge.

The change is purely additive documentation clarification — moving optional annotations inline and reordering attributes in one table row for readability. The code snippet comment for dataset.id gains useful context. No logic, schema, or API contracts are modified.

No files require special attention. The single changed file is a documentation page with no executable code paths.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User Code
    participant Baggage as OTel Baggage
    participant BSP as BaggageSpanProcessor
    participant Root as Item Root Span
    participant Child as Child Spans
    participant LF as Langfuse

    User->>Baggage: Set experiment context baggage
    User->>Root: Start root span with Baggage and no parent
    BSP->>Root: Copy Baggage entries as span attributes
    Root->>Root: Set required attributes: input and output
    Root->>Root: Set optional attributes: expected_output and metadata
    Root->>Root: Set item.id and root_observation_id
    Root->>Child: Propagate Baggage to child spans
    BSP->>Child: Copy Baggage entries as span attributes
    Child->>LF: Export child spans
    Root->>LF: Export root span
    LF->>LF: Synthesize into experiment and item traces
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User Code
    participant Baggage as OTel Baggage
    participant BSP as BaggageSpanProcessor
    participant Root as Item Root Span
    participant Child as Child Spans
    participant LF as Langfuse

    User->>Baggage: Set experiment context baggage
    User->>Root: Start root span with Baggage and no parent
    BSP->>Root: Copy Baggage entries as span attributes
    Root->>Root: Set required attributes: input and output
    Root->>Root: Set optional attributes: expected_output and metadata
    Root->>Root: Set item.id and root_observation_id
    Root->>Child: Propagate Baggage to child spans
    BSP->>Child: Copy Baggage entries as span attributes
    Child->>LF: Export child spans
    Root->>LF: Export root span
    LF->>LF: Synthesize into experiment and item traces
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(opentelemetry): clarify optional at..."](https://github.com/langfuse/langfuse-docs/commit/ab51fc123e4475fe67fd0ad659972eff085da730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44822636)</sub>

<!-- /greptile_comment -->