### PR TITLE
Fix link to OpenRouter Broadcast feature documentation

### DIFF
--- a/content/integrations/gateways/openrouter.mdx
+++ b/content/integrations/gateways/openrouter.mdx
@@ -23,7 +23,7 @@ There is more information on e.g. cost tracking or interoperability with Langfus
 
 ## 1. OpenRouter Broadcast Tracing with Langfuse (No-Code) [#broadcast]
 
-OpenRouter's [Broadcast feature](https://openrouter.ai/docs/guides/features/broadcast/overview) can automatically send traces to Langfuse without any code changes. To enable this integration, go to your [OpenRouter settings](https://openrouter.ai/settings) and connect your Langfuse API keys. Once set up, all requests processed through OpenRouter will be traced and made available in your Langfuse project.
+OpenRouter's [Broadcast feature](https://openrouter.ai/docs/guides/features/broadcast) can automatically send traces to Langfuse without any code changes. To enable this integration, go to your [OpenRouter settings](https://openrouter.ai/settings) and connect your Langfuse API keys. Once set up, all requests processed through OpenRouter will be traced and made available in your Langfuse project.
 
 <Frame className="my-10" fullWidth>
   ![OpenRouter settings showing the Langfuse Broadcast


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the OpenRouter Broadcast documentation link by removing the obsolete `/overview` path segment.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only updates the OpenRouter Broadcast hyperlink target and preserves the surrounding MDX content and rendering behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix link to OpenRouter Broadcast feature..."](https://github.com/langfuse/langfuse-docs/commit/947eb0f0a216fb0607e6cca4a529996848379849) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47922506)</sub>

<!-- /greptile_comment -->