### PR TITLE
docs: lead blob storage export page with enriched exports, not legacy

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -19,7 +19,7 @@ import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx
   }}
 />
 
-You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. Exports contain enriched observations (each observation row includes its trace attributes) and `scores`; integrations on a legacy [export source](#export-source-fast-preview) additionally export separate `traces` and `observations` files.
+You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. By default, exports contain enriched observations (each observation row includes its trace attributes) and `scores`; integrations on a legacy [export source](#export-source-fast-preview) export separate `traces` and `observations` files (plus `scores`) instead.
 
 Those exports can run every `20 minutes`, or on an `hourly`, `daily`, or `weekly` schedule.
 Navigate to your project settings and select `Integrations > Blob Storage` to set up a new export.

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Export to Blob Storage
-description: Export traces, observations, enriched observations, and scores to Blob Storage, e.g. S3, GCS, or Azure Blob Storage.
+description: Export enriched observations, scores, and legacy traces and observations to Blob Storage, e.g. S3, GCS, or Azure Blob Storage.
 sidebarTitle: Export to Blob Storage
 ---
 
@@ -19,7 +19,7 @@ import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx
   }}
 />
 
-You can create schedule exports to a Blob Storage, e.g. S3, GCS, or Azure Blob Storage, for `traces`, `observations`, enriched observations, and `scores`.
+You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. Exports contain enriched observations (each observation row includes its trace attributes) and `scores`; integrations on a legacy [export source](#export-source-fast-preview) additionally export separate `traces` and `observations` files.
 
 Those exports can run every `20 minutes`, or on an `hourly`, `daily`, or `weekly` schedule.
 Navigate to your project settings and select `Integrations > Blob Storage` to set up a new export.
@@ -51,11 +51,11 @@ Parquet observation exports do not include the per-unit model price columns (`in
 **Self-hosted deployments running ClickHouse < 25.11:** Parquet export failures may not surface as errors. A run can complete — and its [manifest](#run-manifest) be written — while the Parquet output is incomplete or invalid. Upgrade to ClickHouse >= 25.11, or use a text format (CSV, JSON, or JSONL) for reliable failure detection.
 </Callout>
 
-## Export source (Fast Preview)
+## Export source (Fast Preview) [#export-source-fast-preview]
 
-Blob Storage integrations now include an `Export Source` selector. Where enriched export is available — on Langfuse Cloud, and on self-hosted deployments with the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`) — new integrations default to `Enriched observations (recommended)` (trace attributes are directly set on observations). On self-hosted deployments without the opt-in, enriched export is not available and new integrations default to `Traces and observations (legacy)`.
+The `Export Source` setting determines which tables the integration exports. Where enriched export is available — on Langfuse Cloud, and on self-hosted deployments with the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`) — new integrations default to `Enriched observations (recommended)`: trace attributes are set directly on each observation row, which avoids warehouse-side joins and provides significantly better export performance. On self-hosted deployments without the opt-in, enriched export is not available and new integrations default to `Traces and observations (legacy)`.
 
-This source uses enriched observations with trace attributes and provides significantly better export performance. `Scores` are always included, regardless of the selected source.
+`Scores` are always included, regardless of the selected source.
 
 Available options, and the directories each source writes under `{prefix}{project-id}/` in your bucket:
 


### PR DESCRIPTION
## Summary

Reframes the intro of the Export to Blob Storage page for readers who only know v4, keeping migration/legacy content secondary:

- Frontmatter description and intro sentence now lead with enriched observations and scores; the separate legacy `traces`/`observations` files are mentioned as the secondary case, with a deep link to the Export source section.
- The Export source section opens by describing what the setting does today ("The `Export Source` setting determines which tables the integration exports") instead of announcing the selector as news ("integrations now include…"). The enriched default's benefit (trace attributes on each row, no warehouse-side joins) is folded into the same sentence.
- The section anchor `#export-source-fast-preview` is now explicitly defined since the intro deep-links to it (same slug as the previously auto-generated one, so existing inbound links — including from the skills repo — are unaffected).

No changes to the field reference page — it already documents enriched first with legacy paths in a separate trailing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reframes the intro of the Export to Blob Storage page to lead with the modern enriched-observations default rather than legacy behavior, fixing a "create schedule" typo and adding an explicit `[#export-source-fast-preview]` anchor so the new deep-link from the opening paragraph resolves to the same slug as before.

- The frontmatter `description` and opening paragraph are reordered to present enriched observations and scores as the primary case, with legacy sources as a secondary mention.
- The `Export Source` section is rewritten from "integrations now include a selector" to "the setting determines which tables are exported," folding the performance benefit into the same sentence and removing the now-redundant follow-up paragraph.
- An explicit heading anchor `[#export-source-fast-preview]` is added (matching the previously auto-generated slug) to future-proof the in-page deep-link.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The doc rewrite is mostly clean, but one sentence in the new opening paragraph misstates what a legacy-source integration exports, which could mislead users into expecting enriched data they will never receive.

The structural intent is sound — leading with the modern enriched default is the right direction. The factual error is in the single introductory sentence: 'additionally export' implies a legacy integration ships enriched observations on top of the legacy files, but the pure legacy source never writes observations_v2/. A user configuring a legacy integration who reads only the intro would have incorrect expectations about the files they receive.

content/docs/api-and-data-platform/features/export-to-blob-storage.mdx — specifically line 22, the new opening paragraph.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Blob Storage Integration] --> B{Export Source setting}
    B -->|Enriched observations\nrecommended / default| C[observations_v2/\nscores/]
    B -->|Traces and observations\nlegacy| D[traces/\nobservations/\nscores/]
    B -->|Legacy + Enriched\ncombined / migration| E[traces/\nobservations/\nobservations_v2/\nscores/]
    C --> F[Run manifest written last]
    D --> F
    E --> F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:22
The word "additionally" implies a legacy-source integration includes enriched observations on top of the legacy files, but the pure `Traces and observations (legacy)` source exports only `traces/`, `observations/`, and `scores/` — no `observations_v2/`. Rewording to make the two modes mutually exclusive matches the export-source table below.

```suggestion
You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. By default, exports contain enriched observations (each observation row includes its trace attributes) and `scores`; integrations on a legacy [export source](#export-source-fast-preview) instead export separate `traces` and `observations` files (plus `scores`), without enriched observations.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: lead blob storage export page with..."](https://github.com/langfuse/langfuse-docs/commit/afe0dee613928f1bbae5025465caf24498b934c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46426558)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->