### PR TITLE
docs: simplify blob storage export guidance

### DIFF
--- a/components-mdx/blob-storage-empty-files.mdx
+++ b/components-mdx/blob-storage-empty-files.mdx
@@ -12,5 +12,5 @@ What an empty file looks like depends on the configured file format:
 Build downstream pipelines to tolerate empty files:
 
 - Treat an empty file as "no data in this window for this table," not as a failure, and don't alert on its presence.
-- Don't assume a file is always present for every window and table. **List the objects in each directory and ingest what's there** rather than relying on a fixed file-per-window pattern.
-- Point pipelines at the directory (for example `observations_v2/` or `scores/`) rather than parsing filenames. The directory prefixes are stable, but the exact filename format within them is not a stable contract.
+- Don't assume every window contains a file for every table.
+- Process the objects listed in the completed run's manifest instead of deriving filenames or listing table directories.

--- a/components-mdx/blob-storage-re-exporting.mdx
+++ b/components-mdx/blob-storage-re-exporting.mdx
@@ -2,7 +2,7 @@ Editing an integration (credentials, bucket, prefix, frequency, file type, expor
 
 There are two ways to re-export historic data:
 
-1. **Change the Export Mode** (`Full history` / `From setup date` / `From custom date`). Changing the mode resets the sync position so the new mode's start-date logic takes effect. For example, switching to `Full history` re-scans from the earliest data. Editing other fields does not reset this.
+1. **Change History** (`Full history` / `From setup date` / `From custom date`). Changing this setting resets the sync position so the selected start date takes effect. For example, switching to `Full history` re-scans from the earliest data. Editing other fields does not reset this.
 2. **Reset the integration.** The **Reset** button removes the integration; you then reconfigure it from scratch and it starts fresh.
 
 **Run Now** triggers an immediate export of data **since the last sync**; it does not re-export history.

--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -1,272 +1,160 @@
 ---
-title: Blob Storage Export Field Reference
-description: Complete reference of all fields exported by the Langfuse blob storage integration, organized by export table (enriched observations, scores, legacy traces, legacy observations).
+title: Blob storage export field reference
+description: Field names and types for enriched observations, scores, and deprecated legacy blob storage exports.
 sidebarTitle: Export Field Reference
 ---
 
-# Blob Storage Export Field Reference [#blob-storage-export-field-reference]
+# Blob storage export field reference [#blob-storage-export-field-reference]
 
-This page lists every field exported by the Langfuse blob storage integration, organized by export table. For setup instructions and configuration, see [Export to Blob Storage](/docs/api-and-data-platform/features/export-to-blob-storage).
+Use this reference when building a consumer for the [blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage). Types match JSON and JSONL output. Timestamps use `YYYY-MM-DD HH:MM:SS.ffffff` in UTC.
 
-Exports can be written as Parquet (default for new integrations), CSV, JSON, or JSONL files. Types are described as they appear in **JSON/JSONL** exports. Timestamps use `YYYY-MM-DD HH:MM:SS.ffffff` format (e.g. `2024-05-29 13:46:19.963000`) in UTC. See [Notes on CSV exports](#csv-exports) for how types map in CSV format and [Notes on Parquet exports](#parquet-exports) for Parquet-specific behavior.
+## Exported files [#export-sources]
 
-## Export sources [#export-sources]
+| File               | When it is exported      |
+| ------------------ | ------------------------ |
+| `observations_v2/` | Current enriched export  |
+| `scores/`          | Every export             |
+| `traces/`          | Deprecated legacy export |
+| `observations/`    | Deprecated legacy export |
 
-The blob storage integration supports three export source modes (configurable per project in **Project Settings > Integrations > Blob Storage**):
-
-| Mode                                                           | Blob paths written                    | Description                                                                                                                                               |
-| -------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Enriched observations (recommended)**                        | `observations_v2/`, `scores/`         | Each observation row includes trace-level fields (`user_id`, `session_id`, `trace_name`, etc.) directly. No warehouse-side JOIN needed for trace context. |
-| **Traces and observations (legacy)**                           | `traces/`, `observations/`, `scores/` | Three separate files per time window. Observations do **not** include trace-level fields; join on `trace_id` in your warehouse.                           |
-| **Traces and observations (legacy) and enriched observations** | All of the above                      | Writes both sets of observation files plus traces and scores.                                                                                             |
-
-Scores are **always** exported regardless of mode.
-
-<Callout type="info">
-  We recommend **Enriched observations** for most use cases: it produces fewer files and avoids cross-file JOINs for trace context.
-</Callout>
+For configuration and migration steps, see [Export to blob storage](/docs/api-and-data-platform/features/export-to-blob-storage).
 
 ## Enriched observations (`observations_v2/`) [#enriched-observations]
 
-Exported in **Enriched observations** and **Traces and observations (legacy) and enriched observations** modes.
+Each row represents one observation and includes its trace context. Only the [selected field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) appear; `core` is always included.
 
-Each row is a single observation with trace-level context included directly, so no warehouse-side JOIN is needed.
-
-<Callout type="info">
-  The columns below are grouped into eleven [field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups), ten of which are toggleable. New integrations export all groups by default. The `core` group is always included; the others can be deselected per integration to shrink files or omit sensitive columns. Field groups also apply to the legacy `observations/` file (with a smaller column set per group), but not to the `traces/` file, which has a fixed column set.
-</Callout>
-
-| Field                     | Type                       | Description                                                                                                                       | Usage notes                                                                                                                                                             |
-| ------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                      | string                     | Unique observation identifier.                                                                                                    | Primary key.                                                                                                                                                            |
-| `trace_id`                | string                     | Parent trace identifier.                                                                                                          | Use to link with scores or group observations by trace.                                                                                                                 |
-| `project_id`              | string                     | Langfuse project identifier.                                                                                                      | All rows in one export belong to the same project.                                                                                                                      |
-| `environment`             | string                     | Environment label.                                                                                                                | Filter by environment.                                                                                                                                                  |
-| `type`                    | string                     | Observation type: `SPAN`, `GENERATION`, `EVENT`, `AGENT`, `TOOL`, `CHAIN`, `RETRIEVER`, `EVALUATOR`, `EMBEDDING`, or `GUARDRAIL`. | See [observation types](/docs/observability/features/observation-types). Generations are LLM calls; spans are arbitrary operations; events are point-in-time markers.   |
-| `parent_observation_id`   | string                     | Parent observation ID (for nested observations).                                                                                  | Reconstruct the trace tree by walking parent pointers. Empty string for root-level observations.                                                                        |
-| `start_time`              | string (timestamp)         | When the observation started.                                                                                                     | Primary time axis for observations.                                                                                                                                     |
-| `end_time`                | string (timestamp) or null | When the observation ended.                                                                                                       | Null for events and in-progress observations.                                                                                                                           |
-| `name`                    | string                     | User-defined observation name.                                                                                                    | Group/filter by name (e.g. function name, model call label).                                                                                                            |
-| `metadata`                | object                     | User-supplied key-value metadata.                                                                                                 | Arbitrary context. Extract keys relevant to your analytics.                                                                                                             |
-| `level`                   | string                     | Log level: `DEBUG`, `DEFAULT`, `WARNING`, `ERROR`.                                                                                | Filter for errors or warnings.                                                                                                                                          |
-| `status_message`          | string                     | Status or error message.                                                                                                          | Inspect for debugging failed observations.                                                                                                                              |
-| `version`                 | string                     | User-provided version string set via the SDK.                                                                                     | Empty string when not set.                                                                                                                                              |
-| `input`                   | string                     | Observation input payload.                                                                                                        | For generations: the prompt/messages sent to the LLM. May be plain text or JSON; may be large. Empty string when not set.                                               |
-| `output`                  | string                     | Observation output payload.                                                                                                       | For generations: the LLM response. May be plain text or JSON; may be large. Empty string when not set.                                                                  |
-| `provided_model_name`     | string                     | Model name as provided by the user/SDK.                                                                                           | The raw model string (e.g. `gpt-4o`, `claude-sonnet-4-20250514`). Empty string for spans and events.                                                                    |
-| `model_parameters`        | string                     | Model call parameters as a JSON-encoded string (e.g. `"{\"temperature\":0.7}"`).                                                  | Parse as JSON. Useful for analyzing how model settings affect quality/cost. Empty string for spans and events.                                                          |
-| `usage_details`           | object (string → integer)  | Token usage breakdown by category.                                                                                                | Extract keys: `input` for input tokens, `output` for output tokens, `total` for total. May contain additional keys like `input_cached_tokens`, `reasoning_tokens`, etc. |
-| `cost_details`            | object (string → number)   | Cost breakdown by category (USD).                                                                                                 | Extract keys: `input` for input cost, `output` for output cost.                                                                                                         |
-| `completion_start_time`   | string (timestamp) or null | When the first token was generated (for streaming).                                                                               | Used to compute `time_to_first_token`. Null for non-streaming calls.                                                                                                    |
-| `prompt_name`             | string                     | Name of the Langfuse prompt used, if any.                                                                                         | Filter for observations using a specific prompt.                                                                                                                        |
-| `prompt_version`          | integer or null            | Version number of the Langfuse prompt used.                                                                                       | Track which prompt version was active.                                                                                                                                  |
-| `total_cost`              | number                     | Total computed cost for this observation (USD).                                                                                   | Observation-level cost. Sum across a trace for trace-level cost.                                                                                                        |
-| `latency`                 | number or null             | Duration in **seconds** (`end_time - start_time`).                                                                                | Null when `end_time` is null.                                                                                                                                           |
-| `time_to_first_token`     | number or null             | Time to first token in **seconds** (`completion_start_time - start_time`).                                                        | Null when `completion_start_time` is null. Measures streaming responsiveness.                                                                                           |
-| `model_id`                | string                     | Langfuse model definition ID (resolved from `provided_model_name`).                                                               | Used to look up pricing. Empty string if no model definition matched.                                                                                                   |
-| `created_at`              | string (timestamp)         | Row creation time.                                                                                                                | System timestamp.                                                                                                                                                       |
-| `updated_at`              | string (timestamp)         | Last update time.                                                                                                                 | Incremental processing.                                                                                                                                                 |
-| `prompt_id`               | string                     | Langfuse prompt definition ID.                                                                                                    | Use with `prompt_name`/`prompt_version` for prompt analytics.                                                                                                           |
-| `tool_calls`              | array of strings           | Raw tool/function call payloads from the LLM response.                                                                            | Parse each element as JSON. Contains the full tool call objects.                                                                                                        |
-| `tool_call_names`         | array of strings           | Names of tools/functions called.                                                                                                  | Quick filter/group without parsing full `tool_calls`.                                                                                                                   |
-| `tool_definitions`        | object                     | Tool/function schemas provided to the LLM.                                                                                        | May be an empty object `{}` when no tools were provided.                                                                                                                |
-| `usage_pricing_tier_id`   | string or null             | ID of the pricing tier used for cost calculation.                                                                                 | Langfuse pricing tier UUID from the model definition. Null if no tiered pricing applies.                                                                                |
-| `usage_pricing_tier_name` | string or null             | Name of the pricing tier used for cost calculation.                                                                               | User-defined tier name from the model definition. Null if no tiered pricing applies.                                                                                    |
-| `input_price`             | string or null             | Per-unit input price from the matched model definition. Decimal string.                                                           | Null if no model definition matched. Cast to numeric in your pipeline. Not included in [Parquet exports](#parquet-exports).                                             |
-| `output_price`            | string or null             | Per-unit output price from the matched model definition. Decimal string.                                                          | Null if no model definition matched. Cast to numeric in your pipeline. Not included in [Parquet exports](#parquet-exports).                                             |
-| `total_price`             | string or null             | Per-unit total price from the matched model definition. Decimal string.                                                           | Null if no model definition matched. Used for models with a flat per-call price. Not included in [Parquet exports](#parquet-exports).                                   |
-| `user_id`                 | string                     | End-user identifier from the parent trace.                                                                                        | Directly available; no JOIN needed.                                                                                                                                     |
-| `session_id`              | string                     | Session identifier from the parent trace.                                                                                         | Directly available; no JOIN needed.                                                                                                                                     |
-| `trace_name`              | string                     | Name of the parent trace.                                                                                                         | Group observations by their parent trace name.                                                                                                                          |
-| `tags`                    | array of strings           | Tags from the parent trace.                                                                                                       | Directly available; no JOIN needed.                                                                                                                                     |
-| `release`                 | string                     | Release tag from the parent trace.                                                                                                | Directly available; no JOIN needed.                                                                                                                                     |
-| `bookmarked`              | boolean                    | Bookmark flag from the parent trace.                                                                                              | Directly available.                                                                                                                                                     |
-| `public`                  | boolean                    | Public flag from the parent trace.                                                                                                | Directly available.                                                                                                                                                     |
+| Field                     | Type                       | Description                                                                                                                       |
+| ------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                      | string                     | Unique observation identifier.                                                                                                    |
+| `trace_id`                | string                     | Trace identifier shared by related observations and scores.                                                                       |
+| `project_id`              | string                     | Langfuse project identifier.                                                                                                      |
+| `environment`             | string                     | Environment label.                                                                                                                |
+| `type`                    | string                     | Observation type: `SPAN`, `GENERATION`, `EVENT`, `AGENT`, `TOOL`, `CHAIN`, `RETRIEVER`, `EVALUATOR`, `EMBEDDING`, or `GUARDRAIL`. |
+| `parent_observation_id`   | string                     | Parent observation identifier; empty for a root observation.                                                                      |
+| `start_time`              | string (timestamp)         | When the observation started.                                                                                                     |
+| `end_time`                | string (timestamp) or null | When the observation ended.                                                                                                       |
+| `name`                    | string                     | User-defined observation name.                                                                                                    |
+| `metadata`                | object                     | User-supplied observation metadata.                                                                                               |
+| `level`                   | string                     | `DEBUG`, `DEFAULT`, `WARNING`, or `ERROR`.                                                                                        |
+| `status_message`          | string                     | Status or error message.                                                                                                          |
+| `version`                 | string                     | User-defined version.                                                                                                             |
+| `input`                   | string                     | Observation input; may contain plain text or JSON.                                                                                |
+| `output`                  | string                     | Observation output; may contain plain text or JSON.                                                                               |
+| `provided_model_name`     | string                     | Model name supplied by the SDK or user.                                                                                           |
+| `model_parameters`        | string                     | Model parameters encoded as JSON.                                                                                                 |
+| `usage_details`           | object (string → integer)  | Token usage by category, such as `input`, `output`, and `total`.                                                                  |
+| `cost_details`            | object (string → number)   | Cost in USD by category.                                                                                                          |
+| `completion_start_time`   | string (timestamp) or null | When the first streamed token was generated.                                                                                      |
+| `prompt_name`             | string                     | Langfuse prompt name.                                                                                                             |
+| `prompt_version`          | integer or null            | Langfuse prompt version.                                                                                                          |
+| `total_cost`              | number                     | Total observation cost in USD.                                                                                                    |
+| `latency`                 | number or null             | Duration in seconds.                                                                                                              |
+| `time_to_first_token`     | number or null             | Time to first token in seconds.                                                                                                   |
+| `model_id`                | string                     | Matched Langfuse model definition identifier.                                                                                     |
+| `created_at`              | string (timestamp)         | Row creation time.                                                                                                                |
+| `updated_at`              | string (timestamp)         | Last row update time.                                                                                                             |
+| `prompt_id`               | string                     | Langfuse prompt identifier.                                                                                                       |
+| `tool_calls`              | array of strings           | Tool calls encoded as JSON strings.                                                                                               |
+| `tool_call_names`         | array of strings           | Names of called tools.                                                                                                            |
+| `tool_definitions`        | object                     | Tool or function schemas supplied to the model.                                                                                   |
+| `usage_pricing_tier_id`   | string or null             | Pricing tier identifier used for cost calculation.                                                                                |
+| `usage_pricing_tier_name` | string or null             | Pricing tier name used for cost calculation.                                                                                      |
+| `input_price`             | string or null             | Matched per-unit input price; omitted from Parquet.                                                                               |
+| `output_price`            | string or null             | Matched per-unit output price; omitted from Parquet.                                                                              |
+| `total_price`             | string or null             | Matched flat per-call price; omitted from Parquet.                                                                                |
+| `user_id`                 | string                     | End-user identifier from the trace.                                                                                               |
+| `session_id`              | string                     | Session identifier from the trace.                                                                                                |
+| `trace_name`              | string                     | Trace name.                                                                                                                       |
+| `tags`                    | array of strings           | Trace tags.                                                                                                                       |
+| `release`                 | string                     | Trace release.                                                                                                                    |
+| `bookmarked`              | boolean                    | Whether the trace is bookmarked.                                                                                                  |
+| `public`                  | boolean                    | Whether the trace is public.                                                                                                      |
 
 <Callout type="info">
-  For integrations created on or after 2026-04-01, `latency` and `time_to_first_token` are in **seconds** (consistent with the `observations/` file). For integrations created before that date, these fields are in **milliseconds** for backward compatibility.
+  Integrations created on or after 2026-04-01 export `latency` and
+  `time_to_first_token` in seconds. Older integrations export these fields in
+  milliseconds for backward compatibility.
 </Callout>
-
-### Deriving trace-level aggregates from a single file [#deriving-trace-aggregates]
-
-With the **Enriched observations** export, you can compute trace-level metrics from the `observations_v2/` file alone, with no cross-file JOIN needed. Group by `trace_id` and compute `SUM(total_cost)` for trace cost and `MAX(end_time) - MIN(start_time)` for trace latency.
 
 ## Scores (`scores/`) [#scores]
 
-**Always exported** regardless of export source mode. Scores with data types `NUMERIC`, `BOOLEAN`, `CATEGORICAL`, and `TEXT` are included.
+Scores are always exported. Their fields are not configurable.
 
-| Field            | Type               | Description                                                               | Usage notes                                                                                                                                                       |
-| ---------------- | ------------------ | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | string             | Unique score identifier.                                                  | Primary key.                                                                                                                                                      |
-| `timestamp`      | string (timestamp) | Score creation timestamp (event time).                                    | Primary time axis for scores.                                                                                                                                     |
-| `project_id`     | string             | Langfuse project identifier.                                              | All rows in one export belong to the same project.                                                                                                                |
-| `environment`    | string             | Environment label.                                                        | Filter by environment.                                                                                                                                            |
-| `trace_id`       | string or null     | Associated trace identifier.                                              | Null for standalone scores not linked to a trace. Join to get trace or observation context.                                                                       |
-| `observation_id` | string or null     | Associated observation identifier (optional).                             | Null if the score is trace-level. Non-null if the score targets a specific observation.                                                                           |
-| `session_id`     | string or null     | Associated session identifier.                                            | Null when not set. Direct access to session context without joining traces.                                                                                       |
-| `dataset_run_id` | string or null     | Associated dataset run identifier (if score came from an evaluation run). | Links scores to experiment/evaluation runs. Null for ad-hoc or annotation scores.                                                                                 |
-| `name`           | string             | Score name (e.g. `accuracy`, `helpfulness`, `hallucination`).             | Group/filter by score metric name.                                                                                                                                |
-| `value`          | number             | Numeric score value.                                                      | For `BOOLEAN`: 0 or 1. For `CATEGORICAL`: index of the category. For `NUMERIC`: the raw value. For `TEXT`: always 0 (not meaningful; use `string_value` instead). |
-| `source`         | string             | Score source: `API`, `ANNOTATION`, `EVAL`.                                | `API` = programmatic via SDK, `ANNOTATION` = human annotation in UI, `EVAL` = LLM-as-judge evaluator.                                                             |
-| `comment`        | string or null     | Optional human comment or evaluator reasoning.                            | Context for the score. Useful for annotation workflows.                                                                                                           |
-| `data_type`      | string             | Score data type: `NUMERIC`, `BOOLEAN`, `CATEGORICAL`, or `TEXT`.          | Determines how to interpret `value` and `string_value`.                                                                                                           |
-| `string_value`   | string or null     | String representation for categorical and text scores.                    | For `CATEGORICAL`: the category label (e.g. `"positive"`, `"neutral"`). For `TEXT`: the free-text content (1–500 characters). Null for numeric scores.            |
-| `created_at`     | string (timestamp) | Row creation time.                                                        | System timestamp.                                                                                                                                                 |
-| `updated_at`     | string (timestamp) | Last update time.                                                         | Incremental processing.                                                                                                                                           |
+| Field            | Type               | Description                                            |
+| ---------------- | ------------------ | ------------------------------------------------------ |
+| `id`             | string             | Unique score identifier.                               |
+| `timestamp`      | string (timestamp) | Score creation time.                                   |
+| `project_id`     | string             | Langfuse project identifier.                           |
+| `environment`    | string             | Environment label.                                     |
+| `trace_id`       | string or null     | Associated trace identifier.                           |
+| `observation_id` | string or null     | Associated observation identifier.                     |
+| `session_id`     | string or null     | Associated session identifier.                         |
+| `dataset_run_id` | string or null     | Associated dataset run identifier.                     |
+| `name`           | string             | Score name.                                            |
+| `value`          | number             | Numeric value; `TEXT` scores use `0`.                  |
+| `source`         | string             | `API`, `ANNOTATION`, or `EVAL`.                        |
+| `comment`        | string or null     | Optional comment or evaluator reasoning.               |
+| `data_type`      | string             | `NUMERIC`, `BOOLEAN`, `CATEGORICAL`, or `TEXT`.        |
+| `string_value`   | string or null     | Category label or text value; null for numeric scores. |
+| `created_at`     | string (timestamp) | Row creation time.                                     |
+| `updated_at`     | string (timestamp) | Last row update time.                                  |
 
-### Enriching scores with trace/observation context [#enriching-scores]
+## Legacy export differences [#legacy-export-paths]
 
-Scores do **not** include trace-level fields inline. To enrich:
-
-| Export mode                          | How to get trace context                                                                                                                                                                                                                                                                                              |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Enriched observations**            | Join scores to the `observations_v2/` file on `trace_id`. Since multiple observations share the same `trace_id`, deduplicate first (e.g. pick one row per `trace_id`) to avoid multiplying score rows. Each observation row already includes `user_id`, `session_id`, `trace_name`, `tags`, `release`, `environment`. |
-| **Traces and observations (legacy)** | Join scores to the `traces/` file on `trace_id` for `user_id`, `environment`, `name`, etc.                                                                                                                                                                                                                            |
-
-## Legacy export paths [#legacy-export-paths]
-
-The following sections cover the **Traces and observations (legacy)** export mode. If you are setting up a new integration, we recommend using **Enriched observations** instead.
+Legacy exports are deprecated. They split trace context into `traces/` and observation data into `observations/`; consumers join them on `trace_id`.
 
 ### Traces (`traces/`) [#traces]
 
-Exported in **Traces and observations (legacy)** and **Traces and observations (legacy) and enriched observations** modes only.
+The trace file has a fixed schema; field groups do not apply.
 
-The `traces/` file has a **fixed column set**; [field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) do not apply to it. For legacy exports, this file is also where trace-level context (`tags`, `release`, trace `name`) lives; these fields are not repeated on legacy `observations/` rows. Join the `observations/` file's `trace_id` to `id` here to combine them.
+| Field         | Type               | Description                      |
+| ------------- | ------------------ | -------------------------------- |
+| `id`          | string             | Unique trace identifier.         |
+| `timestamp`   | string (timestamp) | Trace creation time.             |
+| `name`        | string             | User-defined trace name.         |
+| `environment` | string             | Environment label.               |
+| `project_id`  | string             | Langfuse project identifier.     |
+| `metadata`    | object             | Trace metadata.                  |
+| `user_id`     | string or null     | End-user identifier.             |
+| `session_id`  | string or null     | Session identifier.              |
+| `release`     | string or null     | Application release.             |
+| `version`     | string or null     | User-defined version.            |
+| `public`      | boolean            | Whether the trace is public.     |
+| `bookmarked`  | boolean            | Whether the trace is bookmarked. |
+| `tags`        | array of strings   | Trace tags.                      |
+| `input`       | string or null     | Trace input.                     |
+| `output`      | string or null     | Trace output.                    |
+| `created_at`  | string (timestamp) | Row creation time.               |
+| `updated_at`  | string (timestamp) | Last row update time.            |
 
-| Field         | Type               | Description                                             | Usage notes                                                                                              |
-| ------------- | ------------------ | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `id`          | string             | Unique trace identifier.                                | Primary key. Use to join with observations and scores via `trace_id`.                                    |
-| `timestamp`   | string (timestamp) | Trace creation timestamp (event time).                  | Primary time axis for traces. Use for partitioning, filtering, and time-series analysis.                 |
-| `name`        | string             | User-defined trace name (e.g. the top-level operation). | Useful for grouping and filtering traces by operation type.                                              |
-| `environment` | string             | Environment label (e.g. `production`, `staging`).       | Filter or partition by environment.                                                                      |
-| `project_id`  | string             | Langfuse project identifier.                            | All rows in one export belong to the same project.                                                       |
-| `metadata`    | object             | User-supplied key-value metadata attached to the trace. | Arbitrary context. Extract keys relevant to your analytics.                                              |
-| `user_id`     | string or null     | End-user identifier associated with the trace.          | Null when not set. Group by user for per-user analytics.                                                 |
-| `session_id`  | string or null     | Session identifier grouping related traces.             | Null when not set. Group traces into sessions for conversation-level analysis.                           |
-| `release`     | string or null     | Application release/version tag.                        | Null when not set. Filter or compare across releases.                                                    |
-| `version`     | string or null     | User-provided version string set via the SDK.           | Null when not set. Track how changes to your application affect metrics over time.                       |
-| `public`      | boolean            | Whether the trace is publicly shareable.                | Filter for public/private traces.                                                                        |
-| `bookmarked`  | boolean            | Whether the trace is bookmarked in the Langfuse UI.     | Filter for bookmarked items.                                                                             |
-| `tags`        | array of strings   | User-defined tags on the trace.                         | Multi-value filtering and grouping.                                                                      |
-| `input`       | string or null     | Trace input payload.                                    | The top-level input to the traced operation. May be plain text or JSON; may be large. Null when not set. |
-| `output`      | string or null     | Trace output payload.                                   | The top-level output. May be plain text or JSON; may be large. Null when not set.                        |
-| `created_at`  | string (timestamp) | Row creation time.                                      | System timestamp. Typically close to `timestamp` but may differ for late-arriving data.                  |
-| `updated_at`  | string (timestamp) | Last update time.                                       | Useful for incremental processing: re-process rows where `updated_at` > last sync.                       |
+<span id="traces-derived-fields" />
 
-#### Fields not in the trace export [#traces-derived-fields]
-
-These fields are not exported directly. Derive them in your warehouse:
-
-| Field          | How to derive                                                                        |
-| -------------- | ------------------------------------------------------------------------------------ |
-| `total_cost`   | Sum observation-level `total_cost` grouped by `trace_id` from the observations file. |
-| `latency`      | Compute `MAX(end_time) - MIN(start_time)` across observations per `trace_id`.        |
-| `observations` | Join the observations file on `trace_id` for the full list.                          |
-| `scores`       | Join the scores file on `trace_id` for the full list.                                |
-| `html_path`    | Construct as `{langfuse_host}/project/{project_id}/traces/{id}`.                     |
+The trace file does not include `total_cost`, `latency`, `observations`, `scores`, or `html_path`.
 
 ### Observations (`observations/`) [#observations]
 
-Exported in **Traces and observations (legacy)** and **Traces and observations (legacy) and enriched observations** modes.
+Legacy observations use the same observation field groups, with these differences:
 
-These rows contain **observation-level data only**. Trace-level fields like `user_id`, `session_id`, and `tags` are not included. Join the `traces/` file on `trace_id` in your warehouse, or switch to the **Enriched observations** export mode.
+<span id="enriched-vs-legacy-differences" />
 
-[Field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) apply to this file as well, with a smaller column set per group than the enriched export. The `trace_context` group has no effect here; its fields live in the `traces/` file. The table below lists all columns when every group is selected.
+| Group           | Difference in the legacy file                                                                      |
+| --------------- | -------------------------------------------------------------------------------------------------- |
+| `basic`         | Does not include `bookmarked`, `public`, `session_id`, or `user_id`.                               |
+| `usage`         | Does not include `usage_pricing_tier_id`.                                                          |
+| `trace_context` | Has no effect; `release`, `tags`, and the trace name are available in the separate `traces/` file. |
 
-| Field                     | Type                       | Description                                                                                                                       | Usage notes                                                                                                                                                             |
-| ------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                      | string                     | Unique observation identifier.                                                                                                    | Primary key.                                                                                                                                                            |
-| `trace_id`                | string                     | Parent trace identifier.                                                                                                          | Join on this to get trace-level fields, or to link with scores.                                                                                                         |
-| `project_id`              | string                     | Langfuse project identifier.                                                                                                      | All rows in one export belong to the same project.                                                                                                                      |
-| `environment`             | string                     | Environment label.                                                                                                                | Filter by environment.                                                                                                                                                  |
-| `type`                    | string                     | Observation type: `SPAN`, `GENERATION`, `EVENT`, `AGENT`, `TOOL`, `CHAIN`, `RETRIEVER`, `EVALUATOR`, `EMBEDDING`, or `GUARDRAIL`. | See [observation types](/docs/observability/features/observation-types). Generations are LLM calls; spans are arbitrary operations; events are point-in-time markers.   |
-| `parent_observation_id`   | string or null             | Parent observation ID (for nested observations).                                                                                  | Reconstruct the trace tree by walking parent pointers. Null for root-level observations.                                                                                |
-| `start_time`              | string (timestamp)         | When the observation started.                                                                                                     | Primary time axis for observations.                                                                                                                                     |
-| `end_time`                | string (timestamp) or null | When the observation ended.                                                                                                       | Null for events and in-progress observations.                                                                                                                           |
-| `name`                    | string                     | User-defined observation name.                                                                                                    | Group/filter by name (e.g. function name, model call label).                                                                                                            |
-| `metadata`                | object                     | User-supplied key-value metadata.                                                                                                 | Arbitrary context. Extract keys relevant to your analytics.                                                                                                             |
-| `level`                   | string                     | Log level: `DEBUG`, `DEFAULT`, `WARNING`, `ERROR`.                                                                                | Filter for errors or warnings.                                                                                                                                          |
-| `status_message`          | string or null             | Status or error message.                                                                                                          | Null when not set. Inspect for debugging failed observations.                                                                                                           |
-| `version`                 | string or null             | User-provided version string set via the SDK.                                                                                     | Null when not set.                                                                                                                                                      |
-| `input`                   | string or null             | Observation input payload.                                                                                                        | For generations: the prompt/messages sent to the LLM. May be plain text or JSON; may be large. Null when not set.                                                       |
-| `output`                  | string or null             | Observation output payload.                                                                                                       | For generations: the LLM response. May be plain text or JSON; may be large. Null when not set.                                                                          |
-| `provided_model_name`     | string or null             | Model name as provided by the user/SDK.                                                                                           | The raw model string (e.g. `gpt-4o`, `claude-sonnet-4-20250514`). Null for spans and events.                                                                            |
-| `model_parameters`        | string or null             | Model call parameters as a JSON-encoded string (e.g. `"{\"temperature\":0.7}"`).                                                  | Parse as JSON. Useful for analyzing how model settings affect quality/cost. Null for spans and events.                                                                  |
-| `usage_details`           | object (string → integer)  | Token usage breakdown by category.                                                                                                | Extract keys: `input` for input tokens, `output` for output tokens, `total` for total. May contain additional keys like `input_cached_tokens`, `reasoning_tokens`, etc. |
-| `cost_details`            | object (string → number)   | Cost breakdown by category (USD).                                                                                                 | Extract keys: `input` for input cost, `output` for output cost.                                                                                                         |
-| `completion_start_time`   | string (timestamp) or null | When the first token was generated (for streaming).                                                                               | Used to compute `time_to_first_token`. Null for non-streaming calls.                                                                                                    |
-| `prompt_name`             | string or null             | Name of the Langfuse prompt used, if any.                                                                                         | Null when no prompt was used. Filter for observations using a specific prompt.                                                                                          |
-| `prompt_version`          | integer or null            | Version number of the Langfuse prompt used.                                                                                       | Track which prompt version was active.                                                                                                                                  |
-| `total_cost`              | number or null             | Total computed cost for this observation (USD).                                                                                   | Null when cost could not be computed. Observation-level cost. Sum across a trace for trace-level cost.                                                                  |
-| `latency`                 | number or null             | Duration in **seconds** (`end_time - start_time`).                                                                                | Null when `end_time` is null.                                                                                                                                           |
-| `time_to_first_token`     | number or null             | Time to first token in **seconds** (`completion_start_time - start_time`).                                                        | Null when `completion_start_time` is null. Measures streaming responsiveness.                                                                                           |
-| `model_id`                | string or null             | Langfuse model definition ID (resolved from `provided_model_name`).                                                               | Used to look up pricing. Null if no model definition matched.                                                                                                           |
-| `created_at`              | string (timestamp)         | Row creation time.                                                                                                                | System timestamp.                                                                                                                                                       |
-| `updated_at`              | string (timestamp)         | Last update time.                                                                                                                 | Incremental processing.                                                                                                                                                 |
-| `prompt_id`               | string or null             | Langfuse prompt definition ID.                                                                                                    | Null when no prompt was used. Use with `prompt_name`/`prompt_version` for prompt analytics.                                                                             |
-| `tool_calls`              | array of strings           | Raw tool/function call payloads from the LLM response.                                                                            | Parse each element as JSON. Contains the full tool call objects.                                                                                                        |
-| `tool_call_names`         | array of strings           | Names of tools/functions called.                                                                                                  | Quick filter/group without parsing full `tool_calls`.                                                                                                                   |
-| `tool_definitions`        | object                     | Tool/function schemas provided to the LLM.                                                                                        | May be an empty object `{}` when no tools were provided.                                                                                                                |
-| `usage_pricing_tier_name` | string or null             | Name of the pricing tier used for cost calculation.                                                                               | User-defined tier name from the model definition. Null if no tiered pricing applies. Unlike the enriched export, `usage_pricing_tier_id` is not included in this file.  |
-| `input_price`             | string or null             | Per-unit input price from the matched model definition. Decimal string.                                                           | Null if no model definition matched. Cast to numeric in your pipeline. Not included in [Parquet exports](#parquet-exports).                                             |
-| `output_price`            | string or null             | Per-unit output price from the matched model definition. Decimal string.                                                          | Null if no model definition matched. Cast to numeric in your pipeline. Not included in [Parquet exports](#parquet-exports).                                             |
-| `total_price`             | string or null             | Per-unit total price from the matched model definition. Decimal string.                                                           | Null if no model definition matched. Used for models with a flat per-call price. Not included in [Parquet exports](#parquet-exports).                                   |
+All other field groups use the same field names as `observations_v2/`. Some nullable values appear as empty strings in enriched JSON/JSONL output.
 
-### Differences between enriched and legacy exports [#enriched-vs-legacy-differences]
+See [upgrade a legacy export](/docs/api-and-data-platform/features/export-to-blob-storage#legacy-export-sources) before changing a consumer.
 
-Combining the legacy `traces/` and `observations/` files yields almost the same data as the enriched `observations_v2/` file. The net differences:
+## Parquet differences [#parquet-exports]
 
-| Direction                               | Fields                                                                           | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Only in enriched                        | `usage_pricing_tier_id`                                                          | The legacy `observations/` file only includes `usage_pricing_tier_name`.                                                                                                                                                                                                                                                                                                                                                                                          |
-| Only in legacy (via the `traces/` file) | Trace-level `input`, `output`, `metadata`, `timestamp`, `version`                | `timestamp` is reliably set (root span start time). Trace-level `input`/`output` are only populated when using the Langfuse SDKs or supported frameworks (e.g. Vercel AI SDK, Genkit, Pydantic AI); they are null for pure OTEL auto-instrumentation. Trace-level `metadata` typically contains instrumentation attributes rather than business data. Trace-level `version` is set independently from the observation-level `version` field in the `basic` group. |
-| Same data, different structure          | `bookmarked`, `public`, `release`, `session_id`, `tags`, `trace_name`, `user_id` | Denormalized into every observation row in the enriched export; in legacy, only available in the `traces/` file (where `trace_name` is called `name`) and joined via `trace_id`.                                                                                                                                                                                                                                                                                  |
+Parquet uses internal encoding and compression, so gzip does not apply.
 
-## Notes on CSV exports [#csv-exports]
+Observation files omit `input_price`, `output_price`, and `total_price`. Use `cost_details` and `total_cost` for cost data.
 
-In CSV format all values are represented as text. Key differences from JSON/JSONL:
+Trace and score fields are the same across all formats.
 
-| JSON type          | CSV representation                                                                                            |
-| ------------------ | ------------------------------------------------------------------------------------------------------------- |
-| string             | Plain text value.                                                                                             |
-| number             | Numeric text (e.g. `1.23`). Parse as float in your pipeline.                                                  |
-| integer            | Numeric text without decimal point (e.g. `1024`).                                                             |
-| boolean            | `true` or `false`.                                                                                            |
-| null               | Empty field.                                                                                                  |
-| array of strings   | JSON-encoded string (e.g. `["tag1","tag2"]`). Parse the field as JSON.                                        |
-| object             | JSON-encoded string (e.g. `{"input":500,"output":120}`). Parse the field as JSON.                             |
-| string (timestamp) | `YYYY-MM-DD HH:MM:SS.ffffff` in UTC (e.g. `2024-05-29 13:46:19.963000`). Parse as timestamp in your pipeline. |
+## File organization [#file-organization]
 
-<Callout type="info">
-  **Price fields:** `input_price`, `output_price`, and `total_price` are exported as **quoted strings** in JSON/JSONL (e.g. `"0.03"`) to preserve decimal precision. In CSV they appear as plain text. Cast these to a numeric or decimal type in your warehouse. Other cost fields (`total_cost`, `cost_details` values) are exported as JSON numbers. The price fields are not included in [Parquet exports](#parquet-exports).
-</Callout>
-
-When loading CSV into a warehouse, cast timestamp fields to your warehouse's timestamp type, numeric fields to float/decimal, and parse JSON-encoded fields (objects, arrays) into native map/array types if your warehouse supports them.
-
-## Notes on Parquet exports [#parquet-exports]
-
-Apache Parquet is the default file type for new integrations. It is a columnar binary format that is encoded and compressed by the storage engine, so gzip compression does not apply; Parquet files are always written with a plain `.parquet` extension.
-
-Parquet observation exports (both `observations_v2/` and legacy `observations/`) do not include the per-unit model price columns `input_price`, `output_price`, and `total_price`. These columns snapshot the matched model definition's price at the time of export (not the price in effect when the observation was recorded), which limits their historical value, and they may be deprecated in the future. For cost data, use `cost_details` and `total_cost`, which capture the computed cost per observation and are included in every file type.
-
-Trace and score exports contain the same fields in all file types.
-
-## File organization in blob storage [#file-organization]
-
-```
-{project_id}/
-├── observations_v2/          # Enriched observations mode (recommended)
-│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
-├── scores/                   # Always exported
-│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
-├── traces/                   # Traces and observations (legacy) mode only
-│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
-├── observations/             # Traces and observations (legacy) mode only
-│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
-└── manifests/                # Run completion manifest, written last
-    └── {timestamp}.json
-```
-
-Files are partitioned by the configured export frequency (every 20 minutes, hourly, daily, or weekly). Each file covers one time window. The `.gz` suffix applies only to gzip-compressed text formats; Parquet files are never gzip-compressed.
-
-The `manifests/` folder contains one JSON file per completed export run, listing every file the run wrote. See [Run completion manifest](/docs/api-and-data-platform/features/export-to-blob-storage#run-manifest).
+See [process exports](/docs/api-and-data-platform/features/export-to-blob-storage#consume-exports) for paths, filenames, and the manifest workflow.

--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -127,6 +127,8 @@ The trace file has a fixed schema; field groups do not apply.
 | `created_at`  | string (timestamp) | Row creation time.               |
 | `updated_at`  | string (timestamp) | Last row update time.            |
 
+Legacy trace-level `input`, `output`, `metadata`, `timestamp`, and `version` do not have direct equivalents in `observations_v2/`. Observation fields with the same names contain observation-level data instead.
+
 <span id="traces-derived-fields" />
 
 The trace file does not include `total_cost`, `latency`, `observations`, `scores`, or `html_path`.

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -178,6 +178,10 @@ Make manifest processing idempotent. Provider events can be delivered more than 
 
 Most integrations can switch directly once their consumer supports the enriched layout:
 
+On self-hosted v4, first [switch the server to `dual` write mode](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#step-3) with v4 preview enabled and [complete the historic data migration](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#historic-data).
+
+Enriched export sources are unavailable in `legacy` mode or when v4 preview is disabled. Switch the integration before the server's [`events_only` cutover](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#cutover).
+
 1. **Prepare the new consumer.** Process `observations_v2/` and `scores/` from each manifest's `files[].key`. Use the [enriched field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-observations).
 2. **Switch the export.** Select **Enriched observations (recommended)**.
 3. **Verify and retire legacy.** Process the next completed export with the new consumer. After it succeeds, retire the consumer that reads `traces/` and `observations/`.
@@ -197,4 +201,4 @@ Do not load both observation layouts into the same production dataset. Check the
 
 - **All deployments:** `traces/` and `observations/` stop receiving files after the switch, including empty files. Use `manifests/` as the run-completion signal.
 - **Langfuse Cloud:** Ignore `DEPRECATION_NOTICE.txt` when processing exports; it is not part of a run.
-- **Self-hosted v4:** Switch the integration to enriched-only before the server's [`events_only` cutover](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#cutover). Dual-layout validation is available only during `dual` write mode with v4 preview enabled.
+- **Self-hosted v4:** Optional dual-layout validation is available only during `dual` write mode with v4 preview enabled.

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -1,13 +1,10 @@
 ---
-title: Export to Blob Storage
+title: Export to blob storage
 description: Export enriched observations, scores, and legacy traces and observations to Blob Storage, e.g. S3, GCS, or Azure Blob Storage.
 sidebarTitle: Export to Blob Storage
 ---
 
-import BlobStorageReExporting from "@/components-mdx/blob-storage-re-exporting.mdx";
-import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx";
-
-# Export via Blob Storage Integration
+# Export to blob storage
 
 <AvailabilityBanner
   availability={{
@@ -19,53 +16,64 @@ import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx
   }}
 />
 
-You can schedule exports to Blob Storage, e.g. S3, GCS, or Azure Blob Storage. Exports contain enriched observations (each observation row includes its trace attributes) and `scores`; every run writes to `observations_v2/`, `scores/`, and `manifests/` under `{prefix}{project-id}/` in your bucket.
+## Overview
 
-Those exports can run every `20 minutes`, or on an `hourly`, `daily`, or `weekly` schedule.
-Navigate to your project settings and select `Integrations > Blob Storage` to set up a new export.
-Select whether you want to use S3, a S3 compatible storage, Google Cloud Storage, or Azure Blob Storage.
+Schedule exports to Amazon S3, S3-compatible storage, Google Cloud Storage, or Azure Blob Storage every 20 minutes, hourly, daily, or weekly.
 
-For every column in each exported file, see the [Export Field Reference](/docs/api-and-data-platform/features/blob-storage-export-fields).
-
-The rest of this page walks through [setting up an export](#set-up-an-export) (file formats, exported columns, and how far back to export), [consuming exports in your pipeline](#consume-exports) (what lands in your bucket and how to detect completed runs), and [monitoring and reconfiguring](#monitor-and-reconfigure) a running integration.
-
-Older integrations may still export via a deprecated legacy source with separate `traces` and `observations` files; see [Legacy export sources](#legacy-export-sources) for the differences and the upgrade path.
-
-## Set up an export [#set-up-an-export]
+## Configure the export [#set-up-an-export]
 
 ### Create the integration
 
-To set up the export navigate to `Your Project` > `Settings` > `Integrations` > `Blob Storage`.
-
-Fill in the settings to authenticate with your vendor, enable the integration, and press save.
-An initial export starts shortly after you enable the integration and then continues on the schedule you selected.
-The export supports Parquet (default), CSV, JSON, and JSONL file formats. See [File formats](#file-formats).
-Read [our blob storage documentation](/self-hosting/deployment/infrastructure/blobstorage) for more information on how to get credentials for your specific vendor.
+1. Open **Project Settings > Integrations > Blob Storage**.
+2. Select your provider and enter its bucket, path, and credentials.
+3. Choose the file format, schedule, history, and field groups.
+4. Enable the integration and save. The first run starts shortly afterward.
 
 <Frame className="my-10" fullWidth>
-  ![Blob Storage Integration Setup](/images/docs/blob-storage.png)
+  ![Blob storage integration setup](/images/docs/blob-storage.png)
 </Frame>
 
-### File formats [#file-formats]
+<span id="export-modes" />
 
-Exports can be written as Apache Parquet, CSV, JSON, or JSONL files. New integrations default to **Parquet**.
+| Setting             | Choices and behavior                                                                                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Provider and access | Amazon S3, S3-compatible storage, Google Cloud Storage, or Azure Blob Storage.                                                                                                                                                                   |
+| Format              | Parquet (default), CSV, JSON, or JSONL. Text formats can be gzip-compressed; Parquet uses its own encoding and compression.                                                                                                                      |
+| Schedule            | Every 20 minutes, hourly, daily, or weekly. Each run exports one time window.                                                                                                                                                                    |
+| History             | **Full history** starts at the project's earliest data; **From setup date** starts when the integration is enabled; **From custom date** starts at a selected date. Changing this setting resets the sync position and re-scans from that point. |
 
-- **Parquet** is a columnar binary format that is encoded and compressed by the storage engine and can be loaded directly by most data warehouses and query engines.
-- **CSV, JSON, and JSONL** are text formats that can optionally be gzip-compressed.
+<span id="file-formats" />
 
-Parquet observation exports do not include the per-unit model price columns (`input_price`, `output_price`, `total_price`). These columns snapshot model definition prices at export time and may be deprecated in the future. Use `cost_details` and `total_cost` for cost data, which are included in every file type. See [Notes on Parquet exports](/docs/api-and-data-platform/features/blob-storage-export-fields#parquet-exports) in the field reference for details.
+**Parquet notes**
 
-<Callout type="warning">
-**Self-hosted deployments running ClickHouse < 25.11:** Parquet export failures may not surface as errors. A run can complete (and its [manifest](#run-manifest) be written) while the Parquet output is incomplete or invalid. Upgrade to ClickHouse >= 25.11, or use a text format (CSV, JSON, or JSONL) for reliable failure detection.
-</Callout>
+- Observation files omit `input_price`, `output_price`, and `total_price`. Use `cost_details` and `total_cost`; trace and score fields are unaffected.
+- On self-hosted ClickHouse older than 25.11, upgrade ClickHouse or use CSV, JSON, or JSONL because incomplete Parquet output may not be reported.
 
-### Choose which columns are exported [#export-field-groups]
+Use **Validate** before saving to check that Langfuse can access the target with the supplied credentials. The integration then writes all output beneath the configured prefix without changing other objects in the bucket.
 
-Field groups let you choose which column groups appear in each row of the observation export. Eleven groups cover the full row, ten of which are toggleable; toggle them in **Project Settings → Integrations → Blob Storage** under **Export Field Groups**.
+Langfuse writes exports to your bucket using this structure:
 
-Groups are listed in the order they appear in the UI; fields within each group are sorted alphabetically. The `core` group is required and always exported.
+```text
+{prefix}{project-id}/
+├── observations_v2/
+│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
+├── scores/
+│   └── {timestamp}.{parquet|json|jsonl|csv}[.gz]
+└── manifests/
+    └── {timestamp}.json
+```
 
-| Group           | Fields (`observations_v2`)                                                                                   |
+### Field selection [#export-field-groups]
+
+Observation columns are configurable; score columns are fixed.
+
+<Tabs items={["Observations", "Scores"]}>
+
+<Tab>
+
+New integrations select all eleven field groups. `core` is required; disable other groups to reduce file size or omit sensitive data.
+
+| Group           | Fields                                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------------ |
 | `core`          | `end_time`, `id`, `parent_observation_id`, `project_id`, `start_time`, `trace_id`, `type`                    |
 | `basic`         | `bookmarked`, `environment`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` |
@@ -79,203 +87,114 @@ Groups are listed in the order they appear in the UI; fields within each group a
 | `trace_context` | `release`, `tags`, `trace_name`                                                                              |
 | `tools`         | `tool_call_names`, `tool_calls`, `tool_definitions`                                                          |
 
-Field groups also apply to [legacy export sources](#legacy-export-sources), where three groups (`basic`, `usage`, `trace_context`) contain fewer columns; see the comparison in that section.
+Changes apply only to future exports. See the [observation field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-observations) for types and descriptions.
+
+</Tab>
+
+<Tab>
+
+Scores are always exported and their fields cannot be selected.
+
+| Category          | Fields                                                                      |
+| ----------------- | --------------------------------------------------------------------------- |
+| Identity          | `id`, `project_id`, `timestamp`, `created_at`, `updated_at`                 |
+| Context and links | `trace_id`, `observation_id`, `session_id`, `dataset_run_id`, `environment` |
+| Score             | `name`, `data_type`, `value`, `string_value`, `source`, `comment`           |
+
+See the [score field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#scores) for types and descriptions.
+
+</Tab>
+
+</Tabs>
+
+### Configure through the API [#field-groups-rest-api]
+
+Use the public endpoint to read or update the integration:
+
+```http
+GET /api/public/integrations/blob-storage
+PUT /api/public/integrations/blob-storage
+```
+
+On `PUT`, `exportFieldGroups` must include `core`; omit the property to keep the current selection. `compressed` applies only to CSV, JSON, and JSONL.
+
+See the [REST API reference](https://api.reference.langfuse.com/#tag/blobstorageintegrations) for authentication, provider settings, and the complete schema.
+
+## Process exports [#consume-exports]
+
+Use each run's manifest as the unit of work.
+
+### Know when an export is complete [#run-manifest]
+
+A run is complete only when its manifest exists at `{prefix}{project-id}/manifests/{timestamp}.json`. Langfuse writes it after every data file uploads successfully.
+
+If an upload fails, no manifest is written. The run is retried and any data objects under the same keys are overwritten.
+
+When a manifest appears:
+
+1. Read `files[]`.
+2. Fetch every full object key in `files[].key`. Do not derive filenames or list table directories.
+3. Deduplicate records by ID because adjacent export windows share an inclusive boundary.
+
+| Field                    | Purpose                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| `window`                 | Inclusive `minTimestamp` and `maxTimestamp` for the run                                 |
+| `exportSource`, `tables` | Export source and tables included                                                       |
+| `files[]`                | Object key, table, format, compression, uploaded size, and row count for each data file |
+
+For Parquet, `files[].rowCount` is `null`; inspect the file metadata when you need a count. Ignore unknown manifest fields so additive changes do not break your parser.
+
+### Trigger your pipeline [#export-events]
+
+Subscribe to object-created events filtered to `{prefix}{project-id}/manifests/`, then fetch the manifest and process each `files[].key`.
+
+- **Amazon S3:** [S3 Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html) or [EventBridge](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html)
+- **Google Cloud Storage:** [Pub/Sub notifications](https://cloud.google.com/storage/docs/pubsub-notifications) for `OBJECT_FINALIZE`
+- **Azure Blob Storage:** [Event Grid](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-event-overview) for `Microsoft.Storage.BlobCreated`
+- **MinIO:** [bucket notifications](https://min.io/docs/minio/linux/administration/monitoring/bucket-notifications.html)
+- **Backblaze B2:** [event notifications](https://www.backblaze.com/docs/cloud-storage-event-notifications)
+
+If your S3-compatible provider has no object-created events, poll the manifest prefix and checkpoint the latest processed key. Manifest names sort by export timestamp.
+
+Make manifest processing idempotent. Provider events can be delivered more than once, and a catch-up can create several manifests close together.
+
+## Troubleshooting [#monitor-and-reconfigure]
+
+- <span id="how-exports-run" />[Export timing, backfills, and retries](/faq/all/blob-storage-export-timing-and-retries) — Understand delays, catch-up bursts, failed runs, and retry behavior.
+- <span id="empty-files" />[Empty export files](/faq/all/blob-storage-empty-files) — Learn why files can be empty and how pipelines should handle them.
+- <span id="export-status" /><span id="re-exporting" />[Configuration changes, errors, and re-exporting](/faq/all/blob-storage-config-changes-and-errors) — Validate changes, clear sticky errors, or export historic data again.
+
+## Upgrade a legacy export [#legacy-export-sources]
+
+<Callout type="warning">
+  Complete this upgrade if your integration uses **Traces and observations
+  (legacy)** or your bucket receives `traces/` and `observations/` files. On
+  Langfuse Cloud, remaining legacy exports switch at the v4 cutover. On
+  self-hosted v4, the legacy source stops producing data after the server
+  switches to `events_only`.
+</Callout>
+
+### Switch to enriched observations [#upgrade-path]
+
+Most integrations can switch directly once their consumer supports the enriched layout:
+
+1. **Prepare the new consumer.** Process `observations_v2/` and `scores/` from each manifest's `files[].key`. Use the [enriched field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-observations).
+2. **Switch the export.** Select **Enriched observations (recommended)**.
+3. **Verify and retire legacy.** Process the next completed export with the new consumer. After it succeeds, retire the consumer that reads `traces/` and `observations/`.
 
 <Callout type="info">
-  Per-unit pricing fields (`input_price`, `output_price`, `total_price`) live in the `model` group; they come from the matched model definition. Deselecting `model` skips the worker-side model pricing lookup entirely. The `usage_pricing_tier_id` and `usage_pricing_tier_name` fields stay in the `usage` group. With the Parquet file type, these three price columns are not included even when `model` is selected. See [File formats](#file-formats).
+**Optional: keep both layouts during the cutover.**
+
+If your pipeline cannot tolerate a cutover gap, temporarily select **Traces and observations (legacy) and enriched observations** after step 1.
+
+This writes `observations/` and `observations_v2/` for subsequent windows only; it does not backfill earlier exports. Run both consumers until the new one is validated, then continue with step 2.
+
+Do not load both observation layouts into the same production dataset. Check the [export compatibility matrix](/docs/compatibility#filter-exports) if this option is unavailable.
+
 </Callout>
 
-New integrations default to all eleven groups, so behavior matches earlier exports unless you narrow the selection.
+**Cutover checks**
 
-#### Configure via REST API [#field-groups-rest-api]
-
-`GET` and `PUT /api/public/integrations/blob-storage` accept and return:
-
-- `exportSource`: `OBSERVATIONS_V2`. The values `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` exist for [legacy integrations](#legacy-export-sources) only.
-- `exportFieldGroups`: a list of group names. Must include `core` when provided. Applies to observation exports for all export sources. When omitted on update, the existing value is preserved.
-- `fileType`: `PARQUET` (default for new integrations), `CSV`, `JSON`, or `JSONL`.
-- `compressed`: boolean; defaults to `true` for new integrations. When `true`, files are written as `.csv.gz`, `.json.gz`, or `.jsonl.gz`. Does not apply to `PARQUET`; Parquet files are compressed by the storage engine and always written as plain `.parquet` files.
-
-See the [API reference](https://api.reference.langfuse.com/#tag/blobstorageintegrations) for the full schema.
-
-### Export modes [#export-modes]
-
-The **Export Mode** determines how far back the integration starts exporting from:
-
-| Mode                 | Starts from                           | When to use                                                                                                          |
-| -------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **Full history**     | The earliest data in your project     | You want a complete one-time backfill of all existing data alongside ongoing exports.                                |
-| **From setup date**  | The moment you enable the integration | You only care about data going forward and don't need history; this is the lightest option to get started.           |
-| **From custom date** | A start date you choose               | You want history from a specific point (for example, the start of a quarter) without exporting everything before it. |
-
-Changing the mode resets the sync position, so it's also the mechanism for re-scanning history. See [Re-exporting data and configuration changes](#re-exporting).
-
-## Consume exports in your pipeline [#consume-exports]
-
-### How exports run [#how-exports-run]
-
-Each run exports one time window of data to your bucket, then advances and exports the next window on your configured schedule.
-
-- **Export delay.** Data is exported with a short delay rather than right up to the current moment, so records still moving through ingestion are not exported half-written. Expect a brief lag between when an event is recorded and when it appears in your bucket.
-- **Catch-up / backfill.** When an integration starts from a historic point (or falls behind), it works forward through the backlog and may write many files in quick succession before settling into its normal cadence. A freshly created full-history integration does this until it catches up to the present.
-
-### Run completion manifest [#run-manifest]
-
-A single export run writes one file per exported table (up to four, depending on the selected export source), so the table files alone don't tell you when a run is complete. As the last object of every successful run, Langfuse writes a manifest file that lists everything the run produced:
-
-```
-{prefix}{project-id}/manifests/{max-timestamp}.json
-```
-
-The manifest is uploaded strictly after all table files of the run. Once it appears, every file it lists is fully available in your bucket; if any upload fails, no manifest is written and the whole run is retried (table files are overwritten under the same keys on retry). The timestamp in the manifest key is the run's `maxTimestamp` in UTC, truncated to whole seconds, with colons replaced by dashes and the milliseconds and trailing `Z` dropped (`2026-07-13T09:00:00.000Z` → `2026-07-13T09-00-00`). This is the same stem used by the run's table files (`{prefix}{project-id}/{table}/{timestamp}.{extension}`), so a run's table files and its manifest share the same timestamp stem.
-
-Example manifest:
-
-```json
-{
-  "version": 1,
-  "projectId": "cm0abcd1234efgh5678ijkl90",
-  "exportSource": "OBSERVATIONS_V2",
-  "window": {
-    "minTimestamp": "2026-07-13T08:00:00.000Z",
-    "maxTimestamp": "2026-07-13T09:00:00.000Z"
-  },
-  "maxTimestamp": "2026-07-13T09:00:00.000Z",
-  "createdAt": "2026-07-13T09:02:11.123Z",
-  "tables": ["observations_v2", "scores"],
-  "files": [
-    {
-      "key": "my-prefix/cm0abcd1234efgh5678ijkl90/observations_v2/2026-07-13T09-00-00.parquet",
-      "table": "observations_v2",
-      "fileType": "PARQUET",
-      "format": "parquet",
-      "compressed": false,
-      "contentType": "application/vnd.apache.parquet",
-      "sizeBytes": 1048576,
-      "rowCount": null
-    },
-    {
-      "key": "my-prefix/cm0abcd1234efgh5678ijkl90/scores/2026-07-13T09-00-00.parquet",
-      "table": "scores",
-      "fileType": "PARQUET",
-      "format": "parquet",
-      "compressed": false,
-      "contentType": "application/vnd.apache.parquet",
-      "sizeBytes": 20480,
-      "rowCount": null
-    }
-  ]
-}
-```
-
-Notes on the schema:
-
-- `version` increments only on breaking changes; new fields may be added without a version bump, so ignore unknown fields when parsing.
-- `window` is the time range of data covered by the run, with both bounds inclusive: a record at exactly `maxTimestamp` also falls into the next run's window. `maxTimestamp` duplicates `window.maxTimestamp`; the timestamp stem in the manifest file name is derived from it as described above.
-- `tables` and `files` reflect the selected export source; `scores` is always included regardless of the source.
-- `files[].key` is the full object key including your configured prefix, so consumers can fetch listed files without reconstructing paths.
-- `files[].fileType` is the configured file type: `JSON`, `CSV`, `JSONL`, or `PARQUET`. `files[].format` additionally encodes compression: one of `parquet`, `json-raw`, `json-gzip`, `jsonl-raw`, `jsonl-gzip`, `csv-raw`, or `csv-gzip`.
-- `files[].sizeBytes` is the uploaded size (after gzip for compressed text formats). `files[].rowCount` is the number of exported rows for text formats and `null` for Parquet files.
-- During [catch-up or backfill](#how-exports-run), each exported window is a separate run with its own manifest, so several manifests can appear in quick succession.
-
-### React to completed export runs [#export-events]
-
-Langfuse does not send a webhook when an export run finishes. Instead, subscribe to your storage provider's native object-created events with a prefix filter on `{prefix}{project-id}/manifests/`. Because the manifest is the last object of each run, this gives you one event per completed run. When the event fires, download the manifest and process the objects listed in `files[].key`.
-
-Provider recipes:
-
-- **AWS S3**: [Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html) on `s3:ObjectCreated:*` to SQS, SNS, or Lambda with a key prefix filter, or [EventBridge rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html) matching the object key prefix.
-- **Google Cloud Storage**: [Pub/Sub notifications](https://cloud.google.com/storage/docs/pubsub-notifications) for `OBJECT_FINALIZE` events; set the object name prefix when creating the notification configuration.
-- **Azure Blob Storage**: [Event Grid](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-event-overview) subscription on `Microsoft.Storage.BlobCreated` with a `subjectBeginsWith` filter, e.g. `/blobServices/default/containers/<container>/blobs/{prefix}{project-id}/manifests/`.
-- **MinIO**: [Bucket notifications](https://min.io/docs/minio/linux/administration/monitoring/bucket-notifications.html) on `s3:ObjectCreated:*` (webhook, Kafka, AMQP, and more) with a prefix filter.
-- **Backblaze B2**: [Event Notifications](https://www.backblaze.com/docs/cloud-storage-event-notifications) (webhooks) with a prefix filter.
-
-For S3-compatible providers without object-created events (for example, Wasabi or DigitalOcean Spaces), poll the manifest prefix instead: list `{prefix}{project-id}/manifests/` on a schedule and process any manifest newer than your last checkpoint. Manifest names sort lexicographically by export timestamp, so a marker-based (`start-after`) listing keeps polling cheap.
-
-### Empty files in your bucket [#empty-files]
-
-<BlobStorageEmptyFiles />
-
-## Monitor and reconfigure [#monitor-and-reconfigure]
-
-### Export status [#export-status]
-
-The integration settings page shows a status badge:
-
-| Badge        | Meaning                                                                                |
-| ------------ | -------------------------------------------------------------------------------------- |
-| **Active**   | Enabled and synced; the next export is scheduled for the future.                       |
-| **Running**  | An export job is currently in progress (shown with a spinner).                         |
-| **Queued**   | An export is due and waiting to run.                                                   |
-| **Pending**  | Enabled but has not run an export yet (`Data exported up to` shows `Never (pending)`). |
-| **Disabled** | The integration is turned off.                                                         |
-| **Error**    | The most recent export failed; an error message and timestamp are shown.               |
-
-The status card on the same page also surfaces:
-
-- **Data exported up to**: timestamp of the last successfully exported window (or `Never (pending)`).
-- **Next export scheduled**: when the next run will happen.
-- **Export mode**: `Full history`, `From setup date`, or `From custom date` (plus the start date where applicable).
-- A **Last export failed** alert with the error message and time when in the Error state.
-
-If a worker crashes mid-export, a 2-hour safety-valve TTL ensures the badge reverts from Running to its underlying state (typically Queued) so the next scheduled run can proceed. Reload the page to see the latest status.
-
-Langfuse retries failed exports on the next run. Repeated failures notify project admins by email and the configured Slack or webhook channel. Configure it under **Project Settings → Notifications**.
-
-### Re-exporting data and configuration changes [#re-exporting]
-
-<BlobStorageReExporting />
-
-## Legacy export sources [#legacy-export-sources]
-
-<Callout type="warning">
-  This section only applies to integrations still using the deprecated `Traces
-  and observations (legacy)` export source. It will be removed in a future
-  release; follow the [upgrade path](#upgrade-path) below. New integrations use
-  `Enriched observations (recommended)` and can skip this section.
-</Callout>
-
-The `Export Source` setting determines which tables the integration exports. Legacy sources export separate `traces` and `observations` files instead of the enriched `observations_v2` file; `scores` are always included, regardless of the source. Directories written under `{prefix}{project-id}/` per source:
-
-| Export source                                                | Directories written                                       |
-| ------------------------------------------------------------ | --------------------------------------------------------- |
-| `Enriched observations (recommended)`                        | `observations_v2/`, `scores/`                             |
-| `Traces and observations (legacy) and enriched observations` | `traces/`, `observations/`, `observations_v2/`, `scores/` |
-| `Traces and observations (legacy)`                           | `traces/`, `observations/`, `scores/`                     |
-
-For the columns in each file, see the [export sources overview](/docs/api-and-data-platform/features/blob-storage-export-fields#export-sources) in the field reference.
-
-[Field groups](#export-field-groups) apply to legacy observation exports as well, but three groups contain fewer columns in the legacy `observations` file; all other groups are identical to the enriched export:
-
-| Group           | Enriched (`observations_v2`)                                                                                 | Legacy (`observations`)                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| `basic`         | `bookmarked`, `environment`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` | `environment`, `level`, `name`, `status_message`, `version` |
-| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`            | Same, without `usage_pricing_tier_id`                       |
-| `trace_context` | `release`, `tags`, `trace_name`                                                                              | No effect; these fields live in the separate `traces` file  |
-
-Where legacy sources are still available:
-
-- **Langfuse Cloud:** only integrations created before 2026-06-22 in projects created before 2026-05-20 keep their configured legacy source and see the selector. All other integrations use `Enriched observations (recommended)` automatically, and the REST API rejects legacy values with `400 BAD_REQUEST`.
-- **Self-hosted:** enriched export requires the v4 preview opt-in (`LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`); without it, integrations use the legacy source. Once a deployment completes the v4 migration (`LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`), legacy sources are no longer available (including previously saved ones), and the selector is hidden.
-
-On Langfuse Cloud, integrations that still export a legacy source also receive a plain-text deprecation notice at `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. It is refreshed on every successful run (written best-effort after the run's [manifest](#run-manifest) and not listed in it) and removed automatically on the next successful run after the integration switches to `Enriched observations (recommended)`. The manifest remains the authoritative run-completion marker; account for this object if your pipelines diff bucket contents or subscribe to object-created events without a prefix filter.
-
-### Upgrade path [#upgrade-path]
-
-To migrate an existing legacy integration safely:
-
-1. Switch to `Traces and observations (legacy) and enriched observations`.
-2. Validate downstream jobs and data consumers while both sources are exported (this mode creates duplicate records by design). See [differences between enriched and legacy exports](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-vs-legacy-differences) for the field-level comparison.
-3. Repoint consumers from the `traces/` and `observations/` directories to `observations_v2/`. Prefer driving consumers from the [run manifest](#run-manifest) instead of watching directories; each manifest lists exactly the files its run wrote.
-4. Switch to `Enriched observations (recommended)` once validation is complete.
-
-<Callout type="warning">
-After the switch, the `traces/` and `observations/` directories receive **no further files at all**, not even [empty files](#empty-files), which are otherwise written for windows without data. Pipelines still watching those directories go silent without an error signal, so complete step 3 before switching. Pipelines driven by the [run manifest](#run-manifest) are not affected: manifests continue to list exactly what each run writes, so manifest-driven consumers follow the source switch automatically.
-</Callout>
-
-## Alternatives
-
-You can also export data via:
-
-- [UI](/docs/api-and-data-platform/features/export-from-ui) - Manual batch-exports from the Langfuse UI
-- [SDKs/API](/docs/api-and-data-platform/features/public-api) - Programmatic access using Langfuse SDKs or API
+- **All deployments:** `traces/` and `observations/` stop receiving files after the switch, including empty files. Use `manifests/` as the run-completion signal.
+- **Langfuse Cloud:** Ignore `DEPRECATION_NOTICE.txt` when processing exports; it is not part of a run.
+- **Self-hosted v4:** Switch the integration to enriched-only before the server's [`events_only` cutover](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#cutover). Dual-layout validation is available only during `dual` write mode with v4 preview enabled.

--- a/content/docs/api-and-data-platform/features/meta.json
+++ b/content/docs/api-and-data-platform/features/meta.json
@@ -6,7 +6,7 @@
     "mcp-server",
     "export-from-ui",
     "export-to-blob-storage",
-    "blob-storage-export-fields",
+    "!blob-storage-export-fields",
     "observations-api",
     "public-api",
     "query-via-sdk",

--- a/content/faq/all/blob-storage-config-changes-and-errors.mdx
+++ b/content/faq/all/blob-storage-config-changes-and-errors.mdx
@@ -12,4 +12,4 @@ Two behaviors of the [blob storage integration](/docs/api-and-data-platform/feat
 
 <BlobStorageReExporting />
 
-For the full list of status badges and what they mean, see [Export status](/docs/api-and-data-platform/features/export-to-blob-storage#export-status).
+For export delays, backfills, and retry behavior, see [How do blob storage export timing and retries work?](/faq/all/blob-storage-export-timing-and-retries).

--- a/content/faq/all/blob-storage-empty-files.mdx
+++ b/content/faq/all/blob-storage-empty-files.mdx
@@ -12,4 +12,4 @@ The [blob storage integration](/docs/api-and-data-platform/features/export-to-bl
 
 <BlobStorageEmptyFiles />
 
-For the full file layout and field reference, see the [Export Field Reference](/docs/api-and-data-platform/features/blob-storage-export-fields).
+See [Process exports](/docs/api-and-data-platform/features/export-to-blob-storage#consume-exports) for the bucket layout and manifest workflow, or the [export field reference](/docs/api-and-data-platform/features/blob-storage-export-fields) for schemas.

--- a/content/faq/all/blob-storage-export-timing-and-retries.mdx
+++ b/content/faq/all/blob-storage-export-timing-and-retries.mdx
@@ -1,0 +1,27 @@
+---
+title: How do blob storage export timing and retries work?
+description: How export delay, catch-up, backfills, and retries affect when files appear in blob storage.
+tags: [platform, integration]
+---
+
+# How do blob storage export timing and retries work?
+
+The [blob storage integration](/docs/api-and-data-platform/features/export-to-blob-storage) exports one time window per run.
+
+## Export delay
+
+Exports intentionally lag behind ingestion so records are not exported while they are still being written. A short delay between an event reaching Langfuse and appearing in your bucket is expected.
+
+## Catch-up and backfills
+
+An integration starting from historic data, or catching up after downtime, works through completed windows until it reaches the delayed live boundary. This can produce many files and manifests in quick succession.
+
+The configured frequency controls the size of each window, not the speed of a backfill.
+
+## Retries
+
+If an upload fails, Langfuse does not write a manifest. The run retries on the next execution and overwrites data objects under the same keys.
+
+Repeated failures notify project admins through configured notification channels. If a worker stops during a run, its running state expires after two hours so a later execution can retry.
+
+Process only runs with a completed [manifest](/docs/api-and-data-platform/features/export-to-blob-storage#run-manifest).

--- a/research/blob-storage-combined-export-source.md
+++ b/research/blob-storage-combined-export-source.md
@@ -1,0 +1,102 @@
+# Research: Combined legacy and enriched blob-storage export source
+
+Research date: 2026-07-28
+
+Implementation reviewed at:
+
+- `langfuse/langfuse` commit [`429ec4fff6512fff49aef50fccb92846f674a98a`](https://github.com/langfuse/langfuse/tree/429ec4fff6512fff49aef50fccb92846f674a98a)
+- `langfuse/langfuse-docs` commit [`ebb4f535124b0ebd35f38e3b64dc35055fef1bae`](https://github.com/langfuse/langfuse-docs/tree/ebb4f535124b0ebd35f38e3b64dc35055fef1bae)
+
+## Short answer
+
+**Traces and observations (legacy) and enriched observations** is a real export-source setting whose only intended use is migration validation. It tells one blob-storage integration to write both observation layouts for each subsequent export window: the legacy `traces/` and `observations/` files and the v4 `observations_v2/` file. The worker still writes `scores/` only once. Langfuse describes the two observation outputs as essentially duplicate data and says the option should only be used while validating downstream consumers before switching to enriched-only. ([UI option definition](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/index.ts#L14-L37), [worker dispatch](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1388-L1424))
+
+It is not the self-hosted v4 `dual` write mode. The export-source setting chooses which already-populated ClickHouse data models the integration reads. The server write mode chooses which data models ingestion populates. The combined export source is usable on self-hosted v4 only while both sides are available: the server must write the events model, keep legacy writes active, and expose the v4 preview path. ([export-source policy](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L19-L36), [worker guards](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1263-L1287))
+
+Most importantly, changing only the export source does **not** reset export history. The integration retains `lastSyncAt`, and the new source applies to the next scheduled or manually triggered window. Only changing `exportMode` resets `lastSyncAt`. Therefore this option does not backfill `observations_v2/` for windows exported before the switch. ([upsert behavior](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/blobstorage-integration/service.ts#L120-L186), [window start](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L182-L255))
+
+## Names in the UI, API, database, and manifest
+
+The same setting has three names:
+
+| Surface                    | Value                                                          |
+| -------------------------- | -------------------------------------------------------------- |
+| UI label                   | **Traces and observations (legacy) and enriched observations** |
+| Public REST `exportSource` | `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`                      |
+| Internal Prisma enum       | `TRACES_OBSERVATIONS_EVENTS`                                   |
+
+The public API intentionally maps its descriptive value to the older internal enum. GET and PUT use the public value, while the database stores the internal value. ([public/internal mapping](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/public-api/types/blob-storage-integrations.ts#L45-L88), [REST serialization and update](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/pages/api/public/integrations/blob-storage/index.ts#L81-L108), [REST deserialization](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/pages/api/public/integrations/blob-storage/index.ts#L151-L198))
+
+The run manifest receives the persisted internal enum directly, so a combined run's manifest reports `TRACES_OBSERVATIONS_EVENTS`, not the public REST value. The manifest then derives `tables` from its files. ([manifest call](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1427-L1438), [manifest builder](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/manifest.ts#L52-L70))
+
+## Exact worker behavior
+
+For a normal combined-source run, the worker creates four table-export promises over one shared `[minTimestamp, maxTimestamp]` window:
+
+1. `scores`
+2. `traces`
+3. `observations`
+4. `observations_v2`
+
+It waits for all four before writing the manifest. The two source branches add only their respective observation layouts; `scores` is scheduled once before either branch. ([execution config and shared window](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1329-L1349), [table dispatch](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1388-L1424))
+
+The objects are written below the configured prefix as:
+
+```text
+{prefix}{projectId}/
+├── traces/{maxTimestamp}.{extension}
+├── observations/{maxTimestamp}.{extension}
+├── observations_v2/{maxTimestamp}.{extension}
+├── scores/{maxTimestamp}.{extension}
+└── manifests/{maxTimestamp}.json
+```
+
+Every table file uses the same formatted `maxTimestamp` stem. The manifest key uses the same timestamp under `manifests/`; each `files[].key` is the complete object key, including prefix and project ID. ([data-object key construction](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L462-L500), [manifest key and file contract](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/manifest.ts#L8-L50))
+
+The legacy files query the old ClickHouse `traces` and `observations` tables. The enriched file is named `observations_v2` externally but is produced by `getEventsForBlobStorageExport*`, which queries the v4 events data model. With the default full field groups, full input/output is requested and the query builder selects `events_full`; a reduced field selection can allow `events_core`. ([legacy trace query](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/repositories/traces.ts#L1186-L1260), [legacy observation query](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/repositories/observations.ts#L1696-L1811), [enriched export query](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/repositories/events.ts#L3038-L3166), [events table selection](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts#L1218-L1256))
+
+The two observation files intentionally represent the same logical observations in different schemas when both data models have been populated. The legacy layout keeps trace rows separate, so consumers join `observations/` to `traces/`; the enriched layout denormalizes trace context into each `observations_v2/` row. A pipeline must compare the layouts separately and must not ingest both into one production fact table without deduplication. `scores/` is not duplicated because the worker exports that table once for every source. ([option's migration-only description](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/index.ts#L19-L35), [field-reference overview](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx#L21-L28), [worker table dispatch](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1391-L1424))
+
+## Window, cursor, retry, and manifest behavior
+
+The integration has one cursor, `lastSyncAt`, not a separate cursor per layout. A run starts at that cursor and advances by at most one configured frequency interval, ending no later than the current time minus the lag buffer. All four table queries use that same inclusive window. ([window calculation](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1212-L1244), [inclusive observation bounds](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/repositories/observations.ts#L1731-L1748), [inclusive events bounds](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/server/repositories/events.ts#L3081-L3090))
+
+The manifest is the commit point. It is written only after every selected table upload succeeds. A table or manifest failure leaves `lastSyncAt` unchanged; the retry therefore uses the same window and overwrites objects at the same timestamp-derived keys. After success, `lastSyncAt` advances to the window's `maxTimestamp`. ([manifest commit contract](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1424-L1438), [successful cursor update](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1462-L1492), [failure-state update](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1518-L1549))
+
+Changing `exportSource` alone neither clears `lastSyncAt` nor schedules a special backfill. The persistence service resets the cursor only when `exportMode` changes. A source-only save therefore changes the files produced by the next due run; a user can also invoke **Run Now**, which the UI describes as exporting data since the last sync. ([source/mode update behavior](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/blobstorage-integration/service.ts#L120-L190), [Run Now behavior in the UI](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx#L147-L158))
+
+This has a direct migration consequence: selecting the combined source is suitable for comparing **new matching windows** side by side. It does not create enriched counterparts for old `traces/` and `observations/` files. Historical enriched comparison additionally requires the v4 events backfill to have populated the new tables and an explicit blob-export re-export/reset procedure. The self-hosted v4 guide makes the events backfill a separate server-migration step. ([historic events backfill](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L258-L264), [source update does not reset the cursor](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/blobstorage-integration/service.ts#L137-L186))
+
+## Relationship to self-hosted v4 write modes
+
+The server write modes and valid blob-export sources form this capability matrix:
+
+| Self-hosted write mode   | Legacy-only source | Combined source | Enriched-only source |
+| ------------------------ | ------------------ | --------------- | -------------------- |
+| `legacy`                 | Works              | Blocked         | Blocked              |
+| `dual`, preview enabled  | Works              | Works           | Works                |
+| `dual`, preview disabled | Works              | Blocked         | Blocked              |
+| `events_only`            | Blocked            | Blocked         | Works                |
+
+The implementation blocks any enriched-containing source when the deployment does not expose enriched export, and it blocks a source in either direction when its underlying tables are not being written. `legacy` does not write events; `events_only` does not write old `traces`/`observations`; `dual` writes both. ([source classification and policy](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L68-L145), [worker write-mode guard](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/exportWriteModeGuard.ts#L8-L38), [preview availability check](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1268-L1287))
+
+The combined export source does not cause dual writes or backfill data itself. In `dual`, ingestion populates both models; older SDK traffic reaches the events model through a delayed propagation pipeline, while compatible SDKs can write it directly. Historical events are populated by a separate background migration. The blob exporter only reads whichever models already contain data for its current window. ([self-hosted dual-write implementation overview](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L322-L329), [historic backfill step](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L258-L264))
+
+## Availability and gating
+
+On Cloud, the two legacy-containing sources—including the combined source—cannot be newly selected for projects created on or after 2026-05-20. They also cannot be newly selected for blob-storage integration rows created on or after 2026-06-22. A persisted legacy value on an older row is grandfathered until the Cloud cutover, but the cutoffs apply when a value is explicitly chosen. ([cutoff definitions and rationale](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L9-L18), [validation](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L192-L233), [current compatibility detail](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/components-mdx/compat/detail-legacy-export-source.mdx#L1))
+
+On self-hosted deployments, the Cloud date cutoffs do not apply. Availability follows the capability matrix above: the UI and write APIs use the deployment's preview flag and write mode to filter or reject options. A persisted-but-now-invalid value remains visible but cannot be saved silently as another value; the worker also fails before export work rather than advancing the cursor on stale or empty tables. ([self-hosted cutoff exemption](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L107-L135), [UI option filtering](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/analytics-integrations/exportSource.ts#L22-L64), [worker guard rationale](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/exportWriteModeGuard.ts#L8-L38))
+
+Two first-party texts are stale relative to the current implementation. The May 20 changelog says all existing Cloud projects remain unaffected, but it predates the June 22 integration-row cutoff. The generated Fern definition also still says enriched export is Cloud-only, although the application and worker enable it for self-hosted deployments with the v4 preview flag. The current compatibility component and source policy should be treated as authoritative for availability. ([older changelog wording](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/changelog/2026-05-20-blob-storage-enriched-default.mdx#L12-L18), [stale Fern note](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/fern/apis/server/definition/blob-storage-integrations.yml#L76-L87), [current policy](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L129-L145))
+
+## Implications for the user-facing migration guide
+
+1. Do not introduce the long UI label without explaining it. Use a plain action such as **Temporarily export both layouts**, followed by the exact selector label in parentheses so users can find it.
+2. State its purpose in one sentence: it writes legacy and enriched observation files for the same **future export windows** so consumers can compare them side by side.
+3. Explicitly say that it does not backfill prior blob-export windows and does not itself enable v4 dual writes.
+4. Make the step conditional. Many Cloud users cannot select it, and self-hosted users can select it only during the `dual` phase with v4 preview enabled. The migration guide needs a direct path for users for whom the option is unavailable.
+5. Keep the duplication warning concrete: compare `observations/` with `observations_v2/`, but do not ingest both into the same production dataset; `scores/` is exported only once.
+6. For self-hosted, order the concepts correctly: enable/populate the v4 events model, optionally use the combined export source for new-window validation, switch the integration to enriched-only, and only then switch the server to `events_only`.
+
+These recommendations are inferences from the implementation and availability constraints above, not separate product contracts.

--- a/research/blob-storage-v4-migration.md
+++ b/research/blob-storage-v4-migration.md
@@ -1,0 +1,81 @@
+# Research: Blob storage export migration for Langfuse v4
+
+Research date: 2026-07-28
+
+## Conclusion
+
+The upgrade guide should describe a consumer migration that must finish before the v4 cutover, not just a change to an integration setting. The safe sequence is:
+
+1. Ensure both the legacy and enriched tables are being written.
+2. Select **Traces and observations (legacy) and enriched observations** on the export integration.
+3. Validate the enriched files and move consumers from `traces/` plus `observations/` to `observations_v2/`.
+4. Select **Enriched observations (recommended)**.
+5. For self-hosted deployments, only then cut the server over to `LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only`.
+
+This order follows the existing export migration procedure and the self-hosted v4 requirement to migrate export configurations before the final cutover. The worker rejects a legacy-containing export source after `events_only`, rather than advancing the export cursor with stale or empty data. ([current export guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L263-L273), [self-hosted v4 guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L229-L277), [worker guard](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/exportWriteModeGuard.ts#L8-L38))
+
+## Availability and timing
+
+Langfuse Cloud is already running the v4 experience, but older organizations can still switch between the v3 and v4 read experiences until the separate, future Cloud v4-only cutover. The cutover date has not been announced. ([v4 overview](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/v4.mdx#L37-L50))
+
+Cloud projects created on or after 2026-05-20 cannot select either legacy-containing source. For older Cloud projects, integrations created on or after 2026-06-22 cannot select a legacy-containing source either. An older integration on an older project can keep its persisted source until the Cloud cutover; the cutoffs apply to newly chosen values. ([export-source policy](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L9-L32), [cutoff constants and validation](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L47-L76), [Cloud validation](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/packages/shared/src/features/analytics-integrations/export-source-policy.ts#L192-L233))
+
+The May 20 changelog is useful historical context but is incomplete on its own: it predates the June 22 integration-level cutoff and therefore says existing Cloud projects are unaffected. The current v4 and compatibility documentation include both cutoffs. ([May 20 changelog](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/changelog/2026-05-20-blob-storage-enriched-default.mdx#L12-L18), [v4 rollout details](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/v4.mdx#L43-L50))
+
+At the future Cloud v4-only cutover, remaining legacy exports will be switched to the enriched source automatically. The public date is still unannounced. ([compatibility detail](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/components-mdx/compat/detail-legacy-export-source.mdx#L1))
+
+For self-hosted deployments, v3 supports the traces-and-observations export and v4 supports enriched observations; the legacy source is deprecated on v4. A blanket statement that “new integrations already use enriched observations” is therefore inaccurate for self-hosted v3. ([self-hosted compatibility matrix](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/versioning.mdx#L94-L98))
+
+## Export source versus server write mode
+
+The integration has three export sources:
+
+| Integration export source                                      | Reads                                            |
+| -------------------------------------------------------------- | ------------------------------------------------ |
+| **Traces and observations (legacy)**                           | Legacy `traces` and `observations` tables        |
+| **Traces and observations (legacy) and enriched observations** | Both legacy tables and the enriched events table |
+| **Enriched observations (recommended)**                        | Enriched events table                            |
+
+The public API maps these to `LEGACY_TRACES_OBSERVATIONS`, `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`, and `OBSERVATIONS_V2`. ([public API source enum](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/web/src/features/public-api/types/blob-storage-integrations.ts#L45-L88))
+
+Self-hosted v4 separately has the server write modes `legacy`, `dual`, and `events_only`. These control which ClickHouse tables receive data; they are not export source settings. In `legacy`, the enriched export cannot run because the enriched tables are not written. In `events_only`, either export source containing legacy tables is rejected because `traces` and `observations` are no longer written. `dual` is the bridge in which both sides are populated. ([self-hosted write modes](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L165-L227), [worker guard](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/exportWriteModeGuard.ts#L8-L38))
+
+The final self-hosted cutover to `events_only` stops all writes to the old `traces` and `observations` tables and is the point of commitment in the server migration. Export configurations are explicitly listed among the items to migrate before that cutover. ([self-hosted migration steps](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L229-L277))
+
+## Output and consumer differences
+
+| Stage      | Paths written below `{prefix}{project-id}/`               | Consumer behavior                                                 |
+| ---------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| Legacy     | `traces/`, `observations/`, `scores/`                     | Join observations to traces on `trace_id` for trace context       |
+| Transition | `traces/`, `observations/`, `observations_v2/`, `scores/` | Compare both representations, then validate the enriched consumer |
+| Enriched   | `observations_v2/`, `scores/`                             | Read trace context directly from each observation row             |
+
+These paths are determined directly by the worker’s export-source branches; scores are always scheduled, legacy-containing sources schedule traces and observations, and enriched-containing sources schedule `observations_v2`. ([worker table selection](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1388-L1424))
+
+Enriched observation rows carry trace context directly, so warehouse-side joins are unnecessary. Legacy `observations/` rows keep trace-level fields such as `user_id`, `session_id`, and `tags` in the separate `traces/` file. Scores are exported for every source. ([field reference: enriched observations](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx#L21-L28), [field reference: scores and legacy paths](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx#L82-L141))
+
+The migration-relevant schema differences are concentrated in three field groups: enriched `basic` adds `bookmarked`, `public`, `session_id`, and `user_id`; enriched `usage` adds `usage_pricing_tier_id`; and enriched `trace_context` places `release`, `tags`, and `trace_name` on each observation rather than in `traces/`. The detailed field reference should remain the canonical schema reference. ([committed field-group comparison](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L248-L255))
+
+During the transition source, both representations contain the same logical observations, so a consumer that ingests both as one dataset will create duplicates unless it separates or deduplicates them. The existing guide therefore describes duplicates as intentional during validation. ([current upgrade path](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L263-L270))
+
+After switching to enriched-only, the legacy directories receive no new objects, including empty files. Consumers that watch those directories can therefore go silent without an error. Manifest-driven consumers continue correctly because each manifest enumerates the files produced by that run. ([current export guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L269-L273), [manifest commit point](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1427-L1438))
+
+## `DEPRECATION_NOTICE.txt`
+
+On Langfuse Cloud only, an integration whose source includes legacy data gets `{prefix}{project-id}/DEPRECATION_NOTICE.txt`. The fixed key is overwritten on each successful legacy-containing run. ([notice definition](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/deprecationNotice.ts#L1-L20), [Cloud-only dispatch](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1440-L1459))
+
+The notice is written best-effort after the manifest and is not part of the manifest. Failure to write or remove it does not fail the export. The next successful enriched-only run attempts to delete a notice left by the legacy integration. ([notice write and removal](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1108-L1159), [run order](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts#L1427-L1459))
+
+Consequently, the notice should not be presented as a completion signal. Pipelines should filter object-created events to `manifests/` and process each manifest’s file keys. ([current export guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L261-L273))
+
+## Recommended structure for the rewritten upgrade guide
+
+1. Open with a scope warning: this applies only when the integration currently writes `traces/` and `observations/`.
+2. Show the three-stage path table from this note.
+3. Give one ordered migration procedure that moves consumers before selecting enriched-only.
+4. Add deployment-specific timing:
+   - Cloud: eligible older integrations can use the transition source; complete the migration before the announced v4-only cutover.
+   - Self-hosted: use the transition source while the server is in `dual`, then select enriched-only before `events_only`.
+5. End with the legacy-directory silence warning and a link to the detailed field reference.
+
+This structure keeps the main action sequence compact while preserving the two operational failure modes that matter: switching the exporter before consumers are ready, and switching the self-hosted server to `events_only` before the exporter is ready. The supporting behavior is documented in the export migration path, the server migration guide, and the worker’s write-mode guard. ([current export guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx#L263-L273), [self-hosted v4 guide](https://github.com/langfuse/langfuse-docs/blob/ebb4f535124b0ebd35f38e3b64dc35055fef1bae/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx#L229-L277), [worker guard](https://github.com/langfuse/langfuse/blob/429ec4fff6512fff49aef50fccb92846f674a98a/worker/src/features/exportWriteModeGuard.ts#L8-L38))


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Simplifies and reorganizes the blob-storage export documentation.
- Condenses setup, field-selection, manifest-processing, and legacy-migration guidance.
- Adds a focused FAQ covering export timing, backfills, and retries.
- Adds research notes documenting combined-source and v4 migration behavior.
- Hides the detailed field reference from sidebar navigation while retaining direct links.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, with a non-blocking documentation gap for consumers of supported CSV exports.

The rewritten field reference removes the CSV representation rules for structured, numeric, and null values, leaving CSV consumers without the format-specific decoding guidance that was previously documented.

**Files Needing Attention:** content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx:9
**Restore CSV type mappings**

The reference says its types describe JSON and JSONL, but the rewrite removes the CSV mapping for objects, arrays, numbers, and nulls even though CSV remains a supported export format. CSV consumers consequently lose the guidance needed to decode JSON-encoded fields and empty null values correctly.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: simplify blob storage export guida..."](https://github.com/langfuse/langfuse-docs/commit/08b67e18170ac52444e9a4212eb532e41cd302be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48119257)</sub>

<!-- /greptile_comment -->