### PR TITLE
Voice agents: tracing guide, audio attachment pattern, Pipecat/LiveKit doc refresh

### DIFF
--- a/content/integrations/frameworks/livekit.mdx
+++ b/content/integrations/frameworks/livekit.mdx
@@ -191,7 +191,7 @@ async def entrypoint(ctx: JobContext):
     await session.start(agent=MyAgent(), room=ctx.room)
 ```
 
-You can find a full end-to-end Python example [on GitHub](https://github.com/livekit/agents/blob/main/examples/voice_agents/langfuse_trace.py).
+You can find a full end-to-end Python example [on GitHub](https://github.com/livekit/agents/blob/main/examples/voice_agents/otel_trace.py).
 
 </Tab>
 <Tab title="JS/TS SDK">
@@ -236,7 +236,7 @@ import LearnMore from "@/components-mdx/integration-learn-more.mdx";
 
 - [LiveKit Agents Documentation](https://docs.livekit.io/agents/)
 - [LiveKit Telemetry Guide](https://docs.livekit.io/agents/build/metrics/)
-- [End-to-end Python example](https://github.com/livekit/agents/blob/main/examples/voice_agents/langfuse_trace.py)
+- [End-to-end Python example](https://github.com/livekit/agents/blob/main/examples/voice_agents/otel_trace.py)
 
 ## GitHub Discussions
 

--- a/content/integrations/frameworks/pipecat.mdx
+++ b/content/integrations/frameworks/pipecat.mdx
@@ -210,90 +210,6 @@ patch_trace_input_output()
 
 </Steps>
 
-## Record and Attach Conversation Audio [#record-audio]
-
-Traces capture transcripts and timings; the recording captures how the conversation actually
-sounded. Pipecat's `AudioBufferProcessor` records both sides of the conversation, and
-Langfuse renders attached [audio files](/docs/observability/features/multi-modality) with an
-audio player on the trace.
-
-Because Pipecat owns the root span, capture the conversation's trace ID with a small span
-processor, then attach the recording to the trace when the audio buffer flushes. This
-requires the Langfuse Python SDK (`pip install langfuse`) and your `LANGFUSE_PUBLIC_KEY`,
-`LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` environment variables in addition to the OTLP
-exporter setup above:
-
-```python filename="main.py"
-import wave
-
-from langfuse import get_client
-from langfuse.media import LangfuseMedia
-from opentelemetry import trace
-from opentelemetry.sdk.trace import SpanProcessor
-
-from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
-
-
-class RootTraceIdCapture(SpanProcessor):
-    """Remembers the trace ID of the conversation's root span."""
-
-    def __init__(self):
-        self.trace_id = None
-
-    def on_start(self, span, parent_context=None):
-        if span.parent is None and self.trace_id is None:
-            self.trace_id = format(span.get_span_context().trace_id, "032x")
-
-
-# Add after setup_tracing()
-capture = RootTraceIdCapture()
-trace.get_tracer_provider().add_span_processor(capture)
-
-audiobuffer = AudioBufferProcessor(
-    num_channels=2,  # stereo: user left, agent right
-    auto_start_recording=True,
-)
-
-pipeline = Pipeline(
-    [
-        transport.input(),
-        stt,
-        user_aggregator,
-        llm,
-        tts,
-        transport.output(),
-        audiobuffer,  # after transport.output() to capture what the user heard
-        assistant_aggregator,
-    ]
-)
-
-
-@audiobuffer.event_handler("on_audio_data")
-async def on_audio_data(buffer, audio, sample_rate, num_channels):
-    path = f"conversation-{conversation_id}.wav"
-    with wave.open(path, "wb") as wf:
-        wf.setnchannels(num_channels)
-        wf.setsampwidth(2)
-        wf.setframerate(sample_rate)
-        wf.writeframes(audio)
-
-    # Attach the recording to the conversation's trace in Langfuse
-    langfuse = get_client()
-    recording = LangfuseMedia(file_path=path, content_type="audio/wav")
-    with langfuse.start_as_current_span(
-        name="conversation-recording",
-        trace_context={"trace_id": capture.trace_id},
-    ) as span:
-        span.update_trace(metadata={"recording": recording})
-    langfuse.flush()
-```
-
-With the default `buffer_size=0`, `on_audio_data` fires once when recording stops at the end
-of the conversation. For long calls, set a positive `buffer_size` to stream audio chunks
-incrementally (see Pipecat's [audio recording guide](https://docs.pipecat.ai/pipecat/fundamentals/recording-audio)).
-For a broader overview of voice-agent tracing patterns, see
-[Trace voice agents in Langfuse](/resources/engineering/voice-agent-tracing).
-
 ## Masking Sensitive Content
 
 Pipecat exports raw conversation content in span attributes (LLM messages, transcripts, TTS
@@ -332,7 +248,6 @@ The tracing system consists of:
 
 - [End-to-end example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse)
 - [Pipecat Tracing Documentation](https://docs.pipecat.ai/api-reference/server/utilities/opentelemetry)
-- [Pipecat Audio Recording Guide](https://docs.pipecat.ai/pipecat/fundamentals/recording-audio)
 - [Trace voice agents in Langfuse](/resources/engineering/voice-agent-tracing)
 
 ## GitHub Discussions

--- a/content/integrations/frameworks/pipecat.mdx
+++ b/content/integrations/frameworks/pipecat.mdx
@@ -24,26 +24,29 @@ _Example of a Pipecat agent conversation in Langfuse._
 
 - **Hierarchical Tracing**: Track entire conversations, turns, and service calls
 - **Service Tracing**: Detailed spans for TTS, STT, and LLM services with rich context
-- **TTFB Metrics**: Capture Time To First Byte metrics for latency analysis
-- **Usage Statistics**: Track character counts for TTS and token usage for LLMs
+- **Latency Metrics**: Capture time-to-first-byte (`metrics.ttfb`, in seconds) per service and end-to-end turn latency (`turn.user_bot_latency_seconds`)
+- **Usage Statistics**: Track character counts for TTS and token usage for LLMs, including audio and reasoning token counts for speech-to-speech models
 
 ## Trace Structure
 
 Traces are organized hierarchically:
 
 ```
