### PR TITLE
docs: document boolean score widgets and monitors

### DIFF
--- a/content/changelog/2026-07-21-boolean-score-dashboards-monitors.mdx
+++ b/content/changelog/2026-07-21-boolean-score-dashboards-monitors.mdx
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-21
-title: Track boolean scores in dashboards and monitors
+title: Track and alert on boolean scores
 description: Visualize true rates and alert on boolean evaluation results.
 author: Tobias Wochinger
 ---

--- a/content/changelog/2026-07-21-boolean-score-dashboards-monitors.mdx
+++ b/content/changelog/2026-07-21-boolean-score-dashboards-monitors.mdx
@@ -1,0 +1,36 @@
+---
+date: 2026-07-21
+title: Track boolean scores in dashboards and monitors
+description: Visualize true rates and alert on boolean evaluation results.
+author: Tobias Wochinger
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Bell, Book, LayoutDashboard } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now use **boolean scores** in dashboard widgets and monitors. Track the rate of passed policy checks or detected hallucinations, filter and break down results by `true` or `false`, and alert when the rate crosses a threshold.
+
+## Learn more
+
+<Cards num={3}>
+  <Card
+    title="Custom dashboards"
+    href="/docs/metrics/features/custom-dashboards"
+    icon={<LayoutDashboard />}
+    arrow
+  />
+  <Card
+    title="Monitors"
+    href="/docs/metrics/features/monitors"
+    icon={<Bell />}
+    arrow
+  />
+  <Card
+    title="Metrics API"
+    href="/docs/metrics/features/metrics-api"
+    icon={<Book />}
+    arrow
+  />
+</Cards>

--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -49,11 +49,12 @@ The v2 Metrics API provides significant performance improvements through an opti
 
 ### Available Views in v2
 
-| View                 | Description                                                         |
-| -------------------- | ------------------------------------------------------------------- |
-| `observations`       | Query observation-level data with optional trace-level aggregations |
-| `scores-numeric`     | Query numeric and boolean scores                                    |
-| `scores-categorical` | Query categorical (string) scores                                   |
+| View                 | Description                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `observations`       | Query observation-level data with optional trace-level aggregations                           |
+| `scores-numeric`     | Query numeric scores                                                                          |
+| `scores-categorical` | Query categorical (string) scores                                                             |
+| `scores-boolean`     | Query boolean scores; group or filter by `booleanValue`, or average `value` for the true rate |
 
 ### Row Limit
 
@@ -126,7 +127,7 @@ The v1 API accepts a JSON query object passed as a URL-encoded parameter:
 
 | Field           | Type   | Required | Description                                                                                                                                                              |
 | --------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `view`          | string | Yes      | The data view to query: `"traces"`, `"observations"`, `"scores-numeric"`, or `"scores-categorical"`                                                                      |
+| `view`          | string | Yes      | The data view to query: `"traces"`, `"observations"`, `"scores-numeric"`, `"scores-categorical"`, or `"scores-boolean"`                                                  |
 | `dimensions`    | array  | No       | Array of dimension objects to group by, e.g. `[{ "field": "name" }]`                                                                                                     |
 | `metrics`       | array  | Yes      | Array of metric objects to calculate, e.g. `[{ "measure": "latency", "aggregation": "p95" }]`                                                                            |
 | `filters`       | array  | No       | Array of filter objects to narrow results, e.g. `[{ "column": "metadata", "operator": "contains", "key": "customKey", "value": "customValue", "type": "stringObject" }]` |
@@ -252,8 +253,9 @@ The v1 Metrics API provides access to several data views, each with its own set 
 | -------------------- | ----------------------------------- |
 | `traces`             | Query data at the trace level       |
 | `observations`       | Query data at the observation level |
-| `scores-numeric`     | Query numeric and boolean scores    |
+| `scores-numeric`     | Query numeric scores                |
 | `scores-categorical` | Query categorical (string) scores   |
+| `scores-boolean`     | Query boolean scores                |
 
 #### Trace Dimensions
 
@@ -342,6 +344,19 @@ The v1 Metrics API provides access to several data views, each with its own set 
 | ------- | ------------------- |
 | `count` | Count of scores     |
 | `value` | Numeric score value |
+
+##### Boolean Scores
+
+| Metric  | Description                                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------------- |
+| `count` | Count of scores                                                                                            |
+| `value` | Numeric score value, where `0` is false and `1` is true. Use the `avg` aggregation to return the true rate |
+
+Boolean scores have an additional dimension:
+
+| Dimension      | Type    | Description                                           |
+| -------------- | ------- | ----------------------------------------------------- |
+| `booleanValue` | boolean | Boolean value of the score for grouping and filtering |
 
 ##### Categorical Scores
 

--- a/content/docs/metrics/features/monitors.mdx
+++ b/content/docs/metrics/features/monitors.mdx
@@ -39,11 +39,13 @@ Navigate to [**Monitors**](https://cloud.langfuse.com/project/~/monitors) in you
 
 Choose what data the monitor measures.
 
-| Field           | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| **Data source** | `Observations`, `Scores (numeric)`, or `Scores (categorical)`     |
-| **Metric**      | Aggregation + measure — e.g. `avg latency`, `count`, `p95 cost`   |
-| **Filters**     | Narrow the dataset (model name, tags, user ID, environment, etc.) |
+| Field           | Description                                                                       |
+| --------------- | --------------------------------------------------------------------------------- |
+| **Data source** | `Observations`, `Scores (numeric)`, `Scores (categorical)`, or `Scores (boolean)` |
+| **Metric**      | Aggregation + measure — e.g. `avg latency`, `count`, `p95 cost`                   |
+| **Filters**     | Narrow the dataset (model name, tags, user ID, environment, Boolean value, etc.)  |
+
+For Boolean scores, the average value is the share of scores that are `true`. Use it to alert on rates such as policy-check passes or detected hallucinations.
 
 ### Set alert conditions
 


### PR DESCRIPTION
## Summary

- Add a concise changelog for Boolean score support in dashboards and monitors introduced by [langfuse/langfuse#15255](https://github.com/langfuse/langfuse/pull/15255).
- Document the `scores-boolean` Metrics API view, its `0` / `1` value mapping, and Boolean score monitor configuration.

## Linear

- [LFE-10590](https://linear.app/clickhouse/issue/LFE-10590/add-boolean-filters-to-widgets)

## Review Focus

none
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents Boolean score support in dashboards, monitors, and the Metrics API. The main changes are:

- Adds a changelog entry with links to related guides.
- Adds the `scores-boolean` Metrics API view and `booleanValue` dimension.
- Explains the `0` / `1` mapping and average true-rate behavior.
- Adds Boolean scores to monitor configuration guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed documentation.
- The Boolean value mapping and true-rate explanation are consistent across the affected pages.
- The new MDX imports are at the top, and the linked documentation routes exist.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(metrics): document boolean score wi..."](https://github.com/langfuse/langfuse-docs/commit/53742809f757beefc61a7eb2eb4d216e9bde41d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46017751)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->