### PR TITLE
Add feature-level links to FeatureOverview and add Administration overview doc

### DIFF
--- a/components/FeatureOverview.tsx
+++ b/components/FeatureOverview.tsx
@@ -11,6 +11,7 @@ const features = [
   {
     icon: TextQuote,
     title: "Observability",
+    href: "#observability",
     items: [
       "Log traces",
       "Lowest level transparency",
@@ -20,6 +21,7 @@ const features = [
   {
     icon: GitPullRequestArrow,
     title: "Prompts",
+    href: "#prompts",
     items: [
       "Version control and deploy",
       "Collaborate on prompts",
@@ -29,6 +31,7 @@ const features = [
   {
     icon: ThumbsUp,
     title: "Evaluation",
+    href: "#evaluation",
     items: [
       "Measure output quality",
       "Monitor production health",
@@ -44,6 +47,14 @@ const platformFeature = {
     "API-first architecture",
     "Data exports to blob storage",
     "Enterprise security and administration",
+  ],
+  links: [
+    { label: "Metrics", href: "/docs/metrics/overview" },
+    {
+      label: "API & Data Platform",
+      href: "/docs/api-and-data-platform/overview",
+    },
+    { label: "Administration", href: "/docs/administration/overview" },
   ],
 };
 
@@ -72,6 +83,12 @@ export const FeatureOverview = () => {
                 </li>
               ))}
             </ul>
+            <a
+              href={feature.href}
+              className="mt-4 inline-flex w-fit text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Learn more --&gt;
+            </a>
           </CornerBox>
         </div>
       ))}
@@ -95,6 +112,17 @@ export const FeatureOverview = () => {
               </li>
             ))}
           </ul>
+          <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2">
+            {platformFeature.links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="inline-flex w-fit text-sm font-medium text-primary underline-offset-4 hover:underline"
+              >
+                {link.label} --&gt;
+              </a>
+            ))}
+          </div>
         </CornerBox>
       </div>
     </div>

--- a/content/docs/administration/meta.json
+++ b/content/docs/administration/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Administration",
   "pages": [
+    "overview",
     "---Auth---",
     "authentication-and-sso",
     "rbac",

--- a/content/docs/administration/overview.mdx
+++ b/content/docs/administration/overview.mdx
@@ -1,0 +1,41 @@
+---
+title: Overview
+description: Manage authentication, access control, security, and project administration settings in Langfuse.
+---
+
+# Administration
+
+Administration in Langfuse covers the settings and controls teams use to run Langfuse securely in production. Configure authentication, manage access, audit activity, retain or delete data, connect model providers, and monitor usage from one place.
+
+<Cards num={2}>
+  <Card
+    title="Authentication and SSO"
+    href="/docs/administration/authentication-and-sso"
+    description="Configure sign-in methods and enterprise SSO for Langfuse."
+  />
+  <Card
+    title="RBAC"
+    href="/docs/administration/rbac"
+    description="Manage organization, project, and feature-level permissions."
+  />
+  <Card
+    title="SCIM and organization API"
+    href="/docs/administration/scim-and-org-api"
+    description="Automate user provisioning, role assignments, and project setup."
+  />
+  <Card
+    title="Audit logs"
+    href="/docs/administration/audit-logs"
+    description="Review security-relevant activity across your organization."
+  />
+  <Card
+    title="Data deletion"
+    href="/docs/administration/data-deletion"
+    description="Delete traces, observations, scores, and media when needed."
+  />
+  <Card
+    title="Data retention"
+    href="/docs/administration/data-retention"
+    description="Automatically remove old project data after a configured retention period."
+  />
+</Cards>


### PR DESCRIPTION
### Motivation

- Surface deeper documentation from the feature summary grid so users can navigate to detailed pages directly from the FeatureOverview component.
- Provide a landing page for the Administration section so the docs navigation has an overview entry for admin-related pages.

### Description

- Added `href` properties to each item in the `features` array and rendered a "Learn more ->" link inside `FeatureOverview.tsx` for each feature. 
- Added a `links` array to `platformFeature` and rendered platform-level quick links in `FeatureOverview.tsx`.
- Updated `content/docs/administration/meta.json` to include the new `overview` entry for Administration. 
- Added a new `content/docs/administration/overview.mdx` file that provides an overview and cards linking to Administration subpages.

### Testing

- Ran `yarn build` for the site and the build completed successfully. 
- Ran `yarn lint` and no linting errors were reported. 
- Ran TypeScript checks with `yarn typecheck` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6361912e98832fb18000c8b871fb74)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds direct feature navigation and a new Administration landing page.
- Adds feature and platform links to the shared FeatureOverview component.
- Registers an Administration overview in the section navigation.
- Adds an Administration overview page with cards for key administrative topics.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the feature links navigate correctly from the `/enterprise` page.

The shared FeatureOverview emits page-relative fragments that resolve on `/docs` but have no matching targets on `/enterprise`, leaving all three newly added feature links inert there.

**Files Needing Attention:** components/FeatureOverview.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
components/FeatureOverview.tsx:14
**Feature fragments break on enterprise**

When `FeatureOverview` renders on `/enterprise`, these page-relative fragments have no matching `observability`, `prompts`, or `evaluation` elements, so all three “Learn more” links update the URL but do not navigate or scroll to content.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add docs overview learn more anchor..."](https://github.com/langfuse/langfuse-docs/commit/cdfd3446432b683899b0d9b9247f34b590da2c6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47165670)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->