### PR TITLE
fix(redirects): resolve /docs/prompts redirect chain

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -209,7 +209,9 @@ const nonPermanentRedirects = [
   ["/docs/schedule-demo", "/talk-to-us"],
   ["/schedule-demo", "/talk-to-us"],
   ["/docs/project-sharing", "/docs/rbac"],
-  ["/docs/prompts", "/docs/prompts/get-started"],
+  // Point directly at the final destination to avoid a redirect chain
+  // (/docs/prompts/get-started is itself redirected to /docs/prompt-management/get-started).
+  ["/docs/prompts", "/docs/prompt-management/get-started"],
   ["/changelog/2024-03-03-posthog-integration", "/docs/analytics/posthog"],
   ["/guides/videos/2-min", "/guides/videos/introducing-langfuse-2.0"],
   ["/tos", "/terms"],


### PR DESCRIPTION
## Problem

Fixes #2135 — a reported broken `/docs/prompts/` link.

`/docs/prompts` was a multi-hop redirect chain, which crawlers and link-checkers flag as broken:

| Request | Response |
|---|---|
| `/docs/prompts/` | 308 → `/docs/prompts` |
| `/docs/prompts` | 307 → `/docs/prompts/get-started` |
| `/docs/prompts/get-started` | 308 → `/docs/prompt-management/get-started` |

The two hops lived in different arrays in `lib/redirects.js`: `/docs/prompts` → `/docs/prompts/get-started` in `nonPermanentRedirects`, and `/docs/prompts/get-started` → `/docs/prompt-management/get-started` in the permanent `mainDocsReorder202507` block.

## Fix

Point `/docs/prompts` directly at the final destination `/docs/prompt-management/get-started` so it resolves in a single hop.

Verified locally with `curl`: `/docs/prompts` now returns a single 307 straight to `/docs/prompt-management/get-started`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates `/docs/prompts` to redirect directly to `/docs/prompt-management/get-started`, eliminating the intermediate redirect hop.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new destination is an existing documentation route, is not itself redirected, and the source has no duplicate redirect entry that would interfere with the change.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redirects): resolve /docs/prompts re..."](https://github.com/langfuse/langfuse-docs/commit/577139291bd9f3897ec149ba83bccf0beafb21fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47926444)</sub>

<!-- /greptile_comment -->