-Conversation (conversation-uuid)
-├── turn-1
-│   ├── stt_deepgramsttservice
-│   ├── llm_openaillmservice
-│   └── tts_cartesiattsservice
-└── turn-2
-    ├── stt_deepgramsttservice
-    ├── llm_openaillmservice
-    └── tts_cartesiattsservice
-    turn-N
-    └── ...
+conversation
+├── turn
+│   ├── stt
+│   ├── llm
+│   └── tts
+└── turn
+    ├── stt
+    ├── llm
+    └── tts
 ```
+
+Speech-to-speech services (e.g., OpenAI Realtime, Gemini Live) emit a different hierarchy
+under each turn: `llm_setup`, `llm_response`, `llm_tool_call`, and `llm_tool_result` spans,
+with audio token usage reported via `gen_ai.usage.audio.input_tokens` and
+`gen_ai.usage.audio.output_tokens` (pipecat-ai 1.6.0+).
 
 This organization helps you track conversation-to-conversation and turn-to-turn.
 
@@ -51,9 +54,9 @@ This organization helps you track conversation-to-conversation and turn-to-turn.
 
 1. **One trace = one full conversation**: Due to the way Pipecat structures its OpenTelemetry spans, a single trace represents one complete conversation. This differs from the typical Langfuse pattern where one trace equals one interaction, and full conversations are grouped under a [session](/docs/observability/features/sessions). With Pipecat, there's no need to group traces under a session—your entire conversation is already contained within a single trace.
 
-2. **Default trace name**: By default, all traces are named `conversation` or the conversation uuid. See [Renaming Traces](#renaming-traces) below for an example of how to patch the spans to customize your trace name.
+2. **Default trace name**: By default, all traces are named `conversation` or the conversation uuid. See [Set the trace name, session, and user](#renaming-traces) below for how to customize this with `additional_span_attributes`.
 
-Learn more about Pipecat span attributes in the [Pipecat documentation](https://docs.pipecat.ai/server/utilities/opentelemetry).
+Learn more about Pipecat span attributes in the [Pipecat documentation](https://docs.pipecat.ai/api-reference/server/utilities/opentelemetry).
 
 ## End-to-end Examples
 
@@ -104,13 +107,22 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64_encoded_api_key>,x-lang
 
 For more details, please refer to the Langfuse [OpenTelemetry documentation](/docs/opentelemetry/get-started).
 
-### Add OpenTelemetry to your Pipeline Task
+### Add OpenTelemetry to your Pipeline Worker
 
-Enable tracing in your Pipecat application:
+Install Pipecat with its tracing extra and the OTLP HTTP exporter:
+
+```bash
+pip install "pipecat-ai[tracing]" opentelemetry-exporter-otlp-proto-http
+```
+
+Then enable tracing in your Pipecat application:
 
 ```python filename="main.py"
 # Initialize OpenTelemetry with the http exporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.utils.tracing.setup import setup_tracing
 
 # Configured automatically from .env
 exporter = OTLPSpanExporter()
@@ -120,23 +132,53 @@ setup_tracing(
     exporter=exporter,
 )
 
