### PR TITLE
docs: rename Langdock Assistants to Agents in integration guide

### DIFF
--- a/content/integrations/no-code/langdock.mdx
+++ b/content/integrations/no-code/langdock.mdx
@@ -1,15 +1,15 @@
 ---
-title: Observability and Tracing for Langdock Assistants
+title: Observability and Tracing for Langdock Agents
 sidebarTitle: Langdock
 logo: /images/integrations/langdock_icon.svg
-description: "Langdock is an enterprise-ready AI platform for creating private assistants in minutes—no code required. Deploy via secure chat, Slack, or API. When connected to Langfuse, every assistant execution is automatically traced and visualized."
+description: "Langdock is an enterprise-ready AI platform for creating private agents in minutes—no code required. Deploy via secure chat, Slack, or API. When connected to Langfuse, every agent execution is automatically traced and visualized."
 ---
 
 # Langdock Integration
 
-> **Langdock** is an enterprise-ready AI platform for creating private assistants in minutes—no code required. Deploy via secure chat, Slack, or API.
+> **Langdock** is an enterprise-ready AI platform for creating private agents in minutes—no code required. Deploy via secure chat, Slack, or API.
 
-When connected to Langfuse, every Langdock assistant execution is automatically traced and visualized.
+When connected to Langfuse, every Langdock agent execution is automatically traced and visualized.
 
 ## Setup
 
@@ -20,33 +20,33 @@ When connected to Langfuse, every Langdock assistant execution is automatically 
 1. Sign up at [cloud.langfuse.com](https://cloud.langfuse.com) or self-host your own instance
 2. Go to **Project → Settings → API Keys** and copy your keys
 
-### Add Langfuse as logging provider in Langdock Assistant Settings
+### Add Langfuse as logging provider in Langdock Agent Settings
 
 1. Open the Langdock `Workspace Settings`
-2. Navigate to `Assistants` settings
-3. Enable `Allow assistant logs`
+2. Navigate to `Agents` settings
+3. Enable `Allow agent logs`
 4. Add your Langfuse host as `Tracing cloud URL`, e.g. `https://cloud.langfuse.com` (EU), `https://us.cloud.langfuse.com` (US), `https://jp.cloud.langfuse.com` (Japan), or `https://hipaa.cloud.langfuse.com` (HIPAA)
 
 <Frame>
-  ![Enable assistant logs in
+  ![Enable agent logs in
   Langdock](/images/docs/langdock_1_enable_assistant_logs.png)
 </Frame>
 
-### Enable tracing when creating an assistant
+### Enable tracing when creating an agent
 
-1. Open **Assistants** → **New assistant** in Langdock
-2. Configure your assistant
+1. Open **Agents** → **New agent** in Langdock
+2. Configure your agent
 3. `Enable Langfuse tracing` and add your Langfuse keys
 4. Click `Save`
 
 <Frame>
-  ![Enable tracing for assistant in
+  ![Enable tracing for agent in
   Langdock](/images/docs/langdock_2_enable_tracing_for_assistant.png)
 </Frame>
 
 </Steps>
 
-Your assistant conversations will now stream traces to Langfuse automatically.
+Your agent conversations will now stream traces to Langfuse automatically.
 
 ## Resources
 


### PR DESCRIPTION
## What

Langdock renamed **Assistants → Agents** across its product. This updates the Langdock integration guide (`content/integrations/no-code/langdock.mdx`, rendered at https://langfuse.com/integrations/no-code/langdock) to match the current UI terminology.

All UI strings were verified against Langdock's current production UI on 2026-07-27.

## Changes

Replaced every "assistant"/"Assistants" with "agent"/"Agents" (13 occurrences) across:

- Frontmatter `title` and `description`
- Intro blockquote and sentence
- Step 2 heading + list ("Navigate to `Agents` settings", "Enable `Allow agent logs`")
- Step 3 heading + list ("Open **Agents** → **New agent**", "Configure your agent")
- Both image alt texts
- Closing sentence

## Verified still correct (unchanged)

- Settings structure: workspace-level `Allow agent logs` + `Tracing cloud URL` under Workspace Settings → Agents; per-agent `Enable Langfuse tracing` toggle with secret/public key fields.
- Langfuse region URLs (EU/US/Japan/HIPAA).
- Resource links.
- `meta.json` already reads "No-Code Agent Builders".

## Known limitation / follow-up

Both screenshots (`public/images/docs/langdock_1_enable_assistant_logs.png` and `langdock_2_enable_tracing_for_assistant.png`) still show the old "assistant" UI copy and carry "assistant" in their filenames. The layout is unchanged, so the references are left as-is. They need a retake from a live Langdock workspace as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Langdock integration guide to use the product’s new “Agents” terminology throughout.
- Renames assistant-related terms in page metadata and introductory content.
- Updates setup instructions, headings, image alt text, and the closing sentence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it makes a consistent documentation-only terminology update without altering integration behavior or page structure.

The changed frontmatter and prose remain valid MDX, and the updated terms are applied consistently across the guide.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: rename Langdock Assistants to Agen..."](https://github.com/langfuse/langfuse-docs/commit/a99e4c93ca5465651cf7f486899a4fa350dd53c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47559061)</sub>

<!-- /greptile_comment -->