### PR TITLE
Add 🪢 knot emoji page (meaning + why it's the Langfuse logo)

### DIFF
--- a/content/resources/engineering/knot-emoji.mdx
+++ b/content/resources/engineering/knot-emoji.mdx
@@ -1,0 +1,58 @@
+---
+title: "🪢 Knot emoji: meaning, Unicode, and why it's the Langfuse logo"
+tags: [guide]
+description: "What the 🪢 knot emoji means, its Unicode codepoint, how to copy and use it, and why an LLM engineering platform picked it as a logo."
+---
+
+# 🪢 Knot emoji: meaning, and why it's the Langfuse logo
+
+🪢 is the knot emoji: a rope tied into a secure loop, added to Unicode in 2020. People use it for literal knots, for tying things together, and for commitments like "tying the knot". It is also the logo of [Langfuse](https://langfuse.com), the open-source LLM engineering platform whose website you are reading right now. Both facts explain each other, and this page covers both.
+
+To copy it: 🪢
+
+## What the knot emoji means [#meaning]
+
+The knot emoji shows a length of rope tied into a knot, most commonly rendered as a figure-eight or square knot on an orange or brown rope. Common uses:
+
+- **Literal knots and rope work.** Sailing, climbing, scouting, and craft contexts use it for actual knots.
+- **Tying things together.** The metaphorical use: connecting parts into one whole, which is the sense Langfuse borrows.
+- **"Tying the knot."** Engagements and weddings, often next to 💍.
+- **Strength and security.** A knot holds; the emoji signals something firmly connected.
+
+Technical facts, as of July 2026:
+
+| Property     | Value                            |
+| ------------ | -------------------------------- |
+| Character    | 🪢                               |
+| Unicode name | Knot                             |
+| Codepoint    | U+1FAA2                          |
+| Added in     | Unicode 13.0 / Emoji 13.0 (2020) |
+| Category     | Objects                          |
+
+## Why 🪢 is the Langfuse logo [#langfuse-logo]
+
+Langfuse started in Y Combinator's W23 batch, and the founders worked through several product ideas before landing on Langfuse. Each idea got its own emoji as a working label. When the team settled on building an LLM engineering platform, the knot fit: Langfuse ties together the activities of AI engineering, from [tracing](/docs/observability/overview) to [evaluation](/docs/evaluation/overview) to [prompt management](/docs/prompt-management/overview) and team collaboration, into one platform. The name works in the same direction: a fuse joins two things, and so does a knot.
+
+There was a second reason, offered with a wink: every serious open source project needs an emoji. The 🦜🔗 of LangChain, the 🦙 of LlamaIndex, and the 🤗 of Hugging Face had set the convention for the LLM ecosystem, and Langfuse joined it. The [GitHub repository](https://github.com/langfuse/langfuse) has carried the 🪢 in its title since the beginning.
+
+## Emoji as developer branding [#emoji-branding]
+
+An emoji logo does real work for an open source project. It renders identically in a GitHub README, a terminal, a package description, and a chat message, places where an image logo cannot follow. It costs nothing to reproduce, survives copy-paste, and makes a project recognizable in a plain-text dependency list. The convention is now strong enough in the LLM tooling ecosystem that the emoji often precedes the name, as in "🪢 Langfuse".
+
+## FAQ [#faq]
+
+### What does the 🪢 emoji mean? [#what-does-it-mean]
+
+🪢 is the knot emoji, showing a rope tied into a knot. It is used for literal knots, for the idea of tying or holding things together, and for engagements ("tying the knot"). In the LLM tooling world it also identifies Langfuse, which uses it as a logo.
+
+### How do I copy the knot emoji? [#copy]
+
+Select and copy this character: 🪢. It is a standard Unicode character (U+1FAA2), so it pastes anywhere Unicode text works, including code comments, READMEs, and commit messages.
+
+### When was the knot emoji added to Unicode? [#unicode-version]
+
+The knot was added as part of Unicode 13.0 and Emoji 13.0 in 2020. Platforms rolled out support over the following year, so it renders on all current operating systems and browsers.
+
+### Why does Langfuse use a knot as its logo? [#why-langfuse]
+
+Langfuse ties together the parts of AI engineering: tracing, evaluation, prompt management, and team collaboration in one open-source platform. The knot is that idea in a single character, and it doubles as the project's emoji in the tradition of 🤗 and 🦙.

--- a/content/resources/engineering/knot-emoji.mdx
+++ b/content/resources/engineering/knot-emoji.mdx
@@ -35,6 +35,55 @@ Langfuse started in Y Combinator's W23 batch, and the founders worked through se
 
 There was a second reason, offered with a wink: every serious open source project needs an emoji. The 🦜🔗 of LangChain, the 🦙 of LlamaIndex, and the 🤗 of Hugging Face had set the convention for the LLM ecosystem, and Langfuse joined it. The [GitHub repository](https://github.com/langfuse/langfuse) has carried the 🪢 in its title since the beginning.
 
+## From emoji to logo [#logo-evolution]
+
+The Langfuse logo has evolved over time, and every version keeps the original knot emoji at heart. The first icon traced the emoji's two interlocking ropes with bold outlines; the current icon keeps the same knot and drops the outlines for a softer mark. The official assets live on the [brand page](/brand).
+
+<div
+  style={{
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "1.25rem",
+    flexWrap: "wrap",
+    margin: "2rem 0",
+    textAlign: "center",
+  }}
+>
+  <figure style={{ margin: 0 }}>
+    <span style={{ fontSize: "4rem", lineHeight: 1 }}>🪢</span>
+    <figcaption style={{ fontSize: "0.8rem", opacity: 0.7 }}>
+      The knot emoji
+    </figcaption>
+  </figure>
+  <span style={{ fontSize: "1.5rem", opacity: 0.5 }}>→</span>
+  <figure style={{ margin: 0 }}>
+    <img
+      src="/icon.svg"
+      alt="First Langfuse icon: knot with bold outlines"
+      width="72"
+      height="72"
+      style={{ display: "block", margin: "0 auto" }}
+    />
+    <figcaption style={{ fontSize: "0.8rem", opacity: 0.7 }}>
+      First icon
+    </figcaption>
+  </figure>
+  <span style={{ fontSize: "1.5rem", opacity: 0.5 }}>→</span>
+  <figure style={{ margin: 0 }}>
+    <img
+      src="/brand-assets/icon/color/langfuse-icon.svg"
+      alt="Current Langfuse icon: knot without outlines"
+      width="72"
+      height="72"
+      style={{ display: "block", margin: "0 auto" }}
+    />
+    <figcaption style={{ fontSize: "0.8rem", opacity: 0.7 }}>
+      Current icon
+    </figcaption>
+  </figure>
+</div>
+
 ## Emoji as developer branding [#emoji-branding]
 
 An emoji logo does real work for an open source project. It renders identically in a GitHub README, a terminal, a package description, and a chat message, places where an image logo cannot follow. It costs nothing to reproduce, survives copy-paste, and makes a project recognizable in a plain-text dependency list. The convention is now strong enough in the LLM tooling ecosystem that the emoji often precedes the name, as in "🪢 Langfuse".

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -13,6 +13,7 @@
     "migrate-from-phoenix",
     "llm-gateway",
     "clickhouse-at-agent-scale",
+    "knot-emoji",
     "llm-cost-management",
     "coding-agent-tracing",
     "opentelemetry-languages",


### PR DESCRIPTION
## What

One new page under `/resources/engineering`, registered in `meta.json`:

**`knot-emoji`** — answers knot-emoji-lookup intent first (meaning, common usages, Unicode facts table, copy-paste) and then tells why 🪢 is the Langfuse logo: the YC W23 pivot story (each idea had its own emoji), the knot as tying together tracing, evals, prompt management, and team collaboration, and the "every serious open source project needs an emoji" tradition alongside 🦜🔗, 🦙, and 🤗. The emoji sits in the `<title>` and H1 so Google can render it for emoji queries; the slug stays ASCII.

## Why

From the internal GEO pipeline (item `knot-emoji-page`, user-requested and approved 2026-07-24; evidence and brief in `langfuse/internal-geo`):

- "🪢" gets ~250 US searches/month and "knot emoji" ~241/month, both Keyword Difficulty 0 (Ahrefs, 2026-07-24).
- The SERP is Emojipedia (DR 91) plus weak emoji-reference sites (DR 67-82); no developer tool ranks. The People-Also-Ask box ("What does the 🪢 mean?") is winnable with the FAQ block.
- langfuse.com currently has zero GSC impressions for these queries.
- Honest framing: this is a brand/curiosity play with no funnel value, approved as such.

## Reviewer attention

- **Unicode dating**: U+1FAA2 is confirmed; "Unicode 13.0 / Emoji 13.0 (2020)" is high-confidence but was authored in a sandbox without web access — one click on emojipedia.org/knot verifies it.
- **The origin story**: told generally (no pre-Langfuse ideas named) from the founders' account; adjust the telling if you want more or less detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC7XpR6AxErDeP12QDHQhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC7XpR6AxErDeP12QDHQhs)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new knot emoji resource page covering its meaning, Unicode details, and connection to the Langfuse brand, and registers the page in the engineering resources navigation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new page conforms to the resources collection schema and established MDX conventions, resolves at the intended route, and links only to existing canonical documentation pages.

</details>

<sub>Reviews (1): Last reviewed commit: ["Add knot emoji page: meaning, Unicode fa..."](https://github.com/langfuse/langfuse-docs/commit/7e31936a9355905f9aef69bdf7b33e39ff5defa2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46951444)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)

<!-- /greptile_comment -->