### PR TITLE
docs(pulse): update changelog + docs for simplified metrics

### DIFF
--- a/content/changelog/2026-07-28-langfuse-pulse.mdx
+++ b/content/changelog/2026-07-28-langfuse-pulse.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-07-28
 title: "Pulse: find the outliers in your traces"
-description: "A compact chart strip above the events table. See cost, latency, and token spikes over time, then click or drag a spike to narrow the table to that window."
+description: "A compact chart strip above the events table. See cost and latency spikes over time, then click or drag a spike to narrow the table to that window."
 author: Nikita Kabardin
 ogVideo: https://static.langfuse.com/changelog-videos/2025-07-28-pulse.mp4
 ---
@@ -11,13 +11,13 @@ import { Book, Cloud } from "lucide-react";
 
 <ChangelogHeader />
 
-The events table is where you go when something in your traces looks off. **Pulse** puts a compact chart strip right above it, so the spikes in your data are the first thing you see. Each bar covers a slice of time and shows the worst single event in that slice: the most expensive call, the slowest response, the biggest token burst. The outlier you are hunting for is a tall bar, not a row you have to sort your way down to.
+The events table is where you go when something in your traces looks off. **Pulse** puts a compact chart strip right above it, so the spikes in your data are the first thing you see. Each bar covers a slice of time: the total cost you spent in it, or how slow it ran at the 95th percentile. The outlier you are hunting for is a tall bar, not a row you have to sort your way down to.
 
 ## Find it, then drill into it
 
 Pulse turns spotting an outlier into navigating to it. Click a tall bar and the table narrows to that time window, showing exactly the events that made the spike. Drag across a range of bars to select a wider span; it applies when you let go. Browser Back returns you to where you started, so poking around costs you nothing.
 
-One dropdown switches what the strip plots. You can view **Cost**, **Latency**, or **Tokens** on their own, or all three at once in **Split** mode. Each metric uses the aggregate that fits it: cost as max or sum, latency as max, p95, or average. The bars are time buckets across your full range, so a quiet stretch reads as a flat baseline rather than empty space.
+One dropdown switches what the strip plots: **Cost** or **Latency**. Cost shows the total spent in each bucket; latency defaults to p95, with the median (p50) one click away. The bars are time buckets across your full range, so a quiet stretch reads as a flat baseline rather than empty space.
 
 This is how you hunt down expensive or slow outliers on the [Langfuse v4](/docs/v4) data model: one cheap aggregate query over time, rather than a per-row sort across your whole dataset.
 

--- a/content/docs/observability/features/pulse.mdx
+++ b/content/docs/observability/features/pulse.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pulse
-description: A compact outlier chart strip above the events table. See cost, latency, and token spikes over time, then click or drag a spike to narrow the table to that window.
+description: A compact outlier chart strip above the events table. See cost and latency spikes over time, then click or drag a spike to narrow the table to that window.
 sidebarTitle: Pulse
 ---
 

--- a/content/docs/observability/features/pulse.mdx
+++ b/content/docs/observability/features/pulse.mdx
@@ -62,7 +62,7 @@ Pulse plots the same filtered query as the events table below it. The time range
 
 A few filters cannot be expressed as an aggregate over time, so the strip cannot apply them:
 
-- **Numeric measures** used as filters (filtering by latency, cost, or token value). These are still available as strip metrics; only filtering the rows by their value is unavailable.
+- **Numeric measures** used as filters (filtering by latency, cost, or token value). Cost and latency remain available as strip metrics; only filtering the rows by their value is unavailable.
 - **Scores**, **metadata**, and **comments** filters.
 - **Full-text search** and field-scoped text search (`input:`, `output:`).
 - **Presence checks** (`has:` and `-has:`).

--- a/content/docs/observability/features/pulse.mdx
+++ b/content/docs/observability/features/pulse.mdx
@@ -8,7 +8,7 @@ import { Book } from "lucide-react";
 
 # Pulse
 
-Pulse is a compact chart strip above the events table. Each bar covers a slice of time and shows the worst single event in that slice: the most expensive call, the slowest response, the biggest token burst. The spike you are hunting for is a tall bar, not a row you have to sort your way down to. Click or drag a spike and the table narrows to that window.
+Pulse is a compact chart strip above the events table. Each bar covers a slice of time: the total cost spent in it, or its p95 latency. The spike you are hunting for is a tall bar, not a row you have to sort your way down to. Click or drag a spike and the table narrows to that window.
 
 <Video
   src="https://static.langfuse.com/changelog-videos/2025-07-28-pulse.mp4"
