### PR TITLE
docs: restructure the blob storage export page for new users

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -19,11 +19,13 @@ import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx
   }}
 />
 
-You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. By default, exports contain enriched observations (each observation row includes its trace attributes) and `scores`; integrations on a legacy [export source](#export-source-fast-preview) export separate `traces` and `observations` files (plus `scores`) instead.
+You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. Exports contain enriched observations (each observation row includes its trace attributes) and `scores`; every run writes to `observations_v2/`, `scores/`, and `manifests/` under `{prefix}{project-id}/` in your bucket.
 
 Those exports can run every `20 minutes`, or on an `hourly`, `daily`, or `weekly` schedule.
 Navigate to your project settings and select `Integrations > Blob Storage` to set up a new export.
 Select whether you want to use S3, a S3 compatible storage, Google Cloud Storage, or Azure Blob Storage.
+
+Older integrations may still export via a deprecated legacy source with separate `traces` and `observations` files; see [Legacy export sources](#legacy-export-sources) for the differences and the upgrade path.
 
 ## Start exporting via Blob Storage
 
@@ -51,99 +53,43 @@ Parquet observation exports do not include the per-unit model price columns (`in
 **Self-hosted deployments running ClickHouse < 25.11:** Parquet export failures may not surface as errors. A run can complete — and its [manifest](#run-manifest) be written — while the Parquet output is incomplete or invalid. Upgrade to ClickHouse >= 25.11, or use a text format (CSV, JSON, or JSONL) for reliable failure detection.
 </Callout>
 
-## Export source (Fast Preview) [#export-source-fast-preview]
-
-The `Export Source` setting determines which tables the integration exports. Where enriched export is available — on Langfuse Cloud, and on self-hosted deployments with the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`) — new integrations default to `Enriched observations (recommended)`: trace attributes are set directly on each observation row, which avoids warehouse-side joins and provides significantly better export performance. On self-hosted deployments without the opt-in, enriched export is not available and new integrations default to `Traces and observations (legacy)`.
-
-`Scores` are always included, regardless of the selected source.
-
-Available options, and the directories each source writes under `{prefix}{project-id}/` in your bucket:
-
-| Export source                                                | Directories written                                       |
-| ------------------------------------------------------------ | --------------------------------------------------------- |
-| `Traces and observations (legacy)`                           | `traces/`, `observations/`, `scores/`                     |
-| `Traces and observations (legacy) and enriched observations` | `traces/`, `observations/`, `observations_v2/`, `scores/` |
-| `Enriched observations (recommended)`                        | `observations_v2/`, `scores/`                             |
-
-Every run also writes a [run manifest](#run-manifest) under `manifests/`. For the columns in each file, see the [export sources overview](/docs/api-and-data-platform/features/blob-storage-export-fields#export-sources) in the field reference.
-
-<Callout type="warning">
-  The `Traces and observations (legacy)` source is deprecated and will be
-  removed in a future release. New integrations should use `Enriched
-  observations (recommended)`, and existing legacy integrations are strongly
-  recommended to [upgrade](#upgrade-path).
-</Callout>
-
-On Langfuse Cloud, integrations that still export a legacy source (including `Traces and observations (legacy) and enriched observations`) also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run — written best-effort after the run's [manifest](#run-manifest) and not listed in it — and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. The manifest remains the authoritative run-completion marker; do not treat the notice as a completion signal. Account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
-
-<Callout type="info">
-**Langfuse Cloud:** Legacy export sources can no longer be newly selected:
-
-- Projects created on or after 2026-05-20 cannot use legacy export sources.
-- In older projects, blob storage integrations created on or after 2026-06-22 — including newly configured ones — cannot select legacy export sources either.
-
-In both cases the Export Source selector is not shown and exports use `Enriched observations (recommended)` automatically; the REST API rejects legacy values with `400 BAD_REQUEST`. Blob storage integrations created before 2026-06-22 keep their configured export source and continue to see the selector.
-
-**Self-hosted:** These date cutoffs do not apply. However, once a deployment has completed the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy export sources are no longer available — including previously saved ones, since the legacy traces/observations tables are no longer written — and the selector is hidden once only the enriched source remains.
-
-</Callout>
-
-### Upgrade path for existing configurations [#upgrade-path]
-
-This migration path applies to **Cloud blob storage integrations created before 2026-06-22 and self-hosted deployments that still write the legacy tables**. Newer Cloud integrations already use `Enriched observations (recommended)` and cannot select legacy sources — including the dual-write source in step 1 below.
-
-Existing integrations continue to use `Traces and observations (legacy)` until changed.
-
-To migrate safely:
-
-1. Switch to `Traces and observations (legacy) and enriched observations`.
-2. Validate downstream jobs and data consumers while both sources are exported (this mode creates duplicate records by design).
-3. Repoint consumers from the `traces/` and `observations/` directories to `observations_v2/`.
-4. Switch to `Enriched observations (recommended)` once validation is complete.
-
-<Callout type="warning">
-After the switch, the `traces/` and `observations/` directories receive **no further files at all** — not even [empty files](#empty-files), which are otherwise written for windows without data. Pipelines still watching those directories go silent without an error signal, so complete step 3 before switching.
-</Callout>
-
-For a field-level comparison of what changes when you switch sources, see [Differences between enriched and legacy exports](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences).
-
-For rollout details, see the [Simplify for Scale changelog](/changelog/2026-03-10-simplify-for-scale).
-
 ## Exported fields
 
 For a complete reference of all fields included in each export file (traces, observations, enriched observations, and scores), see the [Export Field Reference](/docs/api-and-data-platform/features/blob-storage-export-fields).
 
 ## Choose which columns are exported [#export-field-groups]
 
-Field groups let you choose which column groups appear in each row of the observation exports. They apply to observation exports for **all export sources** — both the enriched `observations_v2` file and the legacy `observations` file — with different column content depending on the source. Eleven groups cover the full row, ten of which are toggleable; toggle them in **Project Settings → Integrations → Blob Storage** under **Export Field Groups**.
+Field groups let you choose which column groups appear in each row of the observation export. Eleven groups cover the full row, ten of which are toggleable; toggle them in **Project Settings → Integrations → Blob Storage** under **Export Field Groups**.
 
 Groups are listed in the order they appear in the UI; fields within each group are sorted alphabetically. The `core` group is required and always exported.
 
-| Group           | Enriched (`observations_v2`)                                                                                 | Legacy (`observations`)                                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `core`          | `end_time`, `id`, `parent_observation_id`, `project_id`, `start_time`, `trace_id`, `type`                    | Same as enriched                                                                                                                 |
-| `basic`         | `bookmarked`, `environment`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` | `environment`, `level`, `name`, `status_message`, `version`                                                                      |
-| `time`          | `completion_start_time`, `created_at`, `updated_at`                                                          | Same as enriched                                                                                                                 |
-| `io`            | `input`, `output`                                                                                            | Same as enriched                                                                                                                 |
-| `metadata`      | `metadata`                                                                                                   | Same as enriched                                                                                                                 |
-| `model`         | `input_price`, `model_id`, `model_parameters`, `output_price`, `provided_model_name`, `total_price`          | Same as enriched                                                                                                                 |
-| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`            | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_name`                                                         |
-| `prompt`        | `prompt_id`, `prompt_name`, `prompt_version`                                                                 | Same as enriched                                                                                                                 |
-| `metrics`       | `latency`, `time_to_first_token`                                                                             | Same as enriched                                                                                                                 |
-| `trace_context` | `release`, `tags`, `trace_name`                                                                              | Not included — available in the separate [`traces` file](/docs/api-and-data-platform/features/blob-storage-export-fields#traces) |
-| `tools`         | `tool_call_names`, `tool_calls`, `tool_definitions`                                                          | Same as enriched                                                                                                                 |
+| Group           | Fields (`observations_v2`)                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `core`          | `end_time`, `id`, `parent_observation_id`, `project_id`, `start_time`, `trace_id`, `type`                    |
+| `basic`         | `bookmarked`, `environment`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` |
+| `time`          | `completion_start_time`, `created_at`, `updated_at`                                                          |
+| `io`            | `input`, `output`                                                                                            |
+| `metadata`      | `metadata`                                                                                                   |
+| `model`         | `input_price`, `model_id`, `model_parameters`, `output_price`, `provided_model_name`, `total_price`          |
+| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`            |
+| `prompt`        | `prompt_id`, `prompt_name`, `prompt_version`                                                                 |
+| `metrics`       | `latency`, `time_to_first_token`                                                                             |
+| `trace_context` | `release`, `tags`, `trace_name`                                                                              |
+| `tools`         | `tool_call_names`, `tool_calls`, `tool_definitions`                                                          |
+
+Field groups also apply to [legacy export sources](#legacy-export-sources), with a smaller column set per group; see [differences between enriched and legacy exports](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences).
 
 <Callout type="info">
   Per-unit pricing fields (`input_price`, `output_price`, `total_price`) live in the `model` group — they come from the matched model definition. Deselecting `model` skips the worker-side model pricing lookup entirely. The `usage_pricing_tier_id` and `usage_pricing_tier_name` fields stay in the `usage` group. With the Parquet file type, these three price columns are not included even when `model` is selected — see [File formats](#file-formats).
 </Callout>
 
-New integrations default to all eleven groups, so behavior matches earlier exports unless you narrow the selection. Field groups apply to observation exports only — the legacy `traces` file always contains a [fixed column set](/docs/api-and-data-platform/features/blob-storage-export-fields#traces).
+New integrations default to all eleven groups, so behavior matches earlier exports unless you narrow the selection.
 
 ### Configure via REST API [#field-groups-rest-api]
 
 `GET` and `PUT /api/public/integrations/blob-storage` accept and return:
 
-- `exportSource` — `LEGACY_TRACES_OBSERVATIONS`, `OBSERVATIONS_V2`, or `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`.
+- `exportSource` — `OBSERVATIONS_V2`. The values `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` exist for [legacy integrations](#legacy-export-sources) only.
 - `exportFieldGroups` — a list of group names. Must include `core` when provided. Applies to observation exports for all export sources. When omitted on update, the existing value is preserved.
 - `fileType` — `PARQUET` (default for new integrations), `CSV`, `JSON`, or `JSONL`.
 - `compressed` — boolean; defaults to `true` for new integrations. When `true`, files are written as `.csv.gz`, `.json.gz`, or `.jsonl.gz`. Does not apply to `PARQUET` — Parquet files are compressed by the storage engine and always written as plain `.parquet` files.
@@ -273,6 +219,45 @@ Langfuse retries failed exports on the next run. Repeated failures notify projec
 ## Empty files in your bucket [#empty-files]
 
 <BlobStorageEmptyFiles />
+
+## Legacy export sources [#legacy-export-sources]
+
+<Callout type="warning">
+  This section only applies to integrations still using the deprecated `Traces
+  and observations (legacy)` export source. It will be removed in a future
+  release; follow the [upgrade path](#upgrade-path) below. New integrations use
+  `Enriched observations (recommended)` and can skip this section.
+</Callout>
+
+The `Export Source` setting determines which tables the integration exports. Legacy sources export separate `traces` and `observations` files instead of the enriched `observations_v2` file; `scores` are always included, regardless of the source. Directories written under `{prefix}{project-id}/` per source:
+
+| Export source                                                | Directories written                                       |
+| ------------------------------------------------------------ | --------------------------------------------------------- |
+| `Enriched observations (recommended)`                        | `observations_v2/`, `scores/`                             |
+| `Traces and observations (legacy) and enriched observations` | `traces/`, `observations/`, `observations_v2/`, `scores/` |
+| `Traces and observations (legacy)`                           | `traces/`, `observations/`, `scores/`                     |
+
+For the columns in each file, see the [export sources overview](/docs/api-and-data-platform/features/blob-storage-export-fields#export-sources) in the field reference.
+
+Where legacy sources are still available:
+
+- **Langfuse Cloud:** only integrations created before 2026-06-22 in projects created before 2026-05-20 keep their configured legacy source and see the selector. All other integrations use `Enriched observations (recommended)` automatically, and the REST API rejects legacy values with `400 BAD_REQUEST`.
+- **Self-hosted:** enriched export requires the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`); without it, integrations use the legacy source. Once a deployment completes the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy sources are no longer available — including previously saved ones — and the selector is hidden.
+
+On Langfuse Cloud, integrations that still export a legacy source also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run — written best-effort after the run's [manifest](#run-manifest) and not listed in it — and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. The manifest remains the authoritative run-completion marker; account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
+
+### Upgrade path [#upgrade-path]
+
+To migrate an existing legacy integration safely:
+
+1. Switch to `Traces and observations (legacy) and enriched observations`.
+2. Validate downstream jobs and data consumers while both sources are exported (this mode creates duplicate records by design). See [differences between enriched and legacy exports](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences) for the field-level comparison.
+3. Repoint consumers from the `traces/` and `observations/` directories to `observations_v2/`.
+4. Switch to `Enriched observations (recommended)` once validation is complete.
+
+<Callout type="warning">
+After the switch, the `traces/` and `observations/` directories receive **no further files at all** — not even [empty files](#empty-files), which are otherwise written for windows without data. Pipelines still watching those directories go silent without an error signal, so complete step 3 before switching.
+</Callout>
 
 ## Alternatives
 


### PR DESCRIPTION
## Summary

Follow-up to #3330, addressing the review feedback that the export page is complex to read. The page now optimizes for new users on the default enriched source, with a single clearly scoped legacy section for existing integrations:

- Intro states what a run writes (`observations_v2/`, `scores/`, `manifests/`) with one pointer line for legacy integrations
- The field-groups table shows only the enriched columns; legacy differences defer to the field reference
- The REST `exportSource` enum leads with `OBSERVATIONS_V2`
- Everything legacy — source selector semantics, per-source directory table, Cloud/self-hosted availability cutoffs, the `DEPRECATION_NOTICE.txt` object, and the four-step upgrade path — is consolidated into one "Legacy export sources" section at the bottom, opening with a skip-this callout
- The "Export source (Fast Preview)" heading (retired term) is gone; no external links targeted its anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes the Blob Storage export documentation around enriched exports while consolidating legacy source behavior and migration guidance into a final section.
- Simplifies the introduction and field-group table for new enriched-export users.
- Reorders the REST API source values around `OBSERVATIONS_V2`.
- Moves legacy availability, directory layouts, deprecation notices, and upgrade steps into one section.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should be corrected before merging because its new wording can direct supported legacy users toward nonexistent output directories or migration options.

The introduction contradicts the retained legacy directory table, while the consolidated legacy section excludes the dual source in its callout and presents an upgrade sequence that self-hosted users cannot execute without first enabling enriched exports.

content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:22
**Legacy runs lack observations_v2**

When an existing Cloud legacy integration or a self-hosted deployment without `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` runs an export, it writes `traces/`, `observations/`, and `scores/`, not `observations_v2/`. Describing `observations_v2/` as an output of every run directs these users to a directory that never receives their observations.

### Issue 2 of 3
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:225-230
**Callout excludes dual legacy source**

When an integration already uses `Traces and observations (legacy) and enriched observations`, this callout says the section applies only to the separately named legacy-only source. That directs the reader to skip migration guidance needed to repoint consumers before the legacy directories stop receiving files.

### Issue 3 of 3
content/docs/api-and-data-platform/features/export-to-blob-storage.mdx:251-254
**Upgrade path omits enriched prerequisite**

When a self-hosted legacy deployment lacks `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`, enriched export sources are unavailable, but the generalized path immediately requires switching to the dual source. The reader cannot perform either that first step or the final enriched-only switch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restructure the blob storage expor..."](https://github.com/langfuse/langfuse-docs/commit/13455da5f12a34bb4ddeb7ea4eb030c1ca37086c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46616542)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->