### PR TITLE
docs: update Codex hook setup guidance

### DIFF
--- a/content/integrations/developer-tools/codex.mdx
+++ b/content/integrations/developer-tools/codex.mdx
@@ -57,6 +57,17 @@ Tracing is **opt-in** via the `TRACE_TO_LANGFUSE` environment variable. The hook
 1. Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting).
 2. Create a new project and copy your API keys from the project settings.
 
+### Check your Codex version
+
+These instructions require Codex 0.146 or later. Codex 0.146 removed the old `plugin_hooks` feature flag; use the current `hooks` flag shown below instead.
+
+```bash
+codex --version
+codex features list
+```
+
+If your Codex version is older than 0.146, update Codex before installing the tracing plugin.
+
 ### Add the plugin marketplace
 
 Add the Langfuse marketplace via the Codex CLI:
@@ -164,13 +175,14 @@ The credential variables also accept a `LANGFUSE_CODEX_` prefix (for example `LA
 
 ### No traces appearing in Langfuse
 
-1. **Hooks are not enabled.** Run `codex features list` and confirm the `hooks` feature is enabled. If it is disabled, set `hooks = true` under `[features]` in `~/.codex/config.toml`.
-2. **The plugin isn't installed or enabled.** Run `codex plugin list --json` and confirm `tracing@codex-observability-plugin` appears with `installed: true` and `enabled: true`. If it is missing, run `codex plugin add tracing@codex-observability-plugin`; if it is disabled, confirm the plugin table in `~/.codex/config.toml` has `enabled = true`.
-3. **The Stop hook is not trusted.** "Installed" and "enabled" do not mean "trusted." Start Codex, open `/hooks` if needed, then review and trust the Langfuse `Stop` hook.
-4. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process, unless you enabled tracing in `~/.codex/langfuse.json`. Also verify the public key starts with `pk-lf-`.
-5. **Restart and test again.** Fully restart Codex, start a new session, and send two short messages before checking Langfuse. A successful local test should show `hook: Stop` followed by `hook: Stop Completed`.
-6. **Check the sidecar state.** The plugin uses a `.langfuse` sidecar to remember which turns were uploaded. If you are retesting the same transcript, that state can prevent duplicate uploads.
-7. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
+1. **Codex is too old.** Run `codex --version`. These instructions require Codex 0.146 or later because the old `plugin_hooks` feature flag was removed. Update Codex if your version is older.
+2. **Hooks are not enabled.** Run `codex features list` and confirm the `hooks` feature is enabled. If it is disabled, set `hooks = true` under `[features]` in `~/.codex/config.toml`.
+3. **The plugin isn't installed or enabled.** Run `codex plugin list --json` and confirm `tracing@codex-observability-plugin` appears with `installed: true` and `enabled: true`. If it is missing, run `codex plugin add tracing@codex-observability-plugin`; if it is disabled, confirm the plugin table in `~/.codex/config.toml` has `enabled = true`.
+4. **The Stop hook is not trusted.** "Installed" and "enabled" do not mean "trusted." Start Codex, open `/hooks` if needed, then review and trust the Langfuse `Stop` hook.
+5. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process, unless you enabled tracing in `~/.codex/langfuse.json`. Also verify the public key starts with `pk-lf-`.
+6. **Restart and test again.** Fully restart Codex, start a new session, and send two short messages before checking Langfuse. A successful local test should show `hook: Stop` followed by `hook: Stop Completed`.
+7. **Check the sidecar state.** The plugin uses a `.langfuse` sidecar to remember which turns were uploaded. If you are retesting the same transcript, that state can prevent duplicate uploads.
+8. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
 
 ### Authentication errors
 

--- a/content/integrations/developer-tools/codex.mdx
+++ b/content/integrations/developer-tools/codex.mdx
@@ -20,7 +20,7 @@ The easiest way to set this up is the [Langfuse Codex Plugin](https://github.com
 codex plugin marketplace add langfuse/codex-observability-plugin
 ```
 
-Then install the tracing plugin, enable its hook, and set your Langfuse keys (full steps below). Requires Node.js 22+ and Codex 0.128+.
+Then install the tracing plugin, enable hooks, review and trust the Langfuse hook, and set your Langfuse keys (full steps below). Requires Node.js 22+ and Codex 0.146+.
 
 </Callout>
 
@@ -38,7 +38,7 @@ Using Codex's plugin hooks, this integration reads the transcript Codex writes f
 
 ## How it works
 
-Codex provides a plugin system with [hooks](https://github.com/openai/codex) that run custom commands at lifecycle points. This integration uses the **Stop hook**, which runs after each Codex turn.
+Codex provides a plugin system with [hooks](https://learn.chatgpt.com/docs/hooks) that run custom commands at lifecycle points. This integration uses the **Stop hook**, which runs after each Codex turn.
 
 1. The plugin registers a `Stop` hook that runs each time Codex finishes a turn.
 2. The hook reads Codex's session transcript (the rollout file).
@@ -73,22 +73,27 @@ Install the tracing plugin from the marketplace:
 codex plugin add tracing@codex-observability-plugin
 ```
 
-Enable plugin hooks and the tracing plugin globally in `~/.codex/config.toml`, or only for a specific project in `<project>/.codex/config.toml`:
+Enable hooks and the tracing plugin globally in `~/.codex/config.toml`, or only for a specific project in `<project>/.codex/config.toml`:
 
 ```toml
 [features]
-plugin_hooks = true
+hooks = true
 
 [plugins."tracing@codex-observability-plugin"]
 enabled = true
 ```
 
-When Codex first runs the plugin hook, approve the **Langfuse Stop hook** if Codex asks for permission. Codex stores hook trust separately from plugin installation. If you previously trusted the hook but it remains inactive, make sure this generated hook-state entry is enabled:
+### Review and trust the hook
 
-```toml
-[hooks.state."tracing@codex-observability-plugin:hooks/hooks.json:stop:0:0"]
-enabled = true
+Start Codex after installing and enabling the plugin:
+
+```bash
+codex
 ```
+
+When **Hooks need review** appears, review the Langfuse `Stop` hook and trust it. You can also type `/hooks` in the Codex CLI to inspect, review, and trust hooks.
+
+Codex stores hook trust separately from plugin installation and plugin enablement. Plugin updates can change the hook definition hash, so Codex may require another review after an update.
 
 ### Set your Langfuse credentials [#set-credentials]
 
@@ -159,11 +164,13 @@ The credential variables also accept a `LANGFUSE_CODEX_` prefix (for example `LA
 
 ### No traces appearing in Langfuse
 
-1. **The plugin isn't installed or enabled.** Run `codex plugin add tracing@codex-observability-plugin`, then confirm `plugin_hooks = true` and the `tracing@codex-observability-plugin` plugin is enabled in `~/.codex/config.toml`.
-2. **The Stop hook is disabled.** Approve the Langfuse Stop hook when Codex prompts you. If the hook has already been trusted, verify that its generated entry under `[hooks.state]` has `enabled = true`.
-3. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process, unless you enabled tracing in `~/.codex/langfuse.json`. Also verify the public key starts with `pk-lf-`.
-4. **Restart and test again.** Fully restart Codex, start a new session, and send two short messages before checking Langfuse.
-5. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
+1. **Hooks are not enabled.** Run `codex features list` and confirm the `hooks` feature is enabled. If it is disabled, set `hooks = true` under `[features]` in `~/.codex/config.toml`.
+2. **The plugin isn't installed or enabled.** Run `codex plugin list --json` and confirm `tracing@codex-observability-plugin` appears with `installed: true` and `enabled: true`. If it is missing, run `codex plugin add tracing@codex-observability-plugin`; if it is disabled, confirm the plugin table in `~/.codex/config.toml` has `enabled = true`.
+3. **The Stop hook is not trusted.** "Installed" and "enabled" do not mean "trusted." Start Codex, open `/hooks` if needed, then review and trust the Langfuse `Stop` hook.
+4. **Tracing isn't turned on.** `TRACE_TO_LANGFUSE` must be the exact string `"true"` and visible to the Codex process, unless you enabled tracing in `~/.codex/langfuse.json`. Also verify the public key starts with `pk-lf-`.
+5. **Restart and test again.** Fully restart Codex, start a new session, and send two short messages before checking Langfuse. A successful local test should show `hook: Stop` followed by `hook: Stop Completed`.
+6. **Check the sidecar state.** The plugin uses a `.langfuse` sidecar to remember which turns were uploaded. If you are retesting the same transcript, that state can prevent duplicate uploads.
+7. **Enable debug logging.** Set `LANGFUSE_CODEX_DEBUG=true` to log to stderr and surface the actual cause.
 
 ### Authentication errors
 
@@ -182,6 +189,7 @@ When enabled, the plugin uploads completed Codex transcript data to Langfuse, in
 
 - [Langfuse Codex Plugin (GitHub)](https://github.com/langfuse/codex-observability-plugin)
 - [OpenAI Codex documentation](https://github.com/openai/codex)
+- [OpenAI Codex hooks documentation](https://learn.chatgpt.com/docs/hooks)
 - [Langfuse Sessions](/docs/observability/features/sessions)
 - [Langfuse TypeScript SDK](/docs/observability/sdk/overview)
 - [Tracing coding agents with Langfuse](/resources/engineering/coding-agent-tracing)

--- a/content/integrations/developer-tools/codex.mdx
+++ b/content/integrations/developer-tools/codex.mdx
@@ -20,7 +20,7 @@ The easiest way to set this up is the [Langfuse Codex Plugin](https://github.com
 codex plugin marketplace add langfuse/codex-observability-plugin
 ```
 
-Then install the tracing plugin, enable hooks, review and trust the Langfuse hook, and set your Langfuse keys (full steps below). Requires Node.js 22+ and Codex 0.146+.
+Then install the tracing plugin, enable hooks, review and trust the Langfuse hook, and set your Langfuse keys (full steps below). Requires Node.js 22+; the current `hooks` setup below requires Codex 0.146+.
 
 </Callout>
 
@@ -59,14 +59,14 @@ Tracing is **opt-in** via the `TRACE_TO_LANGFUSE` environment variable. The hook
 
 ### Check your Codex version
 
-These instructions require Codex 0.146 or later. Codex 0.146 removed the old `plugin_hooks` feature flag; use the current `hooks` flag shown below instead.
+Use Codex 0.146 or later for this setup. The tracing plugin existed before Codex 0.146, but Codex 0.146 removed the old `plugin_hooks` feature flag; the current setup uses the `hooks` flag and hook review flow shown below.
 
 ```bash
 codex --version
 codex features list
 ```
 
-If your Codex version is older than 0.146, update Codex before installing the tracing plugin.
+If your Codex version is older than 0.146, update Codex before following this guide.
 
 ### Add the plugin marketplace
 
@@ -175,7 +175,7 @@ The credential variables also accept a `LANGFUSE_CODEX_` prefix (for example `LA
 
 ### No traces appearing in Langfuse
 
-1. **Codex is too old.** Run `codex --version`. These instructions require Codex 0.146 or later because the old `plugin_hooks` feature flag was removed. Update Codex if your version is older.
+1. **Codex is too old or still uses legacy hook config.** Run `codex --version`. This guide assumes Codex 0.146 or later because the old `plugin_hooks` feature flag was removed. Update Codex if your version is older, and replace any old `plugin_hooks` config with `hooks`.
 2. **Hooks are not enabled.** Run `codex features list` and confirm the `hooks` feature is enabled. If it is disabled, set `hooks = true` under `[features]` in `~/.codex/config.toml`.
 3. **The plugin isn't installed or enabled.** Run `codex plugin list --json` and confirm `tracing@codex-observability-plugin` appears with `installed: true` and `enabled: true`. If it is missing, run `codex plugin add tracing@codex-observability-plugin`; if it is disabled, confirm the plugin table in `~/.codex/config.toml` has `enabled = true`.
 4. **The Stop hook is not trusted.** "Installed" and "enabled" do not mean "trusted." Start Codex, open `/hooks` if needed, then review and trust the Langfuse `Stop` hook.

--- a/content/resources/engineering/coding-agent-tracing.mdx
+++ b/content/resources/engineering/coding-agent-tracing.mdx
@@ -41,7 +41,7 @@ All nine developer-tool integrations, as of July 2026:
 | Agent                                                          | Mechanism                                          | Setup shape                                              |
 | -------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
 | [Claude Code](/integrations/developer-tools/claude-code)       | Stop hook script (runs after each response)        | Hook script + Langfuse keys in env                       |
-| [OpenAI Codex](/integrations/developer-tools/codex)            | Plugin hooks (Stop hook per turn)                  | Plugin in `~/.codex/config.toml`; Node 22+, Codex 0.128+ |
+| [OpenAI Codex](/integrations/developer-tools/codex)            | Codex hooks (Stop hook per turn)                   | Plugin in `~/.codex/config.toml`; Node 22+, Codex 0.146+ |
 | [GitHub Copilot](/integrations/developer-tools/github-copilot) | Native OpenTelemetry export                        | Point OTLP exporter at Langfuse; no SDK, no code changes |
 | [Cursor](/integrations/developer-tools/cursor)                 | Agent-session tracing                              | See integration page                                     |
 | [Kiro IDE](/integrations/developer-tools/kiro)                 | Agent activity tracing                             | See integration page                                     |

--- a/content/resources/engineering/coding-agent-tracing.mdx
+++ b/content/resources/engineering/coding-agent-tracing.mdx
@@ -38,17 +38,17 @@ Three drivers show up consistently:
 
 All nine developer-tool integrations, as of July 2026:
 
-| Agent                                                          | Mechanism                                          | Setup shape                                              |
-| -------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
-| [Claude Code](/integrations/developer-tools/claude-code)       | Stop hook script (runs after each response)        | Hook script + Langfuse keys in env                       |
-| [OpenAI Codex](/integrations/developer-tools/codex)            | Codex hooks (Stop hook per turn)                   | Plugin in `~/.codex/config.toml`; Node 22+, Codex 0.146+ |
-| [GitHub Copilot](/integrations/developer-tools/github-copilot) | Native OpenTelemetry export                        | Point OTLP exporter at Langfuse; no SDK, no code changes |
-| [Cursor](/integrations/developer-tools/cursor)                 | Agent-session tracing                              | See integration page                                     |
-| [Kiro IDE](/integrations/developer-tools/kiro)                 | Agent activity tracing                             | See integration page                                     |
-| [Kiro CLI](/integrations/developer-tools/kiro-cli)             | Terminal session tracing                           | See integration page                                     |
-| [OpenCode](/integrations/developer-tools/opencode)             | Session tracing (turns, tools, retries, reasoning) | See integration page                                     |
-| [Augment Code](/integrations/developer-tools/augment-code)     | Conversation + tool execution tracing              | See integration page                                     |
-| [VS Code (MCP)](/integrations/developer-tools/vscode)          | Langfuse MCP server in Copilot agent mode          | Query prompts/traces/datasets from the editor            |
+| Agent                                                          | Mechanism                                          | Setup shape                                                                |
+| -------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------- |
+| [Claude Code](/integrations/developer-tools/claude-code)       | Stop hook script (runs after each response)        | Hook script + Langfuse keys in env                                         |
+| [OpenAI Codex](/integrations/developer-tools/codex)            | Codex hooks (Stop hook per turn)                   | Plugin in `~/.codex/config.toml`; Node 22+, Codex 0.146+ for current setup |
+| [GitHub Copilot](/integrations/developer-tools/github-copilot) | Native OpenTelemetry export                        | Point OTLP exporter at Langfuse; no SDK, no code changes                   |
+| [Cursor](/integrations/developer-tools/cursor)                 | Agent-session tracing                              | See integration page                                                       |
+| [Kiro IDE](/integrations/developer-tools/kiro)                 | Agent activity tracing                             | See integration page                                                       |
+| [Kiro CLI](/integrations/developer-tools/kiro-cli)             | Terminal session tracing                           | See integration page                                                       |
+| [OpenCode](/integrations/developer-tools/opencode)             | Session tracing (turns, tools, retries, reasoning) | See integration page                                                       |
+| [Augment Code](/integrations/developer-tools/augment-code)     | Conversation + tool execution tracing              | See integration page                                                       |
+| [VS Code (MCP)](/integrations/developer-tools/vscode)          | Langfuse MCP server in Copilot agent mode          | Query prompts/traces/datasets from the editor                              |
 
 The VS Code entry is the inverse direction: instead of tracing the agent, it gives the agent
 access to your Langfuse data via MCP. This becomes useful once traces exist and you want to analyze them


### PR DESCRIPTION
## Summary
- replace the removed Codex `plugin_hooks` feature flag with `hooks`
- add a required review-and-trust step for the Langfuse Stop hook, including `/hooks` and hook hash re-review guidance
- expand troubleshooting with `codex features list`, `codex plugin list --json`, trust-state guidance, Stop hook success output, debug logging, and `.langfuse` sidecar notes

## Testing
- `/Users/annabellschafer/langfuse-docs/node_modules/.bin/prettier --experimental-cli --check .`
- `node scripts/check-h1-headings.js`
- `git diff --check`
- `rg -n "plugin_hooks" content/integrations/developer-tools/codex.mdx` (no matches)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the Codex tracing guide for the current hooks feature and trust workflow.
- Replaces `plugin_hooks` with `hooks` and raises the documented Codex minimum.
- Adds hook review and re-review instructions.
- Expands troubleshooting for feature, plugin, trust, sidecar, and debug state.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after reconciling the non-blocking Codex minimum-version inconsistency.

The setup and trust-flow updates are coherent, but users currently receive conflicting 0.128+ and 0.146+ compatibility requirements across the documentation.

**Files Needing Attention:** content/integrations/developer-tools/codex.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/integrations/developer-tools/codex.mdx:23
**Conflicting Codex minimum versions**

This line now requires Codex 0.146+, while `content/resources/engineering/coding-agent-tracing.mdx` still advertises Codex 0.128+ for the same integration. Users on versions 0.128–0.145 therefore receive contradictory compatibility guidance and cannot determine whether an upgrade is required.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update Codex hook setup guidance"](https://github.com/langfuse/langfuse-docs/commit/860b0148a4bf38e52e48aab1cf3d0b28cb635b05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49644346)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->