### PR TITLE
Add demo video to dashboard API changelog post

### DIFF
--- a/content/changelog/2026-07-17-dashboard-and-widget-operations-in-api.mdx
+++ b/content/changelog/2026-07-17-dashboard-and-widget-operations-in-api.mdx
@@ -3,6 +3,7 @@ date: 2026-07-17
 title: Manage dashboards via API, CLI, and MCP
 description: Create and manage dashboards and widgets programmatically through the public API and Langfuse CLI, let AI agents build them via the Langfuse MCP server, or ask the Langfuse Assistant in the UI.
 author: Lysander
+ogVideo: https://static.langfuse.com/docs-videos/dashboard-widget-api.mp4
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";


### PR DESCRIPTION
Adds `ogVideo` frontmatter to the [dashboard and widget operations changelog post](https://langfuse.com/changelog/2026-07-17-dashboard-and-widget-operations-in-api), pointing at `https://static.langfuse.com/docs-videos/dashboard-widget-api.mp4`. ChangelogHeader renders it gif-style at the top of the post and it becomes the OG video for social embeds.

## Before merging

- [ ] **Upload the video to the bucket**: the file is `widget-api.mp4` (7.6 MB, 41 s, 1928×1080, currently in Jannik's Downloads). Upload it to `static.langfuse.com/docs-videos/` as **`dashboard-widget-api.mp4`** (renamed for a descriptive URL). The post will show a broken video until the file is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a demo video to the dashboard API changelog post. The main changes are:

- Adds an externally hosted video to the post header.
- Uses the same video in Open Graph metadata.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The referenced video must be uploaded before this change is deployed.

- The frontmatter follows the existing `ogVideo` schema and URL convention.
- The current URL points to an asset that the PR says is not live.
- A missing asset breaks both the in-page player and social video preview.

content/changelog/2026-07-17-dashboard-and-widget-operations-in-api.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/changelog/2026-07-17-dashboard-and-widget-operations-in-api.mdx:6
**Unpublished Video Breaks Post Header**

The PR states that this asset has not been uploaded yet, but the URL is rendered directly in the post header and emitted as its Open Graph video. Deploying before the upload makes the header player request a missing file and gives social crawlers a broken video URL.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update 2026-07-17-dashboard-and-widget-o..."](https://github.com/langfuse/langfuse-docs/commit/507dfa535f497260fbddccf6fb149b82701c6580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46237979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->