### PR TITLE
docs: fix remaining outdated v2 metrics and observations API reference anchors

### DIFF
--- a/content/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
+++ b/content/changelog/2025-12-17-v2-metrics-and-observations-api.mdx
@@ -94,6 +94,6 @@ import { Book, FileCode } from "lucide-react";
 <Cards num={2}>
   <Card title="Metrics API Documentation" href="/docs/analytics/metrics-api#v2" icon={<Book />} />
   <Card title="Observations API Documentation" href="/docs/api-and-data-platform/features/observations-api" icon={<Book />} />
-  <Card title="v2 Metrics API Reference" href="https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics" icon={<FileCode />} />
-  <Card title="v2 Observations API Reference" href="https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations" icon={<FileCode />} />
+  <Card title="v2 Metrics API Reference" href="https://api.reference.langfuse.com/#tag/metrics/GET/api/public/v2/metrics" icon={<FileCode />} />
+  <Card title="v2 Observations API Reference" href="https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations" icon={<FileCode />} />
 </Cards>

--- a/content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx
+++ b/content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx
@@ -68,7 +68,7 @@ Example exact metadata filter:
 ]
 ```
 
-Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/public/v2/observations`. See the [Observations API v2 docs](/docs/api-and-data-platform/features/observations-api#v2) and [API reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for the full filter schema.
+Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/public/v2/observations`. See the [Observations API v2 docs](/docs/api-and-data-platform/features/observations-api#v2) and [API reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the full filter schema.
 
 ## More full-text search improvements to come
 

--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -45,7 +45,7 @@ The v2 Observations API is a redesigned endpoint optimized for high-performance 
 
 Always include `fromStartTime` and `toStartTime` to keep each request bounded.
 
-The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. For single-observation lookups, pass a URL-encoded `filter` condition on the `id` column; see the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for the filter schema.
+The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. For single-observation lookups, pass a URL-encoded `filter` condition on the `id` column; see the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
 
 ### Key Improvements
 

--- a/content/docs/observability/features/full-text-search.mdx
+++ b/content/docs/observability/features/full-text-search.mdx
@@ -62,7 +62,7 @@ Example exact metadata filter:
 ]
 ```
 
-Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/public/v2/observations`. See the [Observations API v2 docs](/docs/api-and-data-platform/features/observations-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/observationsv2/GET/api/public/v2/observations) for the full filter schema.
+Pass the JSON array as the URL-encoded `filter` query parameter on `GET /api/public/v2/observations`. See the [Observations API v2 docs](/docs/api-and-data-platform/features/observations-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the full filter schema.
 
 ## GitHub Discussions
 

--- a/content/guides/cookbook/example_metrics_api_v2.mdx
+++ b/content/guides/cookbook/example_metrics_api_v2.mdx
@@ -192,4 +192,4 @@ score_summary_df
 
 You can adapt the same helper for other v2 views such as `scores-categorical`, add filters on fields like environment or trace name, or export the resulting `DataFrame` for downstream reporting.
 
-To explore the full query schema and supported fields, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics).
+To explore the full query schema and supported fields, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/v2/metrics).

--- a/cookbook/example_metrics_api_v2.ipynb
+++ b/cookbook/example_metrics_api_v2.ipynb
@@ -273,7 +273,7 @@
         "\n",
         "You can adapt the same helper for other v2 views such as `scores-categorical`, add filters on fields like environment or trace name, or export the resulting `DataFrame` for downstream reporting.\n",
         "\n",
-        "To explore the full query schema and supported fields, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics).\n"
+        "To explore the full query schema and supported fields, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api#v2) and the [API reference](https://api.reference.langfuse.com/#tag/metrics/GET/api/public/v2/metrics).\n"
       ]
     }
   ],


### PR DESCRIPTION
Follow-up to #3071. That PR fixed the two API-reference callout links (`observations-api.mdx` and `metrics-api.mdx`); this covers the remaining stale occurrences of the same broken anchors elsewhere in the docs.

## What changed

The API reference (`api.reference.langfuse.com`, a live unversioned Scalar rendering of the current OpenAPI spec) renamed its tag slugs: `ObservationsV2` → `Observations` and `MetricsV2` → `Metrics` (v1 moved to `LegacyObservationsV1`/`LegacyMetricsV1`). The `#tag/observationsv2/...` and `#tag/metricsv2/...` deep-links therefore point to tag slugs that no longer exist. The v2 endpoints themselves are unchanged and still current, so these links now land off-target.

Updated anchors in:

- `content/docs/api-and-data-platform/features/observations-api.mdx` — upgrade-path paragraph
- `content/docs/observability/features/full-text-search.mdx`
- `content/changelog/2025-12-17-v2-metrics-and-observations-api.mdx` — both reference cards
- `content/changelog/2026-05-27-clickhouse-full-text-search-fast-mode.mdx`
- `cookbook/example_metrics_api_v2.ipynb` (notebook source) + its generated `content/guides/cookbook/example_metrics_api_v2.mdx`

The changelog links are repaired rather than frozen because the reference is unversioned and the v2 API still exists, so the old anchors are dead for readers today; no factual claims in the entries were altered.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR repairs six documentation files containing dead deep-links to the Langfuse API reference, where the tag slugs `ObservationsV2`/`MetricsV2` were renamed to `Observations`/`Metrics` in the live Scalar rendering. No prose, code, or factual claims were altered.

- Changelog entries (`2025-12-17`, `2026-05-27`), two feature docs (`observations-api.mdx`, `full-text-search.mdx`), and the metrics cookbook (both the notebook source and its generated `.mdx` output) all have their `#tag/observationsv2/...` or `#tag/metricsv2/...` fragment replaced with the current slug (`#tag/observations/...` / `#tag/metrics/...`).
- The notebook source (`cookbook/example_metrics_api_v2.ipynb`) and its generated counterpart (`content/guides/cookbook/example_metrics_api_v2.mdx`) are updated in sync, which is the correct pattern.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All six files receive purely mechanical URL-anchor fixes; no logic, configuration, or generated content is altered beyond the fragment strings themselves.

Every changed line is a targeted string replacement of a dead URL fragment with its current equivalent. The notebook source and its generated MDX are updated in lockstep, the prose around each link is untouched, and there are no logic, config, or API contract changes.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Doc page / Notebook link"] -->|"Old (dead) anchor"| B["#tag/observationsv2/ ...\n#tag/metricsv2/ ..."]
    A -->|"New (live) anchor"| C["#tag/observations/ ...\n#tag/metrics/ ..."]
    B -->|"404 / wrong section"| D["api.reference.langfuse.com"]
    C -->|"Correct section"| D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Doc page / Notebook link"] -->|"Old (dead) anchor"| B["#tag/observationsv2/ ...\n#tag/metricsv2/ ..."]
    A -->|"New (live) anchor"| C["#tag/observations/ ...\n#tag/metrics/ ..."]
    B -->|"404 / wrong section"| D["api.reference.langfuse.com"]
    C -->|"Correct section"| D
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix outdated v2 metrics and observ..."](https://github.com/langfuse/langfuse-docs/commit/fc1e2215b5fb3827e82856f43e919cc0e39b2682) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44887901)</sub>

<!-- /greptile_comment -->