### PR TITLE
Update QA chatbot SDK grounding experiment

### DIFF
--- a/components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts
+++ b/components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts
@@ -42,15 +42,20 @@ const DEFAULT_MAX_CONCURRENCY = 3;
 const DEFAULT_MCP_URL = "https://langfuse.com/api/mcp";
 
 const IN_APP_EVALUATORS = [
-  "sdk-integration-docs-groundedness",
-  "sdk-integration-docs-citation-completeness",
-  "sdk-integration-package-version-completeness",
+  "sdk-integration-questions-groundedness",
+  "sdk-integration-questions-completeness",
 ];
 
 type ExperimentTelemetry = Parameters<
   typeof generateText
 >[0]["experimental_telemetry"];
 type ExperimentTelemetryMetadata = Record<string, string | number | boolean>;
+type ExperimentMessages = Parameters<typeof generateText>[0]["messages"];
+
+type CompiledExperimentPrompt = {
+  instructions?: string;
+  messages: ExperimentMessages;
+};
 
 function makeExperimentTelemetry(
   metadata: ExperimentTelemetryMetadata,
@@ -218,7 +223,7 @@ function isReasoningModel(model: string) {
 function compileExperimentMessages(
   prompt: Awaited<ReturnType<LangfuseClient["prompt"]["get"]>>,
   input: unknown,
-): Parameters<typeof generateText>[0]["messages"] {
+): CompiledExperimentPrompt {
   const chatHistory = getChatHistory(input);
   const fallbackUserMessage = getLastUserMessage(input);
   const datasetMessages: Array<{ role: string; content: string }> =
@@ -260,7 +265,18 @@ function compileExperimentMessages(
     compiledMessages.push(...datasetMessages);
   }
 
-  return compiledMessages as Parameters<typeof generateText>[0]["messages"];
+  const instructions = compiledMessages
+    .filter((message) => message.role === "system")
+    .map((message) => message.content)
+    .join("\n\n");
+  const modelMessages = compiledMessages.filter(
+    (message) => message.role !== "system",
+  );
+
+  return {
+    instructions: instructions || undefined,
+    messages: modelMessages as ExperimentMessages,
+  };
 }
 
 async function runOneExperiment(
@@ -302,7 +318,7 @@ async function runOneExperiment(
   const dataset = await langfuse.dataset.get(args.datasetName);
 
   const task = async (item: { input: unknown }): Promise<string> => {
-    const compiledMessages = compileExperimentMessages(prompt, item.input);
+    const compiledPrompt = compileExperimentMessages(prompt, item.input);
     const transport = new StreamableHTTPClientTransport(new URL(args.mcpUrl), {
       sessionId: `sdk-integration-grounding-${crypto.randomUUID()}`,
     }) as unknown as Parameters<typeof createMCPClient>[0]["transport"];
@@ -324,7 +340,8 @@ async function runOneExperiment(
               },
             }
           : {}),
-        messages: compiledMessages,
+        instructions: compiledPrompt.instructions,
+        messages: compiledPrompt.messages,
         tools: tools as Parameters<typeof generateText>[0]["tools"],
         stopWhen: stepCountIs(10),
         experimental_telemetry: makeExperimentTelemetry({
@@ -352,7 +369,7 @@ async function runOneExperiment(
     name: `${args.runSeries}-${params.model}`,
     runName,
     description:
-      "SDK integration docs-grounding experiment using the product QA chatbot prompt and Langfuse docs MCP. Langfuse in-app evaluators score docs groundedness, citation completeness, and package/version completeness.",
+      "SDK integration docs-grounding experiment using the product QA chatbot prompt and Langfuse docs MCP. Langfuse in-app evaluators score groundedness and completeness.",
     task,
     maxConcurrency: args.maxConcurrency,
     metadata: {


### PR DESCRIPTION
Summary: Update QA chatbot SDK grounding experiment evaluator names and pass system prompt content via instructions while keeping model messages non-system. Checks: pnpm run format, pnpm run format:check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the QA chatbot SDK grounding experiment. The main changes are:

- Renamed the groundedness and completeness evaluator metadata.
- Moved system-role prompt content into the AI SDK `instructions` field.
- Kept only non-system entries in the model message list.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks mergeable after confirming that the renamed evaluators are provisioned.

- The prompt conversion preserves system content and non-system message order.
- The repository setup still creates the old evaluator names, so environments using it may expose incomplete evaluator metadata.

components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/qaChatbot/experiments/run_sdk_integration_grounding_experiment.ts:45-46
**Evaluator Names Diverge From Setup**

When the repository's evaluator setup is used, it registers the three `sdk-integration-docs-*` evaluators rather than these new `sdk-integration-questions-*` names. Unless the new evaluators are provisioned elsewhere, the experiment metadata names evaluators that are not configured and no longer identifies the package-version evaluator, so the run can be reported or selected with incomplete scoring.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update QA chatbot SDK grounding experime..."](https://github.com/langfuse/langfuse-docs/commit/e5e9880f7242ab34d80900819e20cceab5b3c2a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46230257)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->