### PR TITLE
fix: hide nested integration pages from index

### DIFF
--- a/components/integrations/IntegrationIndex.tsx
+++ b/components/integrations/IntegrationIndex.tsx
@@ -163,7 +163,7 @@ function loadFilesystemPages(category: string): IntegrationPage[] {
   try {
     const allParams = integrationsSource.generateParams();
     return allParams
-      .filter(({ slug }) => slug.length >= 2 && slug[0] === category)
+      .filter(({ slug }) => slug.length === 2 && slug[0] === category)
       .map(({ slug }) => {
         const page = integrationsSource.getPage(slug);
         if (!page) return null;


### PR DESCRIPTION
## What changed

Restrict filesystem-backed integration directory cards to direct category children. Nested documentation routes, such as the OpenTelemetry experiments and ingestion-migration pages, remain available in their parent integration's docs navigation but no longer appear as standalone integrations.

## Why

After #3364 introduced nested OpenTelemetry pages, `/integrations#native` treated those subpages as separate Native integrations. The directory should list integrations, not every nested documentation route.

Linear: [LFE-14416](https://linear.app/clickhouse/issue/LFE-14416/document-custom-ingestion-migration-to-v4-ready-opentelemetry)

## Validation

- Prettier check
- Fumadocs source generation
- `git diff --check`
- local `/integrations` render returned HTTP 200
- verified the OpenTelemetry card remains
- verified there are zero experiment or migration subpage links in the rendered integrations index

Local checks ran with the bundled Node 24 runtime because the repository-configured Node 22 shim is unavailable in the Codex environment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restricts filesystem-backed integration cards to direct category children.
- Keeps top-level integrations visible in the directory.
- Excludes nested integration documentation routes from standalone cards.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The filter now selects category-and-integration slugs while excluding deeper documentation routes, matching the integration index’s one-card-per-top-level-integration behavior.

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide nested integration pages from ..."](https://github.com/langfuse/langfuse-docs/commit/0164b4cfce3758f3aa362114141a225d47a15982) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46633692)</sub>

**Context used:**

- Knowledge Base — [Cookbook and Integrations Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/cookbook-integrations.md)

<!-- /greptile_comment -->