### PR TITLE
docs: document secure remote experiment triggers

### DIFF
--- a/content/changelog/2026-07-28-secure-remote-experiment-triggers.mdx
+++ b/content/changelog/2026-07-28-secure-remote-experiment-triggers.mdx
@@ -1,0 +1,28 @@
+---
+date: 2026-07-28
+title: Secure remote experiment triggers
+description: Authenticate remote experiment trigger requests with signed and custom headers.
+author: Marlies
+canonical: /docs/evaluation/experiments/experiments-via-sdk#optional-trigger-sdk-experiment-from-ui
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book } from "lucide-react";
+
+<ChangelogHeader />
+
+Remote experiment triggers can now be secured before your evaluation service starts a run.
+
+- Enable the optional `x-langfuse-signature` HMAC header so your service can verify that requests came from Langfuse.
+- Add custom headers for service-specific authentication or routing.
+- Return a fast 2xx response and continue the experiment asynchronously.
+
+Existing remote experiment configurations continue to work without signing or custom headers.
+
+<Cards num={1}>
+  <Card
+    title="Remote experiment trigger documentation"
+    href="/docs/evaluation/experiments/experiments-via-sdk#optional-trigger-sdk-experiment-from-ui"
+    icon={<Book />}
+  />
+</Cards>

--- a/content/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/content/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -643,7 +643,7 @@ console.log(await result.format());
 
 When setting up Experiments via SDK, it can be useful to allow triggering the experiment runs from the Langfuse UI.
 
-You need to set up a webhook to receive the trigger request from Langfuse.
+You need to set up an HTTP endpoint to receive the trigger request from Langfuse.
 
 <Steps>
 
@@ -670,6 +670,8 @@ You need to set up a webhook to receive the trigger request from Langfuse.
 
 **Enter** the URL of your external evaluation service that will receive the webhook when experiments are triggered.
 **Specify** a default config that will be sent to your webhook. Users can modify this when triggering experiments.
+
+Remote experiment trigger requests can optionally include the same HMAC-signed `x-langfuse-signature` header used by [prompt webhooks](/docs/prompt-management/features/webhooks-slack-integrations). Enable request signing in the setup form and configure additional custom headers in **Advanced Options**. Existing triggers without signing or custom headers continue to work. Your endpoint should return a 2xx response quickly and run the experiment asynchronously.
 
 <Frame className="max-w-lg">
   ![New Experiment Button](/images/docs/trigger-remote-experiment-2.png)

--- a/content/docs/prompt-management/features/webhooks-slack-integrations.mdx
+++ b/content/docs/prompt-management/features/webhooks-slack-integrations.mdx
@@ -54,7 +54,7 @@ Choose the prompt‑version actions that should fire the webhook:
 - **Headers**: Default headers include:
   - `Content-Type: application/json`
   - `User-Agent: Langfuse/1.0`
-  - `x-langfuse-signature: <sig>` (see note on HMAC signature verification below)
+  - `x-langfuse-signature: t=<timestamp>,v1=<signature>` (see note on HMAC signature verification below)
 - **Add custom static headers if required.**
 
 ### Inspect the payload
@@ -119,7 +119,7 @@ def verify_langfuse_signature(
     raw_body : str
         The request body exactly as received (no decoding or reformatting).
     signature_header : str
-        The value of the `Langfuse-Signature` header, e.g. "t=1720701136,s=0123abcd...".
+        The value of the `x-langfuse-signature` header, e.g. "t=1720701136,v1=0123abcd...".
     secret : str
         Your Langfuse signing secret.
 

--- a/content/docs/prompt-management/features/webhooks-slack-integrations.mdx
+++ b/content/docs/prompt-management/features/webhooks-slack-integrations.mdx
@@ -128,7 +128,7 @@ def verify_langfuse_signature(
     bool
         True if the signature is valid, otherwise False.
     """
-    # Split "t=timestamp,s=signature" into the two expected key/value chunks
+    # Split "t=timestamp,v1=signature" into the two expected key/value chunks
     try:
         ts_pair, sig_pair = signature_header.split(",", 1)
     except ValueError:  # wrong format / missing comma


### PR DESCRIPTION
## What changed

- Correct the webhook signature documentation to use the actual `x-langfuse-signature: t=<timestamp>,v1=<signature>` format.
- Document optional request signing and custom headers for remote experiment triggers.
- Add a changelog entry for the new remote-trigger authentication options.

## Validation

- Ran `pnpm run format`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents secure remote experiment triggers.
- Corrects the documented webhook signature header to the timestamped `v1` format.
- Adds guidance for optional request signing, custom headers, and asynchronous trigger handling.
- Adds a changelog entry linking to the remote-trigger documentation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking gaps in the signature documentation.

The signature format is corrected, but the Python example retains the former field name in an adjacent comment and the remote-trigger instructions omit how users obtain or rotate the signing secret.

**Files Needing Attention:** content/docs/prompt-management/features/webhooks-slack-integrations.mdx, content/docs/evaluation/experiments/experiments-via-sdk.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/prompt-management/features/webhooks-slack-integrations.mdx:122
**Align the signature field names**

The updated docstring presents the signature as `v1=...`, while the parser comment immediately below still describes `s=signature`. Using both names in this security-sensitive example obscures which field integrations should expect.

### Issue 2
content/docs/evaluation/experiments/experiments-via-sdk.mdx:674
**Document the signing secret lifecycle**

The new guidance tells users to enable request signing and verify the resulting header, but does not explain where the remote-trigger signing secret is obtained or how it is rotated. Without that information, users cannot reliably configure the linked verification code and can reject every legitimate trigger with a wrong or stale secret.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document secure remote experiment ..."](https://github.com/langfuse/langfuse-docs/commit/46ad0bc5ee19fb83fbe99d6457e6c4accdb2abfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47921977)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)

<!-- /greptile_comment -->