### PR TITLE
Track agent prompt copy clicks

### DIFF
--- a/components/academy/AgentPromptCallout.tsx
+++ b/components/academy/AgentPromptCallout.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
+import { usePathname } from "next/navigation";
 import { useState } from "react";
 
 export interface AgentPromptCalloutProps {
@@ -19,11 +21,20 @@ export function AgentPromptCallout({
   lede,
   prompt,
 }: AgentPromptCalloutProps) {
+  const pathname = usePathname();
+  const capture = usePostHogClientCapture();
   const [copied, setCopied] = useState(false);
+  const trimmedPrompt = prompt.trim();
 
   const onCopy = () => {
     if (typeof navigator === "undefined" || !navigator.clipboard) return;
-    navigator.clipboard.writeText(prompt.trim()).then(
+    capture("copy_agent_prompt", {
+      source: "agent_prompt_callout",
+      path: pathname ?? "",
+      prompt_char_count: trimmedPrompt.length,
+    });
+
+    navigator.clipboard.writeText(trimmedPrompt).then(
       () => {
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
@@ -61,7 +72,7 @@ export function AgentPromptCallout({
       )}
 
       <div className="agent-prompt__prompt">
-        <pre className="agent-prompt__code">{prompt.trim()}</pre>
+        <pre className="agent-prompt__code">{trimmedPrompt}</pre>
         <button
           type="button"
           onClick={onCopy}

--- a/components/academy/japan/AgentPromptCallout.tsx
+++ b/components/academy/japan/AgentPromptCallout.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
+import { usePathname } from "next/navigation";
 import { useState } from "react";
 
 export interface AgentPromptCalloutProps {
@@ -19,11 +21,20 @@ export function AgentPromptCallout({
   lede,
   prompt,
 }: AgentPromptCalloutProps) {
+  const pathname = usePathname();
+  const capture = usePostHogClientCapture();
   const [copied, setCopied] = useState(false);
+  const trimmedPrompt = prompt.trim();
 
   const onCopy = () => {
     if (typeof navigator === "undefined" || !navigator.clipboard) return;
-    navigator.clipboard.writeText(prompt.trim()).then(
+    capture("copy_agent_prompt", {
+      source: "agent_prompt_callout",
+      path: pathname ?? "",
+      prompt_char_count: trimmedPrompt.length,
+    });
+
+    navigator.clipboard.writeText(trimmedPrompt).then(
       () => {
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
@@ -61,7 +72,7 @@ export function AgentPromptCallout({
       )}
 
       <div className="agent-prompt__prompt">
-        <pre className="agent-prompt__code">{prompt.trim()}</pre>
+        <pre className="agent-prompt__code">{trimmedPrompt}</pre>
         <button
           type="button"
           onClick={onCopy}

--- a/src/usePostHogClientCapture.ts
+++ b/src/usePostHogClientCapture.ts
@@ -5,6 +5,11 @@ import { usePostHog } from "posthog-js/react";
 // This preserves existing PostHog event structure while adding type safety
 interface EventDefinitions {
   copy_page: { type: "copy" | "chatgpt" | "claude" | "mcp" };
+  copy_agent_prompt: {
+    source: "agent_prompt_callout";
+    path: string;
+    prompt_char_count: number;
+  };
 }
 
 type EventName = keyof EventDefinitions;


### PR DESCRIPTION
Summary: Track AgentPromptCallout copy clicks in PostHog with path and prompt length, without sending copied prompt contents. Tests: pnpm run format:check, pnpm exec tsc --noEmit --pretty false.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds analytics for AgentPromptCallout copy clicks. The main changes are:

- Records the current path and trimmed prompt length in PostHog.
- Keeps copied prompt contents out of the analytics payload.
- Reuses the trimmed prompt for display and clipboard writes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new hooks run within an existing client component and the application-level PostHog provider.
- Tracking occurs only after clipboard support is detected and does not include prompt contents.

</details>

<sub>Reviews (1): Last reviewed commit: ["Track agent prompt copy clicks"](https://github.com/langfuse/langfuse-docs/commit/b3f6117da937e3137b9a6d88b83eb49fd39cbc31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45898514)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->