### PR TITLE
Voice demo agent: fix searchLangfuseDocs timeouts, add thinking sound

### DIFF
--- a/components/voiceAgent/livekit-agent/agent.py
+++ b/components/voiceAgent/livekit-agent/agent.py
@@ -100,7 +100,13 @@ def setup_langfuse(
     return trace_provider, clients
 
 
-LANGFUSE_DOCS_MCP = mcp.MCPServerHTTP(url="https://langfuse.com/api/mcp")
+# client_session_timeout_seconds defaults to 5s, which the RAG-backed
+# searchLangfuseDocs tool regularly exceeds (the MCP client then reports
+# "An internal error occurred" to the LLM).
+LANGFUSE_DOCS_MCP = mcp.MCPServerHTTP(
+    url="https://langfuse.com/api/mcp",
+    client_session_timeout_seconds=30,
+)
 
 
 class Kelly(Agent):

--- a/components/voiceAgent/livekit-agent/agent.py
+++ b/components/voiceAgent/livekit-agent/agent.py
@@ -15,6 +15,9 @@ from livekit.agents import (
     Agent,
     AgentServer,
     AgentSession,
+    AudioConfig,
+    BackgroundAudioPlayer,
+    BuiltinAudioClip,
     JobContext,
     cli,
     inference,
@@ -342,6 +345,16 @@ async def entrypoint(ctx: JobContext):
                 "transcript": False,
             },
         )
+
+        # Audible cue while the agent is thinking or calling the docs tools, so
+        # slower turns (e.g. RAG searches) don't feel like dead air.
+        background_audio = BackgroundAudioPlayer(
+            thinking_sound=[
+                AudioConfig(BuiltinAudioClip.KEYBOARD_TYPING, volume=0.6),
+                AudioConfig(BuiltinAudioClip.KEYBOARD_TYPING2, volume=0.5),
+            ],
+        )
+        await background_audio.start(room=ctx.room, agent_session=session)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two follow-ups to #3385 for the voice demo agent:

- **Fix `searchLangfuseDocs` failures.** LiveKit's `MCPServerHTTP` defaults `client_session_timeout_seconds` to **5 seconds**, and the RAG-backed search (Inkeep) regularly takes longer — every slow call surfaced to the LLM as "An internal error occurred". Confirmed in traces: both failing `function_tool` spans ended at exactly 5.00s while the fast docs tools (`getLangfuseOverview` 0.15s, `getLangfuseDocsPage` 0.5s) succeeded in the same session, and a direct call to the production MCP endpoint returned a full result. Raised the client session timeout to 30s.
- **Thinking sound during slow turns.** `BackgroundAudioPlayer` now plays LiveKit's built-in keyboard-typing clips while the agent is in the thinking state (LLM inference + tool calls), so longer docs searches no longer feel like dead air.

Both changes are deployed and verified on the LiveKit test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)