### PR TITLE
docs: clarify Okta SCIM requires two applications

### DIFF
--- a/content/docs/administration/authentication-and-sso.mdx
+++ b/content/docs/administration/authentication-and-sso.mdx
@@ -130,7 +130,7 @@ Langfuse does not support exceptions on enforced domains. There are no "break gl
 
 #### Okta [#okta]
 
-##### Step 1: Create an OIDC Application in Okta
+**Step 1: Create an OIDC Application in Okta**
 
 1. Log in to the Okta Admin Console
 2. Navigate to **Applications** > **Applications**
@@ -139,7 +139,7 @@ Langfuse does not support exceptions on enforced domains. There are no "break gl
 5. Select **Web Application** as the Application type
 6. Click **Next**
 
-##### Step 2: Configure the Application
+**Step 2: Configure the Application**
 
 1. Enter an **App integration name** (e.g., "Langfuse")
 2. Set the **Sign-in redirect URI** to:
@@ -150,19 +150,19 @@ Langfuse does not support exceptions on enforced domains. There are no "break gl
 5. Under **Assignments**, choose how to assign users
 6. Click **Save**
 
-##### Step 3: Retrieve Credentials
+**Step 3: Retrieve Credentials**
 
 1. On the application's **General** tab, copy the **Client ID** and **Client Secret**
 2. Note your Okta **Issuer URL** (e.g., `https://example.okta.com`)
 
-##### Step 4: Verify Your Domain in Langfuse
+**Step 4: Verify Your Domain in Langfuse**
 
 1. In Langfuse, open **Organization Settings > SSO**
 2. In the **Verify Domain** section, click **Add Domain** and enter the domain that should use Okta
 3. Copy the DNS TXT record provided by Langfuse into your DNS provider
 4. Wait for DNS propagation, then click **Verify** in Langfuse
 
-##### Step 5: Configure SSO in Langfuse
+**Step 5: Configure SSO in Langfuse**
 
 1. In **Organization Settings > SSO**, find your verified domain in the **SSO Configuration** section
 2. Click **Configure SSO**
@@ -171,7 +171,7 @@ Langfuse does not support exceptions on enforced domains. There are no "break gl
 5. Enter the **Issuer URL**, **Client ID**, and **Client Secret**
 6. Save the configuration
 
-##### Step 6: Assign Users
+**Step 6: Assign Users**
 
 1. In Okta, go to your Langfuse application's **Assignments** tab
 2. Assign users or groups who should have access to Langfuse

--- a/content/docs/administration/authentication-and-sso.mdx
+++ b/content/docs/administration/authentication-and-sso.mdx
@@ -201,7 +201,8 @@ https://cloud.langfuse.com/auth/sso-initiate?provider=<PROVIDER>
 
 ##### User Provisioning with SCIM
 
