### PR TITLE
docs: Scores API v2 → v3 migration guide (LFE-11063)

### DIFF
--- a/content/changelog/2026-06-10-scores-v3-api.mdx
+++ b/content/changelog/2026-06-10-scores-v3-api.mdx
@@ -45,4 +45,4 @@ GET /api/public/v3/scores?fields=details,subject,annotation
 
 **Migrating from v2.** v3 queries scores directly instead of joining traces, which keeps response times predictable at any volume. Filters therefore target score properties: for trace-level questions like "scores for traces of user X", the [Metrics API](/docs/metrics/features/metrics-api) replaces the v2 `userId` and `traceTags` filters and the `trace` field group. Every filter is now an explicit, typed parameter, replacing v2's JSON-stringified `filter` argument, and fetching a single score works through the `id` filter, replacing the get-by-id endpoint. Invalid filter combinations are rejected with HTTP 400.
 
-The full parameter reference is in the [API docs](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores).
+For a step-by-step upgrade path, see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2). The full parameter reference is in the [API docs](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores).

--- a/content/docs/api-and-data-platform/features/meta.json
+++ b/content/docs/api-and-data-platform/features/meta.json
@@ -9,6 +9,7 @@
     "mcp-server",
     "observations-api",
     "public-api",
-    "query-via-sdk"
+    "query-via-sdk",
+    "scores-api"
   ]
 }

--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -85,7 +85,9 @@ You can use your editor's Intellisense to explore the API methods and their para
 <Callout type="info">
 
 In Python SDK v4 and JS/TS SDK v5, the high-performance resources are the
-defaults: `api.observations`, `api.scores`, and `api.metrics`. Legacy v1
+defaults: `api.observations`, `api.metrics`, and — for score reads —
+`api.scores_v3` / `api.scoresV3` (`api.scores`, the v2 reads, is
+deprecated; see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2)). Legacy v1
 resources moved under `api.legacy.*` (Python: `*_v1`, JS/TS: `*V1`). See
 [Query via SDKs](/docs/api-and-data-platform/features/query-via-sdk) for SDK examples.
 

