### PR TITLE
Update enterprise support policy link

### DIFF
--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -146,30 +146,7 @@ We're here to help you find the right solution for your use case.
 <Details>
 <Summary>Support SLO for our enterprise customers</Summary>
 
-Here are our general SLOs of our support for our Enterprise Cloud customers. These can be customized upon request.
-
-**Severity Levels:**
-
-- High (Sev 1): production downtime as a fault of Langfuse, critical security issues.
-- Medium (Sev 2): major functionality degraded for customer.
-- Low (Sev 3): minor defect, cosmetic issue, general inquiry / support.
-
-**Coverage Hours:**
-
-- High Severity: 24/7 support, including weekends and holidays.
-- Medium/Low Priority: Business hours (Monday–Friday, 09:00–21:00 Langfuse local time, excluding announced holidays).
-
-**Acknowledgement Targets:**
-
-- High Priority: Within 1 hour.
-- Medium Priority: Within 24 business hours.
-- Low Priority: Within 48 business hours.
-
-**Resolution Targets:**
-
-- High Priority: Continuous effort until resolved or a suitable workaround is in place, with updates every 2 hours.
-- Medium Priority: Addressed in the next maintenance release or hot-fix, with updates on progress.
-- Low Priority: Scheduled for the regular development cycle, with updates provided upon release.
+For current support availability, response targets, and severity definitions, see the [ClickHouse Support Services Policy](https://clickhouse.com/legal/support-services-policy). Your applicable support terms are defined in your agreement and may be customized upon request.
 
 </Details>
 


### PR DESCRIPTION
## Summary

- Replace the hard-coded enterprise support SLOs with a link to the ClickHouse Support Services Policy.
- Clarify that applicable terms are defined in the customer agreement and may be customized.

## Why

The published values could become stale. Linking to the support policy keeps the enterprise FAQ aligned with the source of truth.

## Validation

- `pnpm run format`
- `pnpm run format:check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the enterprise FAQ to avoid publishing potentially stale support targets.
- Replaces hard-coded support severities, coverage hours, and response targets with the ClickHouse Support Services Policy.
- Clarifies that each customer’s agreement defines the applicable and potentially customized terms.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the focused content change preserves valid MDX rendering while replacing stale-prone policy details with an authoritative reference.

The new text uses standard Markdown link syntax supported by both the rendered MDX page and its plain-Markdown output, and no broken content or build behavior is introduced.
</details>

<sub>Reviews (1): Last reviewed commit: ["Update enterprise support policy link"](https://github.com/langfuse/langfuse-docs/commit/672505bea55f2305280c7779f61fed5a32e5d464) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49558904)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->