### PR TITLE
docs: update v4 docs for self-hosted GA release

### DIFF
--- a/components/VersionTimeline.tsx
+++ b/components/VersionTimeline.tsx
@@ -71,17 +71,17 @@ const ROWS: { id: string; name: string; segments: Segment[] }[] = [
         from: { year: 2026, month: 1 },
         to: { year: 2026, month: 8 },
         href: "/self-hosting/upgrade/versioning#sdk-server",
-        title: "Self-hosted GA version is v3",
+        title:
+          "Self-hosted v3 was the GA version until July 2026; it receives security patches until end of January 2027",
         className: SEGMENT_STYLES.previous,
       },
       {
-        label: "v4 (dates will follow)",
+        label: "v4",
         from: { year: 2026, month: 8 },
         to: AXIS_END,
-        href: "/self-hosting/upgrade",
-        title:
-          "v4 for self-hosted deployments is coming soon; the release date will follow",
-        className: SEGMENT_STYLES.expected,
+        href: "/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4",
+        title: "Self-hosted v4 is generally available since July 29, 2026",
+        className: SEGMENT_STYLES.ga,
       },
     ],
   },

--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -19,7 +19,7 @@ Reference for how Langfuse's server, SDK, and API versions relate across Langfus
 
 <VersionTimeline />
 
-[Langfuse v4](/docs/v4) is generally available: Langfuse Cloud, where v4 has been rolling out in preview since March 2026, will switch to v4 as the only experience, at which point remaining legacy APIs and ingestion paths are also removed. Self-hosted release is on the way, exact dates will follow.
+[Langfuse v4](/docs/v4) is generally available: self-hosted deployments upgrade with the [v3 to v4 migration guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4), and Langfuse Cloud, where v4 has been rolling out in preview since March 2026, will switch to v4 as the only experience, at which point remaining legacy APIs and ingestion paths are also removed.
 
 **The compatibility rule:** each Langfuse server major version aims to support the current and the previous SDK major version of each language. New SDK versions require a recent server version, as some features may not be available on older servers; see the [feature availability matrix](#sdk-server).
 

--- a/content/docs/v4.mdx
+++ b/content/docs/v4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Langfuse v4 is live"
-description: Langfuse v4 is live on Cloud, with an observations-first data model that makes tables, dashboards, APIs, and evaluations dramatically faster at scale.
+description: Langfuse v4 is live on Cloud and generally available for self-hosted deployments, with an observations-first data model that makes tables, dashboards, APIs, and evaluations dramatically faster at scale.
 ---
 
 import { Book, Github, Table, GitCompare } from "lucide-react";
@@ -10,7 +10,7 @@ import { ObservationsTableDiagram } from "@/components/ObservationsTableDiagram"
 
 # Langfuse v4 is live
 
-Langfuse v4 is live on Langfuse Cloud. It makes tables, dashboards, APIs, and evaluations dramatically faster at scale. Dashboard load times for large projects improve by at least 10x.
+Langfuse v4 is live on Langfuse Cloud and generally available for [self-hosted deployments](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4). It makes tables, dashboards, APIs, and evaluations dramatically faster at scale. Dashboard load times for large projects improve by at least 10x.
 
 At its core is an observations-first data model built for agentic systems. Query any LLM call, tool execution, or agent step directly, without costly joins or read-time deduplication.
 
@@ -32,6 +32,13 @@ Selecting one observation instead of assembling data across an entire trace is m
 
 Observations-first lets you query and evaluate the relevant sub-agent, tool call, or LLM call directly. Immutable observations also avoid repeated trace-output updates and costly read-time deduplication.
 
+The new data model also unlocks a set of new features:
+
+- [Full-text search](/docs/observability/features/full-text-search) across inputs, outputs, and metadata
+- [Filter search bar](/docs/observability/features/filter-search-bar) for fast, keyboard-driven filtering
+- [Monitors and alerts](/docs/metrics/features/monitors) on your application metrics
+- The significantly faster [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) and [Metrics API v2](/docs/metrics/features/metrics-api#v2)
+
 Learn more in the [data model docs](/docs/observability/data-model#observations-and-traces) and the [observations guide](/faq/all/explore-observations-in-v4).
 
 ## Timeline [#timeline]
@@ -51,7 +58,7 @@ On Langfuse Cloud, review your project's remaining [migration actions in the app
 
 ## Upgrade [#upgrade]
 
-Follow the [step-by-step upgrade guide](/faq/all/upgrade-to-langfuse-v4). It covers Langfuse Cloud, direct API and OpenTelemetry users, and self-hosted deployments.
+Follow the [step-by-step upgrade guide](/faq/all/upgrade-to-langfuse-v4). It covers Langfuse Cloud, direct API and OpenTelemetry users, and self-hosted deployments. Self-hosted deployments upgrade the server with the [v3 to v4 migration guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 Check the [Versions & Compatibility matrix](/docs/compatibility#sdk-server) to see which SDK and server versions work together.
 

--- a/content/faq/all/upgrade-to-langfuse-v4.mdx
+++ b/content/faq/all/upgrade-to-langfuse-v4.mdx
@@ -55,10 +55,10 @@ Select **Migration Status** to review organization-wide progress. The page shows
 
 ### Self-hosted deployments [#self-hosted]
 
-Self-hosted v4 is currently a release candidate. Use the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4) to test the migration in staging, but wait for a stable v4 release before migrating production.
+Self-hosted v4 is generally available. Follow the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4) to migrate your deployment; the `legacy` and `dual` write modes let you schedule each migration step independently.
 
 There is no forced cutover date. Langfuse v3 receives security patches through January 2027. The [self-hosted compatibility matrix](/self-hosting/upgrade/versioning#sdk-server) lists supported SDKs and APIs.
 
 ## Questions [#questions]
 
-Use the [general v4 discussion](https://github.com/orgs/langfuse/discussions/12518) for managed rollout questions and the [self-hosted v4 discussion](https://github.com/orgs/langfuse/discussions/14157) for server migration questions.
+Ask rollout and migration questions in the [v4 GitHub Discussion](https://github.com/orgs/langfuse/discussions/12518); we use that thread for updates and answers.

--- a/content/guides/cookbook/example_data_migration-jp.mdx
+++ b/content/guides/cookbook/example_data_migration-jp.mdx
@@ -395,7 +395,7 @@ print(f"プロンプト — 移行: {migrated}, 失敗: {failed}")
 
 ここがデータ移行のメインパートです。移行元の各トレース (とネストされたオブザベーション) を、移行先の OTLP インジェストエンドポイント `/api/public/otel/v1/traces` に送ります。オブザベーションの `start_time` / `end_time` を取り込み時点で正しくセットできるのは OTLP エンドポイント **だけ** です。従来のREST経由のインジェストだと、これらのフィールドは上書きされてしまいます。
 
-> **セルフホスト環境の場合:** Observations API v2 には [Langfuse v4](https://langfuse.com/docs/v4) が必要です。セルフホスト向けの v4 対応は現在準備中です。セルフホストの Langfuse から移行する場合は、下の `observations.get_many(...)` の呼び出しを `src.api.trace.get(trace.id).observations` (v1 エンドポイント) に置き換えてください。
+> **セルフホスト環境の場合:** Observations API v2 には [Langfuse v4](https://langfuse.com/docs/v4) が必要です。セルフホスト向けにも v4 は一般提供されています。まだ Langfuse v3 を利用しているセルフホスト環境から移行する場合は、下の `observations.get_many(...)` の呼び出しを `src.api.trace.get(trace.id).observations` (v1 エンドポイント) に置き換えてください。
 
 
 ```python

--- a/content/guides/cookbook/example_data_migration.mdx
+++ b/content/guides/cookbook/example_data_migration.mdx
@@ -404,7 +404,7 @@ print(f"Prompts — migrated: {migrated}, failed: {failed}")
 
 This is the core of the migration. We push each source trace (and its nested observations) into the destination's OTLP ingestion endpoint at `/api/public/otel/v1/traces`. The OTLP endpoint is the **only** way to set the authoritative `start_time` / `end_time` of an observation at ingest — the legacy REST ingestion rewrites those fields.
 
-> **Self-hosted deployments:** the v2 Observations API requires [Langfuse v4](https://langfuse.com/docs/v4); self-hosted v4 support is in progress. If you are migrating from a self-hosted Langfuse instance, replace the `observations.get_many(...)` calls below with `src.api.trace.get(trace.id).observations` (which hits the v1 endpoint).
+> **Self-hosted deployments:** the v2 Observations API requires [Langfuse v4](https://langfuse.com/docs/v4), which is generally available for self-hosted deployments. If you are migrating from a self-hosted instance that still runs Langfuse v3, replace the `observations.get_many(...)` calls below with `src.api.trace.get(trace.id).observations` (which hits the v1 endpoint).
 
 
 

--- a/content/integrations/no-code/langflow.mdx
+++ b/content/integrations/no-code/langflow.mdx
@@ -149,7 +149,7 @@ services:
 
   # https://github.com/langfuse/langfuse/blob/main/docker-compose.yml
   langfuse-worker:
-    image: langfuse/langfuse-worker:3
+    image: langfuse/langfuse-worker:4
     restart: always
     depends_on: &langfuse-depends-on
       postgres:
@@ -208,7 +208,7 @@ services:
       REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
 
   langfuse-web:
-    image: langfuse/langfuse:3
+    image: langfuse/langfuse:4
     restart: always
     depends_on: *langfuse-depends-on
     ports:
@@ -227,7 +227,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
 
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:25.12
     restart: always
     user: "101:101"
     environment:

--- a/content/self-hosting/administration/automated-access-provisioning.mdx
+++ b/content/self-hosting/administration/automated-access-provisioning.mdx
@@ -1,7 +1,7 @@
 ---
 title: Automated Access Provisioning (self-hosted)
 description: Optionally, you can configure automated access provisioning for new users when self-hosting Langfuse.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Automated Access Provisioning"
 ---
 

--- a/content/self-hosting/administration/headless-initialization.mdx
+++ b/content/self-hosting/administration/headless-initialization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Headless Initialization (self-hosted)
 description: Learn how to automatically initialize Langfuse resources via environment variables.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Headless Initialization"
 ---
 

--- a/content/self-hosting/administration/index.mdx
+++ b/content/self-hosting/administration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Administration Overview (self-hosted)
 description: Comprehensive overview of administration capabilities for self-hosted Langfuse deployments.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: Overview
 ---
 

--- a/content/self-hosting/administration/instance-management-api.mdx
+++ b/content/self-hosting/administration/instance-management-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: Manage Organizations via API
 description: Learn how to create, update, and delete organizations via the Langfuse API on self-hosted installations.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Management API (EE)"
 ---
 

--- a/content/self-hosting/administration/organization-creators.mdx
+++ b/content/self-hosting/administration/organization-creators.mdx
@@ -1,7 +1,7 @@
 ---
 title: Allowlist of organization creators (self-hosted)
 description: Learn how to restrict organization creation to a specific set of users in your self-hosted Langfuse deployment.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Organization Creators (EE)"
 ---
 

--- a/content/self-hosting/administration/ui-customization.mdx
+++ b/content/self-hosting/administration/ui-customization.mdx
@@ -1,7 +1,7 @@
 ---
 title: UI Customization (self-hosted)
 description: Learn how to customize the Langfuse UI for your organization.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "UI Customization (EE)"
 ---
 

--- a/content/self-hosting/configuration/backups.mdx
+++ b/content/self-hosting/configuration/backups.mdx
@@ -1,7 +1,7 @@
 ---
 title: Backup Strategies for Langfuse
 description: Comprehensive guide to backing up your self-hosted Langfuse deployment including ClickHouse, Postgres, and MinIO.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Backups"
 ---
 

--- a/content/self-hosting/configuration/caching.mdx
+++ b/content/self-hosting/configuration/caching.mdx
@@ -1,7 +1,7 @@
 ---
 title: Caching (self-hosted)
 description: Langfuse provides caching for API keys and prompts to improve performance and reduce database load.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Caching"
 ---
 

--- a/content/self-hosting/configuration/code-evaluators.mdx
+++ b/content/self-hosting/configuration/code-evaluators.mdx
@@ -1,7 +1,7 @@
 ---
 title: Code evaluators (self-hosted)
 description: Configure dispatchers and workers for self-hosted code evaluator execution.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Code evaluators"
 ---
 

--- a/content/self-hosting/configuration/custom-base-path.mdx
+++ b/content/self-hosting/configuration/custom-base-path.mdx
@@ -1,7 +1,7 @@
 ---
 title: Custom Base Path (self-hosted)
 description: Follow this guide to deploy Langfuse on a custom base path, e.g. https://yourdomain.com/langfuse.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Custom Base Path"
 ---
 

--- a/content/self-hosting/configuration/encryption.mdx
+++ b/content/self-hosting/configuration/encryption.mdx
@@ -1,7 +1,7 @@
 ---
 title: Encryption (self-hosted)
 description: Learn how to encrypt your self-hosted Langfuse deployment. This guide covers encryption in transit (HTTPS), at rest (database) and application-level encryption.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Encryption"
 ---
 

--- a/content/self-hosting/configuration/index.mdx
+++ b/content/self-hosting/configuration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration via Environment Variables (self-hosted)
 description: Langfuse has extensive configuration options via environment variables.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Environment Variables"
 ---
 

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Scaling Langfuse Deployments
 description: Learn how to scale your self-hosted Langfuse deployment to handle more traffic and data.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Sizing & Scaling"
 ---
 

--- a/content/self-hosting/configuration/transactional-emails.mdx
+++ b/content/self-hosting/configuration/transactional-emails.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transactional Emails (self-hosted)
 description: Learn how to configure transactional emails for your self-hosted Langfuse deployment.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Transactional Emails"
 ---
 

--- a/content/self-hosting/deployment/aws.mdx
+++ b/content/self-hosting/deployment/aws.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Langfuse on AWS with Terraform
 description: Step-by-step guide to run Langfuse on AWS via Terraform.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "AWS (Terraform)"
 ---
 

--- a/content/self-hosting/deployment/azure.mdx
+++ b/content/self-hosting/deployment/azure.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Langfuse on Azure with Terraform
 description: Step-by-step guide to run Langfuse on Azure via Terraform.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Azure (Terraform)"
 ---
 

--- a/content/self-hosting/deployment/docker-compose.mdx
+++ b/content/self-hosting/deployment/docker-compose.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Docker Compose Deployment (Self-Hosted)"
 description: "Step-by-step guide to deploy and run Langfuse locally or on a VM using Docker Compose. The simplest way to self-host Langfuse with Docker."
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Local/VM (Docker Compose)"
 ---
 

--- a/content/self-hosting/deployment/gcp.mdx
+++ b/content/self-hosting/deployment/gcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Langfuse on GCP with Terraform
 description: Step-by-step guide to run Langfuse on GCP via Terraform.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "GCP (Terraform)"
 ---
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -2,7 +2,7 @@
 title: "S3 / Blob Storage Configuration (Self-Hosted)"
 sidebarTitle: Blob Storage (S3)
 description: "Configure S3 or S3-compatible blob storage for self-hosted Langfuse. Store raw events, multi-modal inputs, and batch exports with AWS S3, MinIO, or compatible services."
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # S3 / Blob Storage

--- a/content/self-hosting/deployment/infrastructure/cache.mdx
+++ b/content/self-hosting/deployment/infrastructure/cache.mdx
@@ -2,7 +2,7 @@
 title: "Cache (Redis/Valkey) Configuration (Self-Hosted)"
 sidebarTitle: Redis / Valkey
 description: "Configure Redis or Valkey as a caching layer and queue for self-hosted Langfuse. Includes Redis environment variables, connection options, and configuration best practices."
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Cache (Redis/Valkey)

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -2,7 +2,7 @@
 title: "ClickHouse (self-hosted)"
 sidebarTitle: Clickhouse
 description: "Configure and host ClickHouse for self-hosted Langfuse. Covers ClickHouse server setup, cloud hosting options, Azure deployment, configuration best practices, and performance tuning."
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # ClickHouse

--- a/content/self-hosting/deployment/infrastructure/containers.mdx
+++ b/content/self-hosting/deployment/infrastructure/containers.mdx
@@ -2,7 +2,7 @@
 title: Application Containers (self-hosted)
 sidebarTitle: Application Containers
 description: Langfuse uses Docker to containerize the application. The application is split into two containers (Langfuse Web and Langfuse Worker).
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Application Containers
@@ -78,7 +78,7 @@ docker run --name langfuse-web \
   -e LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=bPxRfiCYEXAMPLEKEY \
   -p 3000:3000 \
   -a STDOUT \
-langfuse/langfuse:3
+langfuse/langfuse:4
 ```
 
 ## Run Langfuse Worker
@@ -103,5 +103,5 @@ docker run --name langfuse-worker \
   -e LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=bPxRfiCYEXAMPLEKEY \
   -p 3030:3030 \
   -a STDOUT \
-langfuse/langfuse-worker:3
+langfuse/langfuse-worker:4
 ```

--- a/content/self-hosting/deployment/infrastructure/llm-api.mdx
+++ b/content/self-hosting/deployment/infrastructure/llm-api.mdx
@@ -2,7 +2,7 @@
 title: LLM API / Gateway (self-hosted)
 sidebarTitle: LLM API / Gateway
 description: Optionally, you can configure Langfuse to use an external LLM API or gateway for add-on features. Langfuse tracing does not need access to the LLM API as traces are captured client-side.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # LLM API / Gateway

--- a/content/self-hosting/deployment/infrastructure/postgres.mdx
+++ b/content/self-hosting/deployment/infrastructure/postgres.mdx
@@ -2,7 +2,7 @@
 title: Postgres Database (self-hosted)
 sidebarTitle: PostgreSQL
 description: Langfuse requires a persistent Postgres database to store its state.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Postgres Database

--- a/content/self-hosting/deployment/kubernetes-helm.mdx
+++ b/content/self-hosting/deployment/kubernetes-helm.mdx
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes (Helm) (self-hosted)
 description: Step-by-step guide to run Langfuse on Kubernetes via Helm.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Kubernetes (Helm)"
 ---
 

--- a/content/self-hosting/deployment/railway.mdx
+++ b/content/self-hosting/deployment/railway.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Langfuse v3 on Railway
 description: Use this guide to deploy Langfuse v3 on Railway via the prebuilt template.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Railway"
 ---
 

--- a/content/self-hosting/deployment/railway.mdx
+++ b/content/self-hosting/deployment/railway.mdx
@@ -1,11 +1,17 @@
 ---
 title: Deploy Langfuse v3 on Railway
 description: Use this guide to deploy Langfuse v3 on Railway via the prebuilt template.
-label: "Version: v4"
+label: "Version: v3"
 sidebarTitle: "Railway"
 ---
 
 # Railway
+
+<Callout type="info">
+
+The Railway template currently deploys **Langfuse v3**. [Subscribe to the self-hosting mailing list](/self-hosting#subscribe) to get notified as soon as a Langfuse v4 template is available. For a v4 deployment today, use one of the other [deployment options](/self-hosting#deployment-options).
+
+</Callout>
 
 You can deploy Langfuse v3 on [Railway](https://railway.app/) via the prebuilt template.
 The template contains all the necessary services and configurations to get you started.

--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -2,7 +2,7 @@
 title: Self-host Langfuse (Open Source LLM Observability)
 sidebarTitle: Overview
 description: Self-host Langfuse - This guide shows you how to deploy open-source LLM observability with Docker, Kubernetes, or VMs on your own infrastructure.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Self-host Langfuse

--- a/content/self-hosting/license-key.mdx
+++ b/content/self-hosting/license-key.mdx
@@ -2,7 +2,7 @@
 title: Enterprise License Key (self-hosted)
 sidebarTitle: License Key (EE)
 description: Learn how to activate a license key for your self-hosted Langfuse deployment.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Enterprise License Key

--- a/content/self-hosting/security/authentication-and-sso.mdx
+++ b/content/self-hosting/security/authentication-and-sso.mdx
@@ -1,7 +1,7 @@
 ---
 title: Authentication and SSO (self-hosted)
 description: "Configure SSO (SAML, OIDC) and authentication for self-hosted Langfuse. Supports Google, GitHub, Azure AD, Okta, and custom OIDC/SAML providers."
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Authentication and SSO"
 ---
 

--- a/content/self-hosting/security/data-masking.mdx
+++ b/content/self-hosting/security/data-masking.mdx
@@ -1,7 +1,7 @@
 ---
 title: Data Masking (self-hosted)
 description: Configure data masking in your self-hosted Langfuse deployment to redact sensitive information from tracing events.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Data Masking"
 ---
 

--- a/content/self-hosting/security/deployment-strategies.mdx
+++ b/content/self-hosting/security/deployment-strategies.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deployment Strategies (self-hosted)
 description: Learn how to manage Langfuse effectively. It covers strategies for handling multiple projects and environments.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Deployment Strategies"
 ---
 

--- a/content/self-hosting/security/networking.mdx
+++ b/content/self-hosting/security/networking.mdx
@@ -1,7 +1,7 @@
 ---
 title: Networking (self-hosted)
 description: Learn how to configure networking for your self-hosted Langfuse deployment. Langfuse can be run without internet access.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Networking"
 ---
 

--- a/content/self-hosting/security/telemetry.mdx
+++ b/content/self-hosting/security/telemetry.mdx
@@ -2,7 +2,7 @@
 title: Telemetry (self-hosted)
 sidebarTitle: Telemetry
 description: Learn what telemetry Langfuse sends from self-hosted deployments, why it is collected, and when it can be disabled.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Telemetry

--- a/content/self-hosting/troubleshooting-and-faq.mdx
+++ b/content/self-hosting/troubleshooting-and-faq.mdx
@@ -2,7 +2,7 @@
 title: Troubleshooting & FAQ for a self-hosted Langfuse deployment
 sidebarTitle: Troubleshooting & FAQ
 description: Learn how to troubleshoot common issues with self-hosted Langfuse.
-label: "Version: v3"
+label: "Version: v4"
 ---
 
 # Troubleshooting & FAQ

--- a/content/self-hosting/upgrade/background-migrations.mdx
+++ b/content/self-hosting/upgrade/background-migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Background Migrations (self-hosted)
 description: Langfuse uses background migrations to perform long-running changes within the storage components when upgrading the application.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "Background Migrations"
 ---
 

--- a/content/self-hosting/upgrade/index.mdx
+++ b/content/self-hosting/upgrade/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to upgrade a self-hosted Langfuse deployment
 description: Use this guide to keep your Langfuse deployment up to date. Updates between minor/patch versions can be applied automatically. For major versions, please refer to the migration guides.
-label: "Version: v3"
+label: "Version: v4"
 sidebarTitle: "How to Upgrade"
 ---
 
@@ -23,7 +23,7 @@ It is recommended to be familiar with our [versioning](/self-hosting/upgrade/ver
 
 Updates within a major version are designed to be non-disruptive and are automatically applied. On start of the application, all migrations are automatically applied to the databases.
 
-You can automatically use the latest version of a major release by using `langfuse/langfuse:3` and `langfuse/langfuse-worker:3` as the image tags in your deployment.
+You can automatically use the latest version of a major release by using `langfuse/langfuse:4` and `langfuse/langfuse-worker:4` as the image tags in your deployment.
 
 To update deployments, follow the update section in our deployment guides:
 

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -7,7 +7,7 @@ description: A guide to upgrade a Langfuse v3 setup to v4.
 
 <Callout type="info">
 
-Please ask in the [v4 rollout GitHub Discussion](https://github.com/orgs/langfuse/discussions/14157) or contact [support](/support) in case you have any questions while upgrading to v4.
+Please ask in the [v4 GitHub Discussion](https://github.com/orgs/langfuse/discussions/12518) or contact [support](/support) in case you have any questions while upgrading to v4.
 
 </Callout>
 
@@ -165,14 +165,20 @@ Langfuse v4 raises the minimum infrastructure versions:
 
 Upgrade ClickHouse **before** the server upgrade. Langfuse v3 releases are fully compatible with current ClickHouse versions, so you can perform the ClickHouse upgrade on your existing v3 deployment and operate it as long as you like before continuing. See the [ClickHouse deployment guide](/self-hosting/deployment/infrastructure/clickhouse) for version and operations guidance.
 
+<Callout type="warning">
+
+**Helm chart with built-in ClickHouse:** deployments that run the ClickHouse instance bundled with the [Langfuse Helm chart](https://github.com/langfuse/langfuse-k8s) (`clickhouse.deploy: true`) cannot upgrade to Langfuse v4 yet, as the chart does not provide an upgrade path to a v4-compatible ClickHouse version. [Subscribe to the self-hosting mailing list](/self-hosting#subscribe) to get notified as soon as an upgrade path is available. Deployments that connect to an external ClickHouse are not affected.
+
+</Callout>
+
 If you plan to use the [automated backfill](#historic-data) for historic data in step 3, also make sure the ClickHouse disks can handle roughly **3x the current data volume**: data is copied into the `events` tables and, for the `observations` table, additionally into an intermediate format that is cleaned up at the end.
 
 ## Step 2: Upgrade the server to Langfuse v4 [#step-2]
 
 Perform a regular [server upgrade](/self-hosting/upgrade) to the latest Langfuse v4 release.
-All ClickHouse schema migrations (the new `events` tables) are applied automatically on startup. Deployments that adopted the tables early via the v3 preview are handled as well: existing tables are detected and skipped.
+All ClickHouse schema migrations (the new `events` tables) are applied automatically on startup. Deployments that ran the v4 preview (v3-tagged images with the preview environment variables) are handled as well: existing tables are detected and skipped.
 
-The only decision to make is the **write mode** you start with. It controls which tables ingestion writes to, and thereby how much of the v3 behavior you retain:
+The only decision to make is the **write mode** you start with. It controls which tables ingestion writes to, and thereby how much of the v3 behavior you retain. The `legacy` and `dual` modes are migration utilities, not permanent operating modes: they will be removed in an upcoming major version, so plan to complete the [cutover](#cutover) to `events_only` as part of your migration.
 
 <Tabs items={["events_only (default)", "dual", "legacy"]}>
 
@@ -337,7 +343,7 @@ Fresh installs need none of the above: deploy Langfuse v4 following the regular 
 
 ## Configuration reference [#configuration]
 
-On Langfuse v4, the new behavior is the default. These variables exist to retain v3 behaviors while your migration is in flight:
+On Langfuse v4, the new behavior is the default. These variables exist to retain v3 behaviors while your migration is in flight; they will be removed in an upcoming major version:
 
 | Variable                                                       | Values / v4 default                         | Use during the migration                                                                                                                                                                                              |
 | -------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -395,14 +401,14 @@ Track progress on the background migrations page in the UI; see [background migr
 
 {/* Seeded from https://github.com/orgs/langfuse/discussions/12518 and https://github.com/orgs/langfuse/discussions/14157 */}
 
-**Do I need to do anything special if I adopted the events tables early via the v3 preview?**
-No. The v4 migrations detect the existing tables and skip their creation. Your deployment upgrades like any other; keep the environment variables you set for the preview until you complete the [cutover](#cutover).
+**Do I need to do anything special if I ran the v4 preview on a v3-tagged image?**
+No. If you adopted the `events` tables early by running the v4 preview (a v3-tagged image with the preview environment variables), the v4 migrations detect the existing tables and skip their creation. Your deployment upgrades like any other; keep the environment variables you set for the preview until you complete the [cutover](#cutover).
 
 **Is it safe to upgrade the SDKs before the server?**
 Yes. Python SDK v4 and JS/TS SDK v5 are fully compatible with Langfuse v3 servers. Two caveats: `client.api.observations.*` and `client.api.metrics.*` point to the new v2 endpoints which are not available on v3 servers (use `client.api.legacy.*` in the meantime), and trace input/output must be set explicitly if you depart from the default root-span behavior.
 
 **Can I stay on the `legacy` or `dual` write mode long-term?**
-They are transition modes: `legacy` forgoes all v4 performance improvements, and `dual` doubles the write load and storage costs. We recommend completing the [cutover](#cutover) once your producers are migrated.
+No. They are transition modes that will be removed in an upcoming major version: `legacy` forgoes all v4 performance improvements, and `dual` doubles the write load and storage costs. Complete the [cutover](#cutover) once your producers are migrated.
 
 **Do I need new infrastructure components?**
 No. The infrastructure is identical to v3 (web/worker, PostgreSQL, ClickHouse, Redis, S3); only the minimum/recommended versions changed, see [step 1](#step-1).
@@ -426,6 +432,6 @@ Langfuse validates the migration configuration on startup and exits on invalid c
 
 If you experience any issues during the migration, please:
 
-1. Ask in the [v4 rollout GitHub Discussion](https://github.com/orgs/langfuse/discussions/14157); we use it as the central thread for the self-hosted rollout. Background on the architecture change is collected in the [announcement discussion](https://github.com/orgs/langfuse/discussions/12518).
+1. Ask in the [v4 GitHub Discussion](https://github.com/orgs/langfuse/discussions/12518); we use it as the central thread for the v4 release and answer questions there.
 2. Create a [GitHub Issue](/issues) for bugs.
 3. Enterprise customers can reach out to [support](/support) directly.

--- a/content/self-hosting/v2/index.mdx
+++ b/content/self-hosting/v2/index.mdx
@@ -8,11 +8,11 @@ label: "Version: v2"
 # Self-host Langfuse v2
 
 <Callout type="info">
-  This guide covers Langfuse v2. For Langfuse v3, see the [v3
-  documentation](/self-hosting). Langfuse v2 receives security updates until end
+  This guide covers Langfuse v2. For the current version, see the [self-hosting
+  documentation](/self-hosting). Langfuse v2 received security updates until end
   of Q1 2025. If you have any questions while upgrading, please refer to the [v3
-  upgrade guide](/self-hosting/upgrade-guides/upgrade-v2-to-v3) or open a thread
-  on [GitHub Discussions](/gh-support).
+  upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3) or open
+  a thread on [GitHub Discussions](/gh-support).
 </Callout>
 
 Langfuse is open source and can be self-hosted using Docker. This section contains guides for different deployment scenarios.

--- a/cookbook/example_data_migration-jp.ipynb
+++ b/cookbook/example_data_migration-jp.ipynb
@@ -461,7 +461,7 @@
         "\n",
         "ここがデータ移行のメインパートです。移行元の各トレース (とネストされたオブザベーション) を、移行先の OTLP インジェストエンドポイント `/api/public/otel/v1/traces` に送ります。オブザベーションの `start_time` / `end_time` を取り込み時点で正しくセットできるのは OTLP エンドポイント **だけ** です。従来のREST経由のインジェストだと、これらのフィールドは上書きされてしまいます。\n",
         "\n",
-        "> **セルフホスト環境の場合:** Observations API v2 には [Langfuse v4](https://langfuse.com/docs/v4) が必要です。セルフホスト向けの v4 対応は現在準備中です。セルフホストの Langfuse から移行する場合は、下の `observations.get_many(...)` の呼び出しを `src.api.trace.get(trace.id).observations` (v1 エンドポイント) に置き換えてください。"
+        "> **セルフホスト環境の場合:** Observations API v2 には [Langfuse v4](https://langfuse.com/docs/v4) が必要です。セルフホスト向けにも v4 は一般提供されています。まだ Langfuse v3 を利用しているセルフホスト環境から移行する場合は、下の `observations.get_many(...)` の呼び出しを `src.api.trace.get(trace.id).observations` (v1 エンドポイント) に置き換えてください。"
       ]
     },
     {

--- a/cookbook/example_data_migration.ipynb
+++ b/cookbook/example_data_migration.ipynb
@@ -460,7 +460,7 @@
         "\n",
         "This is the core of the migration. We push each source trace (and its nested observations) into the destination's OTLP ingestion endpoint at `/api/public/otel/v1/traces`. The OTLP endpoint is the **only** way to set the authoritative `start_time` / `end_time` of an observation at ingest — the legacy REST ingestion rewrites those fields.\n",
         "\n",
-        "> **Self-hosted deployments:** the v2 Observations API requires [Langfuse v4](https://langfuse.com/docs/v4); self-hosted v4 support is in progress. If you are migrating from a self-hosted Langfuse instance, replace the `observations.get_many(...)` calls below with `src.api.trace.get(trace.id).observations` (which hits the v1 endpoint).\n"
+        "> **Self-hosted deployments:** the v2 Observations API requires [Langfuse v4](https://langfuse.com/docs/v4), which is generally available for self-hosted deployments. If you are migrating from a self-hosted instance that still runs Langfuse v3, replace the `observations.get_many(...)` calls below with `src.api.trace.get(trace.id).observations` (which hits the v1 endpoint).\n"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Langfuse v4.0.0 was tagged yesterday (July 29, 2026). This PR updates the docs to treat v4 as the current GA release everywhere, and addresses the feedback on the v3 → v4 upgrade guide.

### GA sweep (no more pre-release claims)

- **v4 FAQ** (`/faq/all/upgrade-to-langfuse-v4`): "currently a release candidate … wait for a stable v4 release" → self-hosted v4 is generally available
- **Compatibility page** (`/docs/compatibility`): "Self-hosted release is on the way, exact dates will follow" → links to the v3→v4 migration guide
- **Version timeline** (`components/VersionTimeline.tsx`): self-hosted row's dashed "v4 (dates will follow)" segment is now a solid GA segment linking to the upgrade guide
- **/docs/v4**: intro and meta description now state v4 is live on Cloud **and** generally available self-hosted
- **Data migration cookbook** (EN + JP): "self-hosted v4 support is in progress" → GA (edited notebooks in `cookbook/`, regenerated markdown)
- Recommended image tags bumped from `langfuse/langfuse:3` to `:4` in the upgrade index and containers page

### Upgrade guide feedback

- **Legacy/dual write modes** are documented as migration utilities, not permanent states — "will be removed in an upcoming major version" (Step 2, configuration reference, FAQ)
- **GitHub discussion links**: all user-facing links now point to the main v4 discussion ([#12518](https://github.com/orgs/langfuse/discussions/12518)) instead of the preview thread (#14157)
- **"v3 preview" wording** clarified in Step 2 and the FAQ: it now reads "the v4 preview (v3-tagged images with the preview environment variables)"
- **Helm built-in ClickHouse**: new warning callout in Step 1 — deployments running the chart's bundled ClickHouse (`clickhouse.deploy: true`) cannot upgrade yet; links to the mailing-list signup at `/self-hosting#subscribe`

### Version labels and related cleanups

- All 36 `label: "Version: v3"` frontmatter entries under `content/self-hosting/` → `"Version: v4"` (no v3 docs snapshot — the pages apply to both majors with inline version callouts, as decided)
- v2 legacy docs callout updated ("For the current version, see the self-hosting documentation") and its upgrade-guide link fixed to the canonical path
- **/docs/v4** gains the v4 feature list: full-text search, filter search bar, monitors and alerts, Observations API v2 and Metrics API v2
- **Langflow guide**: combined docker-compose aligned with `langfuse/langfuse` main — `langfuse:4` images and `clickhouse-server:25.12` (previously unpinned)

## Checks

- `pnpm run format` clean
- `node scripts/check-h1-headings.js` passes
- New internal links point to existing pages; anchors (`#subscribe`, `#v2`) are explicitly defined
- Cookbook regeneration churn in unrelated integration pages (local nbconvert version diff) was reverted; only the intended one-line changes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes self-hosted Langfuse v4 to GA throughout the documentation.
- Updates release timelines, compatibility guidance, image tags, migration documentation, and v4 feature descriptions.
- Relabels current self-hosting documentation for v4 and updates the generated English and Japanese migration cookbooks.
- Adds migration limitations for Helm's bundled ClickHouse and clarifies temporary write modes and support channels.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Railway guide must not be presented as v4 until its v3-specific template and instructions are updated or the page is clearly marked as v3-only.

The broader GA documentation update is coherent, but the blanket version-label sweep makes the Railway page advertise v4 while still directing users to an explicitly v3 deployment artifact.

**Files Needing Attention:** content/self-hosting/deployment/railway.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/deployment/railway.mdx:4
**V4 badge points to v3 deployment**

When users open this newly v4-labeled page, its title, instructions, and deploy button still direct them to the Langfuse v3 Railway template, so they cannot use the guide to deploy the advertised v4 release.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update v4 docs for self-hosted GA ..."](https://github.com/langfuse/langfuse-docs/commit/9c6a4e92d8b44fe71f63d0a35f769bb180ee9991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48638916)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Cookbook and Integrations Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/cookbook-integrations.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)
</details>

<!-- /greptile_comment -->