-# Enable tracing in your PipelineTask
-task = PipelineTask(
+# Enable tracing in your PipelineWorker
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         allow_interruptions=True,
-        enable_metrics=True,  # Required for some service metrics
+        enable_metrics=True,  # Required for TTFB and processing-time metrics
+        enable_usage_metrics=True,  # Required for token/character usage
     ),
-    enable_tracing=True,  # Enables both turn and conversation tracing
+    enable_tracing=True,
     conversation_id="customer-123",  # Optional - will auto-generate if not provided
 )
 ```
 
+<Callout type="info">
+  `PipelineTask` was deprecated in pipecat-ai 1.3.0 in favor of `PipelineWorker`
+  (same parameters) and is scheduled for removal in 2.0. On older Pipecat versions,
+  use `PipelineTask` from `pipecat.pipeline.task` instead.
+</Callout>
+
 For more details, please refer to the [OpenTelemetry Python Documentation](https://opentelemetry-python.readthedocs.io/).
 
-### Add Trace Input and Output
+### Set the Trace Name, Session, and User [#renaming-traces]
 
-By default, Pipecat traces don't include the conversation input and output at the trace level. You can patch Pipecat's service decorators to set the `langfuse.trace.input` and `langfuse.trace.output` attributes, capturing the first LLM call's messages as the trace input and the last LLM response as the trace output:
+By default, all Pipecat traces are named `conversation` or use the conversation UUID. Pass
+`additional_span_attributes` to set attributes on the root `conversation` span — including
+Langfuse's [trace attributes](/docs/observability/features/metadata) such as the trace name,
+[session](/docs/observability/features/sessions), [user](/docs/observability/features/users),
+and tags — without any patching:
+
+```python filename="main.py"
+worker = PipelineWorker(
+    pipeline,
+    params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+    enable_tracing=True,
+    conversation_id=conversation_id,
+    additional_span_attributes={
+        "langfuse.trace.name": "pipecat-chatbot",
+        "langfuse.session.id": conversation_id,
+        "langfuse.user.id": user_id,
+        "langfuse.trace.tags": ["voice-agent"],
+    },
+)
+```
+
+### Add Trace Input and Output (Optional)
+
+By default, Pipecat traces don't include the conversation input and output at the trace level. You can patch Pipecat's service decorators to set the `langfuse.trace.input` and `langfuse.trace.output` attributes, capturing the first LLM call's messages as the trace input and the last LLM response as the trace output (verified with pipecat-ai 1.6.0; this patch targets Pipecat internals and may need updating with future releases):
 
 ```python filename="main.py"
 def patch_trace_input_output():
@@ -166,44 +208,109 @@ def patch_trace_input_output():
 patch_trace_input_output()
 ```
 
-### Renaming Traces (Optional) [#renaming-traces]
+</Steps>
 
-By default, all Pipecat traces are named `conversation` or use the conversation UUID. To customize the trace name, extend the patch to set the `langfuse.trace.name` attribute:
+## Record and Attach Conversation Audio [#record-audio]
+
+Traces capture transcripts and timings; the recording captures how the conversation actually
+sounded. Pipecat's `AudioBufferProcessor` records both sides of the conversation, and
+Langfuse renders attached [audio files](/docs/observability/features/multi-modality) with an
+audio player on the trace.
+
+Because Pipecat owns the root span, capture the conversation's trace ID with a small span
+processor, then attach the recording to the trace when the audio buffer flushes. This
+requires the Langfuse Python SDK (`pip install langfuse`) and your `LANGFUSE_PUBLIC_KEY`,
+`LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` environment variables in addition to the OTLP
+exporter setup above:
 
 ```python filename="main.py"
-def patch_trace_name():
-    from pipecat.utils.tracing import service_decorators
-    original = service_decorators.add_llm_span_attributes
-    first_call = [True]
+import wave
 
-    def patched(span, *args, **kwargs):
-        original(span, *args, **kwargs)
+from langfuse import get_client
+from langfuse.media import LangfuseMedia
+from opentelemetry import trace
+from opentelemetry.sdk.trace import SpanProcessor
 
-        # Set a custom trace name on the first LLM call
-        if first_call[0]:
-            span.set_attribute("langfuse.trace.name", "pipecat-chatbot")
-            first_call[0] = False
+from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 
-    service_decorators.add_llm_span_attributes = patched
 
