### PR TITLE
docs: add Neon AI Gateway integration guide

### DIFF
--- a/content/integrations/gateways/meta.json
+++ b/content/integrations/gateways/meta.json
@@ -6,6 +6,7 @@
     "helicone",
     "kong-ai-plugin",
     "litellm",
+    "neon",
     "openrouter",
     "portkey",
     "truefoundry",

--- a/content/integrations/gateways/neon.mdx
+++ b/content/integrations/gateways/neon.mdx
@@ -1,0 +1,155 @@
+---
+title: "Neon AI Gateway Integration"
+sidebarTitle: Neon AI Gateway
+description: "Learn how to integrate Langfuse with Neon AI Gateway using the OpenAI SDK."
+---
+
+# Neon AI Gateway Integration
+
+In this guide, we'll show you how to integrate [Langfuse](/) with [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview).
+
+> **What is Neon AI Gateway?** [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference endpoint provided by Neon. One Neon credential gives access to models from multiple providers, so there are no separate provider accounts or provider API keys. Each Neon branch has its own gateway host, and credentials are scoped to a branch and its descendants.
+
+> **What is Langfuse?** [Langfuse](/) is an open source AI engineering platform that helps teams trace LLM calls, monitor performance, and debug issues in their AI applications.
+
+Since Neon AI Gateway uses the OpenAI API schema, we can use Langfuse's native integration with the OpenAI SDK, available in both [Python](/integrations/model-providers/openai-py) and [TypeScript](/integrations/model-providers/openai-js).
+
+<Callout type="info">
+  Neon AI Gateway is in beta. It requires a paid Neon plan and a project in the AWS US East (Ohio) region (`aws-us-east-2`).
+</Callout>
+
+## Get started
+
+```bash
+pip install langfuse openai
+```
+
+Neon exposes two environment variables. `NEON_AI_GATEWAY_TOKEN` is the bearer credential and `NEON_AI_GATEWAY_BASE_URL` is the bare branch host with no path. Create the credential with the `ai_gateway:invoke` scope in the Neon Console, or run `neon env pull --file .env` to write both variables for the current branch. See [AI Gateway authentication](https://neon.com/docs/ai-gateway/authentication) for details.
+
+```python
+import os
+
+# Set your Langfuse API keys
+LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY="pk-lf-..."
+# 🇪🇺 EU region
+LANGFUSE_BASE_URL="https://cloud.langfuse.com"
+# Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
+
+# Neon AI Gateway credential and branch host
+os.environ["NEON_AI_GATEWAY_TOKEN"] = "nt_live_..."
+os.environ["NEON_AI_GATEWAY_BASE_URL"] = "https://<your-neon-branch-host>"
+```
+
+## Example 1: Simple LLM Call
+
+Neon serves chat completions at `/v1/chat/completions`, so append `/v1` to the branch host and pass the credential as `api_key`. The [Langfuse OpenAI SDK wrapper](/integrations/model-providers/openai-py) then logs each call as a generation.
+
+- `base_url` is the branch host plus `/v1`.
+- `model` takes a short Neon model ID such as `gpt-5-mini`, `gemini-3-flash`, or `qwen3-next-80b-a3b-instruct`.
+
+```python
+# Import the Langfuse OpenAI SDK wrapper
+from langfuse.openai import openai
+import os
+
+# Create an OpenAI client pointed at your Neon branch host
+client = openai.OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/v1",
+)
+
+# Make a chat completion request
+response = client.chat.completions.create(
+    model="gpt-5-mini",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me a fun fact about space."}
+    ],
+    name="fun-fact-request"  # Optional: Name of the generation in Langfuse
+)
+
+# Print the assistant's reply
+print(response.choices[0].message.content)
+```
+
+## Example 2: Nested LLM Calls
+
+The `@observe()` decorator captures execution details of any Python function, including nested LLM calls, inputs, outputs, and execution times.
+
+```python
+from langfuse import observe
+from langfuse.openai import openai
+import os
+
+client = openai.OpenAI(
+    api_key=os.environ["NEON_AI_GATEWAY_TOKEN"],
+    base_url=f"{os.environ['NEON_AI_GATEWAY_BASE_URL']}/v1",
+)
+
+@observe()  # This decorator enables tracing of the function
+def analyze_text(text: str):
+    # First LLM call: Summarize the text
+    summary_response = summarize_text(text)
+    summary = summary_response.choices[0].message.content
+
+    # Second LLM call: Analyze the sentiment of the summary
+    sentiment_response = analyze_sentiment(summary)
+    sentiment = sentiment_response.choices[0].message.content
+
+    return {
+        "summary": summary,
+        "sentiment": sentiment
+    }
+
+@observe()  # Nested function to be traced
+def summarize_text(text: str):
+    return client.chat.completions.create(
+        model="gpt-5-mini",
+        messages=[
+            {"role": "system", "content": "You summarize texts in a concise manner."},
+            {"role": "user", "content": f"Summarize the following text:\n{text}"}
+        ],
+        name="summarize-text"
+    )
+
+@observe()  # Nested function to be traced
+def analyze_sentiment(summary: str):
+    return client.chat.completions.create(
+        model="gpt-5-mini",
+        messages=[
+            {"role": "system", "content": "You analyze the sentiment of texts."},
+            {"role": "user", "content": f"Analyze the sentiment of the following summary:\n{summary}"}
+        ],
+        name="analyze-sentiment"
+    )
+
+# Example usage
+text_to_analyze = "Neon branches a Postgres database in seconds, which makes preview environments cheap to create."
+analyze_text(text_to_analyze)
+```
+
+## Switching branches
+
+A Neon credential is valid on the branch it was created on and on every branch descended from it, so a credential minted on `main` also works for preview and CI branches forked from `main`. Only `NEON_AI_GATEWAY_BASE_URL` changes between environments. Point it at the branch you want to trace and the Langfuse traces follow.
+
+## Cost tracking
+
+Neon returns token usage but no cost field, and `GET /v1/models` currently reports `pricing` as `null`. Langfuse therefore has no cost to ingest for these generations, so cost is not tracked automatically. To see spend in Langfuse, define the Neon model IDs as [custom model definitions](/docs/observability/features/token-and-cost-tracking#custom-model-definitions) with prices from the [Neon model catalog](https://neon.com/docs/ai-gateway/models), which is also published as the [`neon` provider on models.dev](https://models.dev/providers/neon).
+
+Note that inference is free during the Neon beta, so any prices you configure describe what the models will cost once billing begins.
+
+## Response content shape
+
+For most models `message.content` is a plain string. For Gemini 3.x, `gpt-oss-120b`, and `qwen35-122b-a10b`, Neon returns an array of typed content blocks instead. Langfuse records whichever shape the model returns, so handle both in code that reads the completion:
+
+```python
+content = response.choices[0].message.content
+text = content if isinstance(content, str) else next(
+    (block["text"] for block in content if block.get("type") == "text"), ""
+)
+```
+
+import LearnMore from "@/components-mdx/integration-learn-more.mdx";
+
+<LearnMore />

--- a/content/integrations/gateways/neon.mdx
+++ b/content/integrations/gateways/neon.mdx
@@ -30,10 +30,10 @@ Neon exposes two environment variables. `NEON_AI_GATEWAY_TOKEN` is the bearer cr
 import os
 
 # Set your Langfuse API keys
-LANGFUSE_SECRET_KEY="sk-lf-..."
-LANGFUSE_PUBLIC_KEY="pk-lf-..."
+os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..."
+os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..."
 # 🇪🇺 EU region
-LANGFUSE_BASE_URL="https://cloud.langfuse.com"
+os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com"
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
 # Neon AI Gateway credential and branch host


### PR DESCRIPTION
## What this adds

A new gateway integration page documenting how to trace [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) calls with Langfuse.

- `content/integrations/gateways/neon.mdx` — new page
- `content/integrations/gateways/meta.json` — adds `neon` to the nav, in the existing alphabetical position between `litellm` and `openrouter`

## How the integration works

Neon AI Gateway is OpenAI-compatible, so this page documents **Langfuse's existing OpenAI SDK wrapper path** (`from langfuse.openai import openai`) pointed at a Neon branch host. It is the same mechanism the other OpenAI-compatible gateway pages use.

To be explicit about scope:

- **No new Langfuse code, SDK, or integration surface is required or implied.** This is documentation only.
- **This is not native provider support in Langfuse**, and the page does not claim it is. Nothing here suggests Neon is a built-in/first-class provider.
- No no-code/automatic forwarding feature is claimed. Neon has no equivalent of OpenRouter's Broadcast, so that pattern is deliberately not copied — the page documents the SDK wrapper only.
- The page also covers `@observe()` for nested calls, which is standard Langfuse behaviour rather than anything Neon-specific.

## Cost tracking wording

Deliberately conservative, because Neon does not return cost data:

- Neon returns token usage but no cost field, and `GET /v1/models` currently reports `pricing` as `null` ([Neon models reference](https://neon.com/docs/ai-gateway/models)).
- The page therefore states plainly that **cost is not tracked automatically**, and points readers at Langfuse [custom model definitions](https://langfuse.com/docs/observability/features/token-and-cost-tracking#custom-model-definitions) if they want spend in Langfuse.
- It notes that inference is free during the Neon beta, so any configured prices describe future billing rather than current spend.

Happy to trim this section if you'd prefer it shorter.

## Missing logo

This page intentionally ships **without a `logo:` frontmatter field**, because I did not want to add a partner asset I'm not in a position to approve.

I checked that this degrades gracefully rather than breaking anything: `logo` is `z.string().nullish()` in `source.config.ts`, and `IntegrationIndex.tsx` early-returns from `IntegrationLogo` when it is absent and passes `icon={undefined}` to the card. The tile renders fine with no icon; no CI job requires a logo. Every other page in `gateways/` does have one, so if you'd like the set to stay visually consistent, please drop in the official asset at `public/images/integrations/neon_icon.svg` (plus `logoAppearance` if needed) and I'll wire up the frontmatter — or tell me which source you consider approved and I'll add it.

## Validation

Run locally and passing:

- **`format` CI job** — `prettier --experimental-cli --check` passes on both changed files, using this repo's `.prettierrc.json` and the exact version from `pnpm-lock.yaml` (`prettier@3.8.3`).
- **`check_h1` CI job** — `node scripts/check-h1-headings.js` passes (exactly one H1).
- **`meta.json`** — parses as valid JSON; nav list stays alphabetically sorted; nav entries and `.mdx` files in `gateways/` match exactly with no orphans on either side.
- **Internal links** — all four targets exist in-tree (`/`, `openai-py`, `openai-js`, `token-and-cost-tracking`). The `#custom-model-definitions` anchor is explicitly defined as `[#custom-model-definitions]` on the target heading, per the repo convention for `#` deep links.
- **External links** — all return HTTP 200 (`neon.com/docs/ai-gateway/{overview,models,authentication}`, `models.dev/providers/neon`).
- **Code snippets** — every Python block compiles (`compile()`, syntax check).
- **`git diff --check`** — clean; no CRLF, tabs, trailing whitespace, or missing final newline.
- **Accuracy re-check** — env var names/shape, the `ai_gateway:invoke` scope, `neon env pull --file .env`, the `/v1` chat completions path, branch-descendant credential scoping, beta/paid-plan/`aws-us-east-2` availability, the `pricing: null` behaviour, and the models that return typed content blocks were all re-verified against the current Neon docs today.

Could **not** run locally, and I want to flag it rather than imply otherwise:

- **`build-and-check-links` and `check-sitemap-links` are unverified locally.** A full dependency install did not complete in my environment, so `pnpm build` never ran, and both `scripts/check-links.js` and `scripts/check-sitemap-links.js` resolve relative links against a running `localhost:3333` server, which requires that build. Instead of skipping link validation entirely I checked the link targets directly, as listed above: every internal target exists in-tree, the one `#` anchor is explicitly defined on its target heading, and all four external URLs return 200. **CI is still the source of truth for these two jobs** — if either flags something, tell me and I'll fix it promptly.
- **No live inference request was made against Neon AI Gateway.** The snippets were verified for syntax and for agreement with Neon's official documented request shape, but they were not executed end-to-end. So this page has no example trace screenshot and no public example trace link, which some integration pages do include. Happy to add both if you'd like them before this leaves draft.

## Other notes

- `md-override/` only contains `pricing.md` / `pricing-self-host.md`, so no override needs syncing for this route.
- Written as hand-authored MDX rather than a `cookbook/` notebook, matching the other hand-written gateway pages (`anannas`, `helicone`, `litellm`, `openrouter`, `vercel-ai-gateway`); only `portkey` and `truefoundry` are notebook-generated, and I did not want to hand-edit generated output.
- Branched off `main` at `fcd1eca`.

## References

- [Neon AI Gateway overview](https://neon.com/docs/ai-gateway/overview)
- [Neon AI Gateway authentication](https://neon.com/docs/ai-gateway/authentication)
- [Neon AI Gateway models](https://neon.com/docs/ai-gateway/models)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds documentation for tracing Neon AI Gateway requests through Langfuse's OpenAI SDK wrapper.
- Adds the Neon integration page with setup, nested tracing, branch switching, cost-tracking, and response-shape guidance.
- Adds Neon to the gateways navigation between LiteLLM and OpenRouter.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation should not merge until its setup snippet actually configures the Langfuse credentials needed to produce traces.

The guide writes Langfuse settings into unused Python locals while the wrapped OpenAI client relies on separately discoverable Langfuse configuration, causing readers who follow the example verbatim to miss the advertised tracing behavior.

**Files Needing Attention:** content/integrations/gateways/neon.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/integrations/gateways/neon.mdx:31-36
**Langfuse credentials remain unconfigured**

When a reader runs these snippets without preconfigured Langfuse credentials, these assignments create ordinary Python variables instead of environment variables, so the wrapped OpenAI client cannot authenticate and export the advertised trace. Assign these values through `os.environ` or explicitly configure a Langfuse client.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Neon AI Gateway integration gu..."](https://github.com/langfuse/langfuse-docs/commit/5b596314d46488451d97187515bc6172b81ff5cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47248821)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->