### PR TITLE
docs: clarify dataset run item API support

### DIFF
--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -94,6 +94,8 @@ Langfuse v4 serves reads from the new APIs that were introduced alongside the da
 The following legacy endpoints are unavailable on deployments that run the default write mode (`events_only`), that is, all new deployments and migrated deployments after the [cutover](#cutover).
 **While you run the `legacy` or `dual` write mode during your migration, these endpoints keep working as before.**
 
+`POST /api/public/dataset-run-items` is the exception to the response behavior above: on `events_only`, it may return a stale object rather than `404` for SDK backwards compatibility. It remains deprecated and must not be used with Langfuse v4 or `events_only`.
+
 Ingestion, replaced by [OpenTelemetry-based ingestion](/integrations/native/opentelemetry):
 
 | Endpoint                       | Behavior on v4                                                                                         |
@@ -133,11 +135,11 @@ Metrics, replaced by the [Metrics API v2](/docs/metrics/features/metrics-api#v2)
 | `GET /api/public/metrics`       | Returns `404`  |
 | `GET /api/public/metrics/daily` | Returns `404`  |
 
-Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes.
+Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes. The legacy `POST /api/public/dataset-run-items` endpoint is only supported for self-hosted deployments still running v3. Do not use it with v4 or `events_only`.
 
 | Endpoint                                          | Behavior on v4 |
 | ------------------------------------------------- | -------------- |
-| `POST /api/public/dataset-run-items`              | Returns `404`  |
+| `POST /api/public/dataset-run-items`              | Returns a stale compatibility object; do not use on v4 or `events_only` |
 | `GET /api/public/dataset-run-items`               | Returns `404`  |
 | `GET /api/public/datasets/:name/runs`             | Returns `404`  |
 | `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`  |

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -94,8 +94,6 @@ Langfuse v4 serves reads from the new APIs that were introduced alongside the da
 The following legacy endpoints are unavailable on deployments that run the default write mode (`events_only`), that is, all new deployments and migrated deployments after the [cutover](#cutover).
 **While you run the `legacy` or `dual` write mode during your migration, these endpoints keep working as before.**
 
-`POST /api/public/dataset-run-items` is the exception to the response behavior above: on `events_only`, it may return a stale object rather than `404` for SDK backwards compatibility. It remains deprecated and must not be used with Langfuse v4 or `events_only`.
-
 Ingestion, replaced by [OpenTelemetry-based ingestion](/integrations/native/opentelemetry):
 
 | Endpoint                       | Behavior on v4                                                                                         |
@@ -135,15 +133,15 @@ Metrics, replaced by the [Metrics API v2](/docs/metrics/features/metrics-api#v2)
 | `GET /api/public/metrics`       | Returns `404`  |
 | `GET /api/public/metrics/daily` | Returns `404`  |
 
-Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes. The legacy `POST /api/public/dataset-run-items` endpoint is only supported for self-hosted deployments still running v3. Do not use it with v4 or `events_only`.
+Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes. The legacy `POST /api/public/dataset-run-items` endpoint is deprecated and must not be used with Langfuse v4 or `events_only`.
 
-| Endpoint                                          | Behavior on v4 |
-| ------------------------------------------------- | -------------- |
-| `POST /api/public/dataset-run-items`              | Returns a stale compatibility object; do not use on v4 or `events_only` |
-| `GET /api/public/dataset-run-items`               | Returns `404`  |
-| `GET /api/public/datasets/:name/runs`             | Returns `404`  |
-| `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`  |
-| `DELETE /api/public/datasets/:name/runs/:runName` | Returns `404`  |
+| Endpoint                                          | Behavior on v4                                  |
+| ------------------------------------------------- | ----------------------------------------------- |
+| `POST /api/public/dataset-run-items`              | Deprecated; do not use with v4 or `events_only` |
+| `GET /api/public/dataset-run-items`               | Returns `404`                                   |
+| `GET /api/public/datasets/:name/runs`             | Returns `404`                                   |
+| `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`                                   |
+| `DELETE /api/public/datasets/:name/runs/:runName` | Returns `404`                                   |
 
 Create experiment data with the Experiment runner SDK (Python and JS/TS), which applies the required experiment semantics automatically; from other languages, send experiment traces to `POST /api/public/otel/v1/traces` with the [experiment attributes](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans) set.
 

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -133,15 +133,15 @@ Metrics, replaced by the [Metrics API v2](/docs/metrics/features/metrics-api#v2)
 | `GET /api/public/metrics`       | Returns `404`  |
 | `GET /api/public/metrics/daily` | Returns `404`  |
 
-Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes. The legacy `POST /api/public/dataset-run-items` endpoint is deprecated and must not be used with Langfuse v4 or `events_only`.
+Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.com/#tag/experiments) (`GET /api/public/experiments`, `GET /api/public/experiment-items`) for reads and the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) for writes. The legacy `POST /api/public/dataset-run-items` endpoint is deprecated and must not be used with Langfuse v4.
 
-| Endpoint                                          | Behavior on v4                                  |
-| ------------------------------------------------- | ----------------------------------------------- |
-| `POST /api/public/dataset-run-items`              | Deprecated; do not use with v4 or `events_only` |
-| `GET /api/public/dataset-run-items`               | Returns `404`                                   |
-| `GET /api/public/datasets/:name/runs`             | Returns `404`                                   |
-| `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`                                   |
-| `DELETE /api/public/datasets/:name/runs/:runName` | Returns `404`                                   |
+| Endpoint                                          | Behavior on v4                                                        |
+| ------------------------------------------------- | --------------------------------------------------------------------- |
+| `POST /api/public/dataset-run-items`              | Returns stale compatibility object for legacy SDKs. Do not use in v4. |
+| `GET /api/public/dataset-run-items`               | Returns `404`                                                         |
+| `GET /api/public/datasets/:name/runs`             | Returns `404`                                                         |
+| `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`                                                         |
+| `DELETE /api/public/datasets/:name/runs/:runName` | Returns `404`                                                         |
 
 Create experiment data with the Experiment runner SDK (Python and JS/TS), which applies the required experiment semantics automatically; from other languages, send experiment traces to `POST /api/public/otel/v1/traces` with the [experiment attributes](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans) set.
 

--- a/content/self-hosting/upgrade/versioning.mdx
+++ b/content/self-hosting/upgrade/versioning.mdx
@@ -89,6 +89,8 @@ import DetailLegacyExportSource from "@/components-mdx/compat/detail-legacy-expo
 | Observations API v2 & Metrics API v2<br />`/api/public/v2/...`                                          | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="none">Unsupported</CompatBadge>           | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | Scores API v3<br />`/api/public/v3/scores`                                                              | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | Deprecated read APIs<br />`traces, observations, sessions, scores, metrics, dataset runs`               | <CompatBadge variant="full">Full</CompatBadge>        | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="none">Unsupported</CompatBadge>           | Deprecated  |
+| **Experiments & dataset runs** · [Experiments docs](/docs/evaluation/experiments/experiments-via-sdk) |                                                       |                                                                 |                                                                 |             |
+| Legacy dataset run item API<br />`POST /api/public/dataset-run-items`                                  | <CompatBadge variant="full">Full</CompatBadge>        | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="deprecated">Deprecated</CompatBadge>      | Self-hosted v3 only |
 | **Metrics & alerts** · [Monitors docs](/docs/metrics/features/monitors)                                 |                                                       |                                                                 |                                                                 |             |
 | [Monitors and alerts](/docs/metrics/features/monitors)                                                  | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="none">Unsupported</CompatBadge>           | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | **Integrations & exports** · [Export docs](/docs/api-and-data-platform/features/export-to-blob-storage) |                                                       |                                                                 |                                                                 |             |
@@ -191,6 +193,14 @@ Deprecated.
 <CompatDetail name="Deprecated read APIs">
 
 <DetailV1ReadApis />
+
+</CompatDetail>
+
+<CompatDetail name="Legacy dataset run item API">
+
+Deprecated. Use `POST /api/public/dataset-run-items` only with self-hosted Langfuse v3 deployments. Do not use it with Langfuse v4 or `events_only`; use the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) or [OTEL experiment ingestion](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans) instead.
+
+On `events_only`, the endpoint may return a stale object rather than `404` for SDK backwards compatibility. This is not a supported v4 ingestion path.
 
 </CompatDetail>
 

--- a/content/self-hosting/upgrade/versioning.mdx
+++ b/content/self-hosting/upgrade/versioning.mdx
@@ -89,8 +89,6 @@ import DetailLegacyExportSource from "@/components-mdx/compat/detail-legacy-expo
 | Observations API v2 & Metrics API v2<br />`/api/public/v2/...`                                          | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="none">Unsupported</CompatBadge>           | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | Scores API v3<br />`/api/public/v3/scores`                                                              | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | Deprecated read APIs<br />`traces, observations, sessions, scores, metrics, dataset runs`               | <CompatBadge variant="full">Full</CompatBadge>        | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="none">Unsupported</CompatBadge>           | Deprecated  |
-| **Experiments & dataset runs** · [Experiments docs](/docs/evaluation/experiments/experiments-via-sdk) |                                                       |                                                                 |                                                                 |             |
-| Legacy dataset run item API<br />`POST /api/public/dataset-run-items`                                  | <CompatBadge variant="full">Full</CompatBadge>        | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="deprecated">Deprecated</CompatBadge>      | Self-hosted v3 only |
 | **Metrics & alerts** · [Monitors docs](/docs/metrics/features/monitors)                                 |                                                       |                                                                 |                                                                 |             |
 | [Monitors and alerts](/docs/metrics/features/monitors)                                                  | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="none">Unsupported</CompatBadge>           | <CompatBadge variant="full">Full</CompatBadge>                  | GA          |
 | **Integrations & exports** · [Export docs](/docs/api-and-data-platform/features/export-to-blob-storage) |                                                       |                                                                 |                                                                 |             |
@@ -193,14 +191,6 @@ Deprecated.
 <CompatDetail name="Deprecated read APIs">
 
 <DetailV1ReadApis />
-
-</CompatDetail>
-
-<CompatDetail name="Legacy dataset run item API">
-
-Deprecated. Use `POST /api/public/dataset-run-items` only with self-hosted Langfuse v3 deployments. Do not use it with Langfuse v4 or `events_only`; use the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) or [OTEL experiment ingestion](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans) instead.
-
-On `events_only`, the endpoint may return a stale object rather than `404` for SDK backwards compatibility. This is not a supported v4 ingestion path.
 
 </CompatDetail>
 


### PR DESCRIPTION
## Summary

- Document `POST /api/public/dataset-run-items` as a deprecated, v3-only endpoint for self-hosted deployments.
- Clarify that it must not be used with Langfuse v4 or `events_only`.
- Correct the migration guide behavior from `404` to the stale compatibility response and point users to the Experiment runner SDK or OTEL experiment ingestion.

Closes LF-62.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies the legacy dataset-run-item endpoint's intended support and migration behavior.
- Documents the stale compatibility response returned on v4 `events_only`.
- Adds the endpoint to the self-hosted version compatibility matrix.
- Directs users to the Experiment runner SDK or OpenTelemetry ingestion.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The compatibility matrix should be corrected before merging because it currently presents an unsupported v4 endpoint as deprecated and therefore apparently usable.

The detailed prose correctly warns that v4 can return a stale object, but the corresponding matrix row communicates Full support on v2 and Deprecated availability on v4 while simultaneously labeling the endpoint self-hosted-v3-only.

**Files Needing Attention:** content/self-hosting/upgrade/versioning.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/upgrade/versioning.mdx:93
**Compatibility badges contradict v3-only support**

When readers use this matrix to determine endpoint availability, the row reports full OSS v2 support and deprecated OSS v4 support even though its status and detail restrict the endpoint to self-hosted v3. On v4, `Deprecated` presents the stale compatibility response as usable ingestion, so users can mistake an unsupported write for success.

```suggestion
| Legacy dataset run item API<br />`POST /api/public/dataset-run-items`                                  | <CompatBadge variant="none">Unsupported</CompatBadge> | <CompatBadge variant="full">Full</CompatBadge>                  | <CompatBadge variant="none">Unsupported</CompatBadge>           | Deprecated  |
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(compatibility): clarify dataset run..."](https://github.com/langfuse/langfuse-docs/commit/2f853903fa1f1ac4573f56690c4228c590ba219a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49017366)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->