### PR TITLE
docs(pulse): update changelog

### DIFF
--- a/content/changelog/2026-07-28-langfuse-pulse.mdx
+++ b/content/changelog/2026-07-28-langfuse-pulse.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-07-28
 title: "Pulse: find the outliers in your traces"
-description: "A compact chart strip above the events table. See cost and latency spikes over time, then click or drag a spike to narrow the table to that window."
+description: "A compact chart strip above the events table. See count, cost, and latency spikes over time, then click or drag a spike to narrow the table to that window."
 author: Nikita Kabardin
 ogVideo: https://static.langfuse.com/changelog-videos/2025-07-28-pulse.mp4
 ---
@@ -11,15 +11,17 @@ import { Book, Cloud } from "lucide-react";
 
 <ChangelogHeader />
 
-The events table is where you go when something in your traces looks off. **Pulse** puts a compact chart strip right above it, so the spikes in your data are the first thing you see. Each bar covers a slice of time: the total cost you spent in it, or how slow it ran at the 95th percentile. The outlier you are hunting for is a tall bar, not a row you have to sort your way down to.
+The events table is where you go when something in your traces looks off. **Pulse** puts a compact chart strip right above it, so the spikes in your data are the first thing you see. Each bar covers a slice of time and shows the number of observations by default. You can also use it to see the total cost you spent or how slow events ran at the 95th percentile. The outlier you are hunting for is a tall bar, not a row you have to sort your way down to.
 
 ## Find it, then drill into it
 
 Pulse turns spotting an outlier into navigating to it. Click a tall bar and the table narrows to that time window, showing exactly the events that made the spike. Drag across a range of bars to select a wider span; it applies when you let go. Browser Back returns you to where you started, so poking around costs you nothing.
 
-One dropdown switches what the strip plots: **Cost** or **Latency**. Cost shows the total spent in each bucket; latency defaults to p95, with the median (p50) one click away. The bars are time buckets across your full range, so a quiet stretch reads as a flat baseline rather than empty space.
+One dropdown switches what the strip plots: **Count**, **Cost**, or **Latency**. Count is selected by default and shows the number of observations in each bucket. Cost shows the total spent; latency defaults to p95, with the median (p50) one click away. The bars are time buckets across your full range, so a quiet stretch reads as a flat baseline rather than empty space.
 
-This is how you hunt down expensive or slow outliers on the [Langfuse v4](/docs/v4) data model: one cheap aggregate query over time, rather than a per-row sort across your whole dataset.
+When active filters or search terms cannot be represented accurately in the aggregate data, Pulse disables the chart instead of showing misleading results. The events table remains available with the selected filters.
+
+This is how you hunt down volume, cost, or latency outliers on the [Langfuse v4](/docs/v4) data model: one cheap aggregate query over time, rather than a per-row sort across your whole dataset.
 
 ## Learn more
 

--- a/content/docs/observability/features/pulse.mdx
+++ b/content/docs/observability/features/pulse.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pulse
-description: A compact outlier chart strip above the events table. See cost and latency spikes over time, then click or drag a spike to narrow the table to that window.
+description: A compact outlier chart strip above the events table. See count, cost, and latency spikes over time, then click or drag a spike to narrow the table to that window.
 sidebarTitle: Pulse
 ---
 
@@ -8,7 +8,7 @@ import { Book } from "lucide-react";
 
 # Pulse
 
-Pulse is a compact chart strip above the events table. Each bar covers a slice of time: the total cost spent in it, or its p95 latency. The spike you are hunting for is a tall bar, not a row you have to sort your way down to. Click or drag a spike and the table narrows to that window.
+Pulse is a compact chart strip above the events table. Each bar covers a slice of time and shows the number of observations by default. You can also use it to see the total cost spent or p95 latency. The spike you are hunting for is a tall bar, not a row you have to sort your way down to. Click or drag a spike and the table narrows to that window.
 
 <Video
   src="https://static.langfuse.com/changelog-videos/2025-07-28-pulse.mp4"
@@ -27,9 +27,9 @@ Pulse is always on above the events table.
 
 ## What each bar shows [#bars]
 
-Each bar is one time bucket. Its height is a single aggregate of the events in that bucket, so a tall bar is a bucket that stands out: an expensive stretch of traffic or a slow window.
+Each bar is one time bucket. Its height is a single aggregate of the events in that bucket, so a tall bar is a bucket that stands out: a high-volume, expensive, or slow window.
 
-The bars span the full selected time range. A bucket with no events is a gap on the baseline rather than absent space, so a quiet stretch reads as a flat baseline and a spike stands out against it. Bars use a square-root height scale: real cost and latency outliers run many times the base load, and a linear scale would flatten everything but the peak, so the scale keeps the base load readable while the outlier still dominates.
+The bars span the full selected time range. A bucket with no events is a gap on the baseline rather than absent space, so a quiet stretch reads as a flat baseline and a spike stands out against it. Bars use a square-root height scale: real count, cost, and latency outliers can run many times the base load, and a linear scale would flatten everything but the peak, so the scale keeps the base load readable while the outlier still dominates.
 
 Bucket width adapts to the range and the available width. Langfuse picks the finest bucket that fits the range into the strip, from one minute up to one week, so a one-hour range and a one-month range both fill the strip with bars.
 
@@ -39,6 +39,7 @@ Hover a bar to read its time bucket, the metric value, and how many events fell 
 
 A dropdown at the left of the strip switches what the bars plot:
 
+- **Count** — the number of observations in each bucket. This is the default.
 - **Cost** — the total spent in each bucket.
 - **Latency** — how slow the bucket ran: `p95` by default, with the median (`p50`) available from a second dropdown next to the metric name.
 
@@ -67,7 +68,7 @@ A few filters cannot be expressed as an aggregate over time, so the strip cannot
 - **Full-text search** and field-scoped text search (`input:`, `output:`).
 - **Presence checks** (`has:` and `-has:`).
 
-When any of these are active, the strip shows a **"N filters not applied"** note. The table still honors those filters; only the strip shows the unfiltered distribution for them. This is the reverse of [chart view](/docs/observability/features/events-table-charts#filter-compatibility), where those filters are dimmed instead, because the chart replaces the table rather than sitting above it.
+When any of these filters or searches are active, Pulse disables the strip instead of showing aggregate data that does not represent the filtered table. The table remains available and continues to honor the active filters.
 
 ## Pulse and charting the table [#vs-chart]
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Pulse changelog to describe count-based aggregation and unsupported-filter handling.
- Adds Count as the default Pulse metric alongside Cost and Latency.
- Explains that unsupported filters or search terms disable the aggregate chart while leaving the events table available.
- Expands the release description to include volume outlier detection.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, though the Pulse feature page should be synchronized with the updated changelog to avoid contradictory guidance.

The changelog itself remains valid MDX, but its newly documented default metric and unsupported-filter behavior disagree with the existing public Pulse documentation.

**Files Needing Attention:** content/changelog/2026-07-28-langfuse-pulse.mdx and content/docs/observability/features/pulse.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/changelog/2026-07-28-langfuse-pulse.mdx:20-22
**Synchronize Pulse behavior documentation**

This changelog introduces Count as the default and says unsupported filters disable the chart, while the existing Pulse feature page lists only Cost and Latency and says the chart remains visible with an unapplied-filters note. Synchronize both pages so readers receive consistent guidance about Pulse metrics and filter behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(pulse): update changelog"](https://github.com/langfuse/langfuse-docs/commit/193ecd38ec522c25b8dd6d1c66474ed16b99e385) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48372148)</sub>

**Context used:**

- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)

<!-- /greptile_comment -->