### PR TITLE
Redesign demo trace link button

### DIFF
--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -28,21 +28,21 @@ export const DemoTraceLink = ({
     <>
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute left-0 top-0 h-3 w-3 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute left-0 top-0 h-2.5 w-2.5 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute right-0 top-0 h-3 w-3 border-r-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute right-0 top-0 h-2.5 w-2.5 border-r-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute bottom-0 left-0 h-3 w-3 border-b-2 border-l-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute bottom-0 left-0 h-2.5 w-2.5 border-b-2 border-l-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute bottom-0 right-0 h-3 w-3 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute bottom-0 right-0 h-2.5 w-2.5 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
-      <span className="relative inline-flex min-h-[32px] w-full min-w-0 items-center justify-center gap-2 border border-line-cta bg-surface-cta-primary px-3 py-1.5 font-sans text-[14px] font-semibold leading-tight text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.18)] transition-colors group-hover:bg-surface-cta-primary/80 group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg sm:w-auto sm:px-4 sm:text-[15px]">
+      <span className="relative inline-flex min-h-[30px] w-full min-w-0 items-center justify-center gap-1.5 border border-line-cta bg-surface-cta-primary px-3 py-1 font-sans text-[14px] font-semibold leading-tight text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.18)] transition-colors group-hover:bg-surface-cta-primary/80 group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg sm:w-auto">
         <Image
           src="/langfuse-icon.svg"
           alt=""
@@ -56,7 +56,7 @@ export const DemoTraceLink = ({
         </span>
         <ArrowUpRight
           aria-hidden="true"
-          className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
+          className="size-3.5 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
           strokeWidth={2.25}
         />
       </span>
@@ -64,7 +64,7 @@ export const DemoTraceLink = ({
   );
 
   const linkClassName = cn(
-    "group relative inline-flex max-w-full p-1 no-underline hover:no-underline focus-visible:outline-none sm:w-fit",
+    "group relative inline-flex max-w-full p-0.5 no-underline hover:no-underline focus-visible:outline-none sm:w-fit",
     className,
   );
 

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -28,33 +28,33 @@ export const DemoTraceLink = ({
     <>
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute left-0 top-0 h-4 w-4 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute left-0 top-0 h-3 w-3 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute right-0 top-0 h-4 w-4 border-r-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute right-0 top-0 h-3 w-3 border-r-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute bottom-0 left-0 h-4 w-4 border-b-2 border-l-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute bottom-0 left-0 h-3 w-3 border-b-2 border-l-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute bottom-0 right-0 h-4 w-4 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
+        className="pointer-events-none absolute bottom-0 right-0 h-3 w-3 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
-      <span className="relative inline-flex min-h-[46px] items-center gap-4 border border-text-secondary bg-[#f4ff63] px-7 py-3 font-sans text-[19px] font-semibold leading-none text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.22)] transition-colors group-hover:bg-[#f7ff7a] group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg">
+      <span className="relative inline-flex min-h-[34px] items-center gap-2.5 border border-text-secondary bg-[#f4ff63] px-4 py-2 font-sans text-[15px] font-semibold leading-none text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.22)] transition-colors group-hover:bg-[#f7ff7a] group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg">
         <Image
           src="/langfuse-icon.svg"
           alt=""
-          width={18}
-          height={18}
+          width={14}
+          height={14}
           aria-hidden="true"
-          className="size-[18px] shrink-0"
+          className="size-3.5 shrink-0"
         />
         <span className="whitespace-nowrap">View trace in Langfuse</span>
         <ArrowUpRight
           aria-hidden="true"
-          className="size-5 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
+          className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
           strokeWidth={2.25}
         />
       </span>
@@ -62,7 +62,7 @@ export const DemoTraceLink = ({
   );
 
   const linkClassName = cn(
-    "group relative inline-flex w-fit p-1.5 no-underline hover:no-underline focus-visible:outline-none",
+    "group relative inline-flex w-fit p-1 no-underline hover:no-underline focus-visible:outline-none",
     className,
   );
 

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -42,7 +42,7 @@ export const DemoTraceLink = ({
         aria-hidden="true"
         className="pointer-events-none absolute bottom-0 right-0 h-3 w-3 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
-      <span className="relative inline-flex min-h-[34px] items-center gap-2.5 border border-text-secondary bg-[#f4ff63] px-4 py-2 font-sans text-[15px] font-semibold leading-none text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.22)] transition-colors group-hover:bg-[#f7ff7a] group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg">
+      <span className="relative inline-flex min-h-[32px] w-full min-w-0 items-center justify-center gap-2 border border-line-cta bg-surface-cta-primary px-3 py-1.5 font-sans text-[14px] font-semibold leading-tight text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.18)] transition-colors group-hover:bg-surface-cta-primary/80 group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg sm:w-auto sm:px-4 sm:text-[15px]">
         <Image
           src="/langfuse-icon.svg"
           alt=""
@@ -51,7 +51,9 @@ export const DemoTraceLink = ({
           aria-hidden="true"
           className="size-3.5 shrink-0"
         />
-        <span className="whitespace-nowrap">View trace in Langfuse</span>
+        <span className="min-w-0 text-left sm:whitespace-nowrap">
+          View trace in Langfuse
+        </span>
         <ArrowUpRight
           aria-hidden="true"
           className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
@@ -62,7 +64,7 @@ export const DemoTraceLink = ({
   );
 
   const linkClassName = cn(
-    "group relative inline-flex w-fit p-1 no-underline hover:no-underline focus-visible:outline-none",
+    "group relative inline-flex max-w-full p-1 no-underline hover:no-underline focus-visible:outline-none sm:w-fit",
     className,
   );
 

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -19,24 +19,8 @@ export const DemoTraceLink = ({
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
 
-  if (!traceUrl) return null;
-
-  return (
-    <a
-      href={traceUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={() => {
-        capture("demo:view_trace_in_langfuse_clicked", {
-          source,
-          trace_url: traceUrl,
-        });
-      }}
-      className={cn(
-        "group relative inline-flex w-fit p-1.5 no-underline hover:no-underline focus-visible:outline-none",
-        className,
-      )}
-    >
+  const linkContent = (
+    <>
       <span
         aria-hidden="true"
         className="pointer-events-none absolute left-0 top-0 h-4 w-4 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
@@ -69,6 +53,37 @@ export const DemoTraceLink = ({
           strokeWidth={2.25}
         />
       </span>
+    </>
+  );
+
+  const linkClassName = cn(
+    "group relative inline-flex w-fit p-1.5 no-underline hover:no-underline focus-visible:outline-none",
+    !traceUrl && "pointer-events-none",
+    className,
+  );
+
+  if (!traceUrl) {
+    return (
+      <span aria-disabled="true" className={linkClassName}>
+        {linkContent}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={traceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        capture("demo:view_trace_in_langfuse_clicked", {
+          source,
+          trace_url: traceUrl,
+        });
+      }}
+      className={linkClassName}
+    >
+      {linkContent}
     </a>
   );
 };

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { ArrowUpRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
@@ -32,19 +33,42 @@ export const DemoTraceLink = ({
         });
       }}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-[2px] border border-line-structure bg-surface-bg px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-line-cta hover:text-text-primary",
+        "group relative inline-flex w-fit p-1.5 no-underline hover:no-underline focus-visible:outline-none",
         className,
       )}
     >
-      <Image
-        src="/langfuse-icon.svg"
-        alt=""
-        width={14}
-        height={14}
+      <span
         aria-hidden="true"
-        className="size-3.5 shrink-0"
+        className="pointer-events-none absolute left-0 top-0 h-4 w-4 border-l-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
       />
-      View trace in Langfuse
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute right-0 top-0 h-4 w-4 border-r-2 border-t-2 border-text-secondary transition-colors group-hover:border-text-primary"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-0 left-0 h-4 w-4 border-b-2 border-l-2 border-text-secondary transition-colors group-hover:border-text-primary"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-0 right-0 h-4 w-4 border-b-2 border-r-2 border-text-secondary transition-colors group-hover:border-text-primary"
+      />
+      <span className="relative inline-flex min-h-[46px] items-center gap-4 border border-text-secondary bg-[#f4ff63] px-7 py-3 font-sans text-[19px] font-semibold leading-none text-text-primary shadow-[0_1px_0_rgba(0,0,0,0.22)] transition-colors group-hover:bg-[#f7ff7a] group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-surface-bg">
+        <Image
+          src="/langfuse-icon.svg"
+          alt=""
+          width={18}
+          height={18}
+          aria-hidden="true"
+          className="size-[18px] shrink-0"
+        />
+        <span className="whitespace-nowrap">View trace in Langfuse</span>
+        <ArrowUpRight
+          aria-hidden="true"
+          className="size-5 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
+          strokeWidth={2.25}
+        />
+      </span>
     </a>
   );
 };

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -20,7 +20,9 @@ export const DemoTraceLink = ({
   className,
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
-  const isPreparingTrace = !traceUrl && Boolean(traceId);
+  const href =
+    traceUrl ||
+    (traceId ? `https://cloud.langfuse.com/project/~/traces/${traceId}` : null);
 
   const linkContent = (
     <>
@@ -50,15 +52,13 @@ export const DemoTraceLink = ({
           className="size-3.5 shrink-0"
         />
         <span className="min-w-0 text-left sm:whitespace-nowrap">
-          {traceUrl ? "View trace in Langfuse" : "Preparing trace..."}
+          View trace in Langfuse
         </span>
-        {traceUrl && (
-          <ArrowUpRight
-            aria-hidden="true"
-            className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
-            strokeWidth={2.25}
-          />
-        )}
+        <ArrowUpRight
+          aria-hidden="true"
+          className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
+          strokeWidth={2.25}
+        />
       </span>
     </>
   );
@@ -68,30 +68,17 @@ export const DemoTraceLink = ({
     className,
   );
 
-  if (!traceUrl && !isPreparingTrace) return null;
-
-  if (isPreparingTrace) {
-    return (
-      <span
-        role="status"
-        aria-live="polite"
-        aria-disabled="true"
-        className={cn(linkClassName, "cursor-wait opacity-80")}
-      >
-        {linkContent}
-      </span>
-    );
-  }
+  if (!href) return null;
 
   return (
     <a
-      href={traceUrl}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() => {
         capture("demo:view_trace_in_langfuse_clicked", {
           source,
-          trace_url: traceUrl,
+          trace_url: href,
         });
       }}
       className={linkClassName}

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -20,9 +20,7 @@ export const DemoTraceLink = ({
   className,
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
-  const href =
-    traceUrl ||
-    (traceId ? `https://cloud.langfuse.com/project/~/traces/${traceId}` : null);
+  const isPreparingTrace = !traceUrl && Boolean(traceId);
 
   const linkContent = (
     <>
@@ -52,13 +50,15 @@ export const DemoTraceLink = ({
           className="size-3.5 shrink-0"
         />
         <span className="min-w-0 text-left sm:whitespace-nowrap">
-          View trace in Langfuse
+          {traceUrl ? "View trace in Langfuse" : "Preparing trace..."}
         </span>
-        <ArrowUpRight
-          aria-hidden="true"
-          className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
-          strokeWidth={2.25}
-        />
+        {traceUrl && (
+          <ArrowUpRight
+            aria-hidden="true"
+            className="size-4 shrink-0 text-text-secondary transition-[color,transform] group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text-primary"
+            strokeWidth={2.25}
+          />
+        )}
       </span>
     </>
   );
@@ -68,17 +68,30 @@ export const DemoTraceLink = ({
     className,
   );
 
-  if (!href) return null;
+  if (!traceUrl && !isPreparingTrace) return null;
+
+  if (isPreparingTrace) {
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        aria-disabled="true"
+        className={cn(linkClassName, "cursor-wait opacity-80")}
+      >
+        {linkContent}
+      </span>
+    );
+  }
 
   return (
     <a
-      href={href}
+      href={traceUrl}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() => {
         capture("demo:view_trace_in_langfuse_clicked", {
           source,
-          trace_url: href,
+          trace_url: traceUrl,
         });
       }}
       className={linkClassName}

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -7,17 +7,22 @@ import { cn } from "@/lib/utils";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
 
 type DemoTraceLinkProps = {
+  traceId?: string | null;
   traceUrl?: string | null;
   source: "qa_chatbot" | "image_generator" | "sentiment_classifier";
   className?: string;
 };
 
 export const DemoTraceLink = ({
+  traceId,
   traceUrl,
   source,
   className,
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
+  const href =
+    traceUrl ||
+    (traceId ? `https://cloud.langfuse.com/project/~/traces/${traceId}` : null);
 
   const linkContent = (
     <>
@@ -58,27 +63,20 @@ export const DemoTraceLink = ({
 
   const linkClassName = cn(
     "group relative inline-flex w-fit p-1.5 no-underline hover:no-underline focus-visible:outline-none",
-    !traceUrl && "pointer-events-none",
     className,
   );
 
-  if (!traceUrl) {
-    return (
-      <span aria-disabled="true" className={linkClassName}>
-        {linkContent}
-      </span>
-    );
-  }
+  if (!href) return null;
 
   return (
     <a
-      href={traceUrl}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() => {
         capture("demo:view_trace_in_langfuse_clicked", {
           source,
-          trace_url: traceUrl,
+          trace_url: href,
         });
       }}
       className={linkClassName}

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { ArrowUpRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { createPublicDemoProjectTraceUrl } from "@/lib/demo-trace-url";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
 
 type DemoTraceLinkProps = {
@@ -14,11 +15,13 @@ type DemoTraceLinkProps = {
 };
 
 export const DemoTraceLink = ({
+  traceId,
   traceUrl,
   source,
   className,
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
+  const resolvedTraceUrl = traceUrl ?? createPublicDemoProjectTraceUrl(traceId);
 
   const linkContent = (
     <>
@@ -64,17 +67,17 @@ export const DemoTraceLink = ({
     className,
   );
 
-  if (!traceUrl) return null;
+  if (!resolvedTraceUrl) return null;
 
   return (
     <a
-      href={traceUrl}
+      href={resolvedTraceUrl}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() => {
         capture("demo:view_trace_in_langfuse_clicked", {
           source,
-          trace_url: traceUrl,
+          trace_url: resolvedTraceUrl,
         });
       }}
       className={linkClassName}

--- a/components/demoTraceLink.tsx
+++ b/components/demoTraceLink.tsx
@@ -14,15 +14,11 @@ type DemoTraceLinkProps = {
 };
 
 export const DemoTraceLink = ({
-  traceId,
   traceUrl,
   source,
   className,
 }: DemoTraceLinkProps) => {
   const capture = usePostHogClientCapture();
-  const href =
-    traceUrl ||
-    (traceId ? `https://cloud.langfuse.com/project/~/traces/${traceId}` : null);
 
   const linkContent = (
     <>
@@ -68,17 +64,17 @@ export const DemoTraceLink = ({
     className,
   );
 
-  if (!href) return null;
+  if (!traceUrl) return null;
 
   return (
     <a
-      href={href}
+      href={traceUrl}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() => {
         capture("demo:view_trace_in_langfuse_clicked", {
           source,
-          trace_url: href,
+          trace_url: traceUrl,
         });
       }}
       className={linkClassName}

--- a/components/imageGenerator/apiHandler.ts
+++ b/components/imageGenerator/apiHandler.ts
@@ -46,14 +46,9 @@ const handler = async (req: Request) => {
           },
           async () => {
             rootObservation.update({ input: prompt });
-            rootObservation.setTraceIO({ input: prompt });
             makeDemoTracePublic(rootObservation);
             await createPublicDemoTraceLink({
               traceId: rootObservation.traceId,
-              name: "Image-Generator",
-              input: prompt,
-              userId,
-              tags: ["image-generator"],
             });
 
             const result = await getOpenAI().images.generate({
@@ -98,7 +93,6 @@ const handler = async (req: Request) => {
                 },
               }),
             });
-            rootObservation.setTraceIO({ output: imageMedia });
             makeDemoTracePublic(rootObservation);
             rootObservation.end();
 
@@ -107,9 +101,6 @@ const handler = async (req: Request) => {
               await flush();
               const publishedTraceLink = await publishPublicDemoTraceLink({
                 traceId: rootObservation.traceId,
-                name: "Image-Generator",
-                userId,
-                tags: ["image-generator"],
               });
               traceUrl = publishedTraceLink.traceUrl;
             } catch (err) {

--- a/components/imageGenerator/index.tsx
+++ b/components/imageGenerator/index.tsx
@@ -204,6 +204,7 @@ export const ImageGenerator = ({
 
               <div className="flex justify-center">
                 <DemoTraceLink
+                  traceId={currentImage.traceId}
                   traceUrl={currentImage.traceUrl}
                   source="image_generator"
                 />

--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -53,15 +53,9 @@ export const handler = async (req: Request) => {
           },
           async () => {
             rootObservation.update({ input: inputText });
-            rootObservation.setTraceIO({ input: inputText });
             makeDemoTracePublic(rootObservation);
             await createPublicDemoTraceLink({
               traceId: rootObservation.traceId,
-              name: "QA-Chatbot",
-              input: inputText,
-              userId,
-              sessionId: chatId,
-              tags: ["qa-chatbot"],
             });
             let traceEnded = false;
             let publishedTraceUrl: string | undefined;
@@ -83,7 +77,6 @@ export const handler = async (req: Request) => {
                 });
               } else {
                 rootObservation.update({ output });
-                rootObservation.setTraceIO({ output });
               }
 
               makeDemoTracePublic(rootObservation);
@@ -94,10 +87,6 @@ export const handler = async (req: Request) => {
                 await flush();
                 const publishedTraceLink = await publishPublicDemoTraceLink({
                   traceId: rootObservation.traceId,
-                  name: "QA-Chatbot",
-                  userId,
-                  sessionId: chatId,
-                  tags: ["qa-chatbot"],
                 });
                 publishedTraceUrl = publishedTraceLink.traceUrl;
               } catch (err) {

--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -95,6 +95,8 @@ export const handler = async (req: Request) => {
                 const publishedTraceLink = await publishPublicDemoTraceLink({
                   traceId: rootObservation.traceId,
                   name: "QA-Chatbot",
+                  input: inputText,
+                  output,
                   userId,
                   sessionId: chatId,
                   tags: ["qa-chatbot"],

--- a/components/qaChatbot/apiHandler.ts
+++ b/components/qaChatbot/apiHandler.ts
@@ -95,8 +95,6 @@ export const handler = async (req: Request) => {
                 const publishedTraceLink = await publishPublicDemoTraceLink({
                   traceId: rootObservation.traceId,
                   name: "QA-Chatbot",
-                  input: inputText,
-                  output,
                   userId,
                   sessionId: chatId,
                   tags: ["qa-chatbot"],

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -43,6 +43,7 @@ import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
 import { FeedbackDialog } from "./FeedbackPopover";
 import { cn } from "@/lib/utils";
 import { DemoTraceLink } from "@/components/demoTraceLink";
+import { createPublicDemoProjectTraceUrl } from "@/lib/demo-trace-url";
 import type { UIMessage } from "ai";
 
 type ChatMessageMetadata = {
@@ -234,7 +235,9 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           status !== "submitted" &&
                           status !== "streaming" &&
                           !hasStreamingParts;
-                        const traceUrl = message.metadata?.traceUrl;
+                        const traceUrl =
+                          message.metadata?.traceUrl ??
+                          createPublicDemoProjectTraceUrl(message.id);
                         const isTraceLinkReady =
                           Boolean(traceUrl) && !hasStreamingParts;
                         const shouldShowTraceLink =

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -235,7 +235,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           status !== "streaming" &&
                           !hasStreamingParts;
                         const traceUrl = message.metadata?.traceUrl;
-                        const isTraceLinkVisible =
+                        const isTraceLinkReady =
                           Boolean(traceUrl || message.id) && !hasStreamingParts;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
@@ -249,7 +249,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                             <Response>{part.text}</Response>
                             {message.role === "assistant" &&
                               isLastTextPart &&
-                              isTraceLinkVisible && (
+                              isTraceLinkReady && (
                                 <DemoTraceLink
                                   traceId={message.id}
                                   traceUrl={traceUrl}

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -236,7 +236,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           !hasStreamingParts;
                         const traceUrl = message.metadata?.traceUrl;
                         const isTraceLinkReady =
-                          Boolean(traceUrl) && !hasStreamingParts;
+                          Boolean(traceUrl || message.id) && !hasStreamingParts;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
                         const hasNextPartDifferentType =
@@ -252,6 +252,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                               isLastTextPart &&
                               isTraceLinkReady && (
                                 <DemoTraceLink
+                                  traceId={message.id}
                                   traceUrl={traceUrl}
                                   source="qa_chatbot"
                                   className="mt-3"

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -235,7 +235,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           status !== "streaming" &&
                           !hasStreamingParts;
                         const traceUrl = message.metadata?.traceUrl;
-                        const isTraceLinkReady =
+                        const isTraceLinkVisible =
                           Boolean(traceUrl || message.id) && !hasStreamingParts;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
@@ -249,7 +249,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                             <Response>{part.text}</Response>
                             {message.role === "assistant" &&
                               isLastTextPart &&
-                              isTraceLinkReady && (
+                              isTraceLinkVisible && (
                                 <DemoTraceLink
                                   traceId={message.id}
                                   traceUrl={traceUrl}

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -248,7 +248,6 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           >
                             <Response>{part.text}</Response>
                             {message.role === "assistant" &&
-                              isNotFirstMessage &&
                               isLastTextPart &&
                               isTraceLinkReady && (
                                 <DemoTraceLink

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -237,6 +237,12 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                         const traceUrl = message.metadata?.traceUrl;
                         const isTraceLinkReady =
                           Boolean(traceUrl || message.id) && !hasStreamingParts;
+                        const shouldShowTraceLink =
+                          message.role === "assistant" &&
+                          isLastMessage &&
+                          isLastTextPart &&
+                          isMessageComplete &&
+                          isTraceLinkReady;
                         // Add spacing if next part is a different type (for consistent spacing between different types)
                         const nextPart = message.parts[i + 1];
                         const hasNextPartDifferentType =
@@ -247,16 +253,14 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                             className={hasNextPartDifferentType ? "mb-4" : ""}
                           >
                             <Response>{part.text}</Response>
-                            {message.role === "assistant" &&
-                              isLastTextPart &&
-                              isTraceLinkReady && (
-                                <DemoTraceLink
-                                  traceId={message.id}
-                                  traceUrl={traceUrl}
-                                  source="qa_chatbot"
-                                  className="mt-3"
-                                />
-                              )}
+                            {shouldShowTraceLink && (
+                              <DemoTraceLink
+                                traceId={message.id}
+                                traceUrl={traceUrl}
+                                source="qa_chatbot"
+                                className="mt-3"
+                              />
+                            )}
                             {message.role === "assistant" &&
                               isLastMessage &&
                               isNotFirstMessage &&

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -236,7 +236,7 @@ export const Chat = ({ className, ...props }: ChatProps) => {
                           !hasStreamingParts;
                         const traceUrl = message.metadata?.traceUrl;
                         const isTraceLinkReady =
-                          Boolean(traceUrl || message.id) && !hasStreamingParts;
+                          Boolean(traceUrl) && !hasStreamingParts;
                         const shouldShowTraceLink =
                           message.role === "assistant" &&
                           isLastMessage &&

--- a/components/sentimentClassifier/apiHandler.ts
+++ b/components/sentimentClassifier/apiHandler.ts
@@ -84,6 +84,8 @@ const handler = async (req: Request) => {
               const publishedTraceLink = await publishPublicDemoTraceLink({
                 traceId: rootObservation.traceId,
                 name: "Sentiment-Classifier",
+                input: text,
+                output: result.object,
                 userId,
                 tags: ["sentiment-classifier"],
               });

--- a/components/sentimentClassifier/apiHandler.ts
+++ b/components/sentimentClassifier/apiHandler.ts
@@ -52,14 +52,9 @@ const handler = async (req: Request) => {
           },
           async () => {
             rootObservation.update({ input: text });
-            rootObservation.setTraceIO({ input: text });
             makeDemoTracePublic(rootObservation);
             await createPublicDemoTraceLink({
               traceId: rootObservation.traceId,
-              name: "Sentiment-Classifier",
-              input: text,
-              userId,
-              tags: ["sentiment-classifier"],
             });
 
             const result = await generateObject({
@@ -74,7 +69,6 @@ const handler = async (req: Request) => {
             });
 
             rootObservation.update({ output: result.object });
-            rootObservation.setTraceIO({ output: result.object });
             makeDemoTracePublic(rootObservation);
             rootObservation.end();
 
@@ -83,9 +77,6 @@ const handler = async (req: Request) => {
               await flush();
               const publishedTraceLink = await publishPublicDemoTraceLink({
                 traceId: rootObservation.traceId,
-                name: "Sentiment-Classifier",
-                userId,
-                tags: ["sentiment-classifier"],
               });
               traceUrl = publishedTraceLink.traceUrl;
             } catch (err) {

--- a/components/sentimentClassifier/apiHandler.ts
+++ b/components/sentimentClassifier/apiHandler.ts
@@ -84,8 +84,6 @@ const handler = async (req: Request) => {
               const publishedTraceLink = await publishPublicDemoTraceLink({
                 traceId: rootObservation.traceId,
                 name: "Sentiment-Classifier",
-                input: text,
-                output: result.object,
                 userId,
                 tags: ["sentiment-classifier"],
               });

--- a/components/sentimentClassifier/index.tsx
+++ b/components/sentimentClassifier/index.tsx
@@ -227,6 +227,7 @@ export const SentimentClassifier = ({
               </div>
 
               <DemoTraceLink
+                traceId={result.traceId}
                 traceUrl={result.traceUrl}
                 source="sentiment_classifier"
               />

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -10,14 +10,10 @@ type PublicDemoTraceParams = {
   traceId?: string;
   name: string;
   input?: unknown;
-  output?: unknown;
   userId?: string;
   sessionId?: string;
   tags?: string[];
 };
-
-const DEMO_TRACE_READINESS_TIMEOUT_MS = 10_000;
-const DEMO_TRACE_READINESS_POLL_INTERVAL_MS = 500;
 
 type PublishableTrace = {
   traceId?: string;
@@ -74,14 +70,12 @@ export const createPublicDemoTraceLink = async ({
     return { traceId };
   }
 
-  return { traceId };
+  return createDemoTraceLink(traceId);
 };
 
 export const publishPublicDemoTraceLink = async ({
   traceId = getActiveTraceId(),
   name,
-  input,
-  output,
   userId,
   sessionId,
   tags,
@@ -91,21 +85,12 @@ export const publishPublicDemoTraceLink = async ({
   }
 
   try {
-    if (input !== undefined || output !== undefined) {
-      await createPublicDemoTraceEvent({
-        traceId,
-        name,
-        input,
-        output,
-        userId,
-        sessionId,
-        tags,
-      });
-    }
-
-    await waitForPublicDemoTrace({
+    await createPublicDemoTraceEvent({
       traceId,
-      requireOutput: output !== undefined,
+      name,
+      userId,
+      sessionId,
+      tags,
     });
 
     return createDemoTraceLink(traceId);
@@ -127,7 +112,6 @@ const createPublicDemoTraceEvent = async ({
   traceId,
   name,
   input,
-  output,
   userId,
   sessionId,
   tags,
@@ -146,7 +130,6 @@ const createPublicDemoTraceEvent = async ({
           name,
           public: true,
           ...(input !== undefined && { input }),
-          ...(output !== undefined && { output }),
           ...(userId && { userId }),
           ...(sessionId && { sessionId }),
           ...(tags && { tags }),
@@ -155,41 +138,3 @@ const createPublicDemoTraceEvent = async ({
     ],
   });
 };
-
-const waitForPublicDemoTrace = async ({
-  traceId,
-  requireOutput,
-}: {
-  traceId: string;
-  requireOutput: boolean;
-}) => {
-  const deadline = Date.now() + DEMO_TRACE_READINESS_TIMEOUT_MS;
-  let lastError: unknown;
-
-  while (Date.now() < deadline) {
-    try {
-      const trace = await demoProjectLangfuseClient.api.trace.get(traceId, {
-        fields: "core,io,observations",
-      });
-      const hasObservations =
-        Array.isArray(trace.observations) && trace.observations.length > 0;
-      const hasOutput = !requireOutput || trace.output !== undefined;
-
-      if (trace.public && hasObservations && hasOutput) {
-        return;
-      }
-    } catch (err) {
-      lastError = err;
-    }
-
-    await wait(DEMO_TRACE_READINESS_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(
-    `Timed out waiting for public Langfuse trace ${traceId} to be ready`,
-    { cause: lastError },
-  );
-};
-
-const wait = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -1,5 +1,6 @@
 import { LangfuseClient } from "@langfuse/client";
 import { getActiveTraceId, setActiveTraceAsPublic } from "@langfuse/tracing";
+import { createPublicDemoProjectTraceUrl } from "@/lib/demo-trace-url";
 
 export type DemoTraceLink = {
   traceId?: string;
@@ -35,7 +36,10 @@ export const createDemoTraceLink = async (
     };
   } catch (err) {
     console.warn("Failed to resolve public Langfuse trace URL", err);
-    return { traceId };
+    return {
+      traceId,
+      traceUrl: createPublicDemoProjectTraceUrl(traceId),
+    };
   }
 };
 

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -10,10 +10,14 @@ type PublicDemoTraceParams = {
   traceId?: string;
   name: string;
   input?: unknown;
+  output?: unknown;
   userId?: string;
   sessionId?: string;
   tags?: string[];
 };
+
+const DEMO_TRACE_READINESS_TIMEOUT_MS = 10_000;
+const DEMO_TRACE_READINESS_POLL_INTERVAL_MS = 500;
 
 type PublishableTrace = {
   traceId?: string;
@@ -70,12 +74,14 @@ export const createPublicDemoTraceLink = async ({
     return { traceId };
   }
 
-  return createDemoTraceLink(traceId);
+  return { traceId };
 };
 
 export const publishPublicDemoTraceLink = async ({
   traceId = getActiveTraceId(),
   name,
+  input,
+  output,
   userId,
   sessionId,
   tags,
@@ -85,12 +91,21 @@ export const publishPublicDemoTraceLink = async ({
   }
 
   try {
-    await createPublicDemoTraceEvent({
+    if (input !== undefined || output !== undefined) {
+      await createPublicDemoTraceEvent({
+        traceId,
+        name,
+        input,
+        output,
+        userId,
+        sessionId,
+        tags,
+      });
+    }
+
+    await waitForPublicDemoTrace({
       traceId,
-      name,
-      userId,
-      sessionId,
-      tags,
+      requireOutput: output !== undefined,
     });
 
     return createDemoTraceLink(traceId);
@@ -112,6 +127,7 @@ const createPublicDemoTraceEvent = async ({
   traceId,
   name,
   input,
+  output,
   userId,
   sessionId,
   tags,
@@ -130,6 +146,7 @@ const createPublicDemoTraceEvent = async ({
           name,
           public: true,
           ...(input !== undefined && { input }),
+          ...(output !== undefined && { output }),
           ...(userId && { userId }),
           ...(sessionId && { sessionId }),
           ...(tags && { tags }),
@@ -138,3 +155,41 @@ const createPublicDemoTraceEvent = async ({
     ],
   });
 };
+
+const waitForPublicDemoTrace = async ({
+  traceId,
+  requireOutput,
+}: {
+  traceId: string;
+  requireOutput: boolean;
+}) => {
+  const deadline = Date.now() + DEMO_TRACE_READINESS_TIMEOUT_MS;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const trace = await demoProjectLangfuseClient.api.trace.get(traceId, {
+        fields: "core,io,observations",
+      });
+      const hasObservations =
+        Array.isArray(trace.observations) && trace.observations.length > 0;
+      const hasOutput = !requireOutput || trace.output !== undefined;
+
+      if (trace.public && hasObservations && hasOutput) {
+        return;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+
+    await wait(DEMO_TRACE_READINESS_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Timed out waiting for public Langfuse trace ${traceId} to be ready`,
+    { cause: lastError },
+  );
+};
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -52,12 +52,7 @@ export const publishPublicDemoTraceLink = async ({
     return {};
   }
 
-  const traceIsReady = await waitForReadableDemoTrace(traceId);
-
-  if (!traceIsReady) {
-    return { traceId };
-  }
-
+  await waitForReadableDemoTrace(traceId);
   return createDemoTraceLink(traceId);
 };
 
@@ -86,10 +81,8 @@ const waitForReadableDemoTrace = async (traceId: string) => {
 
       if (statusCode !== 404) {
         console.warn("Failed to verify public Langfuse trace readiness", err);
-        return false;
+        return;
       }
     }
   }
-
-  return false;
 };

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -48,6 +48,16 @@ export const createPublicDemoTraceLink = async ({
 export const publishPublicDemoTraceLink = async ({
   traceId = getActiveTraceId(),
 }: PublicDemoTraceParams): Promise<DemoTraceLink> => {
+  if (!traceId) {
+    return {};
+  }
+
+  const traceIsReady = await waitForReadableDemoTrace(traceId);
+
+  if (!traceIsReady) {
+    return { traceId };
+  }
+
   return createDemoTraceLink(traceId);
 };
 
@@ -57,4 +67,29 @@ export const makeDemoTracePublic = (trace?: PublishableTrace) => {
   }
 
   setActiveTraceAsPublic();
+};
+
+const waitForReadableDemoTrace = async (traceId: string) => {
+  for (const delayMs of [0, 250, 500, 1000, 1500, 2000]) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    try {
+      await demoProjectLangfuseClient.api.trace.get(traceId);
+      return true;
+    } catch (err) {
+      const statusCode =
+        typeof err === "object" && err !== null && "statusCode" in err
+          ? err.statusCode
+          : undefined;
+
+      if (statusCode !== 404) {
+        console.warn("Failed to verify public Langfuse trace readiness", err);
+        return false;
+      }
+    }
+  }
+
+  return false;
 };

--- a/lib/demo-project-trace.ts
+++ b/lib/demo-project-trace.ts
@@ -8,11 +8,6 @@ export type DemoTraceLink = {
 
 type PublicDemoTraceParams = {
   traceId?: string;
-  name: string;
-  input?: unknown;
-  userId?: string;
-  sessionId?: string;
-  tags?: string[];
 };
 
 type PublishableTrace = {
@@ -46,58 +41,14 @@ export const createDemoTraceLink = async (
 
 export const createPublicDemoTraceLink = async ({
   traceId = getActiveTraceId(),
-  name,
-  input,
-  userId,
-  sessionId,
-  tags,
 }: PublicDemoTraceParams): Promise<DemoTraceLink> => {
-  if (!traceId) {
-    return {};
-  }
-
-  try {
-    await createPublicDemoTraceEvent({
-      traceId,
-      name,
-      input,
-      userId,
-      sessionId,
-      tags,
-    });
-  } catch (err) {
-    console.warn("Failed to create public Langfuse trace", err);
-    return { traceId };
-  }
-
   return createDemoTraceLink(traceId);
 };
 
 export const publishPublicDemoTraceLink = async ({
   traceId = getActiveTraceId(),
-  name,
-  userId,
-  sessionId,
-  tags,
 }: PublicDemoTraceParams): Promise<DemoTraceLink> => {
-  if (!traceId) {
-    return {};
-  }
-
-  try {
-    await createPublicDemoTraceEvent({
-      traceId,
-      name,
-      userId,
-      sessionId,
-      tags,
-    });
-
-    return createDemoTraceLink(traceId);
-  } catch (err) {
-    console.warn("Failed to publish public Langfuse trace", err);
-    return { traceId };
-  }
+  return createDemoTraceLink(traceId);
 };
 
 export const makeDemoTracePublic = (trace?: PublishableTrace) => {
@@ -106,35 +57,4 @@ export const makeDemoTracePublic = (trace?: PublishableTrace) => {
   }
 
   setActiveTraceAsPublic();
-};
-
-const createPublicDemoTraceEvent = async ({
-  traceId,
-  name,
-  input,
-  userId,
-  sessionId,
-  tags,
-}: PublicDemoTraceParams & { traceId: string }) => {
-  const timestamp = new Date().toISOString();
-
-  await demoProjectLangfuseClient.api.ingestion.batch({
-    batch: [
-      {
-        id: crypto.randomUUID(),
-        type: "trace-create",
-        timestamp,
-        body: {
-          id: traceId,
-          timestamp,
-          name,
-          public: true,
-          ...(input !== undefined && { input }),
-          ...(userId && { userId }),
-          ...(sessionId && { sessionId }),
-          ...(tags && { tags }),
-        },
-      },
-    ],
-  });
 };

--- a/lib/demo-trace-url.ts
+++ b/lib/demo-trace-url.ts
@@ -1,0 +1,10 @@
+const PUBLIC_DEMO_PROJECT_URL =
+  "https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi";
+
+export const createPublicDemoProjectTraceUrl = (traceId?: string | null) => {
+  if (!traceId) {
+    return undefined;
+  }
+
+  return `${PUBLIC_DEMO_PROJECT_URL}/traces/${encodeURIComponent(traceId)}`;
+};


### PR DESCRIPTION
## Summary
- Redesign the demo trace link as a yellow framed CTA matching the mockup.
- Keep the Langfuse icon, external arrow, trace URL behavior, and PostHog click tracking.

## Checks
- pnpm exec tsc --noEmit --pretty false
- git diff --check

Visual screenshot not captured: Playwright was unavailable in the shell runtime and sandboxed browser launch was blocked.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR redesigns the demo trace link while retaining its existing navigation and analytics behavior.
- Replaces the compact link styling with a yellow framed CTA.
- Adds decorative corner borders and larger icon, label, and external-arrow treatments.
- Adds hover and keyboard-focus visual states.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The responsive clipping of the redesigned CTA should be fixed before merging.

The new fixed-size icons, large padding and gaps, and non-wrapping label create a minimum width that exceeds the content area of existing padded, overflow-clipping demo cards on narrow viewports.

**Files Needing Attention:** components/demoTraceLink.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/demoTraceLink.tsx:56-65
**CTA overflows narrow demo cards**

When a demo is viewed on a narrow mobile viewport, the large padding and gaps, fixed-size icons, and non-wrapping label make the CTA wider than the card's content area, causing its right side to be clipped by the card's overflow handling.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Redesign demo trace link button"](https://github.com/langfuse/langfuse-docs/commit/a5f6a5c565843a75f7a11a023ad52729520bb61a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47892325)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->