### PR TITLE
docs(self-hosting): clarify worker queue metric and add legacy metric note

### DIFF
--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -30,9 +30,16 @@ On very high loads, it may become necessary to apply additional settings that in
 For most environments, we recommend to scale the worker containers by their CPU load as this is a straightforward metric to measure.
 A load above 50% for a 2 CPU container is an indicator that the instance is saturated and that the throughput should increase by adding more containers.
 
-In addition, the Langfuse worker also publishes queue length metrics via statsd that can be used to scale the worker containers.
-`langfuse.queue.ingestion.length` is the main metric that we use to make scaling decisions.
+In addition, the Langfuse worker publishes tagged queue depth metrics via StatsD that can be used to scale the worker containers.
+`langfuse.queue.ingestion.depth` with the tag `type:waiting` is the main metric that we use to make scaling decisions.
 The queue metrics can also be published to AWS CloudWatch by setting `ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING=true` to configure auto-scalers based on AWS metrics.
+
+<details>
+<summary>Queue metric for Langfuse versions before 3.169.0</summary>
+
+Langfuse versions before [3.169.0](https://github.com/langfuse/langfuse/releases/tag/v3.169.0) do not emit the tagged queue depth metric. Use the legacy `langfuse.queue.ingestion.length` metric when configuring autoscaling for these versions.
+
+</details>
 
 ### Reducing ClickHouse reads within the ingestion processing
 

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -34,10 +34,18 @@ In addition, the Langfuse worker publishes tagged queue depth metrics via StatsD
 `langfuse.queue.ingestion.depth` with the tag `type:waiting` is the main metric that we use to make scaling decisions.
 The queue metrics can also be published to AWS CloudWatch by setting `ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING=true` to configure auto-scalers based on AWS metrics.
 
+<Callout type="info">
+
+Starting with Langfuse [3.170.0](https://github.com/langfuse/langfuse/releases/tag/v3.170.0), tagged queue metrics ending in `.depth`, `.rate`, or `.dlq_oldest_age` are published in the `Langfuse` CloudWatch namespace with every tag except `unit` flattened into the metric name as a `.tag_value` segment, sorted by tag name, instead of publishing the tags as dimensions. Therefore, the StatsD metric and tag above are published to CloudWatch as `langfuse.queue.ingestion.depth.type_waiting`.
+
+</Callout>
+
 <details>
-<summary>Queue metric for Langfuse versions before 3.169.0</summary>
+<summary>Queue metric compatibility for Langfuse 3.169.0 and earlier</summary>
 
 Langfuse versions before [3.169.0](https://github.com/langfuse/langfuse/releases/tag/v3.169.0) do not emit the tagged queue depth metric. Use the legacy `langfuse.queue.ingestion.length` metric when configuring autoscaling for these versions.
+
+Langfuse 3.169.0 emits the tagged depth metric to StatsD, but its CloudWatch publisher does not flatten the tags and therefore does not provide a distinct waiting-depth series. Upgrade to 3.170.0 or later before using the queue depth metric for CloudWatch autoscaling.
 
 </details>
 


### PR DESCRIPTION
### Motivation
- Clarify the autoscaling metric emitted by Langfuse workers and document compatibility for older releases to prevent misconfiguration.

### Description
- Update docs to state that workers emit a tagged StatsD metric `langfuse.queue.ingestion.depth` with tag `type:waiting`, replace reference to legacy `langfuse.queue.ingestion.length`, and add a collapsible note explaining that versions before `3.169.0` only emit the legacy metric.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68766122b48323b34347a8146e7797)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies the worker queue-depth metric used for autoscaling.
- Documents `langfuse.queue.ingestion.depth` with the `type:waiting` tag.
- Adds a collapsible compatibility note directing releases before 3.169.0 to the legacy queue-length metric.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The CloudWatch-specific metric name needs clarification before this autoscaling guidance is safe to publish.

CloudWatch flattens the documented StatsD tag into the metric name, so operators following the adjacent CloudWatch guidance can configure an alarm against a series that is never emitted.

**Files Needing Attention:** content/self-hosting/configuration/scaling.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/configuration/scaling.mdx:34-35
**CloudWatch uses a flattened metric name**

When operators configure CloudWatch autoscaling from this guidance, the publisher flattens the tag into a metric name such as `langfuse.queue.ingestion.depth.type_waiting` rather than exposing `langfuse.queue.ingestion.depth` with a `type:waiting` dimension, causing an alarm configured with the documented StatsD selector to receive no data. Document the CloudWatch-specific name alongside the tagged StatsD form.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note legacy ingestion queue metric"](https://github.com/langfuse/langfuse-docs/commit/8cc096ace9a0cf1f5975b9ef38a8eee63b0406c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47900059)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->