### PR TITLE
Refresh roadmap with current product focus areas

### DIFF
--- a/content/docs/roadmap.mdx
+++ b/content/docs/roadmap.mdx
@@ -1,136 +1,61 @@
 ---
 title: Roadmap
-description: Sneak peek into upcoming new features and changes in Langfuse. This page is updated regularly.
+description: Explore the current product focus areas for Langfuse.
 ---
 
 # Langfuse roadmap
 
-Langfuse is [open source](/open-source) and we want to be fully transparent what we're working on and what's next. This roadmap is a living document and we'll update it as we make progress. Please see [roadmap](#roadmap), [product vision](#vision), and [recent releases](#releases) for details below.
+Langfuse is [open source](/open-source), and we want to be transparent about where the project is going. This page summarizes the product areas we are currently investing in.
 
 <Callout type="info">
-  **Your feedback is highly appreciated**. Feel like something is missing? Add
-  new [ideas on GitHub](/ideas) or vote on existing ones. Both are a great way
-  to contribute to Langfuse and help us understand what is important to you.
+  This roadmap is directional, not a commitment to ship individual features or
+  dates. Priorities may evolve as we learn from users and the community.
 </Callout>
 
-## Roadmap [#roadmap]
+## Current focus areas [#roadmap]
 
-The current focus is to make the existing foundation excellent and connect the
-pieces into a continuous improvement loop for agents.
+Our goal is to make Langfuse the best open platform for understanding, evaluating, and improving AI agents (see [Why Langfuse?](/why)).
 
-### Agent observability and views
+### Langfuse Gateway
 
-- Make the v4 observations table, filter sidebar, saved views, and default views
-  excellent for agent traces.
-- Build agent-level views for traces per agent, cost, latency, steps, tool
-  calls, and aggregate step/tool behavior.
-- Improve trace detail pages for long-running agent traces, including compact
-  representations, selected JSON paths, and better ways to move from charts to
-  the underlying spans.
-- Improve full-text search, metadata filtering, custom dimensions, and
-  dashboard-to-trace workflows so teams can slice observations with less noise.
+Bring model access, observability, and governance into one Langfuse-native control plane.
 
-### Evals and experiments
+- Provide a thin, bring-your-own-key gateway with virtual keys and access controls across Langfuse Cloud and self-hosted deployments.
+- Connect requests directly to Langfuse tracing and cost tracking, with clear visibility into model usage and spend.
 
-- Ship public APIs for experiments and evaluators.
-- Scale the evaluator data model and support new evaluator types.
-- Improve experiment charts, comparison flows, evaluator management, and the
-  evaluator template library.
-- Expand code evaluators, categorical and boolean judges, free-text scores,
-  multimodal datasets, and the trace-level eval deprecation path.
+### Proactive issue detection
 
-### Workflow automation and agents
+Help teams find the problems that matter without manually reviewing every trace.
 
-- Build the first in-product Langfuse agent for reading Langfuse data, using
-  screen context, and helping with tasks such as comparing traces.
-- Use skills, guides, and academy content to automate AI engineering workflows
-  outside the product before packaging the best ones in-product.
-- Improve the Langfuse CLI, MCP surfaces, and skill management so external
-  agents can inspect data shape, query Langfuse efficiently, and execute common
-  workflows.
-- Prioritize repeatable workflows such as low-score analysis, failure
-  clustering, evaluator setup, production-to-dataset refreshes, synthetic data
-  generation, and experiment triggering.
+- Build a consistent representation of agent traces, including long-running and multi-span interactions.
+- Group interactions into recurring topics, behaviors, and failure modes, and surface the most important issues with useful summaries and examples.
+- Make it easier to turn production issues into datasets, evaluations, experiments, and improvement workflows.
 
-### Platform reliability and scale
+### Better evals and experiments
 
-- Finish the v4 rollout across Langfuse Cloud and self-hosted deployments.
-- Continue scaling ingestion for large agent workloads and make read paths
-  faster through pre-aggregation where needed.
-- Make system integration points such as blob exports, S3 exports, public APIs,
-  metrics, observations access, and the CLI boringly reliable.
+Extend evaluation and experimentation workflows for increasingly complex agent systems.
 
-### Alerts, workflows, and enterprise controls
+- Improve the evaluator foundation and use AI to generate code-based evaluators for specific use cases.
+- Evaluate complete agent trajectories and other multi-span interactions.
+- Make it easier to compare prompts, models, and runtime changes, including experiments on production traffic.
 
-- Ship alerting for evals, metrics, and operational thresholds across delivery
-  channels such as Slack, PagerDuty, webhooks, and email.
-- Explore webhooks and automations for observability and evaluation events.
-- Improve API-key scoping, move toward bearer keys, and expand admin controls
-  for enterprise deployments.
-- Improve the self-hosted and Helm chart experience, use the ClickHouse Operator, and explore hybrid or BYOC
-  deployment models for customers that need stronger data isolation or direct
-  ClickHouse access.
+### Scale and enterprise controls
 
-### Multimodal and playground
+Expand the capabilities teams use to operate Langfuse at increasing scale in the cloud or on their own infrastructure.
 
-- Close multimodal gaps so traces, playground, datasets, and evals feel like one
-  consistent system.
+- Unify query behavior and improve ingestion reliability, performance, and scale for large agent workloads.
+- Make model pricing and regional matching more accurate, and clearly flag missing price definitions.
+- Improve API key management, role-based access controls, self-hosting, security, and compliance.
 
