### PR TITLE
fix: Docs feedback submission widget errors on Edge runtime

### DIFF
--- a/lib/feedback-slack.ts
+++ b/lib/feedback-slack.ts
@@ -178,7 +178,9 @@ export async function sendFeedbackToSlack(
 
   const response = await fetch(webhookUrl, {
     method: "POST",
-    redirect: "error",
+    // Edge runtime only supports "follow" | "manual"; with "manual" a redirect
+    // surfaces as a non-ok response and is rejected below.
+    redirect: "manual",
     signal: AbortSignal.timeout(FEEDBACK_SLACK_TIMEOUT_MS),
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),


### PR DESCRIPTION
Since d6dd5ee, `POST /api/feedback` (Edge runtime) threw `TypeError: Invalid redirect value` because Edge `fetch` doesn't support `redirect: "error"` — every docs page rating returned a 500 before Slack was contacted.

Fix: use `redirect: "manual"`; the existing `!response.ok` check already rejects redirect responses, preserving the don't-follow-redirects intent on both Edge (widget) and Node (MCP).

Verified locally against the Edge dev sandbox: with a dummy `hooks.slack.com` webhook the request now goes out and a redirect response is rejected with `Slack webhook returned 302`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes docs feedback delivery on the Edge runtime.
- Changes the Slack webhook request from unsupported `redirect: "error"` to `redirect: "manual"`.
- Continues rejecting redirect responses through the existing non-success response check.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The supported manual redirect mode allows the Edge request to execute, while the existing response check continues to reject non-success responses as intended.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use Edge-compatible redirect option..."](https://github.com/langfuse/langfuse-docs/commit/d26c496b022d109dbeb2fc3be43eaefaa5a835eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47491708)</sub>

<!-- /greptile_comment -->