### PR TITLE
Publish demo traces as public links

### DIFF
--- a/components/imageGenerator/apiHandler.ts
+++ b/components/imageGenerator/apiHandler.ts
@@ -1,15 +1,13 @@
 import OpenAI from "openai";
-import {
-  observe,
-  propagateAttributes,
-  updateActiveObservation,
-  setActiveTraceIO,
-  getActiveTraceId,
-} from "@langfuse/tracing";
+import { propagateAttributes, startActiveObservation } from "@langfuse/tracing";
 import { LangfuseMedia } from "@langfuse/core";
-import { after } from "next/server";
 import { flush } from "@/src/instrumentation";
 import { rateLimit } from "@/lib/rateLimit";
+import {
+  createPublicDemoTraceLink,
+  makeDemoTracePublic,
+  publishPublicDemoTraceLink,
+} from "@/lib/demo-project-trace";
 
 let _openai: OpenAI | null = null;
 const getOpenAI = () => (_openai ??= new OpenAI());
@@ -36,74 +34,110 @@ const handler = async (req: Request) => {
     });
   }
 
-  return propagateAttributes(
-    {
-      traceName: "Image-Generator",
-      tags: ["image-generator"],
-      userId,
-    },
-    async () => {
-      const traceId = getActiveTraceId();
-      setActiveTraceIO({ input: prompt });
-
+  return startActiveObservation(
+    "image-generator",
+    async (rootObservation) => {
       try {
-        const result = await getOpenAI().images.generate({
-          model: "gpt-image-1",
-          prompt,
-          size: "1024x1024",
-          quality: "low",
-        });
-
-        const imageData = result.data?.[0]?.b64_json;
-        if (!imageData) {
-          throw new Error("No image data returned");
-        }
-
-        const imageMedia = new LangfuseMedia({
-          contentBytes: Buffer.from(imageData, "base64"),
-          contentType: "image/png",
-          source: "bytes",
-        });
-
-        const usage = (result as any).usage as
-          | {
-              input_tokens?: number;
-              output_tokens?: number;
-              total_tokens?: number;
-            }
-          | undefined;
-
-        updateActiveObservation(
+        return await propagateAttributes(
           {
-            input: prompt,
-            output: imageMedia,
-            model: "gpt-image-1",
-            modelParameters: {
+            traceName: "Image-Generator",
+            tags: ["image-generator"],
+            userId,
+          },
+          async () => {
+            rootObservation.update({ input: prompt });
+            rootObservation.setTraceIO({ input: prompt });
+            makeDemoTracePublic(rootObservation);
+            await createPublicDemoTraceLink({
+              traceId: rootObservation.traceId,
+              name: "Image-Generator",
+              input: prompt,
+              userId,
+              tags: ["image-generator"],
+            });
+
+            const result = await getOpenAI().images.generate({
+              model: "gpt-image-1",
+              prompt,
               size: "1024x1024",
               quality: "low",
-            },
-            ...(usage && {
-              usageDetails: {
-                input_tokens: usage.input_tokens ?? 0,
-                output_tokens: usage.output_tokens ?? 0,
-                total: usage.total_tokens ?? 0,
+            });
+
+            const imageData = result.data?.[0]?.b64_json;
+            if (!imageData) {
+              throw new Error("No image data returned");
+            }
+
+            const imageMedia = new LangfuseMedia({
+              contentBytes: Buffer.from(imageData, "base64"),
+              contentType: "image/png",
+              source: "bytes",
+            });
+
+            const usage = (result as any).usage as
+              | {
+                  input_tokens?: number;
+                  output_tokens?: number;
+                  total_tokens?: number;
+                }
+              | undefined;
+
+            rootObservation.update({
+              input: prompt,
+              output: imageMedia,
+              model: "gpt-image-1",
+              modelParameters: {
+                size: "1024x1024",
+                quality: "low",
               },
-            }),
+              ...(usage && {
+                usageDetails: {
+                  input_tokens: usage.input_tokens ?? 0,
+                  output_tokens: usage.output_tokens ?? 0,
+                  total: usage.total_tokens ?? 0,
+                },
+              }),
+            });
+            rootObservation.setTraceIO({ output: imageMedia });
+            makeDemoTracePublic(rootObservation);
+            rootObservation.end();
+
+            let traceUrl: string | undefined;
+            try {
+              await flush();
+              const publishedTraceLink = await publishPublicDemoTraceLink({
+                traceId: rootObservation.traceId,
+                name: "Image-Generator",
+                userId,
+                tags: ["image-generator"],
+              });
+              traceUrl = publishedTraceLink.traceUrl;
+            } catch (err) {
+              console.warn("Failed to flush public Langfuse trace", err);
+            }
+
+            return new Response(
+              JSON.stringify({
+                image: { base64: imageData, mediaType: "image/png" },
+                traceId: rootObservation.traceId,
+                traceUrl,
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
           },
-          { asType: "generation" },
-        );
-
-        after(async () => await flush());
-
-        return new Response(
-          JSON.stringify({
-            image: { base64: imageData, mediaType: "image/png" },
-            traceId,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
         );
       } catch (err) {
-        after(async () => await flush());
+        rootObservation.update({
+          level: "ERROR",
+          statusMessage: err instanceof Error ? err.message : String(err),
+        });
+        rootObservation.end();
+
+        try {
+          await flush();
+        } catch (flushErr) {
+          console.warn("Failed to flush errored Langfuse trace", flushErr);
+        }
 
         return new Response(
           JSON.stringify({
@@ -114,13 +148,13 @@ const handler = async (req: Request) => {
         );
       }
     },
+    {
+      asType: "generation",
+      endOnExit: false,
+    },
   );
 };
 
-export const POST = observe(handler, {
-  name: "image-generator",
-  asType: "generation",
-  captureOutput: false,
-});
+export const POST = handler;
 
 export const maxDuration = 60;

--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -162,84 +162,134 @@ export const handler = async (req: Request) => {
               },
             );
 
-            const tools = await mcpClient.tools();
-
+            let mcpClientClosed = false;
             const closeMcpClient = async () => {
+              if (mcpClientClosed) return;
+              mcpClientClosed = true;
+
               await mcpClient.close().catch((err) => {
                 console.warn("Failed to close QA chatbot MCP client", err);
               });
             };
 
-            const result = streamText({
-              model: openai(String(prompt.config.model)),
-              providerOptions: {
-                openai: {
-                  reasoningSummary,
-                  textVerbosity,
-                  reasoningEffort,
-                } satisfies OpenAIResponsesProviderOptions,
-              },
-              instructions: systemPrompt || undefined,
-              messages: modelMessages,
-              tools: tools as Parameters<typeof streamText>[0]["tools"],
-              stopWhen: stepCountIs(10),
-              runtimeContext: {
-                langfusePrompt,
-              },
-              experimental_telemetry: {
-                isEnabled: true,
-                functionId: "qa-chatbot",
-                includeRuntimeContext: {
-                  langfusePrompt: true,
-                },
-                integrations: [langfuseAiTelemetry],
-              },
-              onError: async ({ error }) => {
+            let removeAbortHandler = () => {};
+
+            try {
+              const tools = await mcpClient.tools();
+              let outputText = "";
+              let traceMetadataEnqueued = false;
+
+              const finalizeTrace = async ({
+                output,
+                error,
+              }: {
+                output?: unknown;
+                error?: unknown;
+              } = {}) => {
                 await closeMcpClient();
-                await finishPublicTrace({ error });
-              },
-            });
+                await finishPublicTrace({ output, error });
+              };
 
-            let outputText = "";
-            const publicTraceStream = result
-              .toUIMessageStream({
-                generateMessageId: () => rootObservation.traceId,
-                sendSources: true,
-                sendReasoning: true,
-              })
-              .pipeThrough(
-                new TransformStream<any, any>({
-                  async transform(chunk, controller) {
-                    if (chunk.type === "text-delta") {
-                      outputText += chunk.delta;
-                    }
+              const enqueueTraceMetadata = (
+                controller: TransformStreamDefaultController<any>,
+              ) => {
+                if (!publishedTraceUrl || traceMetadataEnqueued) {
+                  return;
+                }
 
-                    if (chunk.type === "finish") {
-                      await closeMcpClient();
-                      await finishPublicTrace({ output: outputText });
+                traceMetadataEnqueued = true;
+                controller.enqueue({
+                  type: "message-metadata",
+                  messageMetadata: { traceUrl: publishedTraceUrl },
+                });
+              };
 
-                      if (publishedTraceUrl) {
-                        controller.enqueue({
-                          type: "message-metadata",
-                          messageMetadata: { traceUrl: publishedTraceUrl },
-                        });
+              const handleAbort = () => {
+                void finalizeTrace({
+                  output: outputText,
+                  error: new Error("Client aborted the response stream"),
+                });
+              };
+
+              removeAbortHandler = () => {
+                req.signal.removeEventListener("abort", handleAbort);
+              };
+
+              req.signal.addEventListener("abort", handleAbort, {
+                once: true,
+              });
+
+              const result = streamText({
+                model: openai(String(prompt.config.model)),
+                providerOptions: {
+                  openai: {
+                    reasoningSummary,
+                    textVerbosity,
+                    reasoningEffort,
+                  } satisfies OpenAIResponsesProviderOptions,
+                },
+                instructions: systemPrompt || undefined,
+                messages: modelMessages,
+                tools: tools as Parameters<typeof streamText>[0]["tools"],
+                stopWhen: stepCountIs(10),
+                runtimeContext: {
+                  langfusePrompt,
+                },
+                experimental_telemetry: {
+                  isEnabled: true,
+                  functionId: "qa-chatbot",
+                  includeRuntimeContext: {
+                    langfusePrompt: true,
+                  },
+                  integrations: [langfuseAiTelemetry],
+                },
+                onError: async ({ error }) => {
+                  removeAbortHandler();
+                  await finalizeTrace({ error });
+                },
+              });
+
+              const publicTraceStream = result
+                .toUIMessageStream({
+                  generateMessageId: () => rootObservation.traceId,
+                  sendSources: true,
+                  sendReasoning: true,
+                })
+                .pipeThrough(
+                  new TransformStream<any, any>({
+                    async transform(chunk, controller) {
+                      if (chunk.type === "text-delta") {
+                        outputText += chunk.delta;
                       }
-                    }
 
-                    controller.enqueue(chunk);
-                  },
-                  async flush() {
-                    if (!traceEnded) {
-                      await closeMcpClient();
-                      await finishPublicTrace({ output: outputText });
-                    }
-                  },
-                }),
-              );
+                      if (chunk.type === "finish") {
+                        removeAbortHandler();
+                        await finalizeTrace({ output: outputText });
+                        enqueueTraceMetadata(controller);
+                      }
 
-            return createUIMessageStreamResponse({
-              stream: publicTraceStream,
-            });
+                      controller.enqueue(chunk);
+                    },
+                    async flush(controller) {
+                      removeAbortHandler();
+
+                      if (!traceEnded) {
+                        await finalizeTrace({ output: outputText });
+                      }
+
+                      enqueueTraceMetadata(controller);
+                    },
+                  }),
+                );
+
+              return createUIMessageStreamResponse({
+                stream: publicTraceStream,
+              });
+            } catch (err) {
+              removeAbortHandler();
+              await closeMcpClient();
+              throw err;
+            }
           },
         );
       } catch (err) {

--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -1,28 +1,30 @@
 import { openai, OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
-import { streamText, UIMessage, stepCountIs } from "ai";
+import {
+  createUIMessageStreamResponse,
+  streamText,
+  stepCountIs,
+  type UIMessage,
+} from "ai";
 import { createMCPClient } from "@ai-sdk/mcp";
 import {
   observe,
   propagateAttributes,
   startActiveObservation,
-  updateActiveObservation,
-  setActiveTraceIO,
 } from "@langfuse/tracing";
+import { LangfuseVercelAiSdkIntegration } from "@langfuse/vercel-ai-sdk";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
-import { LangfuseClient } from "@langfuse/client";
-import { getActiveTraceId } from "@langfuse/tracing";
-import { after } from "next/server";
 import { flush } from "@/src/instrumentation";
-import { trace } from "@opentelemetry/api";
+import {
+  createPublicDemoTraceLink,
+  demoProjectLangfuseClient,
+  makeDemoTracePublic,
+  publishPublicDemoTraceLink,
+} from "@/lib/demo-project-trace";
 
-const langfuseClient = new LangfuseClient({
-  baseUrl: process.env.NEXT_PUBLIC_EU_LANGFUSE_BASE_URL,
-  publicKey: process.env.NEXT_PUBLIC_EU_LANGFUSE_PUBLIC_KEY,
-  secretKey: process.env.EU_LANGFUSE_SECRET_KEY,
-});
+const langfuseAiTelemetry = new LangfuseVercelAiSdkIntegration();
 
 const tracedGetPrompt = observe(
-  langfuseClient.prompt.get.bind(langfuseClient.prompt),
+  demoProjectLangfuseClient.prompt.get.bind(demoProjectLangfuseClient.prompt),
   { name: "get-langfuse-prompt" },
 );
 
@@ -38,124 +40,231 @@ export const handler = async (req: Request) => {
     (part) => part.type === "text",
   )?.text;
 
-  return propagateAttributes(
-    {
-      traceName: "QA-Chatbot",
-      tags: ["qa-chatbot"],
-      sessionId: chatId,
-      userId,
-    },
-    async () => {
-      updateActiveObservation({ input: inputText }, { asType: "generation" });
-      setActiveTraceIO({ input: inputText });
-
-      const prompt = await tracedGetPrompt("langfuse-docs-assistant-chat", {
-        type: "chat",
-      });
-
-      const reasoningSummary = prompt.config.reasoningSummary as
-        | "low"
-        | "medium"
-        | "high"
-        | undefined;
-      const textVerbosity = prompt.config.textVerbosity as
-        | "low"
-        | "medium"
-        | "high"
-        | undefined;
-      const reasoningEffort = prompt.config.reasoningEffort as
-        | "low"
-        | "medium"
-        | "high"
-        | undefined;
-
-      const chatHistory = messages.map((msg) => ({
-        role: msg.role,
-        content: msg.parts
-          .filter((part) => part.type === "text")
-          .map((part) => part.text)
-          .join(""),
-      }));
-
-      const compiledPrompt = prompt.compile({}, { chat_history: chatHistory });
-      const systemPrompt = compiledPrompt
-        .filter((message) => message.role === "system")
-        .map((message) => message.content)
-        .join("\n\n");
-      const modelMessages = compiledPrompt.filter(
-        (message) => message.role !== "system",
-      );
-
-      const mcpClient = await startActiveObservation(
-        "create-mcp-client",
-        async () => {
-          const mcpUrl = new URL("https://langfuse.com/api/mcp", req.url);
-
-          return createMCPClient({
-            transport: new StreamableHTTPClientTransport(mcpUrl, {
-              sessionId: `qa-chatbot-${crypto.randomUUID()}`,
-            }),
-          });
-        },
-      );
-
-      const tools = await mcpClient.tools();
-
-      const result = streamText({
-        model: openai(String(prompt.config.model)),
-        providerOptions: {
-          openai: {
-            reasoningSummary,
-            textVerbosity,
-            reasoningEffort,
-          } satisfies OpenAIResponsesProviderOptions,
-        },
-        instructions: systemPrompt || undefined,
-        messages: modelMessages,
-        tools: tools as Parameters<typeof streamText>[0]["tools"],
-        stopWhen: stepCountIs(10),
-        runtimeContext: {
-          langfusePrompt: prompt,
-        },
-        telemetry: {
-          functionId: "qa-chatbot",
-          includeRuntimeContext: {
-            langfusePrompt: true,
+  return startActiveObservation(
+    "handle-chatbot-message",
+    async (rootObservation) => {
+      try {
+        return await propagateAttributes(
+          {
+            traceName: "QA-Chatbot",
+            tags: ["qa-chatbot"],
+            sessionId: chatId,
+            userId,
           },
-        },
-        onFinish: async (result) => {
-          await mcpClient.close();
+          async () => {
+            rootObservation.update({ input: inputText });
+            rootObservation.setTraceIO({ input: inputText });
+            makeDemoTracePublic(rootObservation);
+            await createPublicDemoTraceLink({
+              traceId: rootObservation.traceId,
+              name: "QA-Chatbot",
+              input: inputText,
+              userId,
+              sessionId: chatId,
+              tags: ["qa-chatbot"],
+            });
+            let traceEnded = false;
+            let publishedTraceUrl: string | undefined;
 
-          const latestText = Array.isArray((result as any).content)
-            ? [...((result as any).content as Array<any>)]
-                .reverse()
-                .find((part: any) => part?.type === "text")?.text
-            : (result as any).content;
+            const finishPublicTrace = async ({
+              output,
+              error,
+            }: {
+              output?: unknown;
+              error?: unknown;
+            } = {}) => {
+              if (traceEnded) return;
 
-          updateActiveObservation(
-            { output: latestText },
-            { asType: "generation" },
-          );
-          setActiveTraceIO({ output: latestText });
-          trace.getActiveSpan()?.end();
-        },
-      });
+              if (error) {
+                rootObservation.update({
+                  level: "ERROR",
+                  statusMessage:
+                    error instanceof Error ? error.message : String(error),
+                });
+              } else {
+                rootObservation.update({ output });
+                rootObservation.setTraceIO({ output });
+              }
 
-      after(async () => await flush());
+              makeDemoTracePublic(rootObservation);
+              rootObservation.end();
+              traceEnded = true;
 
-      return result.toUIMessageStreamResponse({
-        generateMessageId: () => getActiveTraceId(),
-        sendSources: true,
-        sendReasoning: true,
-      });
+              try {
+                await flush();
+                const publishedTraceLink = await publishPublicDemoTraceLink({
+                  traceId: rootObservation.traceId,
+                  name: "QA-Chatbot",
+                  userId,
+                  sessionId: chatId,
+                  tags: ["qa-chatbot"],
+                });
+                publishedTraceUrl = publishedTraceLink.traceUrl;
+              } catch (err) {
+                console.warn("Failed to flush public Langfuse trace", err);
+              }
+            };
+
+            const prompt = await tracedGetPrompt(
+              "langfuse-docs-assistant-chat",
+              {
+                type: "chat",
+              },
+            );
+
+            const reasoningSummary = prompt.config.reasoningSummary as
+              | "low"
+              | "medium"
+              | "high"
+              | undefined;
+            const textVerbosity = prompt.config.textVerbosity as
+              | "low"
+              | "medium"
+              | "high"
+              | undefined;
+            const reasoningEffort = prompt.config.reasoningEffort as
+              | "low"
+              | "medium"
+              | "high"
+              | undefined;
+
+            const chatHistory = messages.map((msg) => ({
+              role: msg.role,
+              content: msg.parts
+                .filter((part) => part.type === "text")
+                .map((part) => part.text)
+                .join(""),
+            }));
+
+            const compiledPrompt = prompt.compile(
+              {},
+              { chat_history: chatHistory },
+            );
+            const langfusePrompt = prompt.toJSON();
+            const systemPrompt = compiledPrompt
+              .filter((message) => message.role === "system")
+              .map((message) => message.content)
+              .join("\n\n");
+            const modelMessages = compiledPrompt.filter(
+              (message) => message.role !== "system",
+            );
+
+            const mcpClient = await startActiveObservation(
+              "create-mcp-client",
+              async () => {
+                const mcpUrl = new URL("https://langfuse.com/api/mcp", req.url);
+
+                return createMCPClient({
+                  transport: new StreamableHTTPClientTransport(mcpUrl, {
+                    sessionId: `qa-chatbot-${crypto.randomUUID()}`,
+                  }),
+                });
+              },
+            );
+
+            const tools = await mcpClient.tools();
+
+            const closeMcpClient = async () => {
+              await mcpClient.close().catch((err) => {
+                console.warn("Failed to close QA chatbot MCP client", err);
+              });
+            };
+
+            const result = streamText({
+              model: openai(String(prompt.config.model)),
+              providerOptions: {
+                openai: {
+                  reasoningSummary,
+                  textVerbosity,
+                  reasoningEffort,
+                } satisfies OpenAIResponsesProviderOptions,
+              },
+              instructions: systemPrompt || undefined,
+              messages: modelMessages,
+              tools: tools as Parameters<typeof streamText>[0]["tools"],
+              stopWhen: stepCountIs(10),
+              runtimeContext: {
+                langfusePrompt,
+              },
+              experimental_telemetry: {
+                isEnabled: true,
+                functionId: "qa-chatbot",
+                includeRuntimeContext: {
+                  langfusePrompt: true,
+                },
+                integrations: [langfuseAiTelemetry],
+              },
+              onError: async ({ error }) => {
+                await closeMcpClient();
+                await finishPublicTrace({ error });
+              },
+            });
+
+            let outputText = "";
+            const publicTraceStream = result
+              .toUIMessageStream({
+                generateMessageId: () => rootObservation.traceId,
+                sendSources: true,
+                sendReasoning: true,
+              })
+              .pipeThrough(
+                new TransformStream<any, any>({
+                  async transform(chunk, controller) {
+                    if (chunk.type === "text-delta") {
+                      outputText += chunk.delta;
+                    }
+
+                    if (chunk.type === "finish") {
+                      await closeMcpClient();
+                      await finishPublicTrace({ output: outputText });
+
+                      if (publishedTraceUrl) {
+                        controller.enqueue({
+                          type: "message-metadata",
+                          messageMetadata: { traceUrl: publishedTraceUrl },
+                        });
+                      }
+                    }
+
+                    controller.enqueue(chunk);
+                  },
+                  async flush() {
+                    if (!traceEnded) {
+                      await closeMcpClient();
+                      await finishPublicTrace({ output: outputText });
+                    }
+                  },
+                }),
+              );
+
+            return createUIMessageStreamResponse({
+              stream: publicTraceStream,
+            });
+          },
+        );
+      } catch (err) {
+        rootObservation.update({
+          level: "ERROR",
+          statusMessage: err instanceof Error ? err.message : String(err),
+        });
+        rootObservation.end();
+
+        try {
+          await flush();
+        } catch (flushErr) {
+          console.warn("Failed to flush errored Langfuse trace", flushErr);
+        }
+
+        throw err;
+      }
+    },
+    {
+      asType: "agent",
+      endOnExit: false,
     },
   );
 };
 
-export const POST = observe(handler, {
-  name: "handle-chatbot-message",
-  endOnExit: false, // end after stream has finished
-  asType: "agent",
-});
+export const POST = handler;
 
-export const maxDuration = 30;
+export const maxDuration = 120;

--- a/components/sentimentClassifier/apiHandler.ts
+++ b/components/sentimentClassifier/apiHandler.ts
@@ -1,15 +1,15 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
-import {
-  observe,
-  propagateAttributes,
-  setActiveTraceIO,
-  getActiveTraceId,
-} from "@langfuse/tracing";
-import { after } from "next/server";
+import { propagateAttributes, startActiveObservation } from "@langfuse/tracing";
+import { LangfuseVercelAiSdkIntegration } from "@langfuse/vercel-ai-sdk";
 import { flush } from "@/src/instrumentation";
 import { rateLimit } from "@/lib/rateLimit";
+import {
+  createPublicDemoTraceLink,
+  makeDemoTracePublic,
+  publishPublicDemoTraceLink,
+} from "@/lib/demo-project-trace";
 
 const SentimentSchema = z.object({
   sentiment: z.enum(["positive", "negative", "neutral"]),
@@ -17,6 +17,8 @@ const SentimentSchema = z.object({
   explanation: z.string(),
   keyPhrases: z.array(z.string()),
 });
+
+const langfuseAiTelemetry = new LangfuseVercelAiSdkIntegration();
 
 export type SentimentResult = z.infer<typeof SentimentSchema>;
 
@@ -38,36 +40,80 @@ const handler = async (req: Request) => {
     });
   }
 
-  return propagateAttributes(
-    {
-      traceName: "Sentiment-Classifier",
-      tags: ["sentiment-classifier"],
-      userId,
-    },
-    async () => {
-      const traceId = getActiveTraceId();
-      setActiveTraceIO({ input: text });
-
+  return startActiveObservation(
+    "sentiment-classifier",
+    async (rootObservation) => {
       try {
-        const result = await generateObject({
-          model: openai("gpt-4o-mini"),
-          schema: SentimentSchema,
-          prompt: `Analyze the sentiment of the following text. Classify it as positive, negative, or neutral. Provide a confidence score between 0 and 1, a brief explanation of your reasoning, and extract the key phrases that influenced your classification.\n\nText: ${text}`,
-          telemetry: {
-            functionId: "sentiment-classifier",
+        return await propagateAttributes(
+          {
+            traceName: "Sentiment-Classifier",
+            tags: ["sentiment-classifier"],
+            userId,
           },
-        });
+          async () => {
+            rootObservation.update({ input: text });
+            rootObservation.setTraceIO({ input: text });
+            makeDemoTracePublic(rootObservation);
+            await createPublicDemoTraceLink({
+              traceId: rootObservation.traceId,
+              name: "Sentiment-Classifier",
+              input: text,
+              userId,
+              tags: ["sentiment-classifier"],
+            });
 
-        setActiveTraceIO({ output: result.object });
+            const result = await generateObject({
+              model: openai("gpt-4o-mini"),
+              schema: SentimentSchema,
+              prompt: `Analyze the sentiment of the following text. Classify it as positive, negative, or neutral. Provide a confidence score between 0 and 1, a brief explanation of your reasoning, and extract the key phrases that influenced your classification.\n\nText: ${text}`,
+              experimental_telemetry: {
+                isEnabled: true,
+                functionId: "sentiment-classifier",
+                integrations: [langfuseAiTelemetry],
+              },
+            });
 
-        after(async () => await flush());
+            rootObservation.update({ output: result.object });
+            rootObservation.setTraceIO({ output: result.object });
+            makeDemoTracePublic(rootObservation);
+            rootObservation.end();
 
-        return new Response(
-          JSON.stringify({ result: result.object, traceId }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
+            let traceUrl: string | undefined;
+            try {
+              await flush();
+              const publishedTraceLink = await publishPublicDemoTraceLink({
+                traceId: rootObservation.traceId,
+                name: "Sentiment-Classifier",
+                userId,
+                tags: ["sentiment-classifier"],
+              });
+              traceUrl = publishedTraceLink.traceUrl;
+            } catch (err) {
+              console.warn("Failed to flush public Langfuse trace", err);
+            }
+
+            return new Response(
+              JSON.stringify({
+                result: result.object,
+                traceId: rootObservation.traceId,
+                traceUrl,
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          },
         );
       } catch (err) {
-        after(async () => await flush());
+        rootObservation.update({
+          level: "ERROR",
+          statusMessage: err instanceof Error ? err.message : String(err),
+        });
+        rootObservation.end();
+
+        try {
+          await flush();
+        } catch (flushErr) {
+          console.warn("Failed to flush errored Langfuse trace", flushErr);
+        }
 
         return new Response(
           JSON.stringify({
@@ -78,11 +124,12 @@ const handler = async (req: Request) => {
         );
       }
     },
+    {
+      endOnExit: false,
+    },
   );
 };
 
-export const POST = observe(handler, {
-  name: "sentiment-classifier",
-});
+export const POST = handler;
 
-export const maxDuration = 30;
+export const maxDuration = 60;

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -1,0 +1,195 @@
+import { LangfuseClient } from "@langfuse/client";
+import { getActiveTraceId, setActiveTraceAsPublic } from "@langfuse/tracing";
+
+export type DemoTraceLink = {
+  traceId?: string;
+  traceUrl?: string;
+};
+
+type PublicDemoTraceParams = {
+  traceId?: string;
+  name: string;
+  input?: unknown;
+  userId?: string;
+  sessionId?: string;
+  tags?: string[];
+};
+
+type PublishPublicDemoTraceParams = PublicDemoTraceParams & {
+  readbackAttempts?: number;
+  readbackDelayMs?: number;
+};
+
+type PublishableTrace = {
+  traceId?: string;
+  setTraceAsPublic: () => unknown;
+};
+
+export const demoProjectLangfuseClient = new LangfuseClient({
+  baseUrl: process.env.NEXT_PUBLIC_EU_LANGFUSE_BASE_URL,
+  publicKey: process.env.NEXT_PUBLIC_EU_LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.EU_LANGFUSE_SECRET_KEY,
+});
+
+export const createDemoTraceLink = async (
+  traceId = getActiveTraceId(),
+): Promise<DemoTraceLink> => {
+  if (!traceId) {
+    return {};
+  }
+
+  try {
+    return {
+      traceId,
+      traceUrl: await demoProjectLangfuseClient.getTraceUrl(traceId),
+    };
+  } catch (err) {
+    console.warn("Failed to resolve public Langfuse trace URL", err);
+    return { traceId };
+  }
+};
+
+export const createPublicDemoTraceLink = async ({
+  traceId = getActiveTraceId(),
+  name,
+  input,
+  userId,
+  sessionId,
+  tags,
+}: PublicDemoTraceParams): Promise<DemoTraceLink> => {
+  if (!traceId) {
+    return {};
+  }
+
+  try {
+    await createPublicDemoTraceEvent({
+      traceId,
+      name,
+      input,
+      userId,
+      sessionId,
+      tags,
+    });
+  } catch (err) {
+    console.warn("Failed to create public Langfuse trace", err);
+    return { traceId };
+  }
+
+  return createDemoTraceLink(traceId);
+};
+
+export const publishPublicDemoTraceLink = async ({
+  traceId = getActiveTraceId(),
+  name,
+  userId,
+  sessionId,
+  tags,
+  readbackAttempts = 9,
+  readbackDelayMs = 3000,
+}: PublishPublicDemoTraceParams): Promise<DemoTraceLink> => {
+  if (!traceId) {
+    return {};
+  }
+
+  try {
+    await createPublicDemoTraceEvent({
+      traceId,
+      name,
+      userId,
+      sessionId,
+      tags,
+    });
+
+    const isPublic = await waitForPublicTrace({
+      traceId,
+      attempts: readbackAttempts,
+      delayMs: readbackDelayMs,
+    });
+
+    if (!isPublic) {
+      return { traceId };
+    }
+
+    return createDemoTraceLink(traceId);
+  } catch (err) {
+    console.warn("Failed to publish public Langfuse trace", err);
+    return { traceId };
+  }
+};
+
+export const makeDemoTracePublic = (trace?: PublishableTrace) => {
+  if (trace) {
+    trace.setTraceAsPublic();
+  }
+
+  setActiveTraceAsPublic();
+};
+
+const createPublicDemoTraceEvent = async ({
+  traceId,
+  name,
+  input,
+  userId,
+  sessionId,
+  tags,
+}: PublicDemoTraceParams & { traceId: string }) => {
+  const timestamp = new Date().toISOString();
+
+  await demoProjectLangfuseClient.api.ingestion.batch({
+    batch: [
+      {
+        id: crypto.randomUUID(),
+        type: "trace-create",
+        timestamp,
+        body: {
+          id: traceId,
+          timestamp,
+          name,
+          public: true,
+          ...(input !== undefined && { input }),
+          ...(userId && { userId }),
+          ...(sessionId && { sessionId }),
+          ...(tags && { tags }),
+        },
+      },
+    ],
+  });
+};
+
+const waitForPublicTrace = async ({
+  traceId,
+  attempts,
+  delayMs,
+}: {
+  traceId: string;
+  attempts: number;
+  delayMs: number;
+}) => {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await demoProjectLangfuseClient.api.trace.get(traceId);
+      const trace =
+        typeof response === "object" && response !== null && "data" in response
+          ? response.data
+          : response;
+
+      if (isPublicTrace(trace)) {
+        return true;
+      }
+    } catch {
+      // Trace ingestion is eventually consistent; retry below.
+    }
+
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return false;
+};
+
+const isPublicTrace = (trace: unknown): trace is { public: true } =>
+  typeof trace === "object" &&
+  trace !== null &&
+  "public" in trace &&
+  trace.public === true;

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -15,11 +15,6 @@ type PublicDemoTraceParams = {
   tags?: string[];
 };
 
-type PublishPublicDemoTraceParams = PublicDemoTraceParams & {
-  readbackAttempts?: number;
-  readbackDelayMs?: number;
-};
-
 type PublishableTrace = {
   traceId?: string;
   setTraceAsPublic: () => unknown;
@@ -84,9 +79,7 @@ export const publishPublicDemoTraceLink = async ({
   userId,
   sessionId,
   tags,
-  readbackAttempts = 9,
-  readbackDelayMs = 3000,
-}: PublishPublicDemoTraceParams): Promise<DemoTraceLink> => {
+}: PublicDemoTraceParams): Promise<DemoTraceLink> => {
   if (!traceId) {
     return {};
   }
@@ -99,16 +92,6 @@ export const publishPublicDemoTraceLink = async ({
       sessionId,
       tags,
     });
-
-    const isPublic = await waitForPublicTrace({
-      traceId,
-      attempts: readbackAttempts,
-      delayMs: readbackDelayMs,
-    });
-
-    if (!isPublic) {
-      return { traceId };
-    }
 
     return createDemoTraceLink(traceId);
   } catch (err) {
@@ -155,41 +138,3 @@ const createPublicDemoTraceEvent = async ({
     ],
   });
 };
-
-const waitForPublicTrace = async ({
-  traceId,
-  attempts,
-  delayMs,
-}: {
-  traceId: string;
-  attempts: number;
-  delayMs: number;
-}) => {
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      const response = await demoProjectLangfuseClient.api.trace.get(traceId);
-      const trace =
-        typeof response === "object" && response !== null && "data" in response
-          ? response.data
-          : response;
-
-      if (isPublicTrace(trace)) {
-        return true;
-      }
-    } catch {
-      // Trace ingestion is eventually consistent; retry below.
-    }
-
-    if (attempt < attempts) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-
-  return false;
-};
-
-const isPublicTrace = (trace: unknown): trace is { public: true } =>
-  typeof trace === "object" &&
-  trace !== null &&
-  "public" in trace &&
-  trace.public === true;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,4 @@
-import { registerTelemetry } from "ai";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
-import { LangfuseVercelAiSdkIntegration } from "@langfuse/vercel-ai-sdk";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 const euSpanProcessor = new LangfuseSpanProcessor({
@@ -34,13 +32,20 @@ const spanProcessors = [
   internalSpanProcessor,
 ];
 
-export const flush = async () =>
-  Promise.all(spanProcessors.map((p) => p.forceFlush()));
+export const flush = async () => {
+  const results = await Promise.allSettled(
+    spanProcessors.map((p) => p.forceFlush()),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.warn("Failed to flush Langfuse span processor", result.reason);
+    }
+  }
+};
 
 const tracerProvider = new NodeTracerProvider({
   spanProcessors,
 });
 
 tracerProvider.register();
-
-registerTelemetry(new LangfuseVercelAiSdkIntegration());


### PR DESCRIPTION
Summary: Makes demo API route traces public, flushes them before returning, and includes traceUrl in Q&A chatbot message metadata plus image/sentiment JSON responses. Keeps AI SDK telemetry per-call and removes the global registration that caused duplicate generation trees; flush now uses allSettled so one regional exporter failure does not block the response. Checks: pnpm exec tsc --noEmit --pretty false; git diff --check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Publishes demo traces and returns their public URLs while moving AI SDK telemetry to individual calls.
- Adds a shared helper for creating, publishing, polling, and resolving public demo traces.
- Reworks image, sentiment, and chatbot handlers to manage root observations and flush traces explicitly.
- Adds chatbot trace metadata to the UI message stream.
- Changes multi-region span flushing to tolerate individual exporter failures and removes global AI SDK telemetry registration.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until trace-link polling is removed from the response-critical path and chatbot cancellation reliably releases its MCP session and observation.

Optional trace publication can consume most of the remaining route deadline after successful model work, and aborted chatbot streams bypass the only cleanup paths for manually managed resources.

**Files Needing Attention:** lib/demo-project-trace.ts and components/qaChatbot/apiHandler.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Handler
  participant Model
  participant Langfuse
  User->>Handler: Demo request
  Handler->>Langfuse: Create public trace
  Handler->>Model: Generate result
  Model-->>Handler: Output
  Handler->>Langfuse: Flush trace
  loop Up to 9 attempts
    Handler->>Langfuse: Read public trace
    Langfuse-->>Handler: Public status
  end
  Handler-->>User: Result and trace URL
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/demo-project-trace.ts:83-84
**Readback polling delays responses**

When Langfuse ingestion remains unavailable or eventually consistent, this helper performs eight three-second waits on the response-critical path. Because every changed handler awaits publication after model generation, successful image and sentiment requests can exceed their route deadline and chatbot responses remain unfinished for roughly 24 additional seconds.

### Issue 2 of 2
components/qaChatbot/apiHandler.ts:210-236
**Cancellation bypasses stream cleanup**

When a user aborts the response before a finish chunk arrives, stream cancellation does not invoke this transform's `flush` callback. The MCP client therefore remains open and the manually managed root observation remains unfinished, leaking the remote session and producing an incomplete trace.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: publish demo trace links"](https://github.com/langfuse/langfuse-docs/commit/91dcd69d63d3e9c6fe7690c02afede508f41d527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47652429)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API Routes](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/api-routes.md)
- Knowledge Base — [QA Chatbot](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/qa-chatbot.md)
- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)
</details>

<!-- /greptile_comment -->