### PR TITLE
docs: restore OpenTelemetry integration label

### DIFF
--- a/content/integrations/native/opentelemetry/index.mdx
+++ b/content/integrations/native/opentelemetry/index.mdx
@@ -1,7 +1,8 @@
 ---
 title: OpenTelemetry (OTEL) for LLM Observability
 description: Connect Langfuse to OpenTelemetry (OTEL) and send OTLP traces from your application or collector to Langfuse.
-sidebarTitle: Overview
+shortTitle: Overview
+sidebarTitle: OpenTelemetry
 logo: /images/integrations/opentelemetry_icon.svg
 ---
 


### PR DESCRIPTION
## What changed

- use `shortTitle: Overview` for the nested OpenTelemetry docs navigation
- restore `sidebarTitle: OpenTelemetry` for the integrations directory card

## Why

After #3364, `/integrations#native` displayed the generic label **Overview** instead of **OpenTelemetry**. The repository already supports separate `shortTitle` and `sidebarTitle` fields, so this keeps the requested **Overview** subpage label without losing the integration name in the directory.

Linear: [LFE-14416](https://linear.app/clickhouse/issue/LFE-14416/document-custom-ingestion-migration-to-v4-ready-opentelemetry)

## Validation

- Prettier check
- H1 heading check
- Fumadocs source generation
- `git diff --check`
- local render verified `/integrations` shows **OpenTelemetry** for the native integration card and the OTEL page sidebar shows **Overview**

Local checks ran with the bundled Node 24 runtime because the repository-configured Node 22 shim is unavailable in the Codex environment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores distinct OpenTelemetry labels for two navigation contexts.
- Uses `shortTitle: Overview` for the nested OpenTelemetry documentation sidebar.
- Uses `sidebarTitle: OpenTelemetry` for the native integrations directory card.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because each changed frontmatter field is consumed by its intended navigation context.

The nested sidebar prioritizes `shortTitle` and therefore displays “Overview,” while the integrations directory card reads `sidebarTitle` and therefore displays “OpenTelemetry.”

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restore OpenTelemetry integration ..."](https://github.com/langfuse/langfuse-docs/commit/24e1ad94138b5a593e2bb50a7d5f8cb9c252a27c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46630420)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Cookbook and Integrations Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/cookbook-integrations.md)

<!-- /greptile_comment -->