-For automated user provisioning, see the [Okta SCIM Setup Guide](/docs/administration/scim-and-org-api#okta).
+Okta does not support SCIM on custom OIDC apps, so you need a **second Okta application** dedicated to SCIM provisioning in addition to the OIDC app above.
+See the [Okta SCIM Setup Guide](/docs/administration/scim-and-org-api#okta).
 
 ## Related Resources
 

--- a/content/docs/administration/scim-and-org-api.mdx
+++ b/content/docs/administration/scim-and-org-api.mdx
@@ -93,11 +93,23 @@ The following SCIM endpoints are available:
 - `GET /Users/{id}`
 - `DELETE /Users/{id}`
 
-### SCIM Vendor Guides
+### SCIM Vendor Guides [#scim-vendor-guides]
 
-#### Okta
+#### Okta [#okta]
 
-This guide will cover how to set up Okta user provisioning for Langfuse. First, you will need to set up [authentication via OIDC](/docs/administration/authentication-and-sso).
+This guide covers how to set up Okta user provisioning for Langfuse.
+
+<Callout type="info">
+  **Okta requires two separate applications.** Okta does not support enabling
+  [SCIM on a custom OIDC app](https://support.okta.com/help/s/article/configure-scim-for-a-custom-oidc-app?language=en_US).
+  Configure:
+
+1. An **OIDC application** for SSO — see [Authentication and SSO → Okta](/docs/administration/authentication-and-sso#okta)
+2. A separate **SAML application** for SCIM provisioning — steps below
+
+The SSO settings on the SCIM/SAML application do not need to work; Langfuse uses the OIDC app for authentication.
+
+</Callout>
 
 <Video
   src="https://static.langfuse.com/docs-videos/2025-08-06-okta-scim-setup.mov.mp4"
@@ -105,16 +117,16 @@ This guide will cover how to set up Okta user provisioning for Langfuse. First, 
   gifStyle
 />
 
-For user provisioning, Langfuse supports the SCIM 2.0 protocol.
-To set up user provisioning in Okta, follow these steps:
+Langfuse supports the SCIM 2.0 protocol for user provisioning.
+After your OIDC SSO app is in place, create a second Okta application for SCIM:
 
-1. **Create a SAML/SCIM Application**:
+1. **Create a SAML application for SCIM** (separate from your OIDC SSO app):
    - Log in to your Okta admin console.
    - Navigate to **Applications** > **Create App Integration**.
    - Choose **SAML 2.0** as the sign-in method and click **Next**.
    - Fill in the application settings. Use your self-hosted domain or one of the Langfuse Cloud domains.
      - **App name**: `Langfuse SCIM`
-     - **Single sign-on URL**: `https://your-langfuse-domain.com` (langfuse uses OIDC for authentication, see above, this will not be used)
+     - **Single sign-on URL**: `https://your-langfuse-domain.com` (placeholder only — Langfuse authenticates via the OIDC app, not this SAML SSO URL)
      - **Audience URI**: `langfuse`
    - Click **Next** and then **Finish**.
 2. **Configure SCIM Settings**:

--- a/content/self-hosting/security/authentication-and-sso.mdx
+++ b/content/self-hosting/security/authentication-and-sso.mdx
@@ -210,7 +210,8 @@ Provider: `JUMPCLOUD`
 
 Provider: `OKTA`
 
-Please find a video guide on setting up Okta authentication and user provisioning with Langfuse [here](/docs/administration/scim-and-org-api#okta-setup-guide).
+For automated user provisioning, Okta requires a **second application** for SCIM in addition to the OIDC app used for SSO.
+See the [Okta SCIM Setup Guide](/docs/administration/scim-and-org-api#okta).
 
 Notes:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies that Okta SSO + SCIM requires **two separate Okta applications** (OIDC for SSO, SAML for SCIM), matching [Okta's documented limitation](https://support.okta.com/help/s/article/configure-scim-for-a-custom-oidc-app?language=en_US).

Resolves [LFE-14692](https://linear.app/clickhouse/issue/LFE-14692/clarify-okta-scim-docs-require-two-applications).

## Changes

- **SCIM vendor guide** (`/docs/administration/scim-and-org-api#okta`): Callout at the top stating the two-app requirement, link to Okta's limitation article, and clearer step wording that the SAML app is separate from the OIDC SSO app.
- **Authentication & SSO** Okta section: Notes that SCIM needs a second Okta app before linking to the SCIM guide. Converts "Step 1–6" labels from headings to bold text so they don't pollute the TOC.
- **Self-hosting Okta notes**: Same two-app clarification; fixes broken `#okta-setup-guide` anchor → `#okta`.
- Adds explicit `[#scim-vendor-guides]` and `[#okta]` anchors on the SCIM page.

## Test plan

- [ ] Review rendered Okta section on `/docs/administration/scim-and-org-api#okta`
- [ ] Review cross-link from `/docs/administration/authentication-and-sso#okta`
- [ ] Confirm Okta SSO steps render as bold text (not TOC headings)
- [ ] Confirm self-hosting Okta link lands on the SCIM Okta guide

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14692](https://linear.app/clickhouse/issue/LFE-14692/clarify-okta-scim-docs-require-two-applications)

<div><a href="https://cursor.com/agents/bc-02a4cde4-0a2e-4b66-9f47-7096b2d6e765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02a4cde4-0a2e-4b66-9f47-7096b2d6e765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR clarifies that Okta SSO and SCIM provisioning require separate OIDC and SAML applications.

- Adds the two-application explanation and explicit anchors to the SCIM vendor guide.
- Updates cloud and self-hosted authentication documentation to link to the corrected Okta SCIM section.
- Converts procedural step headings to bold labels to keep them out of the table of contents.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge, with its cross-links and Okta application roles described consistently.

The changes clarify the setup flow and repair the self-hosting link without introducing an established broken anchor, invalid MDX construct, or contradictory provisioning instruction.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: use bold text instead of headings ..."](https://github.com/langfuse/langfuse-docs/commit/af46af0e029e17d7b5e568af0cae28973fac13d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49740452)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)
</details>

<!-- /greptile_comment -->