### PR TITLE
Improve demo chatbot code rendering

### DIFF
--- a/components/ai-elements/code-block.tsx
+++ b/components/ai-elements/code-block.tsx
@@ -60,7 +60,7 @@ export const CodeBlock = ({
     <CodeBlockContext.Provider value={{ code }}>
       <div
         className={cn(
-          "relative w-full overflow-hidden rounded-md bg-muted/30 text-foreground",
+          "relative w-full overflow-x-auto rounded-md bg-muted/30 text-foreground",
           className,
         )}
         {...props}
@@ -82,7 +82,7 @@ export const CodeBlock = ({
             codeTagProps={{
               className: "font-mono",
             }}
-            className="dark:hidden overflow-hidden"
+            className="dark:hidden min-w-max"
           >
             {code}
           </SyntaxHighlighter>
@@ -102,7 +102,7 @@ export const CodeBlock = ({
             codeTagProps={{
               className: "font-mono",
             }}
-            className="hidden dark:block overflow-hidden"
+            className="hidden dark:block min-w-max"
           >
             {code}
           </SyntaxHighlighter>

--- a/components/ai-elements/response.tsx
+++ b/components/ai-elements/response.tsx
@@ -160,6 +160,94 @@ function parseIncompleteMarkdown(text: string): string {
   return result;
 }
 
+const looseCodeLabelPattern = /^(\s*)([-*+]\s+)Code:\s*$/i;
+
+function inferCodeLanguage(codeLines: string[]): string {
+  const code = codeLines.join("\n");
+
+  if (/^\s*(from|import|def|class)\s/m.test(code) || /^\s*@\w+/m.test(code)) {
+    return "python";
+  }
+
+  if (
+    /^\s*(import|export)\s.+\sfrom\s/m.test(code) ||
+    /^\s*(const|let|var|type|interface)\s/m.test(code)
+  ) {
+    return "typescript";
+  }
+
+  if (/^\s*(curl|pnpm|npm|npx|pip|uv|python|node)\s/m.test(code)) {
+    return "bash";
+  }
+
+  return "text";
+}
+
+function normalizeLooseListCodeBlocks(text: string): string {
+  if (!text || typeof text !== "string") {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  const normalized: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const match = line.match(looseCodeLabelPattern);
+
+    if (!match) {
+      normalized.push(line);
+      continue;
+    }
+
+    const baseIndent = match[1];
+    const contentIndent = `${baseIndent}  `;
+    const codeLines: string[] = [];
+    let j = i + 1;
+
+    while (j < lines.length) {
+      const candidate = lines[j];
+
+      if (candidate.trim() === "") {
+        codeLines.push("");
+        j++;
+        continue;
+      }
+
+      if (candidate.startsWith(contentIndent)) {
+        codeLines.push(candidate.slice(contentIndent.length));
+        j++;
+        continue;
+      }
+
+      break;
+    }
+
+    while (codeLines.length > 0 && codeLines[codeLines.length - 1] === "") {
+      codeLines.pop();
+      j--;
+    }
+
+    const firstCodeLine = codeLines.find((codeLine) => codeLine.trim() !== "");
+    if (!firstCodeLine || firstCodeLine.trim().startsWith("```")) {
+      normalized.push(line);
+      continue;
+    }
+
+    const listIndent = `${baseIndent}  `;
+    normalized.push(
+      line,
+      "",
+      `${listIndent}\`\`\`${inferCodeLanguage(codeLines)}`,
+    );
+    normalized.push(...codeLines.map((codeLine) => `${listIndent}${codeLine}`));
+    normalized.push(`${listIndent}\`\`\``);
+    i = j - 1;
+  }
+
+  return normalized.join("\n");
+}
+
 // Create a hardened version of ReactMarkdown
 const HardenedMarkdown = hardenReactMarkdown(ReactMarkdown);
 
@@ -321,7 +409,7 @@ const components: Options["components"] = {
     );
   },
   pre: ({ node, className, children }) => {
-    let language = "javascript";
+    let language = "text";
 
     if (typeof node?.properties?.className === "string") {
       language = node.properties.className.replace("language-", "");
@@ -330,7 +418,13 @@ const components: Options["components"] = {
     // Extract code content from children safely
     let code = "";
     if (isValidElement(children)) {
-      const element = children as ReactElement<{ children?: ReactNode }>;
+      const element = children as ReactElement<{
+        children?: ReactNode;
+        className?: string;
+      }>;
+      if (element.props?.className?.startsWith("language-")) {
+        language = element.props.className.replace("language-", "");
+      }
       const inner = element.props?.children;
       if (typeof inner === "string") {
         code = inner;
@@ -365,11 +459,16 @@ export const Response = memo(
     parseIncompleteMarkdown: shouldParseIncompleteMarkdown = true,
     ...props
   }: ResponseProps) => {
+    const normalizedChildren =
+      typeof children === "string"
+        ? normalizeLooseListCodeBlocks(children)
+        : children;
+
     // Parse the children to remove incomplete markdown tokens if enabled
     const parsedChildren =
-      typeof children === "string" && shouldParseIncompleteMarkdown
-        ? parseIncompleteMarkdown(children)
-        : children;
+      typeof normalizedChildren === "string" && shouldParseIncompleteMarkdown
+        ? parseIncompleteMarkdown(normalizedChildren)
+        : normalizedChildren;
 
     return (
       <div


### PR DESCRIPTION
## Summary
- Normalize loose `- Code:` sections in streamed AI responses into fenced code blocks before markdown rendering.
- Preserve fenced-code language detection from the rendered `code` child and default untagged blocks to plain text.
- Let code blocks scroll horizontally instead of clipping/wrapping long code into unreadable paragraphs.

## Checks
- `pnpm run format`
- `pnpm run format:check`
- `pnpm exec tsc --noEmit --pretty false`
- `curl -I http://127.0.0.1:3333/docs/demo` -> HTTP 200 after first compile

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Improves streamed chatbot code rendering by:
- Converting loose list-style `Code:` sections into fenced Markdown code blocks with inferred language tags.
- Reading fenced-code language metadata from the rendered code child and defaulting untagged blocks to plain text.
- Making long code blocks horizontally scrollable in both light and dark themes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The normalization is limited to exact list-item Code labels followed by indented content, preserves existing fenced blocks, and the layout changes place intrinsic-width code inside a bounded horizontal scroll container.
</details>

<sub>Reviews (1): Last reviewed commit: ["Improve demo chatbot code rendering"](https://github.com/langfuse/langfuse-docs/commit/c81657353ae042b8f02ffc54f05d74272eb446e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48029339)</sub>

**Context used:**

- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->