### PR TITLE
docs: state the v2 scores read sunset date (LFE-11063)

### DIFF
--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -103,7 +103,7 @@ Scores:
 # Scores API v3 (recommended)
 scores = langfuse.api.scores_v3.get_many_v3(id="ScoreId")
 
-# Scores API v2 (deprecated)
+# Scores API v2 (deprecated, sunset 2026-10-31)
 scores = langfuse.api.scores.get_many(score_ids="ScoreId")
 ```
 
@@ -203,7 +203,7 @@ Scores:
 // Scores API v3 (recommended)
 const scoresV3 = await langfuse.api.scoresV3.getManyV3();
 
-// Scores API v2 (deprecated)
+// Scores API v2 (deprecated, sunset 2026-10-31)
 const scores = await langfuse.api.scores.getMany();
 ```
 

--- a/content/docs/api-and-data-platform/features/query-via-sdk.mdx
+++ b/content/docs/api-and-data-platform/features/query-via-sdk.mdx
@@ -103,7 +103,7 @@ Scores:
 # Scores API v3 (recommended)
 scores = langfuse.api.scores_v3.get_many_v3(id="ScoreId")
 
-# Scores API v2 (deprecated, sunset 2026-10-31)
+# Scores API v2 (deprecated, sunset 2026-11-16)
 scores = langfuse.api.scores.get_many(score_ids="ScoreId")
 ```
 
@@ -203,7 +203,7 @@ Scores:
 // Scores API v3 (recommended)
 const scoresV3 = await langfuse.api.scoresV3.getManyV3();
 
-// Scores API v2 (deprecated, sunset 2026-10-31)
+// Scores API v2 (deprecated, sunset 2026-11-16)
 const scores = await langfuse.api.scores.getMany();
 ```
 

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -162,7 +162,7 @@ scores = langfuse.api.scores_v3.get_many_v3(
     limit=100,
 )
 
-# v2 (deprecated): langfuse.api.scores.get_many(...)
+# v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.get_many(...)
 ```
 
 Also available as async via `langfuse.async_api.scores_v3.get_many_v3(...)`.
@@ -184,7 +184,7 @@ const scores = await langfuse.api.scoresV3.getManyV3({
   limit: 100,
 });
 
-// v2 (deprecated): langfuse.api.scores.getMany(...)
+// v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.getMany(...)
 ```
 
 </Tab>

--- a/content/docs/api-and-data-platform/features/scores-api.mdx
+++ b/content/docs/api-and-data-platform/features/scores-api.mdx
@@ -162,7 +162,7 @@ scores = langfuse.api.scores_v3.get_many_v3(
     limit=100,
 )
 
-# v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.get_many(...)
+# v2 (deprecated, sunset 2026-11-16): langfuse.api.scores.get_many(...)
 ```
 
 Also available as async via `langfuse.async_api.scores_v3.get_many_v3(...)`.
@@ -184,7 +184,7 @@ const scores = await langfuse.api.scoresV3.getManyV3({
   limit: 100,
 });
 
-// v2 (deprecated, sunset 2026-10-31): langfuse.api.scores.getMany(...)
+// v2 (deprecated, sunset 2026-11-16): langfuse.api.scores.getMany(...)
 ```
 
 </Tab>

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -213,7 +213,7 @@ The deprecated endpoint's filters map to v2 `filters` entries: `traceName` and `
 
 ## Scores [#scores]
 
-**Deprecated:** `GET /scores` (v1), `GET /scores/{scoreId}`, `GET /v2/scores`, `GET /v2/scores/{scoreId}`. On Langfuse v4, these will return `404`.
+**Deprecated:** `GET /scores` (v1), `GET /scores/{scoreId}`, `GET /v2/scores`, `GET /v2/scores/{scoreId}`. Langfuse Cloud serves these endpoints until **October 31, 2026** (`2026-10-31`); migrate to v3 before this date. On Langfuse v4, these will return `404`.
 
 **Replacement:** [`GET /v3/scores`](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores). See the [Scores API v3 announcement](/changelog/2026-06-10-scores-v3-api) for background.
 

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -213,7 +213,7 @@ The deprecated endpoint's filters map to v2 `filters` entries: `traceName` and `
 
 ## Scores [#scores]
 
-**Deprecated:** `GET /scores` (v1), `GET /scores/{scoreId}`, `GET /v2/scores`, `GET /v2/scores/{scoreId}`. Langfuse Cloud serves these endpoints until **October 31, 2026** (`2026-10-31`); migrate to v3 before this date. On Langfuse v4, these will return `404`.
+**Deprecated:** `GET /scores` (v1), `GET /scores/{scoreId}`, `GET /v2/scores`, `GET /v2/scores/{scoreId}`. Langfuse Cloud serves these endpoints until **November 16, 2026** (`2026-11-16`); migrate to v3 before this date. On Langfuse v4, these will return `404`.
 
 **Replacement:** [`GET /v3/scores`](https://api.reference.langfuse.com/#tag/scores/GET/api/public/v3/scores). See the [Scores API v3 announcement](/changelog/2026-06-10-scores-v3-api) for background.
 


### PR DESCRIPTION
## Summary

Documents the **2026-11-16** sunset date for the deprecated v2 score read endpoints on Langfuse Cloud, shipped in langfuse/langfuse#15168 ([LFE-10895](https://linear.app/clickhouse/issue/LFE-10895)). This PR is intentionally scoped to the sunset date only:

- Adds the Cloud sunset date to the Scores section of the [deprecated-API migration FAQ](https://langfuse.com/faq/all/deprecated-api-migration#scores).
- Extends the `v2 (deprecated)` SDK example comments on `scores-api` and `query-via-sdk` with the sunset date.

The migration guide itself already merged via #3335 / #3362; the former merge gate on langfuse/langfuse#15168 is resolved since that PR shipped on 2026-07-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)