--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -229,14 +229,15 @@ try {
 
 ## Retrieve Data via the API
 
-For new data extraction workflows, use the v2 data APIs:
+For new data extraction workflows, use the high-performance data APIs:
 
 - [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) - Retrieve observation data (spans, generations, events) from Langfuse for custom workflows, evaluation pipelines, and analytics.
+- [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3) - Retrieve score data (evaluations, annotations, and API-ingested scores) with a typed value field and cursor-based pagination.
 - [Metrics API v2](/docs/metrics/features/metrics-api#v2) - Retrieve aggregated analytics and metrics from your Langfuse data.
 
 <Callout type="info">
 
-Older trace, observation, and metrics read APIs remain available, but are not recommended as the default for new extraction workflows because they are less performant at scale. See [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) for row-level data and [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregates.
+Older trace, observation, score, and metrics read APIs remain available, but are not recommended as the default for new extraction workflows because they are less performant at scale. See [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) for row-level trace and observation data, [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3) for score data, and [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregates.
 
 </Callout>
 

--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -30,19 +30,20 @@ The `api` namespace is auto-generated from the Public API (OpenAPI). Method name
 
 <Callout type="warning">
 
-From Python SDK v4 and JS/TS SDK v5 onward, the high-performance v2 data APIs
+From Python SDK v4 and JS/TS SDK v5 onward, the high-performance data APIs
 are the defaults:
 
 - `api.observations` (formerly `api.observations_v_2` / `api.observationsV2`)
-- `api.scores` (formerly `api.score_v_2` / `api.scoreV2`)
+- `api.scores_v3` / `api.scoresV3` — the v3 scores reads; `api.scores` (v2 reads) is deprecated, see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2)
 - `api.metrics` (formerly `api.metrics_v_2` / `api.metricsV2`)
 
 The old v2 aliases were removed in Python SDK v4 and JS/TS SDK v5.
 
-The older trace, observation, and metrics read APIs remain available, but they
+The older trace, observation, score, and metrics read APIs remain available, but they
 are not recommended as the default for new data extraction workflows because
 they are less performant at scale. See [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2)
-for row-level data and [Metrics API v2](/docs/metrics/features/metrics-api#v2)
+for row-level data, [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)
+for score data, and [Metrics API v2](/docs/metrics/features/metrics-api#v2)
 for aggregates.
 
 </Callout>
@@ -102,8 +103,14 @@ sessions = langfuse.api.sessions.list(limit=50)
 Scores:
 
 ```python
-scores = langfuse.api.scores.get_many(score_ids = "ScoreId")
+# Scores API v3 (recommended)
+scores = langfuse.api.scores_v3.get_many_v3(id="ScoreId")
+
+# Scores API v2 (deprecated, sunset 2026-10-31)
+scores = langfuse.api.scores.get_many(score_ids="ScoreId")
 ```
+
+To move existing v2 score reads to v3, see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2).
 
 Prompts:
 
@@ -196,8 +203,14 @@ const sessions = await langfuse.api.sessions.list({ limit: 50 });
 Scores:
 
 ```ts
+// Scores API v3 (recommended)
+const scoresV3 = await langfuse.api.scoresV3.getManyV3();
+
+// Scores API v2 (deprecated, sunset 2026-10-31)
 const scores = await langfuse.api.scores.getMany();
 ```
+
+To move existing v2 score reads to v3, see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2).
 
 Prompts:
 
@@ -220,6 +233,7 @@ Explore more entities via Intellisense on `langfuse.api`.
 ## Related Resources
 
 - To move existing trace or observation reads to v2, see [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2).
+- To move existing score reads to v3, see the [Scores API migration guide](/docs/api-and-data-platform/features/scores-api#upgrade-from-v2).
 - To move existing metrics queries to v2, see [Metrics API v2](/docs/metrics/features/metrics-api#v2).
 - For large-scale data exports (e.g., all traces for fine-tuning or analytics), consider using the [Blob Storage Export](/docs/api-and-data-platform/features/export-to-blob-storage) to automatically sync data to S3, GCS, or Azure on a schedule instead of paginating through the API.
 - To manually export filtered data from the Langfuse UI, see [Export from UI](/docs/api-and-data-platform/features/export-from-ui).

--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -106,7 +106,7 @@ Scores:
 # Scores API v3 (recommended)
 scores = langfuse.api.scores_v3.get_many_v3(id="ScoreId")
 
-# Scores API v2 (deprecated, sunset 2026-10-31)
+# Scores API v2 (deprecated)
 scores = langfuse.api.scores.get_many(score_ids="ScoreId")
 ```
 
@@ -206,7 +206,7 @@ Scores:
 // Scores API v3 (recommended)
 const scoresV3 = await langfuse.api.scoresV3.getManyV3();
 
-// Scores API v2 (deprecated, sunset 2026-10-31)
+// Scores API v2 (deprecated)
 const scores = await langfuse.api.scores.getMany();
 ```
 

--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Query via SDKs
 sidebarTitle: Query via SDKs
-description: Query Langfuse data via Python and JS/TS SDKs using the high-performance v2 data APIs.
+description: Query Langfuse data via Python and JS/TS SDKs using the high-performance data APIs.
 ---
 
 # Query Data via SDKs

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -14,7 +14,7 @@ For general information about API authentication, base URLs, and SDK access, see
 
 <Callout type="info">
 
-The v2 score read endpoints are deprecated. Use Scores API v3 for all score reads. The score write endpoints (`POST /api/public/scores` and `DELETE /api/public/scores/{scoreId}`) are unchanged — no migration is needed for writes.
+This page covers reading scores. Scores are created via `POST /api/public/scores` or the SDK helpers — see [scores via API/SDK](/docs/evaluation/evaluation-methods/scores-via-sdk). Migrating from the deprecated v2 read endpoints? Jump to [Migrating from Scores API v2](#upgrade-from-v2).
 
 </Callout>
 
@@ -36,44 +36,42 @@ GET /api/public/v3/scores
 
 On self-hosted deployments, the v3 endpoint is available from Langfuse v3.179.0.
 
-The v3 Scores API is a redesigned endpoint optimized for predictable, high-performance score retrieval. It queries scores directly instead of joining trace data, returns a single typed `value` field, and uses cursor-based pagination.
+The Scores API queries scores directly instead of joining trace data, which keeps response times predictable at any volume. Responses carry a single typed `value` field, and results are paginated with a cursor.
 
-### Upgrade from Scores API v2 [#upgrade-from-v2]
+### Typed `value` Field
 
-| Existing usage                                             | Recommended replacement                                                                                  |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| List scores with `GET /api/public/v2/scores`               | Use `GET /api/public/v3/scores`                                                                          |
-| Fetch one score with `GET /api/public/v2/scores/{scoreId}` | Use `GET /api/public/v3/scores?id=<scoreId>` — v3 has no get-by-id endpoint; the `id` filter replaces it |
-| Create scores with `POST /api/public/scores`               | Unchanged                                                                                                |
-| Delete scores with `DELETE /api/public/scores/{scoreId}`   | Unchanged                                                                                                |
+Every score has a single `value` field whose type follows `dataType` — no decoding of booleans from `1`/`0` or looking up category strings:
 
-<Callout type="warning">
+| `dataType`    | `value` type | Notes                         |
+| ------------- | ------------ | ----------------------------- |
+| `NUMERIC`     | number       |                               |
+| `BOOLEAN`     | boolean      |                               |
+| `CATEGORICAL` | string       | The category                  |
+| `TEXT`        | string       |                               |
+| `CORRECTION`  | string       | Empty string if no correction |
 
-**v2 read deprecation**
+If your pipeline handles mixed score types, branch on `dataType`.
 
-The v2 score read endpoints are deprecated. Self-hosted deployments on Langfuse v4 and later do not include them — migrate to v3 before upgrading. On Langfuse Cloud they remain available for a transition period.
+### Field Groups
 
-</Callout>
+Responses always include a lean core — `id`, `projectId`, `name`, `value`, `dataType`, `source`, `timestamp`, `environment`, `createdAt`, `updatedAt` — and you opt into additional groups via a comma-separated `fields` parameter:
 
-### Key Changes
+```
+?fields=details,subject,annotation
+```
 
-**1. One Typed `value` Field**
+| Group        | Fields                                                   |
+| ------------ | -------------------------------------------------------- |
+| core         | Always included (see above)                              |
+| `details`    | comment, configId, metadata                              |
+| `subject`    | subject (the entity the score is attached to, see below) |
+| `annotation` | authorUserId, queueId                                    |
 
-The v2 API split score values across a numeric `value` and a separate `stringValue` field. The v3 API returns a single `value` field whose type follows `dataType`:
+Unknown group names return HTTP 400.
 
-| `dataType`    | v3 `value` type | v2 behavior                                                                                                               |
-| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `NUMERIC`     | number          | `value` (number)                                                                                                          |
-| `BOOLEAN`     | boolean         | `value` (`1`/`0`) plus `stringValue` (`"True"`/`"False"`)                                                                 |
-| `CATEGORICAL` | string          | `value` (numeric category mapping from the score config; not meaningful without one) plus `stringValue` (category string) |
-| `TEXT`        | string          | `stringValue` only                                                                                                        |
-| `CORRECTION`  | string          | `value` (always `0`) plus `stringValue` (correction content)                                                              |
+### `subject` Object
 
-When migrating, read `value` directly and branch on `dataType` if your pipeline handles mixed score types — no more decoding booleans from `1`/`0` or looking up category strings.
-
-**2. `subject` Object Replaces Flat Reference Fields**
-
-v2 score objects carried flat, nullable `traceId`, `observationId`, `sessionId`, and `datasetRunId` fields. v3 replaces them with an opt-in `subject` object (request it via `fields=subject`) that is discriminated by `kind`:
+Every score is attached to exactly one entity. Request the `subject` field group to see which one — it is discriminated by `kind`:
 
 ```json
 { "kind": "observation", "id": "obs-1", "traceId": "trace-1" }
@@ -82,67 +80,26 @@ v2 score objects carried flat, nullable `traceId`, `observationId`, `sessionId`,
 - `kind: "trace"` — `id` is the trace ID
 - `kind: "observation"` — `id` is the observation ID; includes the parent `traceId`
 - `kind: "session"` — `id` is the session ID
-- `kind: "experiment"` — `id` is the dataset run ID (v2's `datasetRunId` is renamed to experiment)
+- `kind: "experiment"` — `id` is the dataset run ID
 
-**3. Re-Partitioned Field Groups**
-
-v2 had two field groups, `score` and `trace`, both returned by default. v3 always returns a lean core and lets you opt into additional groups via a comma-separated `fields` parameter:
-
-```
-?fields=details,subject,annotation
-```
-
-| Group        | Fields                                                                                                      |
-| ------------ | ----------------------------------------------------------------------------------------------------------- |
-| core         | Always included: id, projectId, name, value, dataType, source, timestamp, environment, createdAt, updatedAt |
-| `details`    | comment, configId, metadata                                                                                 |
-| `subject`    | subject (the entity the score is attached to, see above)                                                    |
-| `annotation` | authorUserId, queueId                                                                                       |
-
-Unknown group names return HTTP 400. The v2 `trace` group (the trace's `userId`, `tags`, `environment`, `sessionId`) has no v3 equivalent because v3 does not join trace data — see [removed capabilities](#removed-capabilities).
-
-**4. Cursor-Based Pagination**
-
-The v2 API uses offset-based pagination (`page` parameter) which becomes increasingly slow for large datasets. The v3 API uses cursor-based pagination for better and more consistent performance.
-
-**How it works:**
+### Cursor-Based Pagination
 
 1. Make your initial request with a `limit` parameter (default 50, max 100)
 2. If more results exist, the response includes a `cursor` in the `meta` object
 3. Pass this cursor via the `cursor` parameter in your next request, repeating the same filter parameters as the initial request — the cursor encodes only the read position, not your query
 4. Repeat until no cursor is returned (you've reached the end)
 
-The response contains no `totalItems`/`totalPages` — total counts were removed by design; iterate the cursor instead. For recurring full exports to your data warehouse, use the [scheduled blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) instead of paginating through the API.
+The response contains no total counts — iterate the cursor until it is absent. For recurring full exports to your data warehouse, use the [scheduled blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) instead of paginating through the API.
 
-**5. New Filter Semantics**
+### Filtering
 
 - **Multi-value filters:** most filters accept comma-separated lists — `id`, `name`, `source`, `dataType`, `environment`, `configId`, `queueId`, `authorUserId`, `traceId`, `sessionId`, `observationId`, `experimentId`. Values within one parameter are OR-ed, parameters are AND-ed: `name=hallucination,toxicity&source=EVAL` returns eval scores named either `hallucination` or `toxicity`.
-- **Value filters replace `operator`:** use `value` for exact matches (comma-separated, requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`) or `valueMin`/`valueMax` for inclusive numeric range bounds (require `dataType=NUMERIC`).
+- **Value filters:** use `value` for exact matches (comma-separated, requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`) or `valueMin`/`valueMax` for inclusive numeric range bounds (require `dataType=NUMERIC`).
 - **Mutual exclusivity:** `traceId`, `sessionId`, and `experimentId` are mutually exclusive. `observationId` requires `traceId` because observation IDs are scoped to a trace.
 - **Case-insensitive enums:** `source` and `dataType` accept any casing (`numeric` and `NUMERIC` are equivalent).
 - **Timestamp bounds:** `fromTimestamp` is inclusive, `toTimestamp` is exclusive.
 
 Invalid filter combinations are rejected with HTTP 400 rather than silently ignored.
-
-### Removed Capabilities and Workarounds [#removed-capabilities]
-
-| v2 capability                         | v3 replacement                                                                    |
-| ------------------------------------- | --------------------------------------------------------------------------------- |
-| `userId` / `traceTags` filters        | Removed (HTTP 400) — v3 does not join trace data by design. See workaround below. |
-| `operator` parameter                  | Use `value` (exact multi-match) or `valueMin`/`valueMax` (numeric range).         |
-| Raw JSON `filter` parameter           | Map each condition to the typed query parameters. See metadata note below.        |
-| `totalItems` / `totalPages` in `meta` | Removed by design — iterate the cursor.                                           |
-| `scoreIds` parameter                  | Renamed to `id` (same comma-separated semantics).                                 |
-| `datasetRunId` parameter              | Renamed to `experimentId`.                                                        |
-
-**Filtering by trace properties (`userId`, `traceTags`):**
-
-- **Row-level:** query the [traces API](https://api.reference.langfuse.com/#tag/trace/GET/api/public/traces) with `userId`/`tags` filters first to collect the matching trace IDs, then pass them to v3's multi-value `traceId` filter (e.g. `traceId=t-1,t-2,t-3`).
-- **Aggregates:** if you only need aggregate score metrics per user, tag, or other trace-level dimensions, use the [Metrics API](/docs/metrics/features/metrics-api) instead — it supports trace-level dimensions and filters directly.
-
-**Filtering by score metadata:** the v2 JSON `filter` parameter supported metadata key-value conditions (`stringObject`). v3 has no metadata filter — request `fields=details` and filter on `metadata` client-side.
-
-**Row-count differences after migration:** because v2 joins trace data by default, it silently drops trace-level scores whose referenced trace cannot be found (e.g., the trace was deleted or never ingested). v3 queries scores directly and returns every matching score, so v3 can return rows that the same query on v2 did not.
 
 ### Common Use Cases
 
@@ -162,7 +119,7 @@ curl \
   "https://cloud.langfuse.com/api/public/v3/scores?traceId=trace-1,trace-2&fields=details,subject"
 ```
 
-**Fetching a single score by ID (replaces v2 get-by-id):**
+**Fetching a single score by ID:**
 
 ```bash
 curl \
@@ -188,7 +145,7 @@ curl \
 
 ### SDK Access [#sdk-access]
 
-The generated SDK clients expose the v3 endpoint directly. Score creation via the SDK helpers (e.g. `create_score` in Python) is unaffected by this migration.
+The generated SDK clients expose the v3 endpoint directly. Score creation uses separate SDK helpers (e.g. `create_score` in Python) — this client is for reads.
 
 <LangTabs items={["Python SDK", "JS/TS SDK"]}>
 <Tab title="Python SDK">
@@ -242,7 +199,7 @@ const scores = await langfuse.api.scoresV3.getManyV3({
 | `limit`         | integer  | Number of items per page. Defaults to 50, max 100 (larger values return HTTP 400)                                                                                                                    |
 | `cursor`        | string   | URL-safe base64 cursor for pagination (from previous response)                                                                                                                                       |
 | `fields`        | string   | Comma-separated field groups to include in addition to core: `details`, `subject`, `annotation`                                                                                                      |
-| `id`            | string   | Comma-separated list of score IDs (replaces v2 `scoreIds` and the get-by-id endpoint)                                                                                                                |
+| `id`            | string   | Comma-separated list of score IDs                                                                                                                                                                    |
 | `name`          | string   | Comma-separated list of score names                                                                                                                                                                  |
 | `source`        | string   | Comma-separated list of score sources (`API`, `ANNOTATION`, `EVAL`), case-insensitive                                                                                                                |
 | `dataType`      | string   | Comma-separated list of data types (`NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT`, `CORRECTION`), case-insensitive. Must be a single value when combined with `value`, `valueMin`, or `valueMax`       |
@@ -256,7 +213,7 @@ const scores = await langfuse.api.scoresV3.getManyV3({
 | `traceId`       | string   | Comma-separated list of trace IDs. Mutually exclusive with `sessionId`, `experimentId`                                                                                                               |
 | `sessionId`     | string   | Comma-separated list of session IDs. Mutually exclusive with `traceId`, `observationId`, `experimentId`                                                                                              |
 | `observationId` | string   | Comma-separated list of observation IDs. Requires `traceId`                                                                                                                                          |
-| `experimentId`  | string   | Comma-separated list of dataset run IDs (replaces v2 `datasetRunId`). Mutually exclusive with `traceId`, `sessionId`, `observationId`                                                                |
+| `experimentId`  | string   | Comma-separated list of dataset run IDs (experiment IDs). Mutually exclusive with `traceId`, `sessionId`, `observationId`                                                                            |
 | `fromTimestamp` | datetime | Inclusive lower bound on the score timestamp                                                                                                                                                         |
 | `toTimestamp`   | datetime | Exclusive upper bound on the score timestamp                                                                                                                                                         |
 
@@ -323,3 +280,67 @@ With `fields=details,subject,annotation`:
 **API Reference:** See the full [v3 Scores API Reference](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores) for all available parameters, response schemas, and interactive examples.
 
 </Callout>
+
+## Migrating from Scores API v2 [#upgrade-from-v2]
+
+<Callout type="warning">
+
+**v2 read deprecation**
+
+The v2 score read endpoints are deprecated. Self-hosted deployments on Langfuse v4 and later do not include them — migrate to v3 before upgrading. On Langfuse Cloud they remain available for a transition period.
+
+</Callout>
+
+Full endpoint mapping — only reads change, the write endpoints stay as they are:
+
+| Existing usage                                             | Recommended replacement                                                                                  |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| List scores with `GET /api/public/v2/scores`               | Use `GET /api/public/v3/scores`                                                                          |
+| Fetch one score with `GET /api/public/v2/scores/{scoreId}` | Use `GET /api/public/v3/scores?id=<scoreId>` — v3 has no get-by-id endpoint; the `id` filter replaces it |
+| Create scores with `POST /api/public/scores`               | Unchanged                                                                                                |
+| Delete scores with `DELETE /api/public/scores/{scoreId}`   | Unchanged                                                                                                |
+
+In the SDKs, replace `langfuse.api.scores.get_many(...)` (Python) / `langfuse.api.scores.getMany(...)` (JS/TS) with the v3 client shown under [SDK access](#sdk-access).
+
+### Response Changes
+
+**One typed `value` field.** The v2 API split score values across a numeric `value` and a separate `stringValue` field. v3 returns a single `value` typed by `dataType` (see [above](#v3)):
+
+| `dataType`    | v2 behavior                                                                                                               | v3 `value` |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `NUMERIC`     | `value` (number)                                                                                                          | number     |
+| `BOOLEAN`     | `value` (`1`/`0`) plus `stringValue` (`"True"`/`"False"`)                                                                 | boolean    |
+| `CATEGORICAL` | `value` (numeric category mapping from the score config; not meaningful without one) plus `stringValue` (category string) | string     |
+| `TEXT`        | `stringValue` only                                                                                                        | string     |
+| `CORRECTION`  | `value` (always `0`) plus `stringValue` (correction content)                                                              | string     |
+
+When migrating, read `value` directly and branch on `dataType` if your pipeline handles mixed score types.
+
+**`subject` object replaces flat reference fields.** v2 score objects carried flat, nullable `traceId`, `observationId`, `sessionId`, and `datasetRunId` fields. v3 replaces them with the opt-in [`subject` object](#v3) (request `fields=subject`); dataset runs appear as `kind: "experiment"` (v2's `datasetRunId`).
+
+**Re-partitioned field groups.** v2 had two field groups, `score` and `trace`, both returned by default. v3 always returns the core fields and offers `details`, `subject`, and `annotation` as opt-ins. The v2 `trace` group (the trace's `userId`, `tags`, `environment`, `sessionId`) has no v3 equivalent because v3 does not join trace data — see [removed capabilities](#removed-capabilities).
+
+### Query Changes
+
+- **Cursor pagination replaces offset pagination.** v2's `page` parameter and `totalItems`/`totalPages` meta are gone — pass `limit` and follow the `cursor` instead.
+- **`operator` is replaced by typed value filters.** Use `value` (exact multi-match) or `valueMin`/`valueMax` (numeric range).
+- **Renamed parameters:** `scoreIds` → `id`, `datasetRunId` → `experimentId` (same comma-separated semantics).
+- **Stricter validation:** `traceId`/`sessionId`/`experimentId` are mutually exclusive and `observationId` requires `traceId`; invalid combinations return HTTP 400 instead of being silently ignored.
+
+### Removed Capabilities and Workarounds [#removed-capabilities]
+
+| v2 capability                         | v3 replacement                                                                    |
+| ------------------------------------- | --------------------------------------------------------------------------------- |
+| `userId` / `traceTags` filters        | Removed (HTTP 400) — v3 does not join trace data by design. See workaround below. |
+| `operator` parameter                  | Use `value` (exact multi-match) or `valueMin`/`valueMax` (numeric range).         |
+| Raw JSON `filter` parameter           | Map each condition to the typed query parameters. See metadata note below.        |
+| `totalItems` / `totalPages` in `meta` | Removed by design — iterate the cursor.                                           |
+
+**Filtering by trace properties (`userId`, `traceTags`):**
+
+- **Row-level:** query the [traces API](https://api.reference.langfuse.com/#tag/trace/GET/api/public/traces) with `userId`/`tags` filters first to collect the matching trace IDs, then pass them to v3's multi-value `traceId` filter (e.g. `traceId=t-1,t-2,t-3`).
+- **Aggregates:** if you only need aggregate score metrics per user, tag, or other trace-level dimensions, use the [Metrics API](/docs/metrics/features/metrics-api) instead — it supports trace-level dimensions and filters directly.
+
+**Filtering by score metadata:** the v2 JSON `filter` parameter supported metadata key-value conditions (`stringObject`). v3 has no metadata filter — request `fields=details` and filter on `metadata` client-side.
+
+**Row-count differences after migration:** because v2 joins trace data by default, it silently drops trace-level scores whose referenced trace cannot be found (e.g., the trace was deleted or never ingested). v3 queries scores directly and returns every matching score, so v3 can return rows that the same query on v2 did not.

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -133,6 +133,8 @@ Invalid filter combinations are rejected with HTTP 400 rather than silently igno
 
 **Filtering by score metadata:** the v2 JSON `filter` parameter supported metadata key-value conditions (`stringObject`). v3 has no metadata filter — request `fields=details` and filter on `metadata` client-side.
 
+**Row-count differences after migration:** because v2 joins trace data by default, it silently drops trace-level scores whose referenced trace cannot be found (e.g., the trace was deleted or never ingested). v3 queries scores directly and returns every matching score, so v3 can return rows that the same query on v2 did not.
+
 ### Common Use Cases
 
 **Pulling failing evals:**

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -1,0 +1,314 @@
+---
+title: Scores API
+sidebarTitle: Scores API
+description: Retrieve scores from Langfuse with the v3 endpoint featuring a typed value field, cursor-based pagination, and selective field retrieval.
+---
+
+# Scores API
+
+The Scores API allows you to retrieve score data (evaluations, annotations, and API-ingested scores) from Langfuse for use in custom workflows, evaluation pipelines, and analytics.
+
+If you need aggregated score metrics (e.g., average scores grouped by trace name, user, or time period) rather than individual scores, the [Metrics API](/docs/metrics/features/metrics-api) is designed for this and avoids the need to fetch and aggregate raw data yourself.
+
+For general information about API authentication, base URLs, and SDK access, see the [Public API documentation](/docs/api-and-data-platform/features/public-api).
+
+<Callout type="info">
+
+The v2 score read endpoints are deprecated. Use Scores API v3 for all score reads. The score write endpoints (`POST /api/public/scores` and `DELETE /api/public/scores/{scoreId}`) are unchanged — no migration is needed for writes.
+
+</Callout>
+
+## Scores API v3 [#v3]
+
+```
+GET /api/public/v3/scores
+```
+
+The v3 Scores API is a redesigned endpoint optimized for predictable, high-performance score retrieval. It queries scores directly instead of joining trace data, returns a single typed `value` field, and uses cursor-based pagination.
+
+### Upgrade from Scores API v2 [#upgrade-from-v2]
+
+| Existing usage                                             | Recommended replacement                                                                                  |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| List scores with `GET /api/public/v2/scores`               | Use `GET /api/public/v3/scores`                                                                          |
+| Fetch one score with `GET /api/public/v2/scores/{scoreId}` | Use `GET /api/public/v3/scores?id=<scoreId>` — v3 has no get-by-id endpoint; the `id` filter replaces it |
+| Create scores with `POST /api/public/scores`               | Unchanged                                                                                                |
+| Delete scores with `DELETE /api/public/scores/{scoreId}`   | Unchanged                                                                                                |
+
+<Callout type="warning">
+
+**v2 read sunset**
+
+- **Langfuse Cloud** serves the v2 score read endpoints until **October 31, 2026** (`2026-10-31`). Migrate to v3 before this date.
+- **Self-hosted:** Langfuse v4 and later do not include the v2 score read endpoints. Migrate to v3 before upgrading.
+
+Until the sunset, v2 read responses include a structured `_deprecation` object (message, replacement endpoint, docs URL, and sunset date) so scripts and coding agents get a machine-readable, request-time migration signal.
+
+</Callout>
+
+### Key Changes
+
+**1. One Typed `value` Field**
+
+The v2 API split score values across a numeric `value` and a separate `stringValue` field. The v3 API returns a single `value` field whose type follows `dataType`:
+
+| `dataType`    | v3 `value` type | v2 behavior                                                             |
+| ------------- | --------------- | ----------------------------------------------------------------------- |
+| `NUMERIC`     | number          | `value` (number)                                                        |
+| `BOOLEAN`     | boolean         | `value` (`1`/`0`) plus `stringValue` (`"True"`/`"False"`)               |
+| `CATEGORICAL` | string          | `value` (numeric category mapping) plus `stringValue` (category string) |
+| `TEXT`        | string          | `stringValue` only                                                      |
+| `CORRECTION`  | string          | `value` (always `0`) plus `stringValue` (correction content)            |
+
+When migrating, read `value` directly and branch on `dataType` if your pipeline handles mixed score types — no more decoding booleans from `1`/`0` or looking up category strings.
+
+**2. `subject` Object Replaces Flat Reference Fields**
+
+v2 score objects carried flat, nullable `traceId`, `observationId`, `sessionId`, and `datasetRunId` fields. v3 replaces them with an opt-in `subject` object (request it via `fields=subject`) that is discriminated by `kind`:
+
+```json
+{ "kind": "observation", "id": "obs-1", "traceId": "trace-1" }
+```
+
+- `kind: "trace"` — `id` is the trace ID
+- `kind: "observation"` — `id` is the observation ID; includes the parent `traceId`
+- `kind: "session"` — `id` is the session ID
+- `kind: "experiment"` — `id` is the dataset run ID (v2's `datasetRunId` is renamed to experiment)
+
+**3. Re-Partitioned Field Groups**
+
+v2 had two field groups, `score` and `trace`, both returned by default. v3 always returns a lean core and lets you opt into additional groups via a comma-separated `fields` parameter:
+
+```
+?fields=details,subject,annotation
+```
+
+| Group        | Fields                                                                                                      |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| core         | Always included: id, projectId, name, value, dataType, source, timestamp, environment, createdAt, updatedAt |
+| `details`    | comment, configId, metadata                                                                                 |
+| `subject`    | subject (the entity the score is attached to, see above)                                                    |
+| `annotation` | authorUserId, queueId                                                                                       |
+
+Unknown group names return HTTP 400. The v2 `trace` group (the trace's `userId`, `tags`, `environment`, `sessionId`) has no v3 equivalent because v3 does not join trace data — see [removed capabilities](#removed-capabilities).
+
+**4. Cursor-Based Pagination**
+
+The v2 API uses offset-based pagination (`page` parameter) which becomes increasingly slow for large datasets. The v3 API uses cursor-based pagination for better and more consistent performance.
+
+**How it works:**
+
+1. Make your initial request with a `limit` parameter (default 50, max 100)
+2. If more results exist, the response includes a `cursor` in the `meta` object
+3. Pass this cursor via the `cursor` parameter in your next request to continue where you left off
+4. Repeat until no cursor is returned (you've reached the end)
+
+The response contains no `totalItems`/`totalPages` — total counts were removed by design; iterate the cursor instead. For recurring full exports to your data warehouse, use the [scheduled blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) instead of paginating through the API.
+
+**5. New Filter Semantics**
+
+- **Multi-value filters:** most filters accept comma-separated lists — `id`, `name`, `source`, `dataType`, `environment`, `configId`, `queueId`, `authorUserId`, `traceId`, `sessionId`, `observationId`, `experimentId`. Values within one parameter are OR-ed, parameters are AND-ed: `name=hallucination,toxicity&source=EVAL` returns eval scores named either `hallucination` or `toxicity`.
+- **Value filters replace `operator`:** use `value` for exact matches (comma-separated, requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`) or `valueMin`/`valueMax` for inclusive numeric range bounds (require `dataType=NUMERIC`).
+- **Mutual exclusivity:** `traceId`, `sessionId`, and `experimentId` are mutually exclusive. `observationId` requires `traceId` because observation IDs are scoped to a trace.
+- **Case-insensitive enums:** `source` and `dataType` accept any casing (`numeric` and `NUMERIC` are equivalent).
+- **Timestamp bounds:** `fromTimestamp` is inclusive, `toTimestamp` is exclusive.
+
+Invalid filter combinations are rejected with HTTP 400 rather than silently ignored.
+
+### Removed Capabilities and Workarounds [#removed-capabilities]
+
+| v2 capability                         | v3 replacement                                                                    |
+| ------------------------------------- | --------------------------------------------------------------------------------- |
+| `userId` / `traceTags` filters        | Removed (HTTP 400) — v3 does not join trace data by design. See workaround below. |
+| `operator` parameter                  | Use `value` (exact multi-match) or `valueMin`/`valueMax` (numeric range).         |
+| Raw JSON `filter` parameter           | Map each condition to the typed query parameters. See metadata note below.        |
+| `totalItems` / `totalPages` in `meta` | Removed by design — iterate the cursor.                                           |
+| `scoreIds` parameter                  | Renamed to `id` (same comma-separated semantics).                                 |
+| `datasetRunId` parameter              | Renamed to `experimentId`.                                                        |
+
+**Filtering by trace properties (`userId`, `traceTags`):**
+
+- **Row-level:** query the [traces API](https://api.reference.langfuse.com/#tag/trace/GET/api/public/traces) with `userId`/`tags` filters first to collect the matching trace IDs, then pass them to v3's multi-value `traceId` filter (e.g. `traceId=t-1,t-2,t-3`).
+- **Aggregates:** if you only need aggregate score metrics per user, tag, or other trace-level dimensions, use the [Metrics API](/docs/metrics/features/metrics-api) instead — it supports trace-level dimensions and filters directly.
+
+**Filtering by score metadata:** the v2 JSON `filter` parameter supported metadata key-value conditions (`stringObject`). v3 has no metadata filter — request `fields=details` and filter on `metadata` client-side.
+
+### Common Use Cases
+
+**Pulling failing evals:**
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v3/scores?name=hallucination,toxicity&dataType=NUMERIC&valueMax=0.5"
+```
+
+**Getting scores for specific traces, including what they are attached to:**
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v3/scores?traceId=trace-1,trace-2&fields=details,subject"
+```
+
+**Fetching a single score by ID (replaces v2 get-by-id):**
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v3/scores?id=your-score-id"
+```
+
+**Paginating through results:**
+
+```bash
+# First request
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v3/scores?fromTimestamp=2026-06-01T00:00:00Z&limit=100"
+
+# Response includes: "meta": { "limit": 100, "cursor": "eyJsYXN0..." }
+
+# Next request with cursor
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v3/scores?fromTimestamp=2026-06-01T00:00:00Z&limit=100&cursor=eyJsYXN0..."
+```
+
+### SDK Access [#sdk-access]
+
+The generated SDK clients expose the v3 endpoint directly. Score creation via the SDK helpers (e.g. `create_score` in Python) is unaffected by this migration.
+
+<LangTabs items={["Python SDK", "JS/TS SDK"]}>
+<Tab title="Python SDK">
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+# v3 (recommended)
+scores = langfuse.api.scores_v3.get_many_v3(
+    name="hallucination,toxicity",
+    data_type="NUMERIC",
+    value_max=0.5,
+    fields="details,subject",
+    limit=100,
+)
+
+# v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.get_many(...)
+```
+
+Also available as async via `langfuse.async_api.scores_v3.get_many_v3(...)`.
+
+</Tab>
+<Tab title="JS/TS SDK">
+
+```ts
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+// v3 (recommended)
+const scores = await langfuse.api.scoresV3.getManyV3({
+  name: "hallucination,toxicity",
+  dataType: "NUMERIC",
+  valueMax: 0.5,
+  fields: "details,subject",
+  limit: 100,
+});
+
+// v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.getMany(...)
+```
+
+</Tab>
+</LangTabs>
+
+### Parameters
+
+| Parameter       | Type     | Description                                                                                                                                                                                    |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limit`         | integer  | Number of items per page. Defaults to 50, max 100 (larger values return HTTP 400)                                                                                                              |
+| `cursor`        | string   | URL-safe base64 cursor for pagination (from previous response)                                                                                                                                 |
+| `fields`        | string   | Comma-separated field groups to include in addition to core: `details`, `subject`, `annotation`                                                                                                |
+| `id`            | string   | Comma-separated list of score IDs (replaces v2 `scoreIds` and the get-by-id endpoint)                                                                                                          |
+| `name`          | string   | Comma-separated list of score names                                                                                                                                                            |
+| `source`        | string   | Comma-separated list of score sources (`API`, `ANNOTATION`, `EVAL`), case-insensitive                                                                                                          |
+| `dataType`      | string   | Comma-separated list of data types (`NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT`, `CORRECTION`), case-insensitive. Must be a single value when combined with `value`, `valueMin`, or `valueMax` |
+| `environment`   | string   | Comma-separated list of environments                                                                                                                                                           |
+| `configId`      | string   | Comma-separated list of score config IDs                                                                                                                                                       |
+| `queueId`       | string   | Comma-separated list of annotation queue IDs                                                                                                                                                   |
+| `authorUserId`  | string   | Comma-separated list of author user IDs                                                                                                                                                        |
+| `value`         | string   | Comma-separated list of exact values. Requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`                                                                                   |
+| `valueMin`      | number   | Inclusive lower bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                        |
+| `valueMax`      | number   | Inclusive upper bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                        |
+| `traceId`       | string   | Comma-separated list of trace IDs. Mutually exclusive with `sessionId`, `experimentId`                                                                                                         |
+| `sessionId`     | string   | Comma-separated list of session IDs. Mutually exclusive with `traceId`, `observationId`, `experimentId`                                                                                        |
+| `observationId` | string   | Comma-separated list of observation IDs. Requires `traceId`                                                                                                                                    |
+| `experimentId`  | string   | Comma-separated list of dataset run IDs (replaces v2 `datasetRunId`). Mutually exclusive with `traceId`, `sessionId`, `observationId`                                                          |
+| `fromTimestamp` | datetime | Inclusive lower bound on the score timestamp                                                                                                                                                   |
+| `toTimestamp`   | datetime | Exclusive upper bound on the score timestamp                                                                                                                                                   |
+
+### Sample Response
+
+With `fields=details,subject,annotation`:
+
+```json
+{
+  "data": [
+    {
+      "id": "score-1",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "name": "hallucination",
+      "value": 0.25,
+      "dataType": "NUMERIC",
+      "source": "EVAL",
+      "timestamp": "2026-06-15T10:30:00Z",
+      "environment": "default",
+      "createdAt": "2026-06-15T10:30:01Z",
+      "updatedAt": "2026-06-15T10:30:01Z",
+      "comment": "Low hallucination risk",
+      "configId": null,
+      "metadata": {},
+      "authorUserId": null,
+      "queueId": null,
+      "subject": {
+        "kind": "observation",
+        "id": "support-chat-7-950dc53a-gen",
+        "traceId": "support-chat-7-950dc53a"
+      }
+    },
+    {
+      "id": "score-2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "name": "helpful",
+      "value": true,
+      "dataType": "BOOLEAN",
+      "source": "ANNOTATION",
+      "timestamp": "2026-06-15T11:00:00Z",
+      "environment": "default",
+      "createdAt": "2026-06-15T11:00:02Z",
+      "updatedAt": "2026-06-15T11:00:02Z",
+      "comment": null,
+      "configId": "cfg-1",
+      "metadata": {},
+      "authorUserId": "user-123",
+      "queueId": "queue-1",
+      "subject": {
+        "kind": "trace",
+        "id": "support-chat-7-950dc53a"
+      }
+    }
+  ],
+  "meta": {
+    "limit": 50,
+    "cursor": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNi0xNVQxMDozMDowMFoiLCJsYXN0SWQiOiJzY29yZS0xIn0"
+  }
+}
+```
+
+<Callout type="info">
+
+**API Reference:** See the full [v3 Scores API Reference](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores) for all available parameters, response schemas, and interactive examples.
+
+</Callout>

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -313,7 +313,7 @@ With `fields=details,subject,annotation`:
   ],
   "meta": {
     "limit": 50,
-    "cursor": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNi0xNVQxMDozMDowMFoiLCJsYXN0SWQiOiJzY29yZS0xIn0"
+    "cursor": "eyJ2IjoxLCJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNi0xNVQxMTowMDowMFoiLCJsYXN0SWQiOiJzY29yZS0yIn0"
   }
 }
 ```

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -37,12 +37,9 @@ The v3 Scores API is a redesigned endpoint optimized for predictable, high-perfo
 
 <Callout type="warning">
 
-**v2 read sunset**
+**v2 read deprecation**
 
-- **Langfuse Cloud** serves the v2 score read endpoints until **October 31, 2026** (`2026-10-31`). Migrate to v3 before this date.
-- **Self-hosted:** Langfuse v4 and later do not include the v2 score read endpoints. Migrate to v3 before upgrading.
-
-Until the sunset, v2 read responses include a structured `_deprecation` object (message, replacement endpoint, docs URL, and sunset date) so scripts and coding agents get a machine-readable, request-time migration signal.
+The v2 score read endpoints are deprecated. Self-hosted deployments on Langfuse v4 and later do not include them — migrate to v3 before upgrading. On Langfuse Cloud they remain available for a transition period.
 
 </Callout>
 
@@ -198,7 +195,7 @@ scores = langfuse.api.scores_v3.get_many_v3(
     limit=100,
 )
 
-# v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.get_many(...)
+# v2 (deprecated): langfuse.api.scores.get_many(...)
 ```
 
 Also available as async via `langfuse.async_api.scores_v3.get_many_v3(...)`.
@@ -220,7 +217,7 @@ const scores = await langfuse.api.scoresV3.getManyV3({
   limit: 100,
 });
 
-// v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.getMany(...)
+// v2 (deprecated): langfuse.api.scores.getMany(...)
 ```
 
 </Tab>

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -20,9 +20,21 @@ The v2 score read endpoints are deprecated. Use Scores API v3 for all score read
 
 ## Scores API v3 [#v3]
 
+<AvailabilityBanner
+  availability={{
+    hobby: "full",
+    core: "full",
+    pro: "full",
+    enterprise: "full",
+    selfHosted: "full",
+  }}
+/>
+
 ```
 GET /api/public/v3/scores
 ```
+
+On self-hosted deployments, the v3 endpoint is available from Langfuse v3.179.0.
 
 The v3 Scores API is a redesigned endpoint optimized for predictable, high-performance score retrieval. It queries scores directly instead of joining trace data, returns a single typed `value` field, and uses cursor-based pagination.
 
@@ -97,7 +109,7 @@ The v2 API uses offset-based pagination (`page` parameter) which becomes increas
 
 1. Make your initial request with a `limit` parameter (default 50, max 100)
 2. If more results exist, the response includes a `cursor` in the `meta` object
-3. Pass this cursor via the `cursor` parameter in your next request to continue where you left off
+3. Pass this cursor via the `cursor` parameter in your next request, repeating the same filter parameters as the initial request — the cursor encodes only the read position, not your query
 4. Repeat until no cursor is returned (you've reached the end)
 
 The response contains no `totalItems`/`totalPages` — total counts were removed by design; iterate the cursor instead. For recurring full exports to your data warehouse, use the [scheduled blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage) instead of paginating through the API.
@@ -225,28 +237,28 @@ const scores = await langfuse.api.scoresV3.getManyV3({
 
 ### Parameters
 
-| Parameter       | Type     | Description                                                                                                                                                                                    |
-| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `limit`         | integer  | Number of items per page. Defaults to 50, max 100 (larger values return HTTP 400)                                                                                                              |
-| `cursor`        | string   | URL-safe base64 cursor for pagination (from previous response)                                                                                                                                 |
-| `fields`        | string   | Comma-separated field groups to include in addition to core: `details`, `subject`, `annotation`                                                                                                |
-| `id`            | string   | Comma-separated list of score IDs (replaces v2 `scoreIds` and the get-by-id endpoint)                                                                                                          |
-| `name`          | string   | Comma-separated list of score names                                                                                                                                                            |
-| `source`        | string   | Comma-separated list of score sources (`API`, `ANNOTATION`, `EVAL`), case-insensitive                                                                                                          |
-| `dataType`      | string   | Comma-separated list of data types (`NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT`, `CORRECTION`), case-insensitive. Must be a single value when combined with `value`, `valueMin`, or `valueMax` |
-| `environment`   | string   | Comma-separated list of environments                                                                                                                                                           |
-| `configId`      | string   | Comma-separated list of score config IDs                                                                                                                                                       |
-| `queueId`       | string   | Comma-separated list of annotation queue IDs                                                                                                                                                   |
-| `authorUserId`  | string   | Comma-separated list of author user IDs                                                                                                                                                        |
-| `value`         | string   | Comma-separated list of exact values. Requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`                                                                                   |
-| `valueMin`      | number   | Inclusive lower bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                        |
-| `valueMax`      | number   | Inclusive upper bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                        |
-| `traceId`       | string   | Comma-separated list of trace IDs. Mutually exclusive with `sessionId`, `experimentId`                                                                                                         |
-| `sessionId`     | string   | Comma-separated list of session IDs. Mutually exclusive with `traceId`, `observationId`, `experimentId`                                                                                        |
-| `observationId` | string   | Comma-separated list of observation IDs. Requires `traceId`                                                                                                                                    |
-| `experimentId`  | string   | Comma-separated list of dataset run IDs (replaces v2 `datasetRunId`). Mutually exclusive with `traceId`, `sessionId`, `observationId`                                                          |
-| `fromTimestamp` | datetime | Inclusive lower bound on the score timestamp                                                                                                                                                   |
-| `toTimestamp`   | datetime | Exclusive upper bound on the score timestamp                                                                                                                                                   |
+| Parameter       | Type     | Description                                                                                                                                                                                          |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limit`         | integer  | Number of items per page. Defaults to 50, max 100 (larger values return HTTP 400)                                                                                                                    |
+| `cursor`        | string   | URL-safe base64 cursor for pagination (from previous response)                                                                                                                                       |
+| `fields`        | string   | Comma-separated field groups to include in addition to core: `details`, `subject`, `annotation`                                                                                                      |
+| `id`            | string   | Comma-separated list of score IDs (replaces v2 `scoreIds` and the get-by-id endpoint)                                                                                                                |
+| `name`          | string   | Comma-separated list of score names                                                                                                                                                                  |
+| `source`        | string   | Comma-separated list of score sources (`API`, `ANNOTATION`, `EVAL`), case-insensitive                                                                                                                |
+| `dataType`      | string   | Comma-separated list of data types (`NUMERIC`, `BOOLEAN`, `CATEGORICAL`, `TEXT`, `CORRECTION`), case-insensitive. Must be a single value when combined with `value`, `valueMin`, or `valueMax`       |
+| `environment`   | string   | Comma-separated list of environments                                                                                                                                                                 |
+| `configId`      | string   | Comma-separated list of score config IDs                                                                                                                                                             |
+| `queueId`       | string   | Comma-separated list of annotation queue IDs                                                                                                                                                         |
+| `authorUserId`  | string   | Comma-separated list of author user IDs                                                                                                                                                              |
+| `value`         | string   | Comma-separated list of exact values. Requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`. For `BOOLEAN` pass `true` or `false`; for `NUMERIC` each value must be a finite number |
+| `valueMin`      | number   | Inclusive lower bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                              |
+| `valueMax`      | number   | Inclusive upper bound on the numeric value. Requires `dataType=NUMERIC`                                                                                                                              |
+| `traceId`       | string   | Comma-separated list of trace IDs. Mutually exclusive with `sessionId`, `experimentId`                                                                                                               |
+| `sessionId`     | string   | Comma-separated list of session IDs. Mutually exclusive with `traceId`, `observationId`, `experimentId`                                                                                              |
+| `observationId` | string   | Comma-separated list of observation IDs. Requires `traceId`                                                                                                                                          |
+| `experimentId`  | string   | Comma-separated list of dataset run IDs (replaces v2 `datasetRunId`). Mutually exclusive with `traceId`, `sessionId`, `observationId`                                                                |
+| `fromTimestamp` | datetime | Inclusive lower bound on the score timestamp                                                                                                                                                         |
+| `toTimestamp`   | datetime | Exclusive upper bound on the score timestamp                                                                                                                                                         |
 
 ### Sample Response
 

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -61,13 +61,13 @@ The v2 score read endpoints are deprecated. Self-hosted deployments on Langfuse 
 
 The v2 API split score values across a numeric `value` and a separate `stringValue` field. The v3 API returns a single `value` field whose type follows `dataType`:
 
-| `dataType`    | v3 `value` type | v2 behavior                                                             |
-| ------------- | --------------- | ----------------------------------------------------------------------- |
-| `NUMERIC`     | number          | `value` (number)                                                        |
-| `BOOLEAN`     | boolean         | `value` (`1`/`0`) plus `stringValue` (`"True"`/`"False"`)               |
-| `CATEGORICAL` | string          | `value` (numeric category mapping) plus `stringValue` (category string) |
-| `TEXT`        | string          | `stringValue` only                                                      |
-| `CORRECTION`  | string          | `value` (always `0`) plus `stringValue` (correction content)            |
+| `dataType`    | v3 `value` type | v2 behavior                                                                                                               |
+| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `NUMERIC`     | number          | `value` (number)                                                                                                          |
+| `BOOLEAN`     | boolean         | `value` (`1`/`0`) plus `stringValue` (`"True"`/`"False"`)                                                                 |
+| `CATEGORICAL` | string          | `value` (numeric category mapping from the score config; not meaningful without one) plus `stringValue` (category string) |
+| `TEXT`        | string          | `stringValue` only                                                                                                        |
+| `CORRECTION`  | string          | `value` (always `0`) plus `stringValue` (correction content)                                                              |
 
 When migrating, read `value` directly and branch on `dataType` if your pipeline handles mixed score types — no more decoding booleans from `1`/`0` or looking up category strings.
 

--- a/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
+++ b/content/docs/evaluation/evaluation-methods/scores-via-sdk.mdx
@@ -138,7 +138,7 @@ with langfuse.start_as_current_observation(as_type="span", name="my-operation"):
 
 </Tab>
 <Tab>
-Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores), the value is returned as a boolean. See [API reference](/docs/api) for more details on POST/GET scores endpoints.
+Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores), the value is returned as a boolean. See [API reference](/docs/api) for more details on POST/GET scores endpoints.
 
 ```python
 from langfuse import get_client
@@ -295,7 +295,7 @@ await langfuse.flush();
 
 </Tab>
 <Tab>
-Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores), the value is returned as a boolean. See [API reference](/docs/api) for more details on POST/GET scores endpoints.
+Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores), the value is returned as a boolean. See [API reference](/docs/api) for more details on POST/GET scores endpoints.
 
 ```ts
 import { LangfuseClient } from "@langfuse/client";
@@ -385,7 +385,7 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 </Tab>
 <Tab>
-Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores), the value is returned as a boolean.
+Boolean scores must be provided as a float, where `1` is true and `0` is false. When read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores), the value is returned as a boolean.
 
 ```bash
 curl -X POST https://cloud.langfuse.com/api/public/scores \
@@ -877,7 +877,7 @@ Certain score properties might be inferred based on your input:
 
 - **If you don't provide a score data type** it will always be inferred. See tables below for details.
 - **For boolean and categorical scores**, we will provide the score value in both numerical and string format where possible. The score value format that is not provided as input, i.e. the translated value is referred to as the inferred value in the tables below.
-- **On read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores)**, boolean scores are returned as a single boolean `value`.
+- **On read via the [v3 scores API](https://api.reference.langfuse.com/#tag/scoresv3/GET/api/public/v3/scores)**, boolean scores are returned as a single boolean `value`.
 - **For categorical scores**, the string representation is always provided and a numerical mapping of the category will be produced only if a `ScoreConfig` was provided.
 
 Detailed Examples:


### PR DESCRIPTION
## Summary

Resolves [LFE-11063](https://linear.app/langfuse/issue/LFE-11063) — migration guide for scores API reads from `GET /api/public/v2/scores` to `GET /api/public/v3/scores`.

- **New page** `/docs/api-and-data-platform/features/scores-api`, mirroring the Observations API page structure: intro → upgrade mapping table → key changes → removed capabilities with workarounds → curl examples → SDK access → parameter table → sample response. All parameter semantics verified against `fern/apis/server/definition/scores-v3.yml` and the v3 route handler/server tests in the langfuse repo.
- **Cross-links:** Scores API v3 added to the "Retrieve Data via the API" list on `public-api`; `query-via-sdk` scores examples now show v3 first with the v2 example kept under a deprecation note (per review discussion); v3 changelog entry links the guide and its API-reference anchor is fixed (`tag/scores` → `tag/scoresv3`).
- No "Cloud-only" callout: the v3 route has no cloud/entitlement gating.

## Merge gating: none (decoupled)

The sunset date (2026-10-31) and the `_deprecation` response-object description were split out to the stacked follow-up #3337, which stays gated on langfuse/langfuse#15168 (LFE-10895). This PR documents only what is already true today (v2 reads deprecated, absent on self-hosted v4+) and **can merge independently**. A one-line follow-up on langfuse#15168 points `SCORES_DEPRECATION.docsUrl` at this page.

## Out of scope / follow-ups

- `cookbook/example_data_migration.ipynb` (+ JP translation) still read scores via v2 `api.scores.get_many` — tracked as a separate Linear ticket (notebooks need editing, regeneration, and a validation re-run).

## Checks

- `pnpm run format` ✔️
- `node scripts/check-h1-headings.js` ✔️
- Dev-server smoke test: all four changed pages render 200, new page contains upgrade table and SDK snippets ✔️

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Example validation (2026-07-20)

Every documented example was executed against a live Langfuse Cloud project (`cmpyefoyg03yiad0jeoymrmcv`), after seeding numeric/boolean/categorical scores at trace, observation, and session level via the unchanged `POST /api/public/scores`:

- **REST: 27/27 assertions passed** — all four curl examples; typed `value` per `dataType` (BOOLEAN → JSON `true`, CATEGORICAL → string); `subject` shape for all three seeded kinds; cursor pagination (3 pages, terminates, no duplicates); and all nine documented 400 cases (`userId`, `traceTags`, `fields=trace`, unknown field group, `limit=101`, `observationId` without `traceId`, `traceId`+`sessionId`, `valueMax` without `dataType`, `value` with `dataType=TEXT`).
- **Python SDK (langfuse 4.14.1)**: the `api.scores_v3.get_many_v3` example and the deprecated `api.scores.get_many` both pass.
- **JS SDK (@langfuse/client 5.4.0)**: the `api.scoresV3.getManyV3` example and the deprecated `api.scores.getMany` both pass.

The run surfaced one undocumented behavioral difference, now covered in the guide: v2's default trace join silently drops trace-level scores whose referenced trace cannot be found, while v3 returns them — row counts can differ after migration.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Scores API v2→v3 migration guide (`scores-api.mdx`) and updates four existing pages to cross-link it: the changelog entry, the public API overview, the SDK query guide, and the sidebar `meta.json`. The guide covers the upgrade mapping table, key API changes (typed value, subject object, field groups, cursor pagination, filter semantics), removed capabilities with workarounds, curl examples, SDK snippets, a parameter reference, and a sample response.

- **`scores-api.mdx`** (new page): comprehensive migration guide that accurately documents the v3 endpoint behavior, including the behavioral difference where v3 returns scores whose traces have been deleted (unlike v2's implicit trace join).
- **`public-api.mdx`**: adds Scores API v3 to the "Retrieve Data" list and deprecation callout, but a separate SDK callout at line 87-90 still lists `api.scores` (deprecated v2 reads) as a high-performance default — creating a contradiction on the same page.
- **`query-via-sdk.mdx`**: updates score examples and the warning callout correctly, but the page's frontmatter `description` still references "v2 data APIs".
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for most readers, but public-api.mdx now has a directly contradictory statement about which scores API namespace to use in the SDK.

The new migration guide content is accurate and well-structured. However, the public-api.mdx SDK callout still tells users that api.scores is the recommended high-performance default while the updated section on the same page directs them to Scores API v3 — readers who land on the SDK section first will follow the deprecated path.

content/docs/api-and-data-platform/features/public-api.mdx — the SDK callout block at lines 87-90 needs to be updated to match the rest of the page's guidance.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
content/docs/api-and-data-platform/features/public-api.mdx:87-90
**Stale SDK defaults callout contradicts updated content below**

This callout lists `api.scores` as one of the "high-performance" defaults in SDK v4/v5, but the PR simultaneously updates the "Retrieve Data via the API" section to recommend Scores API v3 and marks `api.scores` (v2 reads) as deprecated. Readers of this SDK section will receive conflicting guidance: the callout says `api.scores` is the recommended high-performance path while the updated section below tells them to use v3. The callout should be updated to reference `api.scores_v3` / `api.scoresV3` as now preferred and link to the migration guide.

### Issue 2 of 4
content/docs/api-and-data-platform/features/query-via-sdk.mdx:4
The frontmatter description still says "v2 data APIs", which is stale now that scores is on v3. This is the text surfaced in search results and link previews.

```suggestion
description: Query Langfuse data via Python and JS/TS SDKs using the high-performance data APIs (Observations v2, Scores v3, Metrics v2).
```

### Issue 3 of 4
content/docs/api-and-data-platform/features/scores-api.mdx:161-175
**Cursor pagination example doesn't clarify filter re-send requirement**

The second cursor request silently repeats `fromTimestamp` and `limit` alongside `cursor`, but the guide never explicitly states whether original filter parameters must accompany each cursor request or whether the cursor is self-contained. A user who reads only the numbered explanation (steps 1–4) and then writes their own loop may pass only `cursor=…` and inadvertently retrieve unfiltered results (or get a server error) if filters are required. A one-line note — e.g., "include the same filter parameters as your initial request along with the cursor" — would prevent this ambiguity.

### Issue 4 of 4
content/docs/api-and-data-platform/features/scores-api.mdx:241
**`value` filter format for BOOLEAN is unspecified**

The table says the `value` parameter "Requires a single `dataType` of `NUMERIC`, `BOOLEAN`, or `CATEGORICAL`" but doesn't say what string to supply for a BOOLEAN score. Users migrating from v2 (where they filtered with `value=1` for true) will not know whether to pass `value=true`, `value=True`, or `value=1` in v3. The Key Changes section confirms the response now uses JSON `true`/`false`, but that doesn't settle the query-parameter encoding. A parenthetical like "(for BOOLEAN use `true` or `false`)" would remove the ambiguity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: decouple guide from LFE-10895 — dr..."](https://github.com/langfuse/langfuse-docs/commit/bfd62d0fbc7ef992133eee28d5593f20245cc5e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45659229)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->