### PR TITLE
docs: improve Metrics API discoverability

### DIFF
--- a/content/docs/metrics/features/metrics-api.mdx
+++ b/content/docs/metrics/features/metrics-api.mdx
@@ -15,6 +15,17 @@ GET /api/public/v2/metrics
 The **Metrics API** enables you to retrieve customized analytics from your Langfuse data.
 This endpoint allows you to specify dimensions, metrics, filters, and time granularity to build powerful custom reports and dashboards for your LLM applications.
 
+## What you can do
+
+Use the Metrics API to:
+
+- Aggregate cost, token usage, volume, latency, and score data.
+- Group results by supported dimensions, such as model or trace attributes.
+- Filter data and analyze trends over time.
+- Power custom reports, dashboards, billing, and monitoring workflows.
+
+For supported views, fields, query parameters, response schemas, and interactive examples, see the [v2 Metrics API Reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics). For practical Python examples, see the [Metrics API v2 cookbook](/guides/cookbook/example_metrics_api_v2).
+
 <Callout type="info">
 
 The deprecated `GET /api/public/metrics` and `GET /api/public/metrics/daily` endpoints are documented, with migration steps, in [Migration of deprecated APIs](/faq/all/deprecated-api-migration).
@@ -90,9 +101,3 @@ curl \
   }' \
   https://cloud.langfuse.com/api/public/v2/metrics
 ```
-
-<Callout type="info">
-
-**API Reference:** See the full [v2 Metrics API Reference](https://api.reference.langfuse.com/#tag/metricsv2/GET/api/public/v2/metrics) for all available parameters, response schemas, and interactive examples.
-
-</Callout>


### PR DESCRIPTION
## What changed
- Added a concise overview of the Metrics API's reporting and analytics use cases.
- Moved the v2 Metrics API reference to the top of the page and linked the practical cookbook.
- Kept the deprecated-API, data-availability, availability, and v1 migration guidance intact.

## Why
Developers can now determine whether the Metrics API fits their use case and reach the full query reference before encountering implementation details.

## Validation
- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR improves Metrics API discoverability by adding an introductory use-case overview and moving links to the v2 API reference and practical cookbook near the top of the page.

- Highlights supported analytics, reporting, billing, dashboard, and monitoring workflows.
- Preserves availability, data-freshness, deprecation, migration, limitations, and query-example guidance.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation clarification needed around which trace-level dimensions support grouping.

The added links resolve and the principal capability claims are supported, but “trace attributes” can reasonably be read to include documented trace fields that Metrics API v2 cannot group by.

**Files Needing Attention:** content/docs/metrics/features/metrics-api.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/metrics/features/metrics-api.mdx:23
**Narrow the trace-dimension claim**

“Trace attributes” includes fields such as user ID, session ID, tags, and metadata in the documented data model, but Metrics API v2 permits grouping only by specific trace-level dimensions such as trace name, release, and version. Naming those dimensions directly avoids sending developers toward unsupported grouping queries.

```suggestion
- Group results by supported dimensions, such as model, trace name, trace release, or trace version.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: improve Metrics API discoverabilit..."](https://github.com/langfuse/langfuse-docs/commit/46f66225e76515c93a693bad22d3c59014b5c94c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49831486)</sub>

<!-- /greptile_comment -->