### PR TITLE
feat: document logical root observation filtering

### DIFF
--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -31,6 +31,7 @@ Each row represents one observation and includes its trace context. Only the [se
 | `environment`             | string                     | Environment label.                                                                                                                |
 | `type`                    | string                     | Observation type: `SPAN`, `GENERATION`, `EVENT`, `AGENT`, `TOOL`, `CHAIN`, `RETRIEVER`, `EVALUATOR`, `EMBEDDING`, or `GUARDRAIL`. |
 | `parent_observation_id`   | string                     | Parent observation identifier; empty for a root observation.                                                                      |
+| `is_root_observation`     | boolean                    | Whether the observation is a logical root.                                                                                        |
 | `start_time`              | string (timestamp)         | When the observation started.                                                                                                     |
 | `end_time`                | string (timestamp) or null | When the observation ended.                                                                                                       |
 | `name`                    | string                     | User-defined observation name.                                                                                                    |
@@ -141,7 +142,7 @@ Legacy observations use the same observation field groups, with these difference
 
 | Group           | Difference in the legacy file                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------- |
-| `basic`         | Does not include `bookmarked`, `public`, `session_id`, or `user_id`.                               |
+| `basic`         | Does not include `bookmarked`, `is_root_observation`, `public`, `session_id`, or `user_id`.        |
 | `usage`         | Does not include `usage_pricing_tier_id`.                                                          |
 | `trace_context` | Has no effect; `release`, `tags`, and the trace name are available in the separate `traces/` file. |
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -73,19 +73,19 @@ Observation columns are configurable; score columns are fixed.
 
 New integrations select all eleven field groups. `core` is required; disable other groups to reduce file size or omit sensitive data.
 
-| Group           | Fields                                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------------------------ |
-| `core`          | `end_time`, `id`, `parent_observation_id`, `project_id`, `start_time`, `trace_id`, `type`                    |
-| `basic`         | `bookmarked`, `environment`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` |
-| `time`          | `completion_start_time`, `created_at`, `updated_at`                                                          |
-| `io`            | `input`, `output`                                                                                            |
-| `metadata`      | `metadata`                                                                                                   |
-| `model`         | `input_price`, `model_id`, `model_parameters`, `output_price`, `provided_model_name`, `total_price`          |
-| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`            |
-| `prompt`        | `prompt_id`, `prompt_name`, `prompt_version`                                                                 |
-| `metrics`       | `latency`, `time_to_first_token`                                                                             |
-| `trace_context` | `release`, `tags`, `trace_name`                                                                              |
-| `tools`         | `tool_call_names`, `tool_calls`, `tool_definitions`                                                          |
+| Group           | Fields                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `core`          | `end_time`, `id`, `parent_observation_id`, `project_id`, `start_time`, `trace_id`, `type`                                           |
+| `basic`         | `bookmarked`, `environment`, `is_root_observation`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` |
+| `time`          | `completion_start_time`, `created_at`, `updated_at`                                                                                 |
+| `io`            | `input`, `output`                                                                                                                   |
+| `metadata`      | `metadata`                                                                                                                          |
+| `model`         | `input_price`, `model_id`, `model_parameters`, `output_price`, `provided_model_name`, `total_price`                                 |
+| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`                                   |
+| `prompt`        | `prompt_id`, `prompt_name`, `prompt_version`                                                                                        |
+| `metrics`       | `latency`, `time_to_first_token`                                                                                                    |
+| `trace_context` | `release`, `tags`, `trace_name`                                                                                                     |
+| `tools`         | `tool_call_names`, `tool_calls`, `tool_definitions`                                                                                 |
 
 Changes apply only to future exports. See the [observation field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#enriched-observations) for types and descriptions.
 

--- a/content/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/content/docs/api-and-data-platform/features/mcp-server.mdx
@@ -88,6 +88,17 @@ The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source 
   access to write operations. For a full list of tools, see the [MCP Reference](https://mcp.reference.langfuse.com).
 </Callout>
 
+## Filter logical root observations [#logical-root-observations]
+
+The observation tools distinguish logical roots from physical parentage:
+
+- `listObservations` accepts the optional boolean `isRootObservation` filter. Set it to `true` to match observations without a physical parent or observations explicitly marked as application roots by the SDK.
+- Physical-parent filtering remains separate. An application-root observation can match `isRootObservation: true` even when it has a physical parent.
+- `isRootObservation` is included in the default observation fields returned by `listObservations`.
+- `getObservationFilterValues` supports `isRootObservation` as a filter-value column, so you can discover and combine logical-root values with other observation filters.
+
+For the complete tool schemas and request examples, see the [MCP Reference](https://mcp.reference.langfuse.com).
+
 ## Set up [#set-up]
 
 <Steps>

--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -52,6 +52,15 @@ The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated r
 
 The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. There is no get-by-id route on v2; for single-observation lookups, pass a URL-encoded `filter` condition on the `id` column instead. See the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
 
+### Logical root observations [#logical-root-observations]
+
+The v2 API distinguishes physical parentage from logical root status:
+
+- `parentObservationId` identifies the physical parent observation. An empty value matches observations without a physical parent.
+- `isRootObservation` is `true` when an observation has no physical parent or the SDK explicitly marked it as an application root.
+
+An application-root observation can therefore have `isRootObservation: true` and a non-null `parentObservationId`. Use `isRootObservation` when you want application roots, and `parentObservationId` when you need to query the physical observation tree.
+
 ### Key Improvements
 
 **1. Selective Field Retrieval**
@@ -67,7 +76,7 @@ The v1 API returns complete rows with all fields (input/output, usage, metadata,
 | Group           | Fields                                                                                                                 |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `core`          | Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type                                 |
-| `basic`         | name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId                                |
+| `basic`         | name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId, isRootObservation             |
 | `time`          | completionStartTime, createdAt, updatedAt                                                                              |
 | `io`            | input, output                                                                                                          |
 | `metadata`      | metadata                                                                                                               |
@@ -157,23 +166,47 @@ curl \
 
 ### Parameters
 
-| Parameter             | Type     | Description                                                               |
-| --------------------- | -------- | ------------------------------------------------------------------------- |
-| `fields`              | string   | Comma-separated list of field groups to include. Defaults to `core,basic` |
-| `limit`               | integer  | Number of items per page. Defaults to 50, max 1,000                       |
-| `cursor`              | string   | Base64-encoded cursor for pagination (from previous response)             |
-| `fromStartTime`       | datetime | Retrieve observations with startTime on or after this datetime            |
-| `toStartTime`         | datetime | Retrieve observations with startTime before this datetime                 |
-| `traceId`             | string   | Filter by trace ID                                                        |
-| `name`                | string   | Filter by observation name                                                |
-| `type`                | string   | Filter by observation type (GENERATION, SPAN, EVENT)                      |
-| `userId`              | string   | Filter by user ID                                                         |
-| `level`               | string   | Filter by log level (DEBUG, DEFAULT, WARNING, ERROR)                      |
-| `parentObservationId` | string   | Filter by parent observation ID                                           |
-| `environment`         | string   | Filter by environment                                                     |
-| `version`             | string   | Filter by version tag                                                     |
-| `parseIoAsJson`       | boolean  | Deprecated: omit or set to `false`; `true` returns a `400` error          |
-| `filter`              | string   | JSON array of filter conditions (takes precedence over query params)      |
+| Parameter             | Type     | Description                                                                                                     |
+| --------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `fields`              | string   | Comma-separated list of field groups to include. Defaults to `core,basic`                                       |
+| `limit`               | integer  | Number of items per page. Defaults to 50, max 1,000                                                             |
+| `cursor`              | string   | Base64-encoded cursor for pagination (from previous response)                                                   |
+| `fromStartTime`       | datetime | Retrieve observations with startTime on or after this datetime                                                  |
+| `toStartTime`         | datetime | Retrieve observations with startTime before this datetime                                                       |
+| `traceId`             | string   | Filter by trace ID                                                                                              |
+| `name`                | string   | Filter by observation name                                                                                      |
+| `type`                | string   | Filter by observation type (GENERATION, SPAN, EVENT)                                                            |
+| `userId`              | string   | Filter by user ID                                                                                               |
+| `level`               | string   | Filter by log level (DEBUG, DEFAULT, WARNING, ERROR)                                                            |
+| `parentObservationId` | string   | Filter by physical parent observation ID. An empty value matches observations without a physical parent.        |
+| `isRootObservation`   | boolean  | Filter by logical root status. Matches observations without a physical parent and SDK-marked application roots. |
+| `environment`         | string   | Filter by environment                                                                                           |
+| `version`             | string   | Filter by version tag                                                                                           |
+| `parseIoAsJson`       | boolean  | Deprecated: omit or set to `false`; `true` returns a `400` error                                                |
+| `filter`              | string   | JSON array of filter conditions (takes precedence over query params)                                            |
+
+#### Filter logical roots
+
+Use the first-class query parameter when you want all logical roots:
+
+```bash
+curl \
+  -H "Authorization: Basic <BASIC AUTH HEADER>" \
+  "https://cloud.langfuse.com/api/public/v2/observations?isRootObservation=true&fromStartTime=2025-12-15T00:00:00Z&toStartTime=2025-12-16T00:00:00Z"
+```
+
+The advanced `filter` parameter supports the same field with boolean `=` and `<>` operators. For example, the decoded JSON value for `filter` can be:
+
+```json
+[
+  {
+    "type": "boolean",
+    "column": "isRootObservation",
+    "operator": "=",
+    "value": true
+  }
+]
+```
 
 ### Sample Response
 
@@ -188,6 +221,7 @@ With all fields included
       "startTime": "2025-12-17T16:09:00.875Z",
       "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       "parentObservationId": null,
+      "isRootObservation": true,
       "type": "GENERATION",
       "endTime": "2025-12-17T16:09:01.456Z",
       "name": "llm-generation",

--- a/content/docs/evaluation/evaluation-methods/code-evaluators.mdx
+++ b/content/docs/evaluation/evaluation-methods/code-evaluators.mdx
@@ -117,6 +117,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 Run evaluators on individual observations within your traces, such as LLM calls, retrieval operations, embedding generations, or tool calls.
 
+Use the **Is Root Observation** filter to target logical roots: observations without a physical parent or observations explicitly marked as application roots by the SDK. A logical root may still have a physical parent; use a name or type filter when you need a specific operation instead.
+
 **Why target observations**
 
 - **Operation-level precision**: Filter by observation type to evaluate only the operations that matter, not complete traces.

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -120,7 +120,9 @@ Run evaluators on individual observations within your traces—such as LLM calls
 
 Observation-level evaluators map variables from the matched observation. They can use fields on that observation, such as `input`, `output`, and `metadata`.
 
-They do not load sibling or child observations from the same trace. If your evaluator needs the overall request and response of an application or agent invocation, target a root observation that records that overall input and output. The evaluator still only sees data on that root observation; it will not automatically include data from child observations unless your application writes the required summary or context onto the root observation.
+They do not load sibling or child observations from the same trace. If your evaluator needs the overall request and response of an application or agent invocation, target a logical root observation that records that overall input and output. A logical root is an observation without a physical parent or an observation explicitly marked as an application root by the SDK. It can therefore have a physical parent. The evaluator still only sees data on that root observation; it will not automatically include data from child observations unless your application writes the required summary or context onto the root observation.
+
+Use the **Is Root Observation** filter to target logical roots. This is different from filtering for an empty physical parent, which only selects observations without a physical parent.
 
 **Why target Observations**
 
@@ -226,7 +228,7 @@ With your evaluator and model selected, configure which data to run the evaluati
 **Configuration Steps**
 
 1. Select "Live Observations" as your evaluation target
-2. Filter to specific observations using observation type, trace name, trace tags, userId, sessionId, metadata, and other attributes
+2. Filter to specific observations using observation type, logical-root status, trace name, trace tags, userId, sessionId, metadata, and other attributes
 3. Configure sampling percentage (e.g., 5%) to manage evaluation costs and throughput
 
 **Requirements**
@@ -332,6 +334,17 @@ The setup is split into two resources:
 A typical flow is to create an evaluator, read back its `variables` and `outputDefinition`, then create one or more evaluation rules that reference it.
 
 The endpoints are designed to be explored and consumed by coding agents. The recommended way to set up evaluators programmatically is to point an agent at the API reference and have it create the evaluators and wire up the evaluation rules for you.
+
+Observation evaluation rules support a boolean `isRootObservation` filter with the `=` and `<>` operators. To target logical roots, include this filter in the rule:
+
+```json
+{
+  "type": "boolean",
+  "column": "isRootObservation",
+  "operator": "=",
+  "value": true
+}
+```
 
 <Callout type="info">
   These endpoints are currently **unstable** and may change while the underlying evaluation data model is being redesigned. See the [Evaluators](https://api.reference.langfuse.com/#tag/unstableevaluators) and [Evaluation Rules](https://api.reference.langfuse.com/#tag/unstableevaluationrules) API reference for the full request and response schemas.

--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -98,6 +98,8 @@ The agent explains the relevant changes during the upgrade. The following sectio
 
 Depending on the existing evaluator, the proposed configuration may target the same observation as before, replace trace fields with values from one observation, or require an instrumentation change so all required values are available together. The [common configuration scenarios](#common-configuration-scenarios) below explains the cases in detail.
 
+When remapping a trace-level evaluator, the default observation filter is `isRootObservation = true`. This targets logical roots, including observations explicitly marked as application roots by the SDK. Review this filter alongside any name or type filters before creating the upgraded evaluator.
+
 **How resulting scores may differ**
 
 Score placement and cardinality may change:
@@ -164,10 +166,13 @@ Filters:
   environment not in ["sdk-experiment"]
   traceName = "user-workflow"
   type = "SPAN"
+  isRootObservation = true
 Variable mapping:
   query = observation.input.key
   generation = observation.output
 ```
+
+The default `isRootObservation = true` filter keeps this example focused on the logical root instead of evaluating every matching observation in the trace.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Document `isRootObservation` in blob storage exports and the v2 Observations API.
- Explain logical roots versus physical parentage across MCP, evaluators, and LLM-as-a-judge workflows.
- Add API examples and migration guidance for targeting logical roots.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Documents logical-root observation filtering across Langfuse data and evaluation workflows.
- Adds `isRootObservation` to the Observations API and MCP documentation, including filtering examples and logical-versus-physical root semantics.
- Adds `is_root_observation` to enriched blob-storage export field documentation.
- Explains logical-root targeting for code evaluators, LLM-as-a-judge rules, and evaluator migration.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge with no concrete correctness or build issue identified.

The changes consistently describe logical roots across the Observations API, MCP tools, exports, evaluators, and migration guidance, without introducing conflicting MDX or independently actionable defects.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  O[Observation] --> P{Has physical parent?}
  P -->|No| R[Logical root]
  P -->|Yes| A{Marked as application root by SDK?}
  A -->|Yes| R
  A -->|No| N[Non-root observation]
  R --> F["isRootObservation = true"]
  F --> W[API, MCP, exports, and evaluator filters]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Document logical root observation filter..."](https://github.com/langfuse/langfuse-docs/commit/6657bc288a1cb1563495180cd39d242179bb1eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48344225)</sub>

**Context used:**

- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->