### PR TITLE
Change blog title from 'steal' to 'copy'

### DIFF
--- a/content/blog/2026-07-16-steal-our-eval-setup.mdx
+++ b/content/blog/2026-07-16-steal-our-eval-setup.mdx
@@ -10,7 +10,7 @@ highlight: true
 import { BlogHeader } from "@/components/blog/BlogHeader";
 
 <BlogHeader
-  title="Yes, you can steal our eval setup"
+  title="Yes, you can copy our eval setup"
   description="Evals need to be custom to your app. At least some of them. A good chunk you can, and should be copying. Here is our setup for our docs chatbot."
   date="July 22, 2026"
   authors={["annabellschafer"]}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the wording of a blog post title.

- Changes the displayed heading from “steal” to “copy.”
- Keeps the heading consistent with the post metadata.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<sub>Reviews (1): Last reviewed commit: ["Change blog title from &#39;steal&#39; to &#39;copy&#39;"](https://github.com/langfuse/langfuse-docs/commit/964ab5850919a60dd3c26db3f3a8f6b3319a69f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46261379)</sub>

<!-- /greptile_comment -->