### PR TITLE
Set up dev environment + note local search caveat

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -149,4 +149,5 @@ Please check the following:
 - **First page load is slow**: After `pnpm dev` starts ("Ready in ~1s"), the first HTTP request compiles on-demand and can take 20-40 seconds. Subsequent pages are much faster.
 - **Langfuse SDK warnings are expected**: The dev server logs `[Langfuse SDK] [WARN] No exporter configured…` on startup. These are harmless — the SDK keys are only needed for optional demo API routes and are not required for the docs site itself.
 - **No env file needed**: All external integrations (OpenAI, Supabase, PostHog, etc.) degrade gracefully when keys are absent. You do not need a `.env` file for routine development.
+- **Site search is inert locally**: The `Ctrl/Cmd+K` search dialog (powered by Inkeep) opens but returns no results without Inkeep keys. This is expected; use sidebar/link navigation to reach pages when testing docs locally.
 - **postinstall runs agent shim sync**: `pnpm install` triggers `scripts/postinstall.sh`, which syncs agent config shims. This is expected and idempotent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the local development environment for the Langfuse docs website (Next.js 16 / Turbopack, single service).

- Installed dependencies with `pnpm install` (Node 22, pnpm 9.5.0).
- Verified lint/format via `pnpm run format:check` (passes).
- Ran the dev server `pnpm dev` on `http://127.0.0.1:3333` and confirmed the homepage, `/docs`, and a tracing doc page render (HTTP 200).
- Completed a hello-world task in the browser: loaded the homepage, navigated to docs, and navigated to the "Get Started with Tracing" page.

## Change

Added one durable note to `.agents/AGENTS.md`: the `Ctrl/Cmd+K` site search (Inkeep) opens but returns no results locally without keys — expected, use link/sidebar navigation when testing docs.

## Demo

[langfuse_docs_dev_walkthrough.mp4](https://cursor.com/agents/bc-08d6b6d6-7f9c-4c97-a5f3-b954184d64ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flangfuse_docs_dev_walkthrough.mp4)

[Homepage](https://cursor.com/agents/bc-08d6b6d6-7f9c-4c97-a5f3-b954184d64ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Tracing docs page](https://cursor.com/agents/bc-08d6b6d6-7f9c-4c97-a5f3-b954184d64ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftracing_doc.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08d6b6d6-7f9c-4c97-a5f3-b954184d64ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08d6b6d6-7f9c-4c97-a5f3-b954184d64ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds local-development guidance explaining that Inkeep-powered site search returns no results without keys and recommending sidebar or link navigation during testing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only adds a focused local-development caveat and does not alter application, build, or runtime behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note Inkeep search is inert in loc..."](https://github.com/langfuse/langfuse-docs/commit/d3488549d7e5705f3d57b594ee2f5c7fe93ce7a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48341886)</sub>

<!-- /greptile_comment -->