### PR TITLE
docs(filters): fix scores namespace, note incomplete filters, add filter-search-bar video

### DIFF
--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Filter Search Bar
 The Filter Search Bar lets you filter and search the Observations and Traces tables by typing a single line of text instead of assembling filters in the sidebar. It parses your query into the same filters the sidebar produces, autocompletes fields and values as you type, and serializes the full query into the URL so you can share an exact view with a link.
 
 <Video
-  src="/images/changelog/2026-06-19-filter-search-bar.mp4"
+  src="https://static.langfuse.com/docs-videos/2026-06-19-filter-search-bar.mp4"
   aspectRatio={16 / 9}
 />
 

--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -8,6 +8,11 @@ sidebarTitle: Filter Search Bar
 
 The Filter Search Bar lets you filter and search the Observations and Traces tables by typing a single line of text instead of assembling filters in the sidebar. It parses your query into the same filters the sidebar produces, autocompletes fields and values as you type, and serializes the full query into the URL so you can share an exact view with a link.
 
+<Video
+  src="/images/changelog/2026-06-19-filter-search-bar.mp4"
+  aspectRatio={16 / 9}
+/>
+
 ```
 level:ERROR type:TOOL environment:production latency:>2 name:*checkout*
 ```
@@ -59,9 +64,9 @@ Use dot paths for nested fields:
 - `metadata.region:eu`
 - `scores.accuracy:>0.8`
 - `scores.is_hallucination:false`
-- `traceScores.helpfulness:positive`
+- `scores.helpfulness:positive`
 
-Score filters support numeric, categorical, and boolean values.
+`scores.*` matches a score by name regardless of its level, so a single namespace covers observation-, trace-, session-, and experiment-level scores. Score filters support numeric, categorical, and boolean values.
 
 Quote keys that contain spaces or special characters after the prefix: `scores."Answer Relevance":>=0.9`, `metadata."my key":eu`.
 
@@ -124,6 +129,10 @@ The full query is serialized into the URL, so sending someone the link reproduce
 ## Reserved tokens
 
 Some operator-like tokens are not supported yet and are flagged instead of being treated as text: `!`, and the lowercase words `and`, `or`, and `not`. Use `-field:value` to exclude and `field:(A OR B)` to match several values of one field. To search for a reserved word as literal text, quote it (`"or"`).
+
+## Incomplete filters
+
+A bare field name with no value, such as `type`, `level`, or `env` on its own, is not yet a complete expression. The bar flags it as invalid and does not apply it to the query until you finish it, for example `type:TOOL`. To search for one of these words as literal text instead, quote it (`"type"`).
 
 ## GitHub Discussions
 


### PR DESCRIPTION
## TL;DR

Corrects the Filter Search Bar docs to match shipped behavior: removes the retired `traceScores.*` namespace, documents that a lone unfinished field name is now flagged and not applied, and adds a walkthrough video near the top of the page.

## What changed

- **Scores namespace correctness fix (most important).** The "Metadata and scores" section showed a `traceScores.helpfulness:positive` example. That namespace was removed from the UI when score filtering was unified across levels (langfuse/langfuse#14692), so the doc had drifted from the product. Replaced it with `scores.helpfulness:positive` and a sentence stating that `scores.*` matches a score by name regardless of its level, so a single namespace covers observation-, trace-, session-, and experiment-level scores.
- **Incomplete filters note.** Added a short section explaining that a bare field name with no value (`type`, `level`, `env` on its own) is flagged as invalid and not applied to the query until it is a complete expression, and that quoting it (`"type"`) searches for the word literally.
- **Video near the top.** Embedded the existing walkthrough asset `/images/changelog/2026-06-19-filter-search-bar.mp4` via the shared `<Video>` component, matching the pattern used on sibling feature pages. No new asset was added.

Addresses part of LFE-10930 (add an image/video to the filter search bar docs) and fixes the documentation drift introduced by the score-filtering unification.

## Verification

Ran the docs dev server against the page: it renders with no MDX/build error, the video asset serves (200, `video/mp4`), and `traceScores` no longer appears in the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects the documented score-filter namespace, clarifies how incomplete field expressions are handled, and embeds the existing Filter Search Bar walkthrough video.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The updated syntax, incomplete-filter guidance, and video embed introduce no supported blocking or non-blocking failure.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(filters): fix scores namespace, not..."](https://github.com/langfuse/langfuse-docs/commit/22470b3b6de96e393a3eeeb7f5def1697150cbcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46948812)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->