### PR TITLE
docs(dashboards): document widget menu, copy-paste, and JSON import/export

### DIFF
--- a/content/docs/metrics/features/custom-dashboards.mdx
+++ b/content/docs/metrics/features/custom-dashboards.mdx
@@ -103,16 +103,30 @@ Because Home is a normal dashboard, every tile is a regular widget. You can drop
 
 ## Managing and sharing widgets
 
-Every widget, both on a dashboard tile and in the widget library, has a **⋯ menu**:
+Every widget has a **⋯ menu**, both on a dashboard tile and on its row in the widget library. From it you can:
 
-- **Copy** copies the widget to your clipboard. Paste it onto any dashboard with **⌘/Ctrl+V**, and it is added and scrolled into view. Paste only activates when the clipboard actually holds a Langfuse widget.
+- **Copy to clipboard** copies the widget so you can paste it onto another dashboard.
+- **Paste to the right** inserts the widget from your clipboard next to the current tile. This item shows on dashboard tiles when the dashboard is editable, and is disabled unless the clipboard holds a Langfuse widget.
 - **Duplicate** creates a copy of the widget in the current project.
-- **Download JSON** exports the widget as a portable file.
+- **Download as JSON** exports the widget as a portable file.
+- **Download data as CSV** exports the widget's current query result. This item shows on dashboard tiles and becomes available once the widget has loaded its data.
 
-Widgets and dashboards use a **versioned JSON format**. A widget carries `{"$langfuseWidget": true, "version": 1}`, and a dashboard the matching `$langfuseDashboard` envelope with each referenced widget's config inlined, so it travels without database IDs. That makes them portable across projects and instances:
+The widget library row menu offers the same **Copy to clipboard**, **Duplicate**, and **Download as JSON** actions, plus **Delete**.
 
-- **Export** a single widget or a whole dashboard as a JSON file.
-- **Import** by dragging the JSON file onto a dashboard. Langfuse validates that it is a Langfuse widget or dashboard and recreates the widgets in your project.
+### Copy and paste widgets
+
+Copy a widget, then paste it onto any dashboard with **⌘/Ctrl+V**. The widget is added to the dashboard and scrolled into view. Paste works only when the clipboard holds a Langfuse widget: other clipboard contents are left untouched, and pasting requires edit access to the target dashboard. Because the copied widget carries its full configuration, you can paste it across dashboards, projects, and instances. Filters that do not apply in the target view are dropped, and Langfuse tells you when that happens.
+
+### Import and export as JSON
+
+Widgets and dashboards use a **versioned JSON format**. A widget exports as `{"$langfuseWidget": true, "version": 1, ...}`, and a dashboard as the matching `{"$langfuseDashboard": true, "version": 1, ...}` envelope with each referenced widget's configuration inlined, so it carries no database IDs. This makes widgets and dashboards portable across projects and instances.
+
+- **Export** a widget from its **⋯ menu** with **Download as JSON**.
+- **Import** by dragging a Langfuse widget or dashboard JSON file onto a dashboard. Langfuse validates the file and recreates the widgets in your project. A dashboard file also restores its widget layout. Files that are not Langfuse widget or dashboard exports are rejected.
+
+### Environment filter precedence
+
+A widget can carry its own environment filter. When it does, that filter overrides the dashboard's environment selector for that widget, and only for the environment. Widgets without their own environment filter follow the dashboard's environment selector as usual, along with the rest of the dashboard filter bar. This keeps a widget that is scoped to a specific environment showing data even when the dashboard selector is set to a different one.
 
 ## Advanced Features
 


### PR DESCRIPTION
## TL;DR

The Custom Dashboards page only described CSV export and drag-to-rearrange. This refreshes the "Managing and sharing widgets" section to document the widget-management ergonomics that shipped: the per-widget / library-row **⋯ menu**, **copy-paste across dashboards and projects** with **⌘/Ctrl+V**, the **versioned JSON import/export** format, and the **environment-filter precedence** rule.

## What changed

`content/docs/metrics/features/custom-dashboards.mdx`, "Managing and sharing widgets":

- **⋯ menu** items, with exact labels: Copy to clipboard, Paste to the right (editable dashboard tiles), Duplicate, Download as JSON, Download data as CSV. Notes the widget-library row menu offers Copy to clipboard / Duplicate / Download as JSON plus Delete.
- **Copy and paste widgets** subsection: copy, then paste with ⌘/Ctrl+V; the widget is added and scrolled into view; paste activates only when the clipboard holds a Langfuse widget; portable across dashboards, projects, and instances; filters that do not apply in the target view are dropped.
- **Import and export as JSON** subsection: the versioned envelope (`{"$langfuseWidget": true, "version": 1, ...}` and `{"$langfuseDashboard": true, "version": 1, ...}` with widget configs inlined, no database IDs); export a widget via Download as JSON; import by dragging a widget or dashboard JSON file onto a dashboard.
- **Environment filter precedence** subsection: a widget's own environment filter overrides the dashboard's environment selector for that widget (environment column only); other dashboard filters still merge.

Verified each menu label, the JSON envelope keys/version, the paste behavior, and the env-override precedence against the source before writing. House voice: declarative, plain, em-dash-free.

## Source PRs

- langfuse/langfuse#14965 (widget menus, copy-paste, versioned JSON import/export)
- langfuse/langfuse#15262 (widget environment filter overrides the dashboard env selector)

<details>
<summary>Verification</summary>

Renders HTTP 200 in the docs dev server (`next dev -p 3343`) with no MDX or build error; the new headings and the JSON envelope render as expected.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the custom dashboards documentation:
- Describes widget and library-row menu actions and availability.
- Documents clipboard-based widget copying across dashboards, projects, and instances.
- Explains versioned JSON import and export for widgets and dashboards.
- Clarifies widget-level environment-filter precedence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The revised MDX uses ordinary Markdown constructs, introduces no broken references or unsupported components, and no concrete inaccurate or misleading behavior was established.

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(dashboards): document widget menu, ..."](https://github.com/langfuse/langfuse-docs/commit/ba5cfcacaf34ab46217d6c9560586ea76ee4e18c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46958183)</sub>

<!-- /greptile_comment -->