### PR TITLE
docs: add Experiments API documentation and update overview

### DIFF
--- a/content/docs/api-and-data-platform/features/experiments-api.mdx
+++ b/content/docs/api-and-data-platform/features/experiments-api.mdx
@@ -1,0 +1,43 @@
+---
+title: Experiments API
+sidebarTitle: Experiments API
+description: Retrieve experiment runs, items, outputs, and evaluation scores from Langfuse.
+---
+
+# Experiments API
+
+The Experiments API lets you retrieve experiment data from Langfuse for
+analysis, evaluation pipelines, notebooks, and CI/CD workflows. An experiment
+is a run of your application against test data. Each experiment item represents
+one input, its expected output, and the actual output produced by your
+application.
+
+For the complete request and response contract, see the
+[Experiments API reference](https://api.reference.langfuse.com/#tag/experiments).
+
+## Choose the right API
+
+| If you want to...                                                                           | Use                                                                                                         |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| List experiment runs and their summaries                                                    | `GET /api/public/experiments`                                                                               |
+| Retrieve experiment items and their inputs, outputs, expected outputs, metadata, and scores | `GET /api/public/experiment-items`                                                                          |
+| Retrieve the complete trace and observation tree for an item                                | [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2), using the item's `traceId` |
+| Query evaluation scores independently                                                       | [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)                                         |
+
+The experiment endpoints support filtering, cursor-based pagination, and
+optional response fields. Refer to the [Experiments API reference](https://api.reference.langfuse.com/#tag/experiments)
+for the available filters and response fields.
+
+## Experiment-level and item-level scores
+
+Experiment-level scores summarize the complete run. Item-level and trace-level
+scores evaluate individual experiment items. The Experiments API returns both
+levels in their corresponding responses, while the [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)
+is useful when scores are the primary data you want to query.
+
+## Related resources
+
+- [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk) — run experiments with the Python or JS/TS SDK.
+- [Experiments data model](/docs/evaluation/experiments/data-model) — understand how datasets, experiments, items, traces, observations, and scores relate.
+- [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) — retrieve row-level trace and observation data.
+- [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3) — retrieve evaluation and annotation scores.

--- a/content/docs/api-and-data-platform/features/experiments-api.mdx
+++ b/content/docs/api-and-data-platform/features/experiments-api.mdx
@@ -6,6 +6,16 @@ description: Retrieve experiment runs, items, outputs, and evaluation scores fro
 
 # Experiments API
 
+<AvailabilityBanner
+  availability={{
+    hobby: "full",
+    core: "full",
+    pro: "full",
+    enterprise: "full",
+    selfHosted: "v4",
+  }}
+/>
+
 The Experiments API lets you retrieve experiment data from Langfuse for
 analysis, evaluation pipelines, notebooks, and CI/CD workflows. An experiment
 is a run of your application against test data. Each experiment item represents
@@ -19,8 +29,8 @@ For the complete request and response contract, see the
 
 | If you want to...                                                                           | Use                                                                                                         |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| List experiment runs and their summaries                                                    | `GET /api/public/experiments`                                                                               |
-| Retrieve experiment items and their inputs, outputs, expected outputs, metadata, and scores | `GET /api/public/experiment-items`                                                                          |
+| List experiment runs and their summaries                                                    | `GET /api/public/experiments?fromStartTime=2026-01-01T00:00:00Z`                                            |
+| Retrieve experiment items and their inputs, outputs, expected outputs, metadata, and scores | `GET /api/public/experiment-items?fromStartTime=2026-01-01T00:00:00Z`                                       |
 | Retrieve the complete trace and observation tree for an item                                | [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2), using the item's `traceId` |
 | Query evaluation scores independently                                                       | [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)                                         |
 

--- a/content/docs/api-and-data-platform/features/meta.json
+++ b/content/docs/api-and-data-platform/features/meta.json
@@ -7,6 +7,7 @@
     "export-from-ui",
     "export-to-blob-storage",
     "!blob-storage-export-fields",
+    "experiments-api",
     "observations-api",
     "public-api",
     "query-via-sdk",

--- a/content/docs/api-and-data-platform/overview.mdx
+++ b/content/docs/api-and-data-platform/overview.mdx
@@ -19,7 +19,7 @@ Example use cases:
 
 ```mermaid
 graph LR
-    LF["Langfuse<br/><br/>• Traces<br/>• Prompts<br/>• Scores"]
+    LF["Langfuse<br/><br/>• Traces<br/>• Prompts<br/>• Scores<br/>•Experiments<br/>•Evaluators"]
 
     LF --> API["Public API"]
     LF --> Dash["In-app Dashboards"]

--- a/content/docs/api-and-data-platform/overview.mdx
+++ b/content/docs/api-and-data-platform/overview.mdx
@@ -35,6 +35,7 @@ Choose the data access path based on what you want to build:
 | Work with Langfuse from a terminal or coding agent             | [CLI](/docs/api-and-data-platform/features/cli)                                    |
 | Connect an AI tool that cannot run shell commands              | [MCP Server](/docs/api-and-data-platform/features/mcp-server)                      |
 | Query aggregate cost, usage, latency, volume, or score metrics | [Metrics API v2](/docs/metrics/features/metrics-api#v2)                            |
+| Retrieve experiment runs, items, and evaluation scores         | [Experiments API](/docs/api-and-data-platform/features/experiments-api)            |
 | Retrieve row-level spans, generations, or events               | [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2)    |
 | Use the API from Python or JS/TS                               | [Query via SDKs](/docs/api-and-data-platform/features/query-via-sdk)               |
 | Export large volumes on a schedule                             | [Blob Storage Export](/docs/api-and-data-platform/features/export-to-blob-storage) |
@@ -55,6 +56,7 @@ import {
   ListTree,
   Bot,
   Terminal,
+  FlaskConical,
 } from "lucide-react";
 
 <Cards num={3}>
@@ -92,6 +94,12 @@ import {
     title="Observations API"
     href="/docs/api-and-data-platform/features/observations-api"
     icon={<ListTree />}
+    arrow
+  />
+  <Card
+    title="Experiments API"
+    href="/docs/api-and-data-platform/features/experiments-api"
+    icon={<FlaskConical />}
     arrow
   />
   <Card

--- a/content/faq/all/retrieve-experiment-scores.mdx
+++ b/content/faq/all/retrieve-experiment-scores.mdx
@@ -17,120 +17,23 @@ Langfuse supports two types of experiment scores:
 
 ## Via API/SDK
 
-Use the [Experiments API](https://api.reference.langfuse.com/#tag/experiments) to retrieve both score levels. Include `fields=scores` when listing experiments for experiment-level scores or experiment items for item- and trace-level scores. Both endpoints require `fromStartTime` and use cursor-based pagination.
+Use the [Experiments API](/docs/api-and-data-platform/features/experiments-api)
+to retrieve both score levels. Use the [API reference](https://api.reference.langfuse.com/#tag/experiments)
+for endpoint parameters, filters, pagination, and response fields.
 
-<LangTabs items={["Python SDK", "JS/TS SDK", "API"]}>
-<Tab>
-
-```python
-from datetime import datetime, timezone
-from langfuse import Langfuse
-
-langfuse = Langfuse()
-from_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
-
-# Find the experiment and include its scores
-experiments = langfuse.api.experiments.list(
-    from_start_time=from_start,
-    name="your-experiment-name",
-    fields="core,scores",
-)
-experiment = experiments.data[0]
-
-# Fetch its items and include item and trace scores
-items = langfuse.api.experiments.list_items(
-    from_start_time=from_start,
-    experiment_id=experiment.id,
-    fields="core,io,scores",
-)
-```
-
-</Tab>
-<Tab>
-
-```ts
-import { LangfuseClient } from "@langfuse/client";
-
-const langfuse = new LangfuseClient();
-const fromStartTime = "2026-01-01T00:00:00Z";
-
-// Find the experiment and include its scores
-const experiments = await langfuse.api.experiments.list({
-  fromStartTime,
-  name: "your-experiment-name",
-  fields: "core,scores",
-});
-const experiment = experiments.data[0];
-
-// Fetch its items and include item and trace scores
-const items = await langfuse.api.experiments.listItems({
-  fromStartTime,
-  experimentId: experiment.id,
-  fields: "core,io,scores",
-});
-```
-
-</Tab>
-<Tab>
-
-```bash
-GET /api/public/experiments?fromStartTime=2026-01-01T00:00:00Z&name=your-experiment-name&fields=core,scores
-GET /api/public/experiment-items?fromStartTime=2026-01-01T00:00:00Z&experimentId=<experiment-id>&fields=core,io,scores
-```
-
-</Tab>
-</LangTabs>
+For full trace and observation details, use the [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2).
+For score-centric queries across experiments, traces, or observations, use the
+[Scores API v3](/docs/api-and-data-platform/features/scores-api#v3).
 
 ### Recommended: Use Experiment Runner SDK
 
-For a better developer experience, use the [Experiment Runner SDK](/changelog/2025-09-17-experiment-runner-sdk) which provides built-in access to all experiment scores and results:
-
-<LangTabs items={["Python SDK", "JS/TS SDK"]}>
-<Tab>
-
-```python
-from langfuse import get_client
-
-langfuse = get_client()
-
-# Run experiment with automatic score collection
-result = langfuse.run_experiment(
-    name="my-experiment",
-    data=my_dataset,
-    task=my_task,
-    evaluators=[my_evaluator]  # optional
-)
-
-# Access all scores directly
-print(result.format())  # includes all scores in formatted output
-```
-
-</Tab>
-<Tab>
-
-```ts
-import { LangfuseClient } from "@langfuse/client";
-
-const langfuse = new LangfuseClient();
-
-// Run experiment with automatic score collection
-const result = await langfuse.experiment.run({
-  name: "my-experiment",
-  data: myDataset,
-  task: myTask,
-  evaluators: [myEvaluator]  // optional
-});
-
-// Access all scores directly
-console.log(await result.format());  // includes all scores in formatted output
-```
-
-</Tab>
-</LangTabs>
+When running a new experiment, the [Experiment Runner SDK](/docs/evaluation/experiments/experiments-via-sdk)
+returns scores and results directly. Use the Experiments API when you need to
+retrieve results from a previous run.
 
 ## Related Resources
 
 - [Scores Data Model](/docs/evaluation/scores/data-model#scores)
 - [Run-Level Scores Changelog](/changelog/2025-05-07-run-level-scores)
-- [Experiment Runner SDK](/changelog/2025-09-17-experiment-runner-sdk)
-- [Experiments Documentation](/docs/evaluation/experiments/experiments-via-sdk)
+- [Experiment Runner SDK](/docs/evaluation/experiments/experiments-via-sdk)
+- [Experiments API](/docs/api-and-data-platform/features/experiments-api)


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated Experiments API guide and links it from the platform overview and experiment-scores FAQ.
- Documents the experiment-run and experiment-item endpoints and related Observations and Scores APIs.
- Adds the guide to sidebar navigation and the API overview cards.
- Replaces duplicated FAQ examples with links to the canonical API and SDK documentation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The required `fromStartTime` parameter should be documented before merging so readers do not construct requests that the experiment endpoints reject.

The new guide exposes both endpoint paths as actionable guidance but does not state that each request requires `fromStartTime`, despite existing repository documentation recording that contract.

**Files Needing Attention:** content/docs/api-and-data-platform/features/experiments-api.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/api-and-data-platform/features/experiments-api.mdx:22-24
**Required time filter omitted**

When a reader constructs either listed request from this table, the documentation omits the required `fromStartTime` parameter, causing the API to reject the request.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Experiments API documentation ..."](https://github.com/langfuse/langfuse-docs/commit/6c4954197db2cec9e0f8dd0d88751620cdcc309f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49053177)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->