### PR TITLE
Show demo trace links in UI

### DIFF
--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
+
+type DemoTraceLinkProps = {
+  traceUrl?: string | null;
+  source: "qa_chatbot" | "image_generator" | "sentiment_classifier";
+  className?: string;
+};
+
+export const DemoTraceLink = ({
+  traceUrl,
+  source,
+  className,
+}: DemoTraceLinkProps) => {
+  const capture = usePostHogClientCapture();
+
+  if (!traceUrl) return null;
+
+  return (
+    <a
+      href={traceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        capture("demo:view_trace_in_langfuse_clicked", {
+          source,
+          trace_url: traceUrl,
+        });
+      }}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[2px] border border-line-structure bg-surface-bg px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-line-cta hover:text-text-primary",
+        className,
+      )}
+    >
+      <Image
+        src="/langfuse-icon.svg"
+        alt=""
+        width={14}
+        height={14}
+        aria-hidden="true"
+        className="size-3.5 shrink-0"
+      />
+      View trace in Langfuse
+    </a>
+  );
+};

--- a/components/imageGenerator/index.tsx
+++ b/components/imageGenerator/index.tsx
@@ -14,12 +14,14 @@ import {
   ThumbsUpIcon,
   ThumbsDownIcon,
 } from "lucide-react";
+import { DemoTraceLink } from "@/components/demoTraceLink";
 
 type GeneratedImage = {
   base64: string;
   mediaType: string;
   prompt: string;
   traceId: string;
+  traceUrl?: string;
 };
 
 const EXAMPLE_PROMPTS = [
@@ -80,6 +82,7 @@ export const ImageGenerator = ({
         mediaType: data.image.mediaType,
         prompt: textPrompt,
         traceId: data.traceId,
+        traceUrl: data.traceUrl,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
@@ -196,6 +199,13 @@ export const ImageGenerator = ({
                   uint8Array={new Uint8Array()}
                   alt={currentImage.prompt}
                   className="max-w-md rounded-[2px] border border-line-structure"
+                />
+              </div>
+
+              <div className="flex justify-center">
+                <DemoTraceLink
+                  traceUrl={currentImage.traceUrl}
+                  source="image_generator"
                 />
               </div>
 

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -42,6 +42,14 @@ import {
 import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
 import { FeedbackDialog } from "./FeedbackPopover";
 import { cn } from "@/lib/utils";
+import { DemoTraceLink } from "@/components/demoTraceLink";
+import type { UIMessage } from "ai";
+
+type ChatMessageMetadata = {
+  traceUrl?: string;
+};
+
+type ChatMessage = UIMessage<ChatMessageMetadata>;
 
 type ChatProps = HTMLAttributes<HTMLDivElement>;
 
@@ -79,7 +87,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
     });
   }, []);
 
-  const { messages, sendMessage, status, regenerate } = useChat({
+  const { messages, sendMessage, status, regenerate } = useChat<ChatMessage>({
     messages: [],
     transport: new DefaultChatTransport({
       api: "/api/qa-chatbot",
@@ -226,6 +234,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           status !== "submitted" &&
                           status !== "streaming" &&
                           !hasStreamingParts;
+                        const traceUrl = message.metadata?.traceUrl;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
                         const hasNextPartDifferentType =
@@ -236,6 +245,16 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                             className={hasNextPartDifferentType ? "mb-4" : ""}
                           >
                             <Response>{part.text}</Response>
+                            {message.role === "assistant" &&
+                              isNotFirstMessage &&
+                              isLastTextPart &&
+                              isMessageComplete && (
+                                <DemoTraceLink
+                                  traceUrl={traceUrl}
+                                  source="qa_chatbot"
+                                  className="mt-3"
+                                />
+                              )}
                             {message.role === "assistant" &&
                               isLastMessage &&
                               isNotFirstMessage &&

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -235,6 +235,8 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           status !== "streaming" &&
                           !hasStreamingParts;
                         const traceUrl = message.metadata?.traceUrl;
+                        const isTraceLinkReady =
+                          Boolean(traceUrl) && !hasStreamingParts;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
                         const hasNextPartDifferentType =
@@ -248,7 +250,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                             {message.role === "assistant" &&
                               isNotFirstMessage &&
                               isLastTextPart &&
-                              isMessageComplete && (
+                              isTraceLinkReady && (
                                 <DemoTraceLink
                                   traceUrl={traceUrl}
                                   source="qa_chatbot"

--- a/components/sentimentClassifier/index.tsx
+++ b/components/sentimentClassifier/index.tsx
@@ -8,6 +8,7 @@ import { Suggestions, Suggestion } from "@/components/ai-elements/suggestion";
 import { getPersistedNanoId } from "@/components/qaChatbot/utils/persistedNanoId";
 import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
 import { SendIcon, ThumbsUpIcon, ThumbsDownIcon } from "lucide-react";
+import { DemoTraceLink } from "@/components/demoTraceLink";
 
 type SentimentResult = {
   sentiment: "positive" | "negative" | "neutral";
@@ -51,6 +52,7 @@ export const SentimentClassifier = ({
   const [result, setResult] = useState<{
     result: SentimentResult;
     traceId: string;
+    traceUrl?: string;
     inputText: string;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -223,6 +225,11 @@ export const SentimentClassifier = ({
               <div className="text-sm text-foreground">
                 {result.result.explanation}
               </div>
+
+              <DemoTraceLink
+                traceUrl={result.traceUrl}
+                source="sentiment_classifier"
+              />
 
               {/* Key phrases */}
               {result.result.keyPhrases.length > 0 && (

--- a/src/usePostHogClientCapture.ts
+++ b/src/usePostHogClientCapture.ts
@@ -10,6 +10,10 @@ interface EventDefinitions {
     path: string;
     prompt_char_count: number;
   };
+  "demo:view_trace_in_langfuse_clicked": {
+    source: "qa_chatbot" | "image_generator" | "sentiment_classifier";
+    trace_url: string;
+  };
 }
 
 type EventName = keyof EventDefinitions;


### PR DESCRIPTION
Summary: Adds a reusable View trace in Langfuse link with the Langfuse icon, displays it in the Q&A chatbot, image generator, and sentiment classifier when a traceUrl is present, and tracks clicks in PostHog. This is UI-only and remains inert until the demo API routes return traceUrl. Checks: pnpm exec tsc --noEmit --pretty false; git diff --check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a reusable, analytics-enabled Langfuse trace link that renders when demo responses provide a trace URL.
- Integrates the link into the Q&A chatbot, image generator, and sentiment classifier.
- Extends the typed PostHog event map for trace-link clicks.
- Keeps the UI hidden until the corresponding API routes supply trace URLs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the trace-link UI intentionally remaining hidden until the demo APIs provide trace URLs.

The new rendering paths consistently tolerate absent trace URLs, external links use safe new-tab attributes, and the analytics payload is covered by the existing typed capture wrapper.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: show demo trace links in UI"](https://github.com/langfuse/langfuse-docs/commit/3cc6b1ad228a91fa213d7ec91d70c654e7d216f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47652049)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [QA Chatbot](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/qa-chatbot.md)
- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)
- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)
</details>

<!-- /greptile_comment -->