### PR TITLE
fix(docs): add redirect for /docs/api-and-data-platform/features

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -99,7 +99,7 @@ const nonPermanentRedirects = [
     "/docs/api-and-data-platform",
     "/docs/prompt-management",
   ].map((path) => [path, path + "/overview"]),
-
+  ["/docs/api-and-data-platform/features", "/docs/api-and-data-platform/overview"],
   // OLD docs redirects
 
   ["/docs/admin-api", "/docs/api#org-scoped-routes"],


### PR DESCRIPTION
Fixes #3394

## Problem
`/docs/api-and-data-platform/features` returns a 404 because it's a directory
without an index page, and the existing redirect rules don't cover it.

## Fix
Added a redirect entry in `lib/redirects.js` mapping the broken path to
`/docs/api-and-data-platform/overview`, following the same pattern as
existing bare-path redirects in the same array. Verified locally that both
the new redirect and the existing bare-path redirect resolve correctly.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a temporary redirect from the non-routable `/docs/api-and-data-platform/features` directory path to the existing API and data platform overview page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new redirect resolves the reported bare-directory 404 without affecting valid content routes.

The redirect source is a directory without an index page, both redirect consumers support the literal tuple, and the destination resolves to an existing overview page.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): add redirect for /docs/api-an..."](https://github.com/langfuse/langfuse-docs/commit/09400e1f6c13807c2fd1e3da0ba1bf567c4af201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48680524)</sub>

<!-- /greptile_comment -->