### PR TITLE
fix(seo): correct doubled marketing canonicals + orphaned post (Ahrefs July 2026)

### DIFF
--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
   MARKETING_SECTIONS,
 } from "@/lib/section-registry";
 import { loadPage, buildSectionMetadata, primitiveOnly } from "@/lib/mdx-page";
+import { buildPageUrl } from "@/lib/og-url";
 import { getMDXComponents } from "@/mdx-components";
 import { WrappedDataProvider } from "@/components/wrapped/WrappedDataContext";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
@@ -109,6 +110,12 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     section,
     config.title,
     effectiveSlug,
+    // Marketing pages route as `/${section}` but use `[section]` as their
+    // Fumadocs slug, so the default `pagePath` would double the segment
+    // (e.g. `/careers/careers`). Pin the canonical to the real public path.
+    isMarketing
+      ? { canonicalFallback: buildPageUrl(`/${section}`) }
+      : undefined,
   );
 }
 

--- a/content/blog/2025-03-19-ai-agent-comparison.mdx
+++ b/content/blog/2025-03-19-ai-agent-comparison.mdx
@@ -50,7 +50,7 @@ Developers who prefer to model AI tasks as stateful workflows gravitate toward L
 
 [How to trace DeepAgents with Langfuse →](/integrations/frameworks/langchain-deepagents)
 
-If you want the "deep agent" pattern (a planner with subagents and file-backed memory) without assembling it yourself from LangGraph parts, DeepAgents is the fastest path inside the LangChain ecosystem.
+If you want the "deep agent" pattern (a planner with subagents and file-backed memory) without assembling it yourself from LangGraph parts, DeepAgents is the fastest path inside the [LangChain ecosystem](/blog/2024-08-what-is-langchain).
 
 ## OpenAI Agents SDK
 


### PR DESCRIPTION
## Monthly Ahrefs site-audit triage — July 2026

Crawl `2026-07-22`, project **9945827** (langfuse.com). Health score **97**, **71** URLs with errors. The audit runs in *subdomains* mode, so most reported errors originate on subdomains not controlled by this repo (filtered out below).

This PR fixes the **Error**-severity issues whose root cause lives in this repo. High-priority **Warning**-tier fixes (og:type, missing H1s) are split into #3374.

### Fix 1 — doubled canonical on marketing pages (42 URLs)

Marketing pages (`/careers`, `/about`, `/privacy`, …) are served through `app/[section]/[[...slug]]` and use `[section]` as their Fumadocs slug (`effectiveSlug = [section]`). `buildSectionMetadata` builds `pagePath` as `/${section}/${slug.join("/")}`, which **doubles the segment** — e.g. `/careers` emitted `<link rel="canonical" href="https://langfuse.com/careers/careers">`. The page renders at the correct URL, but the canonical (and OG url) pointed at a non-existent doubled path.

This single bug produced two distinct Ahrefs errors on the same 21 pages:
- **Non-canonical page in sitemap** — the real page is in the sitemap but declares a different (doubled) canonical.
- **Canonical URL has no incoming internal links** — nothing links to the doubled canonical target.

Fix: pass `canonicalFallback: buildPageUrl(\`/${section}\`)` for marketing sections so the canonical pins to the real public path. Frontmatter `canonical` still takes precedence (no marketing page currently sets one). Systematic — corrects every current and future marketing page routed through `[section]`, not just the 21 crawled.

Affected pages: `/careers`, `/about`, `/privacy`, `/enterprise`, `/imprint`, `/press`, `/talk-to-us`, `/support`, `/cookie-policy`, `/agents`, `/non-profit`, `/kr`, `/wrapped`, `/research`, `/watch-demo`, `/startups`, `/cn`, `/oss-friends`, `/role-finder`, `/brand`, `/community`.

### Fix 2 — orphaned "What is LangChain?" post (1 URL)

`/blog/2024-08-what-is-langchain` is intentionally hidden from the blog index (`showInBlogIndex: false`) as an SEO landing article, so it had **zero incoming internal links** and Ahrefs flagged it as an orphan. Rather than force it back into the index (against intent), added a contextual link from the "LangChain DeepAgents" section of the AI agent framework comparison post, where the explainer is genuinely relevant.

### Issue → fix mapping

| Ahrefs Error issue | Crawled URLs | Root cause in repo? | Fix |
|---|---|---|---|
| Canonical URL has no incoming internal links | 21 | ✅ doubled canonical | Fix 1 — `app/[section]/[[...slug]]/page.tsx` |
| Non-canonical page in sitemap | 21 | ✅ same doubled canonical | Fix 1 |
| Orphan page (`/blog/2024-08-what-is-langchain`) | 1 | ✅ no internal links | Fix 2 — contextual link added |
| Image file size too large | 19 | ❌ asset optimization | Out of scope (deferred effort) |
| Hreflang and HTML lang mismatch | 9 | ❌ needs locale-aware `<html lang>` | Out of scope (needs sign-off) |

### Verification

- `node -e 'require("./lib/redirects.js")'` loads cleanly (no redirect changes in this PR).
- All canonical destinations return HTTP 200 on production (`/careers`, `/about`, `/privacy`, `/community`, `/enterprise`, `/research`, `/kr`, `/cn`, …).
- Orphan link target `/blog/2024-08-what-is-langchain` returns 200; no `md-override` counterpart to sync.
- Confirmed the pre-fix canonical bug against the running dev server (`.../careers/careers`).
- `pnpm prettier` run on both touched files. Did not run `pnpm build` locally (per repo policy).

### Intentionally out of scope

- **Image file size too large** (19 URLs): asset-optimization effort, mostly on `static.langfuse.com`. Repo policy is `.mp4` on `static.langfuse.com/docs-videos`, never `.gif`.
- **Hreflang and HTML lang mismatch** (9 URLs): `/japan` and `/academy/japan/*`; requires making the hardcoded `<html lang="en">` in `app/layout.tsx` locale-aware — a global change needing explicit sign-off.
- **Warning-tier fixes** (og:type site-wide, missing H1s): split into #3374.
- **Subdomain errors** not controlled by this repo: `*.docs-snapshot.langfuse.com`, `js/python/api.reference.langfuse.com`, `cloud.langfuse.com`, `static.langfuse.com`, `chat.langfuse.com`, and Cloudflare `cdn-cgi/l/email-protection` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)