### PR TITLE
Add Langfuse v4 release top banner

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -2,22 +2,21 @@ import Link from "next/link";
 import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 
 export function Banner() {
-  return null;
-  // return (
-  //   <FumadocsBanner
-  //     id="fd-top-banner-ai-engineer-world-fair-2026"
-  //     height="2rem"
-  //     className="bg-black text-white [&_a]:text-white [&_button]:text-white"
-  //   >
-  //     <Link href="https://www.ai.engineer/worldsfair">
-  //       <span className="sm:hidden">
-  //         Langfuse @ AI Engineer · Booth LG-39 →
-  //       </span>
-  //       <span className="hidden sm:inline">
-  //         Langfuse @ AI Engineer World Fair in San Francisco · Find us at booth
-  //         LG-39 →
-  //       </span>
-  //     </Link>
-  //   </FumadocsBanner>
-  // );
+  return (
+    <FumadocsBanner
+      height="2rem"
+      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
+    >
+      <Link href="/docs/v4">
+        <span className="sm:hidden">
+          Langfuse v4 is here: up to 165× faster ·{" "}
+          <span className="underline underline-offset-2">Read more</span>
+        </span>
+        <span className="hidden sm:inline">
+          Langfuse v4 is here: real-time, up to 165× faster ·{" "}
+          <span className="underline underline-offset-2">Read more</span>
+        </span>
+      </Link>
+    </FumadocsBanner>
+  );
 }

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -9,7 +9,7 @@ export function Banner() {
     >
       <Link href="/docs/v4">
         <span className="sm:hidden">
-          Langfuse v4 is here: up to 165× faster ·{" "}
+          Langfuse v4: 165× faster ·{" "}
           <span className="underline underline-offset-2">Read more</span>
         </span>
         <span className="hidden sm:inline">

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -5,11 +5,11 @@ export function Banner() {
   return (
     <FumadocsBanner
       height="2rem"
-      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
+      className="bg-black text-white [&_a]:text-white"
     >
       <Link href="/docs/v4">
         <span className="sm:hidden">
-          Langfuse v4: 165× faster ·{" "}
+          Langfuse v4: up to 165× faster ·{" "}
           <span className="underline underline-offset-2">Read more</span>
         </span>
         <span className="hidden sm:inline">


### PR DESCRIPTION
## Summary

Revives the site-wide top banner (previously used for AI Engineer World Fair, left commented out) to announce the Langfuse v4 release.

- Links to [/docs/v4](https://langfuse.com/docs/v4) with an underlined "Read more" CTA
- Desktop copy: "Langfuse v4 is here: real-time, up to 165× faster · Read more"
- Mobile copy (shortened to fit one line down to 320px): "Langfuse v4: up to 165× faster · Read more"
- Non-dismissible: no `id` is passed, so fumadocs renders no close button (the `id` only exists to persist dismissal state); `--fd-banner-height` is still set, so navbar/sidebar offsets adjust automatically

## Review

Two review rounds done: round 1 caught mobile copy overflowing the fixed 2rem height at 320px; round 2 (independent pass) confirmed layout/z-index/SSR/dark-mode clean and caught a dead `[&_button]` selector plus a dropped "up to" qualifier on mobile. Verified in-browser at 320/375/1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a site-wide Langfuse v4 release banner.
- Links the banner to `/docs/v4`.
- Provides shortened mobile copy and full desktop copy.
- Uses a fixed 2rem height without a dismissal identifier.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete functional or security defects identified.

The shared banner renders static responsive copy, targets an existing `/docs/v4` page, and preserves the Fumadocs height configuration used for layout offsets.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: review round 2 — restore &quot;up to&quot; qu..."](https://github.com/langfuse/langfuse-docs/commit/4e35c9f7b69bf2ec2b99d0b879acb4a021f976f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48386802)</sub>

**Context used:**

- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->