### PR TITLE
Clarify OTEL span billing impact and defuse handbook refund/OTEL wording

### DIFF
--- a/content/faq/all/existing-otel-setup.mdx
+++ b/content/faq/all/existing-otel-setup.mdx
@@ -388,14 +388,18 @@ setLangfuseTracerProvider(langfuseProvider);
 
 Your Langfuse dashboard shows HTTP requests, database queries, or other infrastructure spans instead of just LLM traces.
 
+<Callout type="warning">
+Every span that reaches Langfuse is ingested as a **billable observation**. If your OpenTelemetry pipeline forwards HTTP, database, or framework spans, they are counted and billed like any other observation, so an over-permissive export configuration can increase your usage and cost significantly. You control what reaches Langfuse through the `should_export_span` / `shouldExportSpan` callback described below. To catch unexpected volume early, set up [spend alerts](/docs/administration/spend-alerts) and review how usage is counted in [billable units](/docs/administration/billable-units).
+</Callout>
+
 **Why this happens**
 
-This usually happens when one of these is true:
+Langfuse attaches its span processor to your [TracerProvider](#global-tracer-provider). If that provider also has OTEL auto-instrumentation attached, spans from your web frameworks, databases, and HTTP clients flow through the same pipeline. They reach Langfuse when one of these is true:
 
-- You configured a custom `should_export_span` / `shouldExportSpan` callback that is too permissive
-- A third-party span matches Langfuse's default LLM-focused criteria (`gen_ai.*` attributes or known LLM scope)
+- Your custom `should_export_span` / `shouldExportSpan` callback is more permissive than the default filter
+- A third-party span matches the default LLM-focused criteria (`gen_ai.*` attributes or a known LLM scope)
 
-This is especially common with [OTEL auto-instrumentation](https://opentelemetry.io/docs/platforms/kubernetes/operator/automatic/), which instruments web frameworks, databases, HTTP clients, and more.
+This is especially common with [OTEL auto-instrumentation](https://opentelemetry.io/docs/platforms/kubernetes/operator/automatic/), which instruments web frameworks, databases, HTTP clients, and more. You decide what reaches Langfuse: the export filter is yours to configure.
 
 **How to debug**
 

--- a/content/handbook/support/how-to-answer-support-questions.mdx
+++ b/content/handbook/support/how-to-answer-support-questions.mdx
@@ -227,7 +227,7 @@ This is the most sensitive billing question. Lead with empathy and _facts_, neve
 1. Open Stripe, search by email domain or org → recent invoice, subscription, billing history.
 2. Determine the source of the increase: plan change, usage increase (more traces/observations), seat increase, or one-off charge.
 3. Cross-check the org in Impersonation View → Usage tab → confirm trace/observation volume in the billing period.
-4. **Specifically check for OTEL-related overcounting.** A common case: customers had a pre-existing OTEL setup, and after wiring it to Langfuse it ingested unrelated HTTP/DB/framework spans that drove up volume. See [/faq/all/existing-otel-setup#unwanted-spans-in-langfuse](/faq/all/existing-otel-setup#unwanted-spans-in-langfuse), the fix is `should_export_span` on the SDK (the older `blocked_instrumentation_scopes` parameter is deprecated).
+4. **Check whether their OTEL configuration is exporting non-LLM spans.** A common case: customers wire a pre-existing OTEL setup into Langfuse and their export filter lets HTTP/DB/framework spans through. Those spans are ingested and billed as observations like any other. The customer controls what is exported via `should_export_span` on the SDK (the older `blocked_instrumentation_scopes` parameter is deprecated). See [/faq/all/existing-otel-setup#unwanted-spans-in-langfuse](/faq/all/existing-otel-setup#unwanted-spans-in-langfuse).
 5. Reply with the specific reason, link the invoice or usage view.
 
 **Reply template:**
@@ -299,10 +299,8 @@ Best,
 **Triage steps:**
 
 1. Confirm what was charged and when via Stripe.
-2. Determine if the charge was correct (customer's mistake / they didn't downgrade in time) or our error (billing bug / contract misalignment / EE-license-removal-doesn't-cancel confusion above).
-3. Customer error and they're on a small plan: explain politely, offer goodwill credit if appropriate.
-4. Our error or genuine misunderstanding: refund.
-5. For approval limits and when to loop in the team, follow the internal refund handling guidelines in the private handbook. Do not approve refunds beyond your limit unilaterally.
+2. Do not confirm, deny, or estimate a refund on the thread. Whether a charge is eligible for a refund or goodwill credit, the approval limits, and when to loop in the team all follow the internal refund handling guidelines in the private handbook.
+3. Acknowledge the request, gather the details finance needs, and route it per those guidelines. Do not approve refunds beyond your limit unilaterally.
 
 **Reply template:**
 
@@ -640,7 +638,7 @@ Related FAQs: [/faq/all/missing-traces](/faq/all/missing-traces), [/faq/all/aws-
 
 <summary>OTEL / OpenTelemetry: unwanted spans, double-counting, semantic conventions</summary>
 
-OTEL is the most common source of _over-ingestion_ surprises. The customer's existing OTEL setup blasts every HTTP request, DB query, and framework span at Langfuse, driving up cost and cluttering the UI.
+A common OTEL configuration issue: the customer's existing OTEL setup exports every HTTP request, DB query, and framework span to Langfuse alongside LLM spans. Because every exported span is ingested and billed as an observation, this increases both cost and UI clutter until the export filter is tightened.
 
 **Triage steps:**
 


### PR DESCRIPTION
## Context

A customer hit the OTEL **unwanted-spans** failure mode (a shared OTEL pipeline forwarding BullMQ/Prisma/HTTP/framework spans to Langfuse) and received a large surprise invoice. They cited two of our docs pages to argue the volume "wasn't real usage" and that the charge was refund-eligible:

- `faq/all/existing-otel-setup#unwanted-spans-in-langfuse`
- `handbook/support/how-to-answer-support-questions` (our **public** support playbook)

Two things in the docs enabled that argument: the OTEL FAQ framed a billing problem as cosmetic UI clutter, and the public support playbook exposed our internal refund decision criteria and used blame-implying language ("OTEL-related overcounting", "over-ingestion surprises") that reads as an admission of fault.

## Changes

**`content/faq/all/existing-otel-setup.mdx`** — "Unwanted Spans" section:
- Added a warning callout: every exported span is a **billable observation**, an over-permissive export config raises cost, and the customer controls this via `shouldExportSpan`.
- Cross-linked [spend alerts](/docs/administration/spend-alerts) and [billable units](/docs/administration/billable-units).
- Reframed "Why this happens" so the export filter is clearly the customer's to configure.

**`content/handbook/support/how-to-answer-support-questions.mdx`**:
- Removed the public refund decision criteria (the "genuine misunderstanding: refund" line + customer-error/our-error breakdown); routes to the private handbook instead.
- Softened the billing/OTEL branch wording ("overcounting", "over-ingestion surprises", "blasts … at Langfuse") to neutral configuration language.

## Still open (not in this PR)

The support playbook is still **publicly indexed** (normal content collection, in sitemap, no noindex). The wording is defused but the page remains readable/citable. De-indexing or gating it is a separate policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the billing impact of permissive OTEL export filters and moves refund decisions out of the public support playbook. The main changes are:

- Adds an OTEL billing warning with spend-alert and billable-unit links.
- Explains how default and custom span filters admit unwanted spans.
- Routes refund eligibility and approval decisions to private guidance.
- Replaces blame-oriented support wording with neutral configuration language.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation is mergeable after scoping its billing claims to usage-metered deployments.

- The OTEL API names, links, and MDX callout are consistent with existing documentation.
- Two unconditional billing statements incorrectly include self-hosted OSS deployments.
- The issue is limited to customer and support guidance.

content/faq/all/existing-otel-setup.mdx and content/handbook/support/how-to-answer-support-questions.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/faq/all/existing-otel-setup.mdx:392
**Self-Hosted Spans Are Not Billed**

This statement also reaches self-hosted OSS users, but the billable-units documentation says OSS has no usage-based billing. Those users are incorrectly told that every ingested span is billable and can increase their Langfuse cost.

```suggestion
Every span that reaches Langfuse is ingested as an **observation**. On usage-metered deployments such as Langfuse Cloud, each observation is billable, so an over-permissive export configuration can increase your usage and cost significantly. You control what reaches Langfuse through the `should_export_span` / `shouldExportSpan` callback described below. To catch unexpected volume early, set up [spend alerts](/docs/administration/spend-alerts) and review how usage is counted in [billable units](/docs/administration/billable-units).
```

### Issue 2 of 2
content/handbook/support/how-to-answer-support-questions.mdx:641
**Billing Claim Ignores Deployment Model**

Support staff can apply this unconditional statement to a self-hosted OSS customer even though that deployment has no usage-based billing. This can produce incorrect billing guidance during OTEL support conversations.

```suggestion
A common OTEL configuration issue: the customer's existing OTEL setup exports every HTTP request, DB query, and framework span to Langfuse alongside LLM spans. Every exported span is ingested as an observation, increasing UI clutter until the export filter is tightened. On usage-metered deployments such as Langfuse Cloud, these observations also increase billable usage.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify OTEL span billing impact and def..."](https://github.com/langfuse/langfuse-docs/commit/99117800a1adb0c0780a98ad291671be6d0c77be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45887289)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->