### PR TITLE
docs: document exported directories per export source and switching effects

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -57,11 +57,15 @@ Blob Storage integrations now include an `Export Source` selector. Where enriche
 
 This source uses enriched observations with trace attributes and provides significantly better export performance. `Scores` are always included, regardless of the selected source.
 
-Available options:
+Available options, and the directories each source writes under `{prefix}{project-id}/` in your bucket:
 
-- `Traces and observations (legacy)`
-- `Traces and observations (legacy) and enriched observations`
-- `Enriched observations (recommended)`
+| Export source                                                | Directories written                                       |
+| ------------------------------------------------------------ | --------------------------------------------------------- |
+| `Traces and observations (legacy)`                           | `traces/`, `observations/`, `scores/`                     |
+| `Traces and observations (legacy) and enriched observations` | `traces/`, `observations/`, `observations_v2/`, `scores/` |
+| `Enriched observations (recommended)`                        | `observations_v2/`, `scores/`                             |
+
+Every run also writes a [run manifest](#run-manifest) under `manifests/`. For the columns in each file, see the [export sources overview](/docs/api-and-data-platform/features/blob-storage-export-fields#export-sources) in the field reference.
 
 <Callout type="warning">
   The `Traces and observations (legacy)` source is deprecated and will be
@@ -69,6 +73,8 @@ Available options:
   observations (recommended)`, and existing legacy integrations are strongly
   recommended to [upgrade](#upgrade-path).
 </Callout>
+
+On Langfuse Cloud, integrations that still export a legacy source (including `Traces and observations (legacy) and enriched observations`) also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run — written after the run's [manifest](#run-manifest) and not listed in it — and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. Account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
 
 <Callout type="info">
 **Langfuse Cloud:** Legacy export sources can no longer be newly selected:
@@ -92,7 +98,12 @@ To migrate safely:
 
 1. Switch to `Traces and observations (legacy) and enriched observations`.
 2. Validate downstream jobs and data consumers while both sources are exported (this mode creates duplicate records by design).
-3. Switch to `Enriched observations (recommended)` once validation is complete.
+3. Repoint consumers from the `traces/` and `observations/` directories to `observations_v2/`.
+4. Switch to `Enriched observations (recommended)` once validation is complete.
+
+<Callout type="warning">
+After the switch, the `traces/` and `observations/` directories receive **no further files at all** — not even [empty files](#empty-files), which are otherwise written for windows without data. Pipelines still watching those directories go silent without an error signal, so complete step 3 before switching.
+</Callout>
 
 For a field-level comparison of what changes when you switch sources, see [Differences between enriched and legacy exports](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences).
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -79,6 +79,7 @@ Available options:
 In both cases the Export Source selector is not shown and exports use `Enriched observations (recommended)` automatically; the REST API rejects legacy values with `400 BAD_REQUEST`. Blob storage integrations created before 2026-06-22 keep their configured export source and continue to see the selector.
 
 **Self-hosted:** These date cutoffs do not apply. However, once a deployment has completed the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy export sources are no longer available — including previously saved ones, since the legacy traces/observations tables are no longer written — and the selector is hidden once only the enriched source remains.
+
 </Callout>
 
 ### Upgrade path for existing configurations [#upgrade-path]

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -74,7 +74,7 @@ Every run also writes a [run manifest](#run-manifest) under `manifests/`. For th
   recommended to [upgrade](#upgrade-path).
 </Callout>
 
-On Langfuse Cloud, integrations that still export a legacy source (including `Traces and observations (legacy) and enriched observations`) also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run — written after the run's [manifest](#run-manifest) and not listed in it — and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. Account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
+On Langfuse Cloud, integrations that still export a legacy source (including `Traces and observations (legacy) and enriched observations`) also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run — written best-effort after the run's [manifest](#run-manifest) and not listed in it — and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. The manifest remains the authoritative run-completion marker; do not treat the notice as a completion signal. Account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
 
 <Callout type="info">
 **Langfuse Cloud:** Legacy export sources can no longer be newly selected:

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -53,7 +53,7 @@ Parquet observation exports do not include the per-unit model price columns (`in
 
 ## Export source (Fast Preview)
 
-Blob Storage integrations now include an `Export Source` selector. New integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations).
+Blob Storage integrations now include an `Export Source` selector. Where enriched export is available — on Langfuse Cloud, and on self-hosted deployments with the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`) — new integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations). On self-hosted deployments without the opt-in, enriched export is not available and new integrations default to `Traces and observations (legacy)`.
 
 This source uses enriched observations with trace attributes and provides significantly better export performance. `Scores` are always included, regardless of the selected source.
 
@@ -71,12 +71,19 @@ Available options:
 </Callout>
 
 <Callout type="info">
-  **Cloud projects created on or after 2026-05-20** will not see the Export Source selector — new Cloud projects export as `Enriched observations (recommended)` automatically. The REST API rejects legacy values for these projects with `400 BAD_REQUEST`. Existing projects and all self-hosted deployments are unaffected.
+**Langfuse Cloud:** Legacy export sources can no longer be newly selected:
+
+- Projects created on or after 2026-05-20 cannot use legacy export sources.
+- In older projects, blob storage integrations created on or after 2026-06-22 — including newly configured ones — cannot select legacy export sources either.
+
+In both cases the Export Source selector is not shown and exports use `Enriched observations (recommended)` automatically; the REST API rejects legacy values with `400 BAD_REQUEST`. Blob storage integrations created before 2026-06-22 keep their configured export source and continue to see the selector.
+
+**Self-hosted:** These date cutoffs do not apply. However, once a deployment has completed the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy export sources are no longer available — including previously saved ones, since the legacy traces/observations tables are no longer written — and the selector is hidden once only the enriched source remains.
 </Callout>
 
 ### Upgrade path for existing configurations [#upgrade-path]
 
-This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
+This migration path applies to **Cloud blob storage integrations created before 2026-06-22 and self-hosted deployments that still write the legacy tables**. Newer Cloud integrations already use `Enriched observations (recommended)` and cannot select legacy sources — including the dual-write source in step 1 below.
 
 Existing integrations continue to use `Traces and observations (legacy)` until changed.
 


### PR DESCRIPTION
Fixes [LFE-11072](https://linear.app/langfuse/issue/LFE-11072) — the export-to-blob-storage page never stated which files/directories each export source writes, what happens to them when you switch sources, or that Cloud legacy-source integrations get an extra bucket object.

**Stacked on #3333** (same page, overlapping sections). GitHub will retarget this PR to `main` automatically once #3333 merges.

## Changes (all in `content/docs/api-and-data-platform/features/export-to-blob-storage.mdx`)

- **Directories per source**: the export source options list is now a table mapping each source to the directories it writes under `{prefix}{project-id}/` (legacy → `traces/`, `observations/`, `scores/`; dual → all four; enriched → `observations_v2/`, `scores/`), plus a pointer to the run manifest and the field reference's [export sources overview](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields#export-sources). Verified against `worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts`.
- **Upgrade path**: new step 3 ("repoint consumers to `observations_v2/`") and a warning callout that after switching to enriched-only, `traces/` and `observations/` receive **no further files at all** — not even empty ones — so pipelines watching them go silent without an error signal.
- **`DEPRECATION_NOTICE.txt`**: documented the Cloud-only `{prefix}{project-id}/DEPRECATION_NOTICE.txt` object — rewritten on every successful run for legacy-source integrations (including the dual source), written after the run's manifest and not listed in it, removed automatically after switching to enriched-only (`worker/src/features/blobstorage/deprecationNotice.ts`) — so bucket-diffing pipelines and unfiltered object-created subscriptions aren't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents three previously undocumented aspects of the blob storage export feature on the `export-to-blob-storage.mdx` page: the specific directories written per export source, the silent-dropout behavior of legacy directories after switching to enriched-only, and the lifecycle of the Cloud-only `DEPRECATION_NOTICE.txt` object.

- Replaces the plain bullet list of export sources with a table mapping each source to its output directories, and adds a note that `manifests/` is always written.
- Adds a new migration step (step 3: repoint consumers) and a warning callout explaining that `traces/` and `observations/` receive no further files — not even empty ones — after switching to enriched-only, so pipelines watching them go silent without an error.
- Documents `DEPRECATION_NOTICE.txt`: Cloud-only, written after the manifest on every run for legacy-source integrations, and automatically deleted after switching to enriched-only.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one documentation accuracy fix: the new DEPRECATION_NOTICE.txt paragraph contradicts the existing claim that the manifest is the last object written per run.

The DEPRECATION_NOTICE.txt paragraph introduces a real ordering contradiction with two pre-existing authoritative claims about the manifest being last. The rest of the changes — directory table, migration steps, warning callout, and Cloud/self-hosted cutoff details — are accurate and well-organized.

content/docs/api-and-data-platform/features/export-to-blob-storage.mdx — the manifest section (line 174) and the event-subscription section (line 233) need a qualifier noting the DEPRECATION_NOTICE.txt exception for Cloud legacy-source integrations.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:77
**Manifest "last object" claim contradicted by DEPRECATION_NOTICE.txt ordering**

This line states `DEPRECATION_NOTICE.txt` is "written after the run's manifest," but lines 174 and 233 both declare the manifest to be "the last object of every successful run" and use that ordering as the explicit rationale for the event-subscription pattern. For Cloud legacy-source integrations, the manifest is no longer the final write, making both of those downstream claims technically false. The manifest section (line 174) and the event-subscription section (line 233) should be qualified to acknowledge this exception, or the `DEPRECATION_NOTICE.txt` paragraph should note that the manifest remains the authoritative run-completion marker and the notice is not a completion signal.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/lfe-11072-..."](https://github.com/langfuse/langfuse-docs/commit/b91d8efd9b318053e9316df9da8fb5dee88c07ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45617266)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->