### PR TITLE
docs: clarify Codex tracing setup

### DIFF
--- a/content/integrations/developer-tools/codex.mdx
+++ b/content/integrations/developer-tools/codex.mdx
@@ -20,7 +20,7 @@ The easiest way to set this up is the [Langfuse Codex Plugin](https://github.com
 codex plugin marketplace add langfuse/codex-observability-plugin
 ```
 
-Then enable plugin hooks and the tracing plugin in `~/.codex/config.toml`, and set your Langfuse keys (full steps below). Requires Node.js 22+ and Codex 0.128+.
+Then install the tracing plugin, enable its hook, and set your Langfuse keys (full steps below). Requires Node.js 22+ and Codex 0.128+.
 
 </Callout>
 
@@ -65,7 +65,13 @@ Add the Langfuse marketplace via the Codex CLI:
 codex plugin marketplace add langfuse/codex-observability-plugin
 ```
 
-### Enable the plugin
+### Install and enable the plugin
+
+Install the tracing plugin from the marketplace:
+
+```bash
+codex plugin add tracing@codex-observability-plugin
+```
 
 Enable plugin hooks and the tracing plugin globally in `~/.codex/config.toml`, or only for a specific project in `<project>/.codex/config.toml`:
 
@@ -74,6 +80,13 @@ Enable plugin hooks and the tracing plugin globally in `~/.codex/config.toml`, o
 plugin_hooks = true
 
 [plugins."tracing@codex-observability-plugin"]
+enabled = true
+```
+
+When Codex first runs the plugin hook, approve the **Langfuse Stop hook** if Codex asks for permission. Codex stores hook trust separately from plugin installation. If you previously trusted the hook but it remains inactive, make sure this generated hook-state entry is enabled:
+
+```toml
+[hooks.state."tracing@codex-observability-plugin:hooks/hooks.json:stop:0:0"]
 enabled = true
 ```
 
@@ -101,9 +114,13 @@ Alternatively, create a JSON config file at `~/.codex/langfuse.json` (global) or
 
 Configuration is resolved as defaults → global config file → project config file → environment variables, with environment variables taking precedence. `LANGFUSE_CODEX_*` variables override the matching standard `LANGFUSE_*` variables, so you can scope credentials to Codex.
 
-### Use Codex
+### Restart Codex and verify tracing
 
-Run Codex as usual. After each turn, the trace is sent to Langfuse:
+Fully restart Codex after changing its global configuration, then start a **new** Codex session. Global configuration applies to new sessions in every project; existing sessions do not load the hook retroactively.
+
+For a reliable test, send two short messages. The Stop hook uploads each completed turn, while the latest turn is finalized on the next hook invocation.
+
+Run Codex as usual:
 
 ```bash
 cd your-project
@@ -112,7 +129,7 @@ codex
 
 ### View traces in Langfuse
 
-Open your Langfuse project to see the captured traces. The structure mirrors how Codex actually works:
+Open your Langfuse project to see the captured traces. Search for `Codex Turn` and widen the time range if needed; Langfuse timestamps may be displayed in UTC. The structure mirrors how Codex actually works:
 
 - **Turn trace** (`Codex Turn`): one trace per turn, from your prompt to the final answer, captured as an [agent observation](/docs/observability/features/observation-types).
 - **Generations**: one per model response in the turn. Each shows the input it received, the model's reasoning and text, the tool calls it requested, and token usage.
@@ -142,9 +159,11 @@ The credential variables also accept a `LANGFUSE_CODEX_` prefix (for example `LA
 
 ### No traces appearing in Langfuse
 
-1. **The plugin isn't enabled.** Confirm `plugin_hooks = true` and the `tracing@codex-observability-plugin` plugin is enabled in `~/.codex/config.toml`.
-2. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process. Also verify the public key starts with `pk-lf-`.
-3. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
+1. **The plugin isn't installed or enabled.** Run `codex plugin add tracing@codex-observability-plugin`, then confirm `plugin_hooks = true` and the `tracing@codex-observability-plugin` plugin is enabled in `~/.codex/config.toml`.
+2. **The Stop hook is disabled.** Approve the Langfuse Stop hook when Codex prompts you. If the hook has already been trusted, verify that its generated entry under `[hooks.state]` has `enabled = true`.
+3. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process, unless you enabled tracing in `~/.codex/langfuse.json`. Also verify the public key starts with `pk-lf-`.
+4. **Restart and test again.** Fully restart Codex, start a new session, and send two short messages before checking Langfuse.
+5. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
 
 ### Authentication errors
 


### PR DESCRIPTION
## Summary

- add the missing tracing-plugin installation command
- document Langfuse Stop hook approval and its separate enabled state
- clarify restart, two-turn verification, and timezone-aware trace discovery
- expand troubleshooting for inactive hooks and JSON-based credentials

## Why

The previous guide could leave users with the marketplace configured but the tracing plugin or its Stop hook inactive, resulting in silent missing traces.

## Validation

- `pnpm exec prettier --experimental-cli --check content/integrations/developer-tools/codex.mdx`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR clarifies how to install and activate the Codex tracing plugin and how to verify that traces arrive.
- Adds the explicit tracing-plugin installation command and Stop-hook approval/state guidance.
- Explains restart and two-turn verification behavior.
- Expands trace-discovery and missing-trace troubleshooting guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The revised setup, lifecycle, credential, and troubleshooting guidance is internally consistent, and no concrete reachable failure caused by the changes remains established.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify Codex tracing setup"](https://github.com/langfuse/langfuse-docs/commit/f8ee617bd765339fd5c867ce338ffc21471f1057) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49581457)</sub>

<!-- /greptile_comment -->