### PR TITLE
Add cloud-ai redirect

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -54,6 +54,7 @@ const nonPermanentRedirects = [
   ["/stickers", "https://forms.gle/Af5BHpWUMZSCT4kg8?_imcp=1"],
   ["/sticker", "https://forms.gle/Af5BHpWUMZSCT4kg8?_imcp=1"],
   ["/ask-ai", "/docs/ask-ai"],
+  ["/cloud-ai", "/cloud"],
   ["/docs/sso", "/self-hosting/authentication-and-sso"],
   ["/billing-portal", "https://billing.stripe.com/p/login/6oE9BXd4u8PR2aYaEE"],
   ["/docs/data-security-privacy", "/security"],


### PR DESCRIPTION
## Summary
- Add a /cloud-ai redirect to /cloud in the shared redirect config

## Checks
- pnpm run format
- pnpm run format:check
- git diff --check
- Node assertion for /cloud-ai -> /cloud redirect

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a shared temporary redirect for the Cloud AI URL.
- Redirects `/cloud-ai` to the existing `/cloud` route.
- Configures the redirect as non-permanent.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new redirect uses the existing tuple format, targets a valid route, and does not conflict with an existing route or redirect.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add cloud-ai redirect"](https://github.com/langfuse/langfuse-docs/commit/f4e7914bdc3cf5ee09147ab64dadcb78654baa38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48426666)</sub>

<!-- /greptile_comment -->