@@ -23,11 +23,11 @@ Pulse is a compact chart strip above the events table. Each bar covers a slice o
   to Langfuse v4](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 </Callout>
 
-Pulse is open by default above the events table. Close it with the **×** in its top-right corner, and reopen it with the **Pulse** button in the table toolbar.
+Pulse is always on above the events table.
 
 ## What each bar shows [#bars]
 
-Each bar is one time bucket. Its height is a single aggregate of the events in that bucket, so a tall bar is a bucket that holds an outlier. The default aggregate is the maximum, so a bar shows the worst single event in its slice.
+Each bar is one time bucket. Its height is a single aggregate of the events in that bucket, so a tall bar is a bucket that stands out: an expensive stretch of traffic or a slow window.
 
 The bars span the full selected time range. A bucket with no events is a gap on the baseline rather than absent space, so a quiet stretch reads as a flat baseline and a spike stands out against it. Bars use a square-root height scale: real cost and latency outliers run many times the base load, and a linear scale would flatten everything but the peak, so the scale keeps the base load readable while the outlier still dominates.
 
@@ -39,22 +39,10 @@ Hover a bar to read its time bucket, the metric value, and how many events fell 
 
 A dropdown at the left of the strip switches what the bars plot:
 
-- **Cost**
-- **Latency**
-- **Tokens**
-- **Split** shows Cost, Latency, and Tokens side by side at once.
+- **Cost** — the total spent in each bucket.
+- **Latency** — how slow the bucket ran: `p95` by default, with the median (`p50`) available from a second dropdown next to the metric name.
 
-Split fits three charts when the strip is wide enough, drops to Cost and Latency on a narrower strip, and is offered as an option only when at least two fit.
-
-Each metric plots the aggregate that fits it. Where a metric offers more than one aggregate, a second dropdown next to the metric name switches it:
-
-| Metric  | Aggregates          | Default |
-| ------- | ------------------- | ------- |
-| Cost    | `max`, `sum`        | `max`   |
-| Latency | `max`, `p95`, `avg` | `max`   |
-| Tokens  | `max`               | `max`   |
-
-`max` is the outlier view: each bar is the single worst event in its bucket. `sum`, `p95`, and `avg` describe the bucket as a whole instead. Your metric and aggregate choices are remembered across visits.
+Your metric and aggregate choices are remembered across visits.
 
 ## Navigate to an outlier [#navigate]
 
@@ -83,7 +71,7 @@ When any of these are active, the strip shows a **"N filters not applied"** note
 
 ## Pulse and charting the table [#vs-chart]
 
-Pulse and [Chart any table](/docs/observability/features/events-table-charts) both draw the events table's data, but they answer different questions. Pulse is an always-on strip above the table for finding and jumping to outliers, one bar per time bucket, with the worst event as the default. Charting the table replaces the table with a full, configurable chart (type, metric, aggregation, breakdown) of the same filtered query, and can be saved to a dashboard. Use Pulse to spot and drill into a spike; switch to a chart when you want to shape a view and keep it.
+Pulse and [Chart any table](/docs/observability/features/events-table-charts) both draw the events table's data, but they answer different questions. Pulse is an always-on strip above the table for finding and jumping to outliers, one bar per time bucket. Charting the table replaces the table with a full, configurable chart (type, metric, aggregation, breakdown) of the same filtered query, and can be saved to a dashboard. Use Pulse to spot and drill into a spike; switch to a chart when you want to shape a view and keep it.
 
 ## Learn more
 


### PR DESCRIPTION
Text-only update for the Pulse follow-up (langfuse/langfuse#15540):

- Strip is always on — removed the ×/reopen instructions
- Cost plots the bucket **sum** (was per-event max)
- Latency defaults to **p95**, offers **p50** (max/avg gone)
- **Tokens** metric and **Split** view removed
- Reframed the "worst single event" narrative to bucket aggregates accordingly

Not touched (flagging deliberately): the changelog's `ogVideo` and any screenshots still show the old UI (mono labels, Tokens/Split, × button) — per Trang, text only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Pulse changelog and product documentation to match the simplified metrics interface.
- Documents bucket-summed Cost and p95/p50 Latency.
- Removes Tokens, Split, and obsolete aggregate options from the body copy.
- States that the Pulse strip is always on and removes close/reopen instructions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The stale Pulse page description should be corrected before merging so metadata and search surfaces do not advertise the removed Tokens metric.

The revised documentation body consistently limits Pulse to Cost and Latency, but the page frontmatter still advertises token spikes and will expose contradictory product information through metadata consumers.

**Files Needing Attention:** content/docs/observability/features/pulse.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/observability/features/pulse.mdx:11
**Metadata still advertises Tokens**

The revised page documents only Cost and Latency, but the frontmatter description still advertises token spikes. Search results and generated documentation indexes therefore tell readers that Pulse supports a metric removed by this update.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(pulse): update changelog + docs tex..."](https://github.com/langfuse/langfuse-docs/commit/3b2e589974f3eea9a8bcca2e0bf6e2c0fa65575f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48253471)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)
</details>

<!-- /greptile_comment -->