### PR TITLE
docs(observations-api): note that v2 has no get-by-id route

### DIFF
--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -50,7 +50,7 @@ The v2 Observations API is a redesigned endpoint optimized for high-performance 
 
 The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated read endpoint (`/api/public/traces`, `/api/public/observations`, `/api/public/sessions`, ...) to its v2 replacement, with parameter mappings and before/after examples. Always include `fromStartTime` and `toStartTime` to keep each request bounded.
 
-The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. For single-observation lookups, pass a URL-encoded `filter` condition on the `id` column; see the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
+The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. There is no get-by-id route on v2; for single-observation lookups, pass a URL-encoded `filter` condition on the `id` column instead. See the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
 
 ### Key Improvements
 


### PR DESCRIPTION
A user hit a `404` on `GET /api/public/v2/observations/{id}` and reasonably suspected an undeployed route, since the response is an HTML "route not found" page rather than a JSON API error.

It's not a rollout gap — the route has never existed. Verified against `langfuse/langfuse@origin/main`: `web/src/pages/api/public/v2/observations/` contains only `index.ts` (compare `v2/scores/[scoreId].ts`, which does exist), and the public OpenAPI spec exposes no v2 per-ID path. The HTML response is the tell: an unmatched path falls through to the Next.js catch-all, whereas anything reaching the API layer returns JSON.

The page already pointed at the `filter`-on-`id` approach but didn't say the per-ID route is absent, so readers were inferring one from the v1 → v2 mapping tables. This adds that clause to the existing sentence.

One line, one file.
