### PR TITLE
docs: link OTEL real-time ingestion setup

### DIFF
--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -32,7 +32,7 @@ Older trace and observation read APIs remain available, but are not recommended 
 
 <Callout type="info">
 
-**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
+**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or [set that header on your OTEL span exporter](/integrations/native/opentelemetry#real-time-ingestion) to see new data in real time.
 
 </Callout>
 

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -417,7 +417,7 @@ If your observation-level evaluator isn't executing, see [Why is my observation-
 
 You can run observation-level LLM-as-a-Judge on historical data from the observations table. This is useful if you have already ingested production data and want to score matching observations retroactively with a new or updated evaluator.
 
-**Prerequisite**: Enable the **[Fast Mode](/docs/v4)** toggle for the evaluator. To use the same evaluator on newly ingested data in real time, either upgrade to the latest SDKs (Python v4+ or JS/TS v5+) or, if you ingest directly via OTEL, set `x-langfuse-ingestion-version: 4` on your OTEL span exporter.
+**Prerequisite**: Enable the **[Fast Mode](/docs/v4)** toggle for the evaluator. To use the same evaluator on newly ingested data in real time, either upgrade to the latest SDKs (Python v4+ or JS/TS v5+) or, if you ingest directly via OTEL, [set `x-langfuse-ingestion-version: 4` on your OTEL span exporter](/integrations/native/opentelemetry#real-time-ingestion).
 
 To backfill scores:
 

--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -33,7 +33,7 @@ The older Metrics API remains available, but is not recommended as the default f
 
 <Callout type="info">
 
-**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or set that header on your OTEL span exporter, to see new data in real time.
+**Data availability:** Data from older SDKs (`langfuse-python` < `4.0.0`, `langfuse-js` < `5.0.0`) or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes on v2 endpoints. Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) or [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5), or [set that header on your OTEL span exporter](/integrations/native/opentelemetry#real-time-ingestion) to see new data in real time.
 
 </Callout>
 

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -23,7 +23,7 @@ Langfuse is now observations-first. Queries that used to require expensive joins
 **How to adopt:**
 
 - **SDK:** Upgrade to [Python SDK v4.7.0+](/docs/observability/sdk/upgrade-path/python-v3-to-v4) / [JS/TS SDK v5.4.0+](/docs/observability/sdk/upgrade-path/js-v4-to-v5). Replace trace update calls with `propagate_attributes()`.
-- **OTEL:** Set the `x-langfuse-ingestion-version: 4` HTTP header on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
+- **OTEL:** Set the [`x-langfuse-ingestion-version: 4` HTTP header](/integrations/native/opentelemetry#real-time-ingestion) on your span exporter. Propagate trace attributes to _all_ observations. [See setup guide](/integrations/native/opentelemetry)
 - **UI:** If your organization was created before April 14, 2026, 14:00 UTC (15:00 CET), enable the **Preview** toggle (bottom-left) to opt in. Organizations created on/after this cutoff are already on "Fast Preview" and do not see the toggle. Filter observations directly in the new unified table and create saved views for productive defaults. [See saved views guide](/faq/all/explore-observations-in-v4)
 - **Evals:** Migrate LLM-as-a-Judge evals to the observation level. [See evals migration guide](/faq/all/llm-as-a-judge-migration)
 
@@ -74,7 +74,7 @@ The toggle remains reversible for organizations created before the cutoff date.
 **Export source cutoff (2026-05-20):** Cloud projects created on or after this date are locked to **Enriched observations (recommended)** as the export source for blob storage, PostHog, and Mixpanel integrations. Legacy export sources are hidden from the UI for these projects. Projects created before this date retain full choice across all export sources.
 
 <Callout type="info">
-Data from SDKs `langfuse-js` < `5.0.0`, `langfuse-python` < `4.0.0`, or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes in the new UI. Upgrade to the latest SDKs or set that header on your OTEL span exporter to see new data in real time.
+Data from SDKs `langfuse-js` < `5.0.0`, `langfuse-python` < `4.0.0`, or direct OpenTelemetry exporters that do not send `x-langfuse-ingestion-version: 4` can be delayed by up to 10 minutes in the new UI. Upgrade to the latest SDKs or [set that header on your OTEL span exporter](/integrations/native/opentelemetry#real-time-ingestion) to see new data in real time.
 </Callout>
 
 ### Migrate to the new experience
@@ -87,7 +87,7 @@ To take advantage of the new data model and explore your data in real time, use 
 
 - **Python SDK:** v4.7.0+ ([migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4))
 - **JS/TS SDK:** v5.4.0+ ([migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5))
-- **Direct OpenTelemetry ingestion:** set `x-langfuse-ingestion-version: 4` on your OTEL span exporter ([OpenTelemetry setup](/integrations/native/opentelemetry))
+- **Direct OpenTelemetry ingestion:** set `x-langfuse-ingestion-version: 4` on your OTEL span exporter ([real-time ingestion setup](/integrations/native/opentelemetry#real-time-ingestion))
 
 For SDK users, the key change is that `update_current_trace()` and `updateActiveTrace()` are replaced by `propagate_attributes()`, which automatically pushes attributes like `user_id`, `session_id`, `metadata`, `tags`, and request-scoped `environment` in the Python SDK to all child observations.
 

--- a/content/faq/all/explore-observations-in-v4.mdx
+++ b/content/faq/all/explore-observations-in-v4.mdx
@@ -62,7 +62,7 @@ Use one of these ingestion paths so your data appears in the unified table in re
 
 - Python SDK v4.7.0+: [migration guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4)
 - JS/TS SDK v5.4.0+: [migration guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5)
-- Direct OpenTelemetry ingestion: set `x-langfuse-ingestion-version: 4` on your OTEL span exporter. If you use OTLP HTTP environment variables, add `x-langfuse-ingestion-version=4` to `OTEL_EXPORTER_OTLP_HEADERS`. See [OpenTelemetry setup](/integrations/native/opentelemetry).
+- Direct OpenTelemetry ingestion: set `x-langfuse-ingestion-version: 4` on your OTEL span exporter. If you use OTLP HTTP environment variables, add `x-langfuse-ingestion-version=4` to `OTEL_EXPORTER_OTLP_HEADERS`. See the [real-time ingestion setup](/integrations/native/opentelemetry#real-time-ingestion).
 
 <Callout type="info">
 If you are still sending data via **older SDK versions**, or via **direct OpenTelemetry ingestion without `x-langfuse-ingestion-version: 4`**, traces can appear in the unified tracing table with a **delay of up to 10 minutes**.
@@ -91,7 +91,7 @@ If something feels confusing, missing, or slower than expected, share feedback v
 
 The most common reason is that data is still being sent via older SDK versions or through a direct OpenTelemetry exporter without `x-langfuse-ingestion-version: 4`.
 In the new Fast Preview experience, those setups can lead to multi-minute delays before traces show up in the unified table.
-If this happens, upgrade to Python SDK v4.7.0+ or JS/TS SDK v5.4.0+, or add the ingestion version header to your OTEL exporter.
+If this happens, upgrade to Python SDK v4.7.0+ or JS/TS SDK v5.4.0+, or [add the ingestion version header to your OTEL exporter](/integrations/native/opentelemetry#real-time-ingestion).
 
 ### How can I get a focused view of my most important operations?
 

--- a/content/integrations/frameworks/quarkus-langchain4j.mdx
+++ b/content/integrations/frameworks/quarkus-langchain4j.mdx
@@ -70,6 +70,8 @@ QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: set this to the Langfuse OTLP URL (e.g. htt
 QUARKUS_OTEL_EXPORTER_OTLP_HEADERS: set this to Authorization=Basic <base64 public:secret>,x-langfuse-ingestion-version=4.
 ```
 
+The [ingestion version header enables real-time ingestion](/integrations/native/opentelemetry#real-time-ingestion) in Langfuse v4.
+
 </Tab>
 <Tab>
 

--- a/content/integrations/frameworks/spring-ai.mdx
+++ b/content/integrations/frameworks/spring-ai.mdx
@@ -220,8 +220,9 @@ export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse
 ```
 
 <Callout type="info">
-  See [OpenTelemetry: Get
-  Started](/docs/opentelemetry/get-started) for more on Basic Auth and the
+  See the [OpenTelemetry setup](/integrations/native/opentelemetry) for Basic
+  Auth and the [real-time ingestion
+  section](/integrations/native/opentelemetry#real-time-ingestion) for the
   `x-langfuse-ingestion-version` header.
 </Callout>
 

--- a/content/integrations/native/opentelemetry.mdx
+++ b/content/integrations/native/opentelemetry.mdx
@@ -278,11 +278,21 @@ For long API Keys on GNU systems, you may have to add `-w 0` at the end since `b
 
 </Callout>
 
-<Callout type="info">
+### Enable real-time ingestion in Langfuse v4 [#real-time-ingestion]
 
-If you want spans ingested directly via OpenTelemetry to appear in real time in Langfuse Cloud Fast Preview, include the `x-langfuse-ingestion-version: 4` header. If your setup uses signal-specific header settings, add the same value to `OTEL_EXPORTER_OTLP_TRACES_HEADERS`.
+If you send spans directly via OpenTelemetry, include the
+`x-langfuse-ingestion-version: 4` header so that new data appears in real time
+in Langfuse Cloud Fast Preview and the v2 Observations and Metrics APIs. Without
+this header, directly ingested OpenTelemetry data can be delayed by up to 10
+minutes. The `OTEL_EXPORTER_OTLP_HEADERS` configuration above already includes
+the header.
 
-</Callout>
+If your setup uses signal-specific header settings, configure the same header
+on the traces exporter:
+
+```bash
+OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
+```
 
 <Callout type="info">
 

--- a/content/resources/engineering/migrate-from-helicone.mdx
+++ b/content/resources/engineering/migrate-from-helicone.mdx
@@ -146,7 +146,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64(public_key:secret
 Key constraints:
 
 - Langfuse supports **OTLP over HTTP via both HTTP/JSON and HTTP/protobuf** (`gRPC` is not supported yet).
-- The `x-langfuse-ingestion-version=4` header enables real-time visibility in the Langfuse v4 tracing table for data sent directly via OTEL.
+- The [`x-langfuse-ingestion-version=4` header](/integrations/native/opentelemetry#real-time-ingestion) enables real-time visibility in the Langfuse v4 tracing table for data sent directly via OTEL.
 - See the [OpenTelemetry integration docs](/integrations/native/opentelemetry) for full setup details.
 
 ### Option C: Replace the Gateway with LiteLLM Proxy

--- a/content/resources/engineering/opentelemetry-languages.mdx
+++ b/content/resources/engineering/opentelemetry-languages.mdx
@@ -22,7 +22,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel" # ðŸ‡ªð
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${AUTH_STRING},x-langfuse-ingestion-version=4"
 ```
 
-If your SDK requires signal-specific configuration, the traces path is `/api/public/otel/v1/traces`. Details and property mapping live in the [OpenTelemetry integration docs](/integrations/native/opentelemetry).
+If your SDK requires signal-specific configuration, the traces path is `/api/public/otel/v1/traces`. See how to [enable real-time ingestion](/integrations/native/opentelemetry#real-time-ingestion), or review the full [OpenTelemetry property mapping](/integrations/native/opentelemetry#property-mapping).
 
 Two rules determine how your spans render in Langfuse:
 


### PR DESCRIPTION
## What changed

- promote the direct OTEL ingestion-version guidance into a stable, explicitly anchored **Enable real-time ingestion in Langfuse v4** section
- document the signal-specific `OTEL_EXPORTER_OTLP_TRACES_HEADERS` configuration
- link v4, v2 API, evaluator, FAQ, integration, and migration guidance directly to the canonical section
- preserve inline headers in copy-paste examples

## Why

The `x-langfuse-ingestion-version: 4` requirement was buried in an unanchored callout. Other pages repeated it but could only send users to the top of a long OpenTelemetry page.

This gives the requirement a durable deep link and makes the expected real-time behavior and delayed-data fallback easier to find.

Linear: [LFE-14381](https://linear.app/clickhouse/issue/LFE-14381/make-otel-real-time-ingestion-guidance-directly-linkable)

## Validation

- installed Prettier binary: write + check on all 10 touched MDX files
- `node scripts/check-h1-headings.js`
- `git diff --check`
- explicit anchor/backlink verification

The repository `pnpm run format` wrapper could not run in this task environment because Node 22 is unavailable; it attempted to use bundled Node 24 and abort a dependency-store migration. The same checked-in Prettier dependency was run directly instead. Full build, link, and sitemap validation are left to CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the OpenTelemetry setup for real-time Langfuse v4 ingestion. The main changes are:

- Adds a stable real-time ingestion section to the OpenTelemetry guide.
- Documents generic and trace-specific exporter header configuration.
- Links API, evaluator, integration, FAQ, and migration pages to the canonical setup.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed documentation.
- The new trace-specific example includes both authentication and ingestion-version headers.
- The new internal links point to explicit targets that follow existing repository conventions.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link OTEL real-time ingestion setu..."](https://github.com/langfuse/langfuse-docs/commit/7a4ccacf0ef4fcace23fd1228df9fb83b741ddb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46293564)</sub>

<!-- /greptile_comment -->