### PR TITLE
docs: add Codex and Pi Agent tabs to MCP server client setup

### DIFF
--- a/content/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/content/docs/api-and-data-platform/features/mcp-server.mdx
@@ -104,7 +104,7 @@ The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source 
 
 ### Client Setup
 
-<Tabs items={["Claude Code", "Cursor", "Other MCP Clients"]}>
+<Tabs items={["Claude Code", "Codex", "Cursor", "Pi Agent", "Other MCP Clients"]}>
 
 <Tab>
 
@@ -137,6 +137,64 @@ The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source 
    ```
 
 2. Verify the connection by asking Claude Code to `list all prompts in the project`. Claude Code should use the `listPrompts` tool to return the list of prompts.
+
+</Tab>
+
+<Tab>
+
+1. Add the Langfuse MCP server to `~/.codex/config.toml`, replace `{your-base64-token}` with your encoded credentials:
+
+<Tabs items={["Cloud EU", "Cloud US", "Cloud Japan", "HIPAA US", "Self-Hosted"]}>
+
+<Tab>
+
+```toml filename="~/.codex/config.toml" /{your-base64-token}/
+[mcp_servers.langfuse]
+url = "https://cloud.langfuse.com/api/public/mcp"
+http_headers = { "Authorization" = "Basic {your-base64-token}" }
+```
+
+</Tab>
+<Tab>
+
+```toml filename="~/.codex/config.toml" /{your-base64-token}/
+[mcp_servers.langfuse]
+url = "https://us.cloud.langfuse.com/api/public/mcp"
+http_headers = { "Authorization" = "Basic {your-base64-token}" }
+```
+
+</Tab>
+<Tab>
+
+```toml filename="~/.codex/config.toml" /{your-base64-token}/
+[mcp_servers.langfuse]
+url = "https://jp.cloud.langfuse.com/api/public/mcp"
+http_headers = { "Authorization" = "Basic {your-base64-token}" }
+```
+
+</Tab>
+<Tab>
+
+```toml filename="~/.codex/config.toml" /{your-base64-token}/
+[mcp_servers.langfuse]
+url = "https://hipaa.cloud.langfuse.com/api/public/mcp"
+http_headers = { "Authorization" = "Basic {your-base64-token}" }
+```
+
+</Tab>
+<Tab>
+
+```toml filename="~/.codex/config.toml" /{your-base64-token}/
+[mcp_servers.langfuse]
+url = "https://your-domain.com/api/public/mcp"
+http_headers = { "Authorization" = "Basic {your-base64-token}" }
+```
+
+</Tab>
+</Tabs>
+
+2. Restart Codex and run `codex mcp list` to confirm the server is registered.
+3. Verify the connection by asking Codex to `list all prompts in the project`. Codex should use the `listPrompts` tool to return the list of prompts.
 
 </Tab>
 
@@ -243,6 +301,106 @@ The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source 
 
 5. Save the file and restart Cursor
 6. The server should appear in the MCP settings with a green dot indicating it's active
+
+</Tab>
+
+<Tab>
+
+[Pi](https://pi.dev) does not ship with built-in MCP support. Use the community-maintained [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension, which exposes MCP servers to Pi through a single proxy tool.
+
+1. Install the extension and restart Pi:
+
+   ```bash
+   pi install npm:pi-mcp-adapter
+   ```
+
+2. Add the Langfuse MCP server to `~/.pi/agent/mcp.json`, replace `{your-base64-token}` with your encoded credentials:
+
+<Tabs items={["Cloud EU", "Cloud US", "Cloud Japan", "HIPAA US", "Self-Hosted"]}>
+
+<Tab>
+
+```json filename="~/.pi/agent/mcp.json" /{your-base64-token}/
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://cloud.langfuse.com/api/public/mcp",
+      "headers": {
+        "Authorization": "Basic {your-base64-token}"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="~/.pi/agent/mcp.json" /{your-base64-token}/
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://us.cloud.langfuse.com/api/public/mcp",
+      "headers": {
+        "Authorization": "Basic {your-base64-token}"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="~/.pi/agent/mcp.json" /{your-base64-token}/
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://jp.cloud.langfuse.com/api/public/mcp",
+      "headers": {
+        "Authorization": "Basic {your-base64-token}"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="~/.pi/agent/mcp.json" /{your-base64-token}/
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://hipaa.cloud.langfuse.com/api/public/mcp",
+      "headers": {
+        "Authorization": "Basic {your-base64-token}"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="~/.pi/agent/mcp.json" /{your-base64-token}/
+{
+  "mcpServers": {
+    "langfuse": {
+      "url": "https://your-domain.com/api/public/mcp",
+      "headers": {
+        "Authorization": "Basic {your-base64-token}"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+3. Restart Pi and verify the connection by asking Pi to `list all prompts in the project`. Pi should use the `listPrompts` tool via the MCP proxy to return the list of prompts.
 
 </Tab>
 


### PR DESCRIPTION
## What changed

Adds two new tabs to the **Client Setup** tabber on the [MCP server docs page](https://langfuse.com/docs/api-and-data-platform/features/mcp-server#client-setup), alongside the existing Claude Code, Cursor, and Other MCP Clients tabs:

- **Codex** — registers the Langfuse MCP server in `~/.codex/config.toml` using `[mcp_servers.langfuse]` with `url` + `http_headers = { "Authorization" = "Basic {your-base64-token}" }`, per OpenAI's official Codex MCP docs for streamable HTTP servers with custom headers. Includes verification steps (`codex mcp list`, then asking Codex to list prompts).
- **Pi Agent** — Pi ships without built-in MCP support, so the tab points to the community-maintained [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension (`pi install npm:pi-mcp-adapter`) and configures the server in `~/.pi/agent/mcp.json` with the adapter's `url` + `headers` format.

Both tabs use region sub-tabs (Cloud EU/US/Japan, HIPAA US, Self-Hosted) matching the existing Cursor tab pattern.

## Notes for reviewers

- Config syntax was verified against OpenAI's Codex MCP documentation and the pi-mcp-adapter README/docs.
- The existing Pi Agent integration page only covers tracing via `pi-langfuse`; MCP access needs the separate adapter extension, hence the community callout in the tab.
- Prettier, the H1 check, and MDX compilation all pass locally. No `md-override/` counterpart exists for this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Codex and Pi Agent setup tabs to the Langfuse MCP server documentation.
- Provides region-specific Codex TOML configurations with Basic authentication.
- Documents Pi Agent setup through the community-maintained MCP adapter.
- Adds registration and connection-verification steps for both clients.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation change appears safe to merge.

The added tab structure is balanced, and the Codex and Pi Agent examples consistently use the documented Langfuse MCP endpoints and Basic authentication scheme without an identified actionable failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Codex and Pi Agent tabs to MCP..."](https://github.com/langfuse/langfuse-docs/commit/b470c9e5b526b1342bec2d7a6324635fb087e997) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47511829)</sub>

<!-- /greptile_comment -->