### PR TITLE
docs(evals): clarify self-hosted migration paths

### DIFF
--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -14,7 +14,7 @@ import { Steps, Step } from "@/components/docs";
     core: "full",
     pro: "full",
     enterprise: "full",
-    selfHosted: "full",
+    selfHosted: "v4",
   }}
 />
 
@@ -44,7 +44,10 @@ Observation-level evaluators run in real time and scale with larger traces and h
 
 ### Before you start
 
-First, upgrade your SDK or ingestion path. Observation-level evaluators run in real time with:
+- **Langfuse Cloud:** First, upgrade your SDK or ingestion path, then upgrade your evaluators.
+- **Self-hosted:** Keep existing evaluators active while you upgrade your SDK or instrumentation and Langfuse using `legacy` or `dual` mode. Migrate the evaluators as a final step before switching to `events_only`.
+
+Observation-level evaluators run in real time with:
 
 - **Python SDK:** v4.7.0+ ([upgrade guide](/docs/observability/sdk/upgrade-path/python-v3-to-v4))
 - **JS/TS SDK:** v5.4.0+ ([upgrade guide](/docs/observability/sdk/upgrade-path/js-v4-to-v5))

--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -14,11 +14,11 @@ import { Steps, Step } from "@/components/docs";
     core: "full",
     pro: "full",
     enterprise: "full",
-    selfHosted: "not-available",
+    selfHosted: "full",
   }}
 />
 
-Trace-level evaluators use Langfuse's old trace-centric data model and are deprecated as part of [Langfuse v4](/docs/v4). Existing evaluators continue to run while you upgrade. Langfuse v4 is currently available on Langfuse Cloud; for self-hosted rollout updates, follow the [GitHub Discussion](https://github.com/orgs/langfuse/discussions/12518).
+Trace-level evaluators use Langfuse's old trace-centric data model and are deprecated as part of [Langfuse v4](/docs/v4). Existing evaluators continue to run while you upgrade.
 
 Observation-level evaluators run in real time and scale with larger traces and higher evaluation volume. Any future multi-span support will also use the observation-centric data model, so upgrading is the foundation for future evaluation capabilities.
 
@@ -72,8 +72,8 @@ In the [v4 data model](/docs/v4), a trace is the logical group of observations t
 
 Click on the **Evaluation** navigation item. The upgrade screen shows the recommended path for your project:
 
-- **In-app upgrade:** Recommended when only minimal configuration changes need to be reviewed and accepted. The [Langfuse Assistant](/docs/langfuse-assistant) guides you through these changes in the app.
-- **Coding assistant:** Recommended when the upgrade requires broader configuration or instrumentation changes. The UI provides the skill and project context to use in your coding editor.
+- **In-app upgrade (Langfuse Cloud):** Recommended when only minimal configuration changes need to be reviewed and accepted. The [Langfuse Assistant](/docs/langfuse-assistant) guides you through these changes in the app.
+- **Coding assistant:** Recommended when the upgrade requires broader configuration or instrumentation changes, and for self-hosted deployments where the Langfuse Assistant is unavailable. The UI provides the skill and project context to use in your coding editor.
 
 In both paths, the agentic flow makes the upgrade conversational: you can inspect the proposed changes, ask questions, and refine them before creating the new evaluators. You do not need to translate or recreate configurations manually.
 

--- a/content/faq/all/upgrade-to-langfuse-v4.mdx
+++ b/content/faq/all/upgrade-to-langfuse-v4.mdx
@@ -57,6 +57,13 @@ Select **Migration Status** to review organization-wide progress. The page shows
 
 Self-hosted v4 is currently a release candidate. Use the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4) to test the migration in staging, but wait for a stable v4 release before migrating production.
 
+For existing self-hosted deployments, use this order:
+
+1. Upgrade your SDKs and instrumentation.
+2. Upgrade Langfuse to v4 using the `legacy` or `dual` write mode.
+3. As one of the final migration steps, move trace-level evaluators to observation targets and legacy-dataset evaluators to experiment targets.
+4. Switch to `events_only` once the new evaluators are validated.
+
 There is no forced cutover date. Langfuse v3 receives security patches through January 2027. The [self-hosted compatibility matrix](/self-hosting/upgrade/versioning#sdk-server) lists supported SDKs and APIs.
 
 ## Questions [#questions]

--- a/content/faq/all/upgrade-to-langfuse-v4.mdx
+++ b/content/faq/all/upgrade-to-langfuse-v4.mdx
@@ -31,7 +31,7 @@ Only follow the rows that apply to your project.
 | Check        | Do this                                                                                                                                                                  |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | APIs         | [Migrate deprecated API calls](/faq/all/deprecated-api-migration) to the supported Observations, Metrics, Scores, and Experiments APIs.                                  |
-| Evaluators   | [Move trace-level and legacy-dataset evaluators](/faq/all/llm-as-a-judge-migration) to observation-level evaluators.                                                     |
+| Evaluators   | [Move trace-level evaluators](/faq/all/llm-as-a-judge-migration) to observation targets and legacy-dataset evaluators to experiment targets.                             |
 | Exports      | [Switch blob storage exports](/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path) to enriched observations.                                        |
 | Integrations | Switch [PostHog](/integrations/analytics/posthog#migrate-export-source) and [Mixpanel](/integrations/analytics/mixpanel#migrate-export-source) to enriched observations. |
 

--- a/content/faq/all/upgrade-to-langfuse-v4.mdx
+++ b/content/faq/all/upgrade-to-langfuse-v4.mdx
@@ -57,13 +57,6 @@ Select **Migration Status** to review organization-wide progress. The page shows
 
 Self-hosted v4 is currently a release candidate. Use the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4) to test the migration in staging, but wait for a stable v4 release before migrating production.
 
-For existing self-hosted deployments, use this order:
-
-1. Upgrade your SDKs and instrumentation.
-2. Upgrade Langfuse to v4 using the `legacy` or `dual` write mode.
-3. As one of the final migration steps, move trace-level evaluators to observation targets and legacy-dataset evaluators to experiment targets.
-4. Switch to `events_only` once the new evaluators are validated.
-
 There is no forced cutover date. Langfuse v3 receives security patches through January 2027. The [self-hosted compatibility matrix](/self-hosting/upgrade/versioning#sdk-server) lists supported SDKs and APIs.
 
 ## Questions [#questions]


### PR DESCRIPTION
## What changed

- make the evaluator migration guide available to self-hosted users
- clarify that self-hosted deployments use the coding-assistant path
- map legacy trace evaluators to observation targets and legacy dataset evaluators to experiment targets
- document the self-hosted order from SDK upgrade through the final `events_only` cutover

## Verification

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run format`
- `pnpm run format:check`
- `git diff --check`