### PR TITLE
docs(self-hosting): document worker queue-consumption liveness healthcheck

### DIFF
--- a/content/self-hosting/configuration/health-readiness-endpoints.mdx
+++ b/content/self-hosting/configuration/health-readiness-endpoints.mdx
@@ -70,6 +70,25 @@ When using this parameter in a Kubernetes liveness probe, set `initialDelaySecon
 
 </Callout>
 
+**Queue consumption liveness:**
+
+Connectivity checks alone cannot detect a worker whose queue consumers have silently stopped — for example after a Redis incident that invalidates BullMQ job locks (`FLUSHALL`, key eviction, failover; see the [cache configuration guide](/self-hosting/deployment/infrastructure/cache#worker-liveness)). A dedicated probe can fail when no queue processes jobs anymore:
+
+```bash
+curl "http://localhost:3030/api/health?failIfQueueConsumptionStuck=true"
+```
+
+- Returns `503` when the worker has neither picked up nor completed a single job — across all queues — for more than `LANGFUSE_QUEUE_CONSUMPTION_STUCK_THRESHOLD_MINUTES` (default `60`). The response body includes diagnostics (registered consumers, last job activity).
+- Built-in scheduled jobs keep a healthy worker busy at least once per hour, so use this parameter in a liveness probe to restart a wedged container automatically.
+- The signal is tracked in memory per container and measured from worker startup, so a freshly started container gets the full threshold as grace period; no `initialDelaySeconds` requirement applies.
+- Containers that run no queue consumers never fail this check.
+
+<Callout type="info">
+
+In deployments with many worker replicas and little traffic, each scheduled job runs on only one replica. If replicas can legitimately sit idle for long periods, raise the threshold to avoid unnecessary restarts.
+
+</Callout>
+
 ## Readiness Check Endpoint
 
 The readiness check indicates whether the web application is ready to receive traffic, particularly useful during graceful shutdowns.

--- a/content/self-hosting/deployment/infrastructure/cache.mdx
+++ b/content/self-hosting/deployment/infrastructure/cache.mdx
@@ -320,6 +320,12 @@ REDIS_TLS_ENABLED=true # required if REDIS_SENTINEL_TLS_ENABLED=true
 REDIS_SENTINEL_TLS_ENABLED=true
 ```
 
+## Detecting a Stalled Worker [#worker-liveness]
+
+Redis-level disruptions that invalidate BullMQ job locks — key eviction under a non-`noeviction` memory policy, a `FLUSHALL`, or a failover — can leave the worker container running while it silently stops consuming all queues.
+The worker health endpoint provides an opt-in check (`?failIfQueueConsumptionStuck=true`) that fails once no jobs have been processed for a configurable period, so a liveness probe can restart the container automatically.
+See [Health and Readiness Check Endpoints](/self-hosting/configuration/health-readiness-endpoints) for details.
+
 ## Sizing Recommendations
 
 Langfuse uses Redis mainly for queuing event metadata that should be processed by the worker.


### PR DESCRIPTION
Full details on the health/readiness endpoints page (opt-in ?failIfQueueConsumptionStuck=true probe, 60 min default threshold, per-container in-memory signal) plus a brief pointer from the Redis/Valkey infrastructure page, where the triggering failure modes (eviction, FLUSHALL, failover) are discussed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Documents the opt-in worker queue-consumption liveness probe and its Redis-related operational context.
- Explains the probe parameter, threshold, diagnostics, startup grace period, per-container behavior, and multi-replica considerations.
- Adds a cache-infrastructure section linking Redis disruptions to stalled-worker detection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

The new MDX uses established repository conventions, its cross-reference and explicit anchor are consistent, and no concrete changed-code defect remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): document worker queu..."](https://github.com/langfuse/langfuse-docs/commit/662f16268e5bc8b086368067750815eeb9282650) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47939289)</sub>

<!-- /greptile_comment -->