### PR TITLE
docs: announce large observation processing

### DIFF
--- a/content/changelog/2026-07-24-large-observation-content.mdx
+++ b/content/changelog/2026-07-24-large-observation-content.mdx
@@ -1,0 +1,22 @@
+---
+date: 2026-07-24
+title: Keep large observation content inspectable
+description: Inspect large observation inputs, outputs, and metadata in the Langfuse UI.
+author: Hassieb
+canonical: /docs/observability/features/multi-modality
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Langfuse now keeps very large observation inputs, outputs, and metadata intact and available for inspection in the UI. When large content reaches the ingestion pipeline, Langfuse processes it server-side and links it from the observation.
+
+This helps when an application inadvertently logs a large base64-encoded image, audio file, or document, or when a model response contains a large embedded payload.
+
+<Callout type="warning" title="Handle media in the client or SDK">
+  Server-side processing is a fallback. We strongly recommend handling media in
+  the client or Langfuse SDK for the best performance.
+</Callout>
+
+Learn more in the [multi-modality and attachments documentation](/docs/observability/features/multi-modality).

--- a/content/docs/observability/features/multi-modality.mdx
+++ b/content/docs/observability/features/multi-modality.mdx
@@ -111,6 +111,13 @@ If you require support for additional file types, please let us know in our [Git
 
 If you use base64 encoded images, audio, or other files in your LLM applications, upgrade to the latest version of the Langfuse SDKs. The Langfuse SDKs automatically detect and handle base64 encoded media by extracting it, uploading it separately as a Langfuse Media file, and including a reference in the trace.
 
+<Callout type="warning" title="Handle media in the client or SDK">
+  If large base64-encoded media reaches Langfuse without client-side processing,
+  Langfuse processes it server-side to keep it intact and available for
+  inspection in the UI. This is a fallback. We strongly recommend handling
+  media in the client or Langfuse SDK.
+</Callout>
+
 This works with standard Data URI ([MDN](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data#syntax)) formatted media (like those used by OpenAI and other LLMs).
 
 This [notebook](/guides/cookbook/example_multi_modal_traces) includes a couple of examples using the OpenAI SDK and LangChain.


### PR DESCRIPTION
## Summary

- add a changelog post announcing that large observation content remains intact and inspectable in the UI
- document server-side processing as a fallback for unprocessed base64 media
- strongly recommend client- or SDK-side media handling

## Why

Applications can inadvertently send large embedded payloads, including base64-encoded media. This update explains that Langfuse keeps this content available for inspection while making the recommended client-side handling explicit.

## Validation

- `prettier --experimental-cli --check .`
- `node scripts/check-h1-headings.js`
- `git diff --check`

## Tracking

- [LFE-14407](https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds documentation announcing server-side processing of large observation content.
- Adds a changelog entry describing preservation and UI inspection of large observation content.
- Documents server-side processing as a fallback for unprocessed base64 media.
- Recommends client- or SDK-side media handling for best performance.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The metadata-preservation claim should be narrowed or qualified before merging because oversized propagated metadata is still documented as being dropped.

The new changelog promises that very large observation metadata remains intact, contradicting the existing 200-character limit for propagated metadata values and potentially giving users an incorrect durability guarantee.

content/changelog/2026-07-24-large-observation-content.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/changelog/2026-07-24-large-observation-content.mdx:13
**Metadata preservation claim is incorrect**

When a propagated metadata value exceeds 200 characters, Langfuse drops it, so the new claim that very large observation metadata remains intact gives users an incorrect durability guarantee.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: announce large observation process..."](https://github.com/langfuse/langfuse-docs/commit/87febc34a50bc61c46302125f641247197801e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46943526)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->