### PR TITLE
docs: correct export source gating on export-to-blob-storage page

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -79,6 +79,7 @@ Available options:
 In both cases the Export Source selector is not shown and exports use `Enriched observations (recommended)` automatically; the REST API rejects legacy values with `400 BAD_REQUEST`. Blob storage integrations created before 2026-06-22 keep their configured export source and continue to see the selector.
 
 **Self-hosted:** These date cutoffs do not apply. However, once a deployment has completed the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy export sources are no longer available — including previously saved ones, since the legacy traces/observations tables are no longer written — and the selector is hidden once only the enriched source remains.
+
 </Callout>
 
 ### Upgrade path for existing configurations [#upgrade-path]

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -53,7 +53,7 @@ Parquet observation exports do not include the per-unit model price columns (`in
 
 ## Export source (Fast Preview)
 
-Blob Storage integrations now include an `Export Source` selector. New integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations).
+Blob Storage integrations now include an `Export Source` selector. Where enriched export is available — on Langfuse Cloud, and on self-hosted deployments with the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`) — new integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations). On self-hosted deployments without the opt-in, enriched export is not available and new integrations default to `Traces and observations (legacy)`.
 
 This source uses enriched observations with trace attributes and provides significantly better export performance. `Scores` are always included, regardless of the selected source.
 
@@ -71,12 +71,19 @@ Available options:
 </Callout>
 
 <Callout type="info">
-  **Cloud projects created on or after 2026-05-20** will not see the Export Source selector — new Cloud projects export as `Enriched observations (recommended)` automatically. The REST API rejects legacy values for these projects with `400 BAD_REQUEST`. Existing projects and all self-hosted deployments are unaffected.
+**Langfuse Cloud:** Legacy export sources can no longer be newly selected:
+
+- Projects created on or after 2026-05-20 cannot use legacy export sources.
+- In older projects, blob storage integrations created on or after 2026-06-22 — including newly configured ones — cannot select legacy export sources either.
+
+In both cases the Export Source selector is not shown and exports use `Enriched observations (recommended)` automatically; the REST API rejects legacy values with `400 BAD_REQUEST`. Blob storage integrations created before 2026-06-22 keep their configured export source and continue to see the selector.
+
+**Self-hosted:** These date cutoffs do not apply. However, once a deployment has completed the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy export sources are no longer available — including previously saved ones, since the legacy traces/observations tables are no longer written — and the selector is hidden once only the enriched source remains.
 </Callout>
 
 ### Upgrade path for existing configurations [#upgrade-path]
 
-This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
+This migration path applies to **Cloud blob storage integrations created before 2026-06-22 and self-hosted deployments that still write the legacy tables**. Newer Cloud integrations already use `Enriched observations (recommended)` and cannot select legacy sources — including the dual-write source in step 1 below.
 
 Existing integrations continue to use `Traces and observations (legacy)` until changed.
 


### PR DESCRIPTION
Fixes [LFE-11070](https://linear.app/langfuse/issue/LFE-11070) — the [Export source (Fast Preview) section](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#export-source-fast-preview) understated the legacy-source gating relative to the implemented policy (`packages/shared/src/features/analytics-integrations/export-source-policy.ts`).

## Changes

- **Info callout rewritten** to cover both Cloud cutoffs: projects created on or after 2026-05-20 *and* blob storage integration rows created on or after 2026-06-22 (`LEGACY_BLOB_EXPORTER_CUTOFF`) — the latter includes newly configured integrations on older projects. Only integrations created before 2026-06-22 keep legacy sources and the selector.
- **Self-hosted claim corrected**: the date cutoffs don't apply, but once `LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`, legacy sources are blocked there too — including previously saved ones (`legacy-writes-disabled`). Naming the env var mirrors the operator-facing in-app message, which does so deliberately.
- **Default claim qualified**: on self-hosted without `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`, enriched export is unavailable and new integrations default to `Traces and observations (legacy)` (`getExportSourceFormValue`).
- **Upgrade path scoping** changed from "pre-cutoff Cloud projects" to "Cloud blob storage integrations created before 2026-06-22" — the dual-write step selects a legacy source, which only grandfathered integration rows may do.

All claims verified against `export-source-policy.ts` and `web/src/features/analytics-integrations/exportSource.ts`.

## Out of scope (noting for follow-up)

`content/integrations/analytics/posthog.mdx:59` and `mixpanel.mdx:82` claim "Pre-cutoff Cloud projects and all self-hosted deployments keep the full choice". The 2026-06-22 exporter cutoff is blob-storage-only, so those pages are correct on the cutoffs, but the self-hosted half is also inaccurate there (enriched needs the preview opt-in; legacy is blocked under `events_only`). Left untouched since the ticket scopes the fix to the blob storage page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the "Export source (Fast Preview)" section of the blob-storage docs to accurately reflect the dual Cloud cutoff policy (project creation date 2026-05-20 AND integration row creation date 2026-06-22) and adds accurate self-hosted caveats for `LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only` and the preview opt-in flag.

- The info callout is expanded from a single Cloud cutoff to two independent Cloud gating conditions, matching the implemented policy in `export-source-policy.ts`.
- The self-hosted paragraph now correctly states that (a) date cutoffs don't apply, (b) `events_only` mode blocks legacy sources, and (c) without the preview opt-in enriched export is unavailable and integrations default to legacy.
- The upgrade path scope is narrowed from "pre-cutoff Cloud projects + all self-hosted" to "Cloud integrations created before 2026-06-22 + self-hosted deployments still writing legacy tables."
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only change with no runtime impact. The rewritten callout and intro paragraph are materially more accurate than before.

The dual Cloud cutoff explanation and self-hosted env-var coverage are a clear improvement. One gap remains: the upgrade path section includes self-hosted deployments but doesn't mention that steps 1 and 3 require enriched sources, which are only available when the preview opt-in is set — an operator without it would hit a dead end with no explanation.

The upgrade path subsection (lines 85–88) of `content/docs/api-and-data-platform/features/export-to-blob-storage.mdx` deserves a second look for the self-hosted opt-in caveat.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Blob Storage Integration Request] --> B{Platform?}
    B -->|Langfuse Cloud| C{Project created\nbefore 2026-05-20?}
    B -->|Self-hosted| D{LANGFUSE_MIGRATION_V4\n_ALLOW_PREVIEW_OPT_IN?}

    C -->|No – post-cutoff project| E[Enriched only\nSelector hidden\nLegacy → 400 BAD_REQUEST]
    C -->|Yes – pre-cutoff project| F{Integration row created\nbefore 2026-06-22?}

    F -->|No – new integration| E
    F -->|Yes – grandfathered row| G[Legacy sources available\nSelector shown]

    D -->|Not set| H[Enriched unavailable\nDefault: legacy\nUpgrade path inaccessible]
    D -->|Set| I{LANGFUSE_MIGRATION_V4\n_WRITE_MODE=events_only?}

    I -->|Not set| J[Legacy + enriched available\nSelector shown\nUpgrade path accessible]
    I -->|Set – events_only| K[Legacy blocked\nEnriched only\nSelector hidden]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Blob Storage Integration Request] --> B{Platform?}
    B -->|Langfuse Cloud| C{Project created\nbefore 2026-05-20?}
    B -->|Self-hosted| D{LANGFUSE_MIGRATION_V4\n_ALLOW_PREVIEW_OPT_IN?}

    C -->|No – post-cutoff project| E[Enriched only\nSelector hidden\nLegacy → 400 BAD_REQUEST]
    C -->|Yes – pre-cutoff project| F{Integration row created\nbefore 2026-06-22?}

    F -->|No – new integration| E
    F -->|Yes – grandfathered row| G[Legacy sources available\nSelector shown]

    D -->|Not set| H[Enriched unavailable\nDefault: legacy\nUpgrade path inaccessible]
    D -->|Set| I{LANGFUSE_MIGRATION_V4\n_WRITE_MODE=events_only?}

    I -->|Not set| J[Legacy + enriched available\nSelector shown\nUpgrade path accessible]
    I -->|Set – events_only| K[Legacy blocked\nEnriched only\nSelector hidden]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:85-88
**Upgrade path inapplicable for self-hosted without preview opt-in**

The upgrade path is scoped to "self-hosted deployments that still write the legacy tables," but steps 1 and 3 both require enriched sources (`Traces and observations (legacy) and enriched observations`, then `Enriched observations (recommended)`). According to the updated intro (line 56), enriched export is only available on self-hosted deployments with `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`. Without that opt-in, a self-hosted operator reading this section would find those two options unavailable and be unable to follow the path, with no indication of why.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: prettier formatting"](https://github.com/langfuse/langfuse-docs/commit/5361a15a7d795809634e550ff97d7f8551b36c58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45610573)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->