### PR TITLE
docs: add context engineering resource

### DIFF
--- a/content/library/index.mdx
+++ b/content/library/index.mdx
@@ -13,6 +13,7 @@ description: A collection of resources, blog posts, and talks to learn more abou
 - **The Prompt Report: A Systematic Survey of Prompting Techniques**, [paper on arxiv](https://arxiv.org/pdf/2406.06608), [summary in tweets](https://x.com/learnprompting/status/1800931910404784380)
 - **How to prompt o1** (o1 isn't a chat model – and that's the point), [blog post](https://www.latent.space/p/o1-skill-issue), _by Ben Hylak_
 - **Effective Context Engineering for AI Agents**, [blog post](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents), _by Anthropic_
+- **The new rules of context engineering for Claude 5 models**, [post on X](https://x.com/trq212/status/2080710971228918066), _by Thariq Shihipar_
 
 ## Agents
 


### PR DESCRIPTION
### Motivation
- Surface a new practical guide on context engineering for Claude 5 models in the AI Engineering Library's Prompting section so readers can find Thariq Shihipar's recommendations alongside related resources.

### Description
- Add a single library entry to `content/library/index.mdx`: `- **The new rules of context engineering for Claude 5 models**, [post on X](https://x.com/trq212/status/2080710971228918066), _by Thariq Shihipar_`.

### Testing
- Ran formatting and checks with `pnpm run format`, `pnpm run format:check`, and `node scripts/check-h1-headings.js`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6405068f08832fa892ebe707d52d45)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a context-engineering resource to the AI Engineering Library.
- Links to Thariq Shihipar’s post on context engineering for Claude 5 models.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change adds a conventional Markdown list item containing an external link and attribution, without introducing MDX components, imports, or structural changes that could affect compilation or rendering.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add context engineering resource"](https://github.com/langfuse/langfuse-docs/commit/a429e47adb28b4e798c4dd0830b6f7e02d2cdd11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47165539)</sub>

<!-- /greptile_comment -->