### PR TITLE
docs: migration guide for legacy → enriched export source on PostHog/Mixpanel pages (LFE-14364)

### DIFF
--- a/content/integrations/analytics/mixpanel.mdx
+++ b/content/integrations/analytics/mixpanel.mdx
@@ -86,17 +86,36 @@ Available options:
 `Traces and observations (legacy)` sources may be deprecated in the future. All new export jobs should use `Enriched observations (recommended)`, and existing legacy jobs are strongly recommended to upgrade.
 </Callout>
 
-### Upgrade path for existing configurations
+### Migrating from the legacy export source [#migrate-export-source]
 
-This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
+This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources. Existing integrations continue to use `Traces and observations (legacy)` until changed.
 
-Existing integrations continue to use `Traces and observations (legacy)` until changed.
+Mixpanel is a schemaless event store, so no setup is needed on the Mixpanel side — the new event name and properties appear automatically once you switch. All migration effort goes into the assets built on top of the events: reports, boards, funnels, cohorts, alerts, and warehouse syncs.
 
-To migrate safely:
+#### What changes when you switch
+
+| Aspect                | `Traces and observations (legacy)`                                                                                | `Enriched observations (recommended)`                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Events emitted        | `[Langfuse] Trace`, `[Langfuse] Generation`, `[Langfuse] Score`                                                    | `[Langfuse] Observation`, `[Langfuse] Score`                                                                                        |
+| Trace-level event     | Dedicated `[Langfuse] Trace` event with trace totals (`langfuse_cost_usd`, `langfuse_count_observations`, `langfuse_latency`) | Removed — trace facts are available as `langfuse_trace_id` / `langfuse_trace_name` properties on every observation event            |
+| Observation coverage  | Generations only                                                                                                   | Every observation type (spans, tool calls, agents, embeddings, …), disambiguated via the new `langfuse_type` property               |
+| Observation name      | `langfuse_generation_name`                                                                                         | `langfuse_observation_name`                                                                                                          |
+| Scores                | `[Langfuse] Score`, unchanged                                                                                      | `[Langfuse] Score`, unchanged                                                                                                        |
+
+Keep in mind:
+
+1. **Nothing is backfilled.** The sync is watermark-based: the old event streams simply stop at the switch date and the new one starts. Reports keyed on the old event names show a hard cliff — add a Mixpanel annotation at the cutover date and keep old boards around for lookback.
+2. **Queries need rewriting, not re-pointing.** Reports on `[Langfuse] Generation` become reports on `[Langfuse] Observation` filtered by `langfuse_type = 'GENERATION'`. Per-trace metrics (total cost, observation count, latency) must be recomputed by aggregating observation events over `langfuse_trace_id`, since there is no trace-summary event anymore.
+3. **Event volume increases.** The legacy source exported one trace event plus generations only; the enriched source exports every observation. Since Mixpanel bills by event volume, expect a corresponding increase.
+4. **The combined mode double-counts by design.** With `Traces and observations (legacy) and enriched observations`, a generation is exported both as a `[Langfuse] Generation` and as a `[Langfuse] Observation` event. Mixpanel's `$insert_id` deduplication is scoped per event name, so these are not collapsed, and metrics that sum cost or tokens across both event types double-count during migration. Use this mode only to build and validate new boards side by side.
+5. **The switch is effectively one-way.** Once legacy writes are off, the legacy sources can no longer be selected.
+
+#### Suggested migration steps
 
 1. Switch to `Traces and observations (legacy) and enriched observations`.
-2. Validate downstream dashboards, transformations, and alerts while both sources are exported (this mode creates duplicate records by design).
-3. Switch to `Enriched observations (recommended)` once validation is complete.
+2. Duplicate your reports and boards onto the `[Langfuse] Observation` event: filter by `langfuse_type`, use `langfuse_observation_name`, and rebuild per-trace metrics as aggregations over `langfuse_trace_id`.
+3. Validate the new numbers against the old ones side by side. Expect intentional coverage differences: the enriched source includes all observation types, not just generations.
+4. Switch to `Enriched observations (recommended)` and annotate the cutover date on any legacy boards you keep.
 
 For rollout details, see the [Simplify for Scale changelog](/changelog/2026-03-10-simplify-for-scale).
 

--- a/content/integrations/analytics/posthog.mdx
+++ b/content/integrations/analytics/posthog.mdx
@@ -63,17 +63,36 @@ Available options:
 `Traces and observations (legacy)` sources may be deprecated in the future. All new export jobs should use `Enriched observations (recommended)`, and existing legacy jobs are strongly recommended to upgrade.
 </Callout>
 
-### Upgrade path for existing configurations
+### Migrating from the legacy export source [#migrate-export-source]
 
-This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources.
+This migration path applies to **pre-cutoff Cloud projects and self-hosted deployments**. Post-cutoff Cloud projects already use `Enriched observations (recommended)` and cannot select legacy sources. Existing integrations continue to use `Traces and observations (legacy)` until changed.
 
-Existing integrations continue to use `Traces and observations (legacy)` until changed.
+PostHog is a schemaless event store, so no setup is needed on the PostHog side — the new event name and properties appear automatically once you switch. All migration effort goes into the assets built on top of the events: insights, dashboards, funnels, cohorts, alerts, and warehouse syncs.
 
-To migrate safely:
+#### What changes when you switch
+
+| Aspect                | `Traces and observations (legacy)`                                                                                | `Enriched observations (recommended)`                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Events emitted        | `langfuse trace`, `langfuse generation`, `langfuse score`                                                          | `langfuse observation`, `langfuse score`                                                                                            |
+| Trace-level event     | Dedicated `langfuse trace` event with trace totals (`langfuse_cost_usd`, `langfuse_count_observations`, `langfuse_latency`) | Removed — trace facts are available as `langfuse_trace_id` / `langfuse_trace_name` properties on every observation event            |
+| Observation coverage  | Generations only                                                                                                   | Every observation type (spans, tool calls, agents, embeddings, …), disambiguated via the new `langfuse_type` property               |
+| Observation name      | `langfuse_generation_name`                                                                                         | `langfuse_observation_name`                                                                                                          |
+| Scores                | `langfuse score`, unchanged                                                                                        | `langfuse score`, unchanged                                                                                                          |
+
+Keep in mind:
+
+1. **Nothing is backfilled.** The sync is watermark-based: the old event streams simply stop at the switch date and the new one starts. Dashboards keyed on the old event names show a hard cliff — add a PostHog annotation at the cutover date and keep old dashboards around for lookback.
+2. **Queries need rewriting, not re-pointing.** Insights on `langfuse generation` become insights on `langfuse observation` filtered by `langfuse_type = 'GENERATION'`. Per-trace metrics (total cost, observation count, latency) must be recomputed by aggregating observation events over `langfuse_trace_id`, since there is no trace-summary event anymore.
+3. **Event volume increases.** The legacy source exported one trace event plus generations only; the enriched source exports every observation. Since PostHog bills by event volume, expect a corresponding increase.
+4. **The combined mode double-counts by design.** With `Traces and observations (legacy) and enriched observations`, a generation is exported both as a `langfuse generation` and as a `langfuse observation` event. PostHog does not deduplicate across event names, so metrics that sum cost or tokens across both event types double-count during migration. Use this mode only to build and validate new dashboards side by side.
+5. **The switch is effectively one-way.** Once legacy writes are off, the legacy sources can no longer be selected.
+
+#### Suggested migration steps
 
 1. Switch to `Traces and observations (legacy) and enriched observations`.
-2. Validate downstream dashboards, transformations, and alerts while both sources are exported (this mode creates duplicate records by design).
-3. Switch to `Enriched observations (recommended)` once validation is complete.
+2. Duplicate your dashboards and insights onto the `langfuse observation` event: filter by `langfuse_type`, use `langfuse_observation_name`, and rebuild per-trace metrics as aggregations over `langfuse_trace_id`.
+3. Validate the new numbers against the old ones side by side. Expect intentional coverage differences: the enriched source includes all observation types, not just generations.
+4. Switch to `Enriched observations (recommended)` and annotate the cutover date on any legacy dashboards you keep.
 
 For rollout details, see the [Simplify for Scale changelog](/changelog/2026-03-10-simplify-for-scale).
 


### PR DESCRIPTION
Automated first pass from ticket [LFE-14364](https://linear.app/clickhouse/issue/LFE-14364).

Expands the thin 3-step "Upgrade path" section on both analytics integration pages (`content/integrations/analytics/posthog.mdx`, `mixpanel.mdx`) into a full customer-facing transition guide for switching from `TRACES_OBSERVATIONS` (legacy) to `EVENTS` (enriched observations):

- What-changes table: event names (`langfuse generation` → `langfuse observation` / `[Langfuse] Generation` → `[Langfuse] Observation`), removed trace-summary event, `langfuse_type` + `langfuse_observation_name`, scores unchanged. Event names verified against `worker/src/features/{posthog,mixpanel}/transformers.ts`.
- Consequences: no backfill (watermark-based cliff, recommend cutover annotation), queries need rewriting not re-pointing (per-trace metrics via aggregation over `langfuse_trace_id`), event-volume billing increase, combined-mode double counting (dedup IDs scoped per event name), one-way switch.
- Suggested 4-step migration flow via the combined source.

⚠️ Before merge:
- **Blocker precondition unverified**: the ticket requires the score-enrichment fix to have landed for the "scores unchanged" claim; if it hasn't, this guide needs an `events_only` caveat instead.
- Prettier could not be run in the sandbox — run `pnpm run format` if the `format` CI job fails (tables likely need realignment).
- Content is duplicated across both pages with platform-specific event names; reviewer may prefer consolidating into `components-mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)