-## Product vision and direction [#vision]
+### A clearer agent-engineering workflow
 
-Langfuse should become the open data and evaluation layer that helps humans, and
-eventually agents, improve agents. We optimize for one [product loop](/academy) above all
-else: track, understand, evaluate, and improve agentic systems.
+Make Langfuse easier to adopt and more coherent across the full improvement loop.
 
-The strategic choice is to stay neutral in the execution layer. Langfuse should
-not become an opinionated agent framework or runtime. Instead, Langfuse should
-own the improvement loop around agentic software: understand agent behavior,
-segment it into useful views, turn production failures into datasets, run
-experiments, and automate repeated workflows through APIs, the CLI, skills, and
-an in-product agent.
+- Create clearer onboarding, home, agent, score, and experiment views.
+- Make Langfuse capabilities available through MCP so external agents can use them in their workflows.
+- Connect tracing, datasets, evaluations, and experiments with fewer manual steps.
 
-The long-term direction is auto-optimizing agents: connect tracing and your code
-repository, and Langfuse can manage the agent improvement loop for you. Langfuse
-understands the instructions, prompts, evals, and skill files that define your
-system; manages versions; runs evaluations; proposes or triggers experiments;
-and keeps humans involved for the highest-leverage judgments.
-
-### Views as the platform primitive
-
-Views should become the primitive for slicing observations into useful product
-surfaces. A view defines which observations matter, how they are grouped, which
-attributes are shown, which metrics and scores matter, and which downstream
-actions are available. This unlocks agent overview dashboards, default templates,
-semantic clustering, evaluation distribution comparisons, and workflow triggers.
-
-### Preference layer
-
-Human judgment remains the ground truth for evaluating agents. Langfuse should
-make it easier to capture explicit feedback, derive implicit signals, align
-LLM-as-a-judge evaluators with human preferences, and route low-confidence cases
-back into human review.
-
-### Semantic grouping
-
-As agents move from routed sub-agent systems to broader dynamic agents, fixed
-labels are not enough. Langfuse should help teams discover meaningful
-interaction groups within a filtered view, compare scores across those groups,
-and turn recurring failures into datasets or experiments.
-
-### Experiments as the hill-climbing surface
-
-Experiments should become a flagship workflow for comparing prompt, model, and
-runtime changes. Langfuse should make baselines, run comparisons, annotations,
-metrics, and next actions easy enough that teams naturally use experiments as
-their agent improvement loop.
-
-### Managed improvement loop
-
-The end state is that Langfuse can monitor an agent system, propose or run
-experiments, refresh test sets from production, assign annotation work when
-human input is needed, and report how the system is improving over time.
-
-## 🚀 Recently released [#releases]
+## Recently released [#releases]
 
 import { changelogSource } from "@/lib/source";
 import { Link } from "@/components/ui/link";
@@ -172,7 +97,7 @@ export const ChangelogList = () => (
   </ul>
 );
 
-10 most recent [changelog](/changelog) items:
+The 10 most recent [changelog](/changelog) updates:
 
 <ChangelogList />
 
@@ -180,26 +105,17 @@ import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
 
 <Callout type="info">
 
-Subscribe to our mailing list to get occasional email updates about new features.
+Subscribe to receive occasional email updates about new features.
 
 <ProductUpdateSignup source="roadmap" className="my-3 max-w-sm" />
 
 </Callout>
 
-## 🙏 Feature requests and bug reports
+## Shape the roadmap [#feedback]
 
-The best way to support Langfuse is to share your feedback, report bugs, and upvote on ideas suggested by others. You can also discuss the roadmap with the team at our next [community hour](/events).
+Your feedback helps us decide what to prioritize:
 
-### Feature requests
-
-import { GhDiscussionsPreview } from "@/components/gh-discussions/GhDiscussionsPreview";
-
-<GhDiscussionsPreview filterCategory="Ideas" itemsPerPage={10} />
-
-### Bug reports
-
-import { Bug } from "lucide-react";
-
-<Cards num={2}>
-  <Card href="/issues" title="Bugs (GitHub Issues)" arrow icon={<Bug />} />
-</Cards>
+- Suggest a [feature or improvement](/ideas), or vote on ideas from other users.
+- Report a [bug](/new-issue).
+- Discuss your use case with the community on [Discord](/discord).
+- Join a [community hour](/events) to talk with the Langfuse team.


### PR DESCRIPTION
## Summary

- Replace the detailed feature backlog with directional focus areas for Langfuse
- Highlight Gateway, proactive issue detection, evals and experiments, scale, and agent-engineering workflows
- Refresh release messaging and feedback links

## Testing

Not run (not requested)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Refreshes the roadmap from a detailed feature backlog to a concise set of directional product priorities.

- Highlights Gateway, proactive issue detection, evals and experiments, scale and enterprise controls, and agent-engineering workflows.
- Updates release messaging and replaces embedded feedback components with direct links to community and reporting channels.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only refresh appears safe to merge.

The revised MDX retains valid syntax and components, and every newly added internal feedback link resolves through an existing page or configured redirect.
</details>

<sub>Reviews (1): Last reviewed commit: ["Refresh roadmap with current product foc..."](https://github.com/langfuse/langfuse-docs/commit/8e276c3dbd80108f39032d8448289c4f80d3b9f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50112361)</sub>

<!-- /greptile_comment -->