-# Apply patch before tracing setup
-patch_trace_name()
+class RootTraceIdCapture(SpanProcessor):
+    """Remembers the trace ID of the conversation's root span."""
+
+    def __init__(self):
+        self.trace_id = None
+
+    def on_start(self, span, parent_context=None):
+        if span.parent is None and self.trace_id is None:
+            self.trace_id = format(span.get_span_context().trace_id, "032x")
+
+
+# Add after setup_tracing()
+capture = RootTraceIdCapture()
+trace.get_tracer_provider().add_span_processor(capture)
+
+audiobuffer = AudioBufferProcessor(
+    num_channels=2,  # stereo: user left, agent right
+    auto_start_recording=True,
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        user_aggregator,
+        llm,
+        tts,
+        transport.output(),
+        audiobuffer,  # after transport.output() to capture what the user heard
+        assistant_aggregator,
+    ]
+)
+
+
+@audiobuffer.event_handler("on_audio_data")
+async def on_audio_data(buffer, audio, sample_rate, num_channels):
+    path = f"conversation-{conversation_id}.wav"
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(audio)
+
+    # Attach the recording to the conversation's trace in Langfuse
+    langfuse = get_client()
+    recording = LangfuseMedia(file_path=path, content_type="audio/wav")
+    with langfuse.start_as_current_span(
+        name="conversation-recording",
+        trace_context={"trace_id": capture.trace_id},
+    ) as span:
+        span.update_trace(metadata={"recording": recording})
+    langfuse.flush()
 ```
 
-You can combine both patches into a single function if you want to set the trace name, input, and output together.
+With the default `buffer_size=0`, `on_audio_data` fires once when recording stops at the end
+of the conversation. For long calls, set a positive `buffer_size` to stream audio chunks
+incrementally (see Pipecat's [audio recording guide](https://docs.pipecat.ai/pipecat/fundamentals/recording-audio)).
+For a broader overview of voice-agent tracing patterns, see
+[Trace voice agents in Langfuse](/resources/engineering/voice-agent-tracing).
 
-</Steps>
+## Masking Sensitive Content
+
+Pipecat exports raw conversation content in span attributes (LLM messages, transcripts, TTS
+text). Since spans go directly to the OTLP endpoint, redaction must happen client-side: add
+your own scrubbing `SpanProcessor` to the tracer provider before the exporter to remove or
+hash PII before it leaves your infrastructure.
 
 ## Understanding the Traces
 
 - **Conversation Spans**: The top-level span representing an entire conversation
-- **Turn Spans**: Child spans of conversations that represent each turn in the dialog
+- **Turn Spans**: Child spans of conversations that represent each turn in the dialog, with attributes like `turn.number`, `turn.was_interrupted`, and `turn.user_bot_latency_seconds` (time from the user finishing to the bot responding)
 - **Service Spans**: Detailed service operations nested under turns
 - **Service Attributes**: Each service includes rich context about its operation:
   - **TTS**: Voice ID, character count, service type
   - **STT**: Transcription text, language, model
-  - **LLM**: Messages, tokens used, model, service configuration
-- **Metrics**: Performance data like `metrics.ttfb_ms` and processing durations
+  - **LLM**: Messages, tokens used (`gen_ai.usage.input_tokens`/`output_tokens`, plus `gen_ai.usage.audio.*` for speech-to-speech models), model, provider (`gen_ai.provider.name`), service configuration
+- **Metrics**: Performance data like `metrics.ttfb` (time to first byte, in seconds) and processing durations
 
 ## How It Works
 
@@ -224,7 +331,9 @@ The tracing system consists of:
 ## References
 
 - [End-to-end example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse)
-- [Pipecat Tracing Documentation](https://docs.pipecat.ai/server/utilities/opentelemetry)
+- [Pipecat Tracing Documentation](https://docs.pipecat.ai/api-reference/server/utilities/opentelemetry)
+- [Pipecat Audio Recording Guide](https://docs.pipecat.ai/pipecat/fundamentals/recording-audio)
+- [Trace voice agents in Langfuse](/resources/engineering/voice-agent-tracing)
 
 ## GitHub Discussions
 

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -13,6 +13,7 @@
     "migrate-from-phoenix",
     "llm-gateway",
     "coding-agent-tracing",
+    "voice-agent-tracing",
     "opentelemetry-languages",
     "pii-masking-llm-applications",
     "code-evaluator-examples",

--- a/content/resources/engineering/voice-agent-tracing.mdx
+++ b/content/resources/engineering/voice-agent-tracing.mdx
@@ -1,0 +1,336 @@
+---
+title: "Trace voice agents: Pipecat, LiveKit, OpenAI Realtime & Gemini Live"
+description: "How to trace voice agents with Langfuse: Pipecat, LiveKit Agents, Vapi, OpenAI Realtime, and Gemini Live. Turn-level latency, audio token costs, and attaching the conversation recording to the trace."
+tags: [guide, agents]
+---
+
+# Trace voice agents in Langfuse
+
+Voice agents are realtime pipelines: audio streams in, speech-to-text, an LLM, and
+text-to-speech (or a single speech-to-speech model) run per turn, and audio streams back out,
+all while the user can interrupt at any moment. Tracing them answers the questions text-based
+tracing can't: **which stage added the latency before the agent spoke**, **what did the
+conversation actually sound like**, and **what did a call cost** once audio tokens are
+counted.
+
+**TL;DR:** Langfuse traces voice agents built with Pipecat and LiveKit Agents through their
+native OpenTelemetry support, giving you one trace per conversation with turn, STT, LLM, and
+TTS spans. Vapi ships a built-in Langfuse integration. Speech-to-speech models (OpenAI
+Realtime, Gemini Live) are covered when they run inside those frameworks, or by
+instrumenting their event stream directly with the Langfuse SDK. The full conversation
+recording can be attached to the trace and replayed from an audio player in the Langfuse UI.
+
+## What a voice-agent trace needs to capture
+
+A useful voice trace goes beyond model inputs and outputs:
+
+1. **Turn structure.** A conversation is a sequence of turns, each with user speech, model
+   work, and agent speech. The trace should mirror this: one trace per conversation, one span
+   per turn, service spans nested inside.
+2. **Latency breakdown.** "The agent felt slow" decomposes into STT finalization, LLM time to
+   first token, and TTS time to first byte. Both Pipecat and LiveKit emit these as span
+   attributes, so the slowest stage of every turn is visible without extra instrumentation.
+3. **Interruptions.** Barge-ins are a defining behavior of voice UX. Turn spans carry
+   interruption flags (`turn.was_interrupted` in Pipecat, `lk.interrupted` in LiveKit), so
+   you can filter for conversations where users cut the agent off.
+4. **Audio token usage and cost.** Speech-to-speech models bill audio tokens at different
+   rates than text tokens. Langfuse stores usage as arbitrary
+   [usage types](/docs/observability/features/token-and-cost-tracking) (e.g.,
+   `input_audio_tokens`, `output_audio_tokens`, `input_cached_tokens`) and applies per-type
+   prices, so realtime-model costs are accounted correctly.
+5. **Transcripts and audio.** Transcripts land on spans as text, which makes them searchable
+   and evaluable. The recording itself can be attached as [media](/docs/observability/features/multi-modality)
+   and replayed next to the trace.
+
+## Supported frameworks and platforms
+
+| Framework / API                                             | Mechanism                                                                                | Notes                                                                           |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Pipecat](/integrations/frameworks/pipecat)                 | Native OpenTelemetry tracing exported to Langfuse's OTLP endpoint                        | One trace per conversation: `conversation` → `turn` → `stt`/`llm`/`tts`         |
+| [LiveKit Agents](/integrations/frameworks/livekit)          | Native OpenTelemetry via a shared `TracerProvider` with the Langfuse SDK (Python & Node) | Emits Langfuse-recognized attributes incl. audio token usage                    |
+| [Vapi](/integrations/no-code/vapi)                          | Built-in integration, add Langfuse keys in the Vapi dashboard                            | No code changes                                                                 |
+| [OpenAI Agents SDK](/integrations/frameworks/openai-agents) | OpenInference instrumentation                                                            | Covers agent workflow runs; for `RealtimeAgent` see [below](#realtime)          |
+| [Google ADK](/integrations/frameworks/google-adk)           | OpenInference instrumentation                                                            | Covers turn-based agents; see [below](#realtime) for Gemini Live via `run_live` |
+| OpenAI Realtime API                                         | Framework path (Pipecat/LiveKit) or manual instrumentation                               | See [below](#realtime)                                                          |
+| Gemini Live API                                             | Framework path (Pipecat/LiveKit) or manual instrumentation                               | See [below](#realtime)                                                          |
+
+Both framework integrations produce one trace per conversation. This differs from the
+typical one-trace-per-request pattern in text applications; there is no need to group turns
+into [sessions](/docs/observability/features/sessions), because the whole conversation is
+already a single tree. Sessions remain useful for grouping repeat calls from the same user.
+
+## Anatomy of a voice-agent trace
+
+With Pipecat (v1.6+), the span tree looks like this:
+
+```
+conversation
+├── turn (turn.number, turn.was_interrupted, turn.user_bot_latency_seconds)
+│   ├── stt   (transcript, gen_ai.provider.name, metrics.ttfb)
+│   ├── llm   (messages, gen_ai.usage.input_tokens/output_tokens, metrics.ttfb)
+│   └── tts   (character count, voice_id, metrics.ttfb)
+└── turn
+    └── ...
+```
+
+Speech-to-speech services swap the STT/LLM/TTS triple for `llm_setup`, `llm_response`,
+`llm_tool_call`, and `llm_tool_result` spans, with audio token usage reported via
+`gen_ai.usage.audio.input_tokens` and `gen_ai.usage.audio.output_tokens`.
+
+LiveKit Agents emits a similar tree (`agent_session` → `user_turn`/`agent_turn` →
+`llm_node`, `function_tool`, `tts_node`, `eou_detection`) and sets
+`langfuse.observation.completion_start_time` on LLM spans, so time-to-first-token renders
+natively in Langfuse. For realtime models, LiveKit reports the audio/text/cached token
+breakdown per turn.
+
+Useful queries once this data is in Langfuse:
+
+- Sort turns by `turn.user_bot_latency_seconds` to find the slowest exchanges.
+- Filter traces on interruption flags to review conversations where users barged in.
+- Break down cost per conversation, per model, or per usage type (audio vs. text tokens) in
+  [dashboards](/docs/metrics/features/custom-dashboards).
+
+## Attach the conversation recording to the trace [#attach-audio]
+
+Transcripts tell you what was said; the recording tells you how it sounded — crosstalk, long
+silences, TTS artifacts, mis-transcriptions. Langfuse supports
+[audio attachments](/docs/observability/features/multi-modality) (WAV, MP3, OGG, and more)
+on the input, output, and metadata of any trace or observation, stores them in object
+storage via presigned uploads, and renders them with an audio player in the trace view.
+
+The pattern has two halves: record the audio in your framework, then attach it to the
+conversation's trace at session end.
+
+### Record the audio
+
+**Pipecat** ships an `AudioBufferProcessor` that captures both sides of the conversation.
+Place it after `transport.output()` so it records what the user actually heard, including
+truncated agent speech after interruptions:
+
+```python
+import wave
+
+from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+
+audiobuffer = AudioBufferProcessor(
+    num_channels=2,  # stereo: user left, agent right
+    auto_start_recording=True,
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        user_aggregator,
+        llm,
+        tts,
+        transport.output(),
+        audiobuffer,  # after transport.output() to capture both sides
+        assistant_aggregator,
+    ]
+)
+
+
+@audiobuffer.event_handler("on_audio_data")
+async def on_audio_data(buffer, audio, sample_rate, num_channels):
+    with wave.open(f"conversation-{conversation_id}.wav", "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(audio)
+```
+
+**LiveKit Agents** records the session for you: start it with `record={"audio": True}` and a
+stereo OGG of the full conversation is written to `ctx.session_directory / "audio.ogg"`,
+available in your `on_session_end` callback. For room-level capture in production, LiveKit's
+room composite egress can write the recording directly to your S3/GCS bucket instead.
+
+### Attach it to the conversation's trace
+
+Because the frameworks own the root span, grab the conversation's trace ID with a small span
+processor on the shared `TracerProvider`:
+
+```python
+from opentelemetry.sdk.trace import SpanProcessor
+
+
+class RootTraceIdCapture(SpanProcessor):
+    """Remembers the trace ID of the conversation's root span."""
+
+    def __init__(self):
+        self.trace_id = None
+
+    def on_start(self, span, parent_context=None):
+        if span.parent is None:
+            self.trace_id = format(span.get_span_context().trace_id, "032x")
+
+
+capture = RootTraceIdCapture()
+trace_provider.add_span_processor(capture)
+```
+
+Then, when the session ends, wrap the file in `LangfuseMedia` and add it to the trace
+metadata from a short-lived span in the same trace:
+
+```python
+from langfuse import get_client
+from langfuse.media import LangfuseMedia
+
+langfuse = get_client()
+
+recording = LangfuseMedia(
+    file_path="conversation-abc.wav",  # or audio.ogg from LiveKit
+    content_type="audio/wav",
+)
+
+with langfuse.start_as_current_span(
+    name="conversation-recording",
+    trace_context={"trace_id": capture.trace_id},
+) as span:
+    span.update_trace(metadata={"recording": recording})
+
+langfuse.flush()  # joins the media upload queue; call before process exit
+```
+
+The SDK computes the file's SHA-256, requests a presigned upload URL, uploads on a
+background thread, and replaces the object with a media reference token in the trace
+metadata. Re-attaching the same file is deduplicated. The recording then renders with an
+audio player on the trace.
+
+If the recording only becomes available later (e.g., LiveKit egress finishing after the
+session, or a telephony provider delivering call recordings asynchronously), use the
+[media API](https://api.reference.langfuse.com/#tag/media) directly: `POST /api/public/media`
+with the trace ID registers and links the file to the trace, followed by a `PUT` of the
+bytes to the returned presigned URL.
+
+If your recordings already live at a stable URL (a public bucket or your telephony
+provider's storage), there is an even lighter option: put the URL into the trace metadata.
+Langfuse renders external media URLs inline from their source without uploading them —
+the trade-off is that playback depends on that URL staying accessible.
+
+## OpenAI Realtime and Gemini Live [#realtime]
+
+Speech-to-speech models replace the STT → LLM → TTS pipeline with a single bidirectional
+stream. There are two ways to trace them with Langfuse:
+
+**Through a framework.** Pipecat and LiveKit both support OpenAI Realtime and Gemini Live as
+speech-to-speech backends, and their OpenTelemetry integrations trace these sessions like
+any other: turn spans, tool calls, interruption flags, and per-turn audio token usage flow
+to Langfuse with the standard setup from the
+[Pipecat](/integrations/frameworks/pipecat) and [LiveKit](/integrations/frameworks/livekit)
+integration guides. If you are building a production voice agent, this is the recommended
+path.
+
+**Direct API instrumentation.** If you talk to the realtime APIs directly, note that the
+SDKs do not emit spans for these sessions today: the OpenAI Agents SDK's tracing does not
+cover `RealtimeAgent` runs, and Google ADK's built-in tracing does not instrument the
+`run_live` path. Instead, instrument the event stream yourself with the Langfuse Python SDK.
+The server events carry everything a trace needs; the essential mapping for OpenAI Realtime:
+
+```python
+from langfuse import get_client
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI()
+langfuse = get_client()
+
+async with client.realtime.connect(model="gpt-realtime") as connection:
+    # ... session.update with input audio transcription enabled ...
+    with langfuse.start_as_current_span(name="realtime-conversation"):
+        user_transcript = None
+        async for event in connection:
+            # skip *.delta events; the *.done events repeat the full payload
+            if event.type == "conversation.item.input_audio_transcription.completed":
+                user_transcript = event.transcript
+            elif event.type == "response.done":
+                usage = event.response.usage
+                langfuse.start_observation(
+                    name="realtime-response",
+                    as_type="generation",
+                    model="gpt-realtime",
+                    input=user_transcript,
+                    output=event.response.output,
+                    usage_details={
+                        "input": usage.input_token_details.text_tokens,
+                        "input_audio_tokens": usage.input_token_details.audio_tokens,
+                        "input_cached_tokens": usage.input_token_details.cached_tokens,
+                        "output": usage.output_token_details.text_tokens,
+                        "output_audio_tokens": usage.output_token_details.audio_tokens,
+                    },
+                ).end()
+
+langfuse.flush()
+```
+
+The same pattern applies to Gemini Live through ADK's `runner.run_live()` loop: enable
+`input_audio_transcription` and `output_audio_transcription` on the `RunConfig`, accumulate
+transcripts from the events, and create a generation per `turn_complete` with the
+text/audio token split from `event.usage_metadata`. Since you own the event loop in both
+APIs, this manual instrumentation composes with turn spans, tool spans, and the
+[audio attachment pattern](#attach-audio) above.
+
+For interruption tracking, open a turn span on `input_audio_buffer.speech_started` and flag
+it as interrupted when speech starts while the agent is still playing audio — the trace then
+mirrors the barge-in behavior users experienced.
+
+## Evaluating voice conversations
+
+Because transcripts are stored as span input/output text, everything in Langfuse's
+[evaluation toolkit](/docs/evaluation/overview) applies to voice: LLM-as-a-judge evaluators
+on turn transcripts (politeness, task completion, correct tool use), user feedback scores
+attached to conversations, and datasets built from production turns for regression testing.
+The attached audio adds the dimension text evals miss — annotators can listen to flagged
+conversations directly in the trace view. For specialized simulation-based voice testing,
+Langfuse integrates with [Coval](/integrations/analytics/coval).
+
+### Voice metrics worth tracking
+
+The metrics that matter for voice agents fall into three buckets, each with a different
+source:
+
+| Metric                                                        | Where it comes from                                                                                                                                                                                            |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Turn latency (user stops speaking → agent responds)           | Span attributes emitted by the framework (`turn.user_bot_latency_seconds` in Pipecat, end-of-utterance spans in LiveKit); aggregate with percentiles in [dashboards](/docs/metrics/features/custom-dashboards) |
+| Time to first token/byte per stage (STT, LLM, TTS)            | `metrics.ttfb` attributes (Pipecat), `completion_start_time` on LLM spans (LiveKit)                                                                                                                            |
+| Interruption rate                                             | Turn-span flags (`turn.was_interrupted`, `lk.interrupted`) — filter traces on them or chart the rate over time                                                                                                 |
+| Cost per call, audio vs. text token split                     | [Usage types and model prices](/docs/observability/features/token-and-cost-tracking)                                                                                                                           |
+| Task completion, unnecessary repetition, verbosity, sentiment | [LLM-as-a-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge) on turn or conversation transcripts                                                                                            |
+| Talk ratio, words per minute, silence gaps, pronunciation     | Computed from the recording by your own audio pipeline or a voice-testing tool, then pushed to the trace as [scores via the SDK/API](/docs/evaluation/evaluation-methods/scores-via-sdk)                       |
+
+The first four are available from the traces alone. The judged metrics run on transcripts
+already stored on spans. Audio-signal metrics are the one category that needs the recording
+itself — another reason to attach it to the trace, where scores, transcript, and audio stay
+on one timeline.
+
+See our guide on [evaluating voice AI agents](/blog/2025-01-22-evaluating-voice-ai-agents)
+for a deeper treatment of voice evaluation workflows.
+
+## FAQ
+
+### Can I listen to conversations in the Langfuse UI?
+
+Yes. Audio attached via the [multi-modality support](/docs/observability/features/multi-modality)
+renders with an audio player on the trace and observation detail views. Supported formats
+include WAV, MP3, OGG, AAC, FLAC, and Opus.
+
+### How are audio tokens priced?
+
+Langfuse tracks usage in arbitrary units per
+[usage type](/docs/observability/features/token-and-cost-tracking). Model definitions can
+assign distinct prices to `input_audio_tokens`, `output_audio_tokens`, and
+`input_cached_tokens`, so speech-to-speech model costs are computed with the correct audio
+rates rather than text-token prices.
+
+### Does this work with self-hosted Langfuse?
+
+Yes. The framework integrations target the standard OTLP endpoint, and media uploads work
+against your configured S3-compatible storage (the maximum upload size defaults to 1 GB via
+`LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH`).
+
+### What about privacy and PII in voice traces?
+
+Voice traces carry raw transcripts by default. When spans flow through the Langfuse SDK
+(LiveKit setup), use its [masking](/docs/observability/features/masking) option to redact
+content before it leaves your infrastructure. For direct OTLP export (Pipecat setup), add a
+scrubbing span processor ahead of the exporter. And consider whether to attach recordings at
+all for regulated workloads.


### PR DESCRIPTION
## Summary

Part of the "Langfuse for voice agents" initiative.

- **New page: [Trace voice agents in Langfuse](https://langfuse.com/resources/engineering/voice-agent-tracing)** (`content/resources/engineering/voice-agent-tracing.mdx`) — search-first overview in the engineering resources hub: supported frameworks (Pipecat, LiveKit, Vapi, OpenAI Agents SDK, Google ADK, OpenAI Realtime, Gemini Live), anatomy of a voice-agent trace, attaching the conversation recording to the trace, manual instrumentation for speech-to-speech APIs, and a voice-metrics reference table.
- **Pipecat doc refresh** (verified against pipecat-ai 1.6.0 source):
  - `PipelineWorker` replaces the deprecated `PipelineTask` (removal planned for 2.0), with `enable_usage_metrics` documented.
  - The trace-renaming monkey-patch section is replaced by the first-class `additional_span_attributes` param (sets `langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id`, `langfuse.trace.tags` on the root span).
  - Corrected attribute names: `metrics.ttfb` (seconds, was `ttfb_ms`), `gen_ai.provider.name` (was `gen_ai.system`); added turn attributes incl. `turn.user_bot_latency_seconds` and the speech-to-speech span hierarchy with `gen_ai.usage.audio.*` tokens.
  - New masking note for PII-sensitive deployments.
- **LiveKit doc fix**: two example links 404'd (`langfuse_trace.py` was renamed to `otel_trace.py` upstream).

A Pipecat "record and attach conversation audio" section was drafted but removed from this PR pending an end-to-end test with a running agent; it will follow separately. A broader LiveKit doc expansion (span reference, session/user metadata, audio recording section) is also in progress separately.

## Verification

- The after-the-fact audio-attachment flow on the resources page was tested end-to-end against the media API: recording registered + uploaded + linked to the root observation, rendered with an audio player in the trace view.
- Pipecat API claims verified against upstream source and changelog (pipecat-ai 1.6.0); LiveKit link targets verified against livekit/agents main.
- `prettier` (format), H1 check pass locally; internal links and anchors verified against existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)