### PR TITLE
docs: recommend expanding worker health check during v4 dual write

### DIFF
--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -213,6 +213,8 @@ Ingestion writes into both the old and the new tables: compatible SDKs directly,
 Each user can switch to the new read experience via the toggle in the UI, and the new [v2 APIs](#api-changes) become available (both gated by `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`, default `true`).
 Expect higher server load and S3 costs than `events_only` (comparable to v3 processing) until you complete the [cutover](#cutover).
 
+We also recommend expanding the health check of the **worker** container to `GET /api/health?failIfEventPropagationStuck=true` (port 3030): it returns `503` when the [propagation job](#dual-write) that moves data from older SDKs into the new tables has stopped making progress, so a stuck dual write surfaces in your existing monitoring instead of going unnoticed. The check passes on deployments where the dual write does not run, so it is safe to keep after the cutover. See [health and readiness endpoints](/self-hosting/configuration/health-readiness-endpoints) for probe configuration.
+
 </Tab>
 
 <Tab>


### PR DESCRIPTION
## Summary

Adds a recommendation to the `dual` write-mode tab in Step 2 of the v3→v4 self-hosting upgrade guide: expand the **worker** container's health check to `GET /api/health?failIfEventPropagationStuck=true` (port 3030) so a stuck dual-write propagation job surfaces in existing monitoring instead of going unnoticed.

Enabling `dual` is the moment the propagation job becomes load-bearing, and the Step 2 tab is where operators are already editing their deployment config. Step 3 ("Switch to the dual write mode") already points legacy-starters to the health endpoint, so this covers deployments that start directly on `dual`. The wording mirrors the existing "How the dual write works" section, including the note that the check is safe to keep after the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds worker health-check guidance to the v3-to-v4 upgrade guide.
- Recommends monitoring the dual-write propagation job through `/api/health?failIfEventPropagationStuck=true` on port 3030.
- Explains the 503 response for stalled propagation and that the check can remain enabled after cutover.
- Links operators to the health and readiness endpoint configuration documentation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The probe recommendation should be updated before merging to prevent operators from putting newly started workers into a Kubernetes crash loop.

The propagation check may return 503 until its minute-boundary heartbeat first runs, while the new guidance does not mention the documented minimum 60-second liveness-probe startup delay.

**Files Needing Attention:** content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx:216
**Missing liveness-probe startup delay**

When an operator uses this endpoint as a Kubernetes liveness probe without `initialDelaySeconds` of at least 60 seconds, the probe can return 503 before the minute-boundary heartbeat first runs, causing Kubernetes to repeatedly restart the worker.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: recommend worker health check expa..."](https://github.com/langfuse/langfuse-docs/commit/1b8f58b5797b759dc1f4e7dc4113b090ca579567) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48989172)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->