### PR TITLE
docs: add redirects for reported broken links

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1584,6 +1584,25 @@ const promptMcpPageRemoval202607 = [
   ],
 ];
 
+// Reported 404s from broken-link issues - August 2026
+const brokenLinksCleanup202608 = [
+  // Paths that never existed / were removed, still linked externally
+  ["/self-hosting/deployment/examples/v4-installation", "/docs/v4"],
+  [
+    "/docs/api-and-data-platform/features",
+    "/docs/api-and-data-platform/overview",
+  ],
+  ["/docs/opentelemetry/introduction", "/integrations/native/opentelemetry"],
+  [
+    "/docs/sdk/python/instrumentation",
+    "/docs/observability/sdk/instrumentation",
+  ],
+  [
+    "/guides/cookbook/otel_integration_python_sdk",
+    "/integrations/native/opentelemetry",
+  ],
+];
+
 const permanentRedirects = [
   // llm-evaluation blog consolidation (2026-07): 101 post merged into the evals leader post
   [
@@ -1631,6 +1650,7 @@ const permanentRedirects = [
   ...resourcesEngineeringMove202606,
   ...goodTraceBestPracticesMove202607,
   ...promptMcpPageRemoval202607,
+  ...brokenLinksCleanup202608,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };


### PR DESCRIPTION
Fixes the five open "Broken link" issues assigned to me. All five URLs were verified to return 404 on langfuse.com, and every redirect target was verified to return 200.

| Reported 404 | Redirects to | Issue |
| --- | --- | --- |
| `/self-hosting/deployment/examples/v4-installation` | `/docs/v4` | #3460 |
| `/docs/api-and-data-platform/features` | `/docs/api-and-data-platform/overview` | #3394 |
| `/docs/opentelemetry/introduction` | `/integrations/native/opentelemetry` | #3167 |
| `/docs/sdk/python/instrumentation` | `/docs/observability/sdk/instrumentation` | #3222 |
| `/guides/cookbook/otel_integration_python_sdk` | `/integrations/native/opentelemetry` | #2508 |

Notes on target choices:

- `examples/v4-installation` never existed. Pointing at the `/docs/v4` overview, which is the right entry point for someone looking for v4 rather than any single deployment guide.
- `features/` is a directory of feature pages with no index file, so `overview` is the section landing page.
- `/docs/opentelemetry/introduction` never existed; the OTel entry point moved to `/integrations/native/opentelemetry`.
- `/docs/sdk/python/instrumentation` predates the language-specific → feature-specific restructure. Sibling paths (`example`, `low-level-sdk`, `sdk-v3`, `sdk-v4`, `decorators`) already have redirects; `instrumentation` was missed.
- `otel_integration_python_sdk` was a cookbook notebook that was removed (the inbound redirect was dropped in 3090e84, but the path itself is still linked externally).

Added as a new `brokenLinksCleanup202608` group, matching the existing `brokenLinksCleanup202602` pattern.

Verified: config loads, all five sources resolve to the intended targets, no conflicting duplicate sources across the 552 total redirects, and `prettier --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)