### PR TITLE
docs(self-hosting): link code evaluators config page back to feature docs

### DIFF
--- a/content/self-hosting/configuration/code-evaluators.mdx
+++ b/content/self-hosting/configuration/code-evaluators.mdx
@@ -7,6 +7,8 @@ sidebarTitle: "Code evaluators"
 
 # Code evaluators
 
+This page covers self-hosted infrastructure setup. For an introduction to the feature, see [Code evaluators](/docs/evaluation/evaluation-methods/code-evaluators).
+
 Self-hosted code evaluators are picked up by the Langfuse worker and executed through a dispatcher backend. The dispatcher currently invokes either AWS Lambda or the local insecure runner synchronously. Production self-hosted deployments need a dispatcher for execution.
 
 Code evaluator availability is derived from `LANGFUSE_CODE_EVAL_DISPATCHER`. If this variable is unset, code evaluators are disabled for self-hosted deployments. Set it on the web service so the UI can show the supported code evaluator templates, and on the worker service so executions can be dispatched.


### PR DESCRIPTION
## Summary
- The self-hosting configuration page for code evaluators (`/self-hosting/configuration/code-evaluators`) had no link back to the feature docs page (`/docs/evaluation/evaluation-methods/code-evaluators`), even though the feature page links to it.
- Adds a one-line pointer at the top of the self-hosting page back to the feature introduction, per [Marc's comment](https://linear.app/clickhouse/issue/LFE-14603/missing-self-hosting-docs-for-optional-infra-needed-for-code-based#comment-cf48eb27) on LFE-14603.

## Test plan
- [x] `pnpm run format` — no diffs beyond the intended change
- [ ] Visually confirm the new link renders correctly on `/self-hosting/configuration/code-evaluators`

Note: LFE-14603 also raises open questions about whether the architecture diagram/infra docs need a dedicated "code eval sandbox" component — that discussion is unresolved in the thread, so this PR only addresses the concrete, uncontested gap (missing back-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds navigation from the self-hosted code evaluator infrastructure guide back to the feature introduction.
- Adds a standard internal Markdown link at the top of the configuration page.
- Targets the existing `/docs/evaluation/evaluation-methods/code-evaluators` documentation route.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new link uses supported Markdown syntax and resolves to an existing documentation route.

The change only adds a valid cross-link between two existing documentation pages and does not alter runtime behavior or infrastructure guidance.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): link code evaluators..."](https://github.com/langfuse/langfuse-docs/commit/76a6f9bfc23edfbd7caef7a85fd674bb2cee8c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48393332)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->