### PR TITLE
Add Codex Docs MCP installation

### DIFF
--- a/components-mdx/docs-mcp-server-installation.mdx
+++ b/components-mdx/docs-mcp-server-installation.mdx
@@ -1,74 +1,7 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-<Tabs items={["Cursor", "Copilot (in VSCode)", "Claude Code", "Windsurf", "Other MCP Clients"]}>
-
-<Tab>
-
-Add Langfuse Docs MCP to Cursor via the one-click install:
-
-<div className="flex gap-2 mt-3 mb-6">
-  <Button asChild>
-    <Link
-      href="https://cursor.com/en/install-mcp?name=langfuse-docs&config=eyJ1cmwiOiJodHRwczovL2xhbmdmdXNlLmNvbS9hcGkvbWNwIn0%3D"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Install MCP Server in Cursor
-    </Link>
-  </Button>
-</div>
-
-<details>
-<summary>Manual configuration</summary>
-
-Add the following to your `mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "langfuse-docs": {
-      "url": "https://langfuse.com/api/mcp"
-    }
-  }
-}
-```
-
-</details>
-
-</Tab>
-
-<Tab>
-
-Add Langfuse Docs MCP to Copilot in VSCode via the one-click install:
-
-<div className="flex gap-2 mt-3 mb-6">
-  <Button asChild>
-    <Link
-      href="vscode:mcp/install?%7B%22name%22%3A%22langfuse-docs%22%2C%22url%22%3A%22https%3A%2F%2Flangfuse.com%2Fapi%2Fmcp%22%7D"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Install MCP Server in VS Code
-    </Link>
-  </Button>
-</div>
-
-<details>
-<summary>Manual configuration</summary>
-
-Add Langfuse Docs MCP to Copilot in VSCode via the following steps:
-
-1. Open Command Palette (⌘+Shift+P)
-2. Open "MCP: Add Server..."
-3. Select `HTTP`
-4. Paste `https://langfuse.com/api/mcp`
-5. Select name (e.g. `langfuse-docs`) and whether to save in user or workspace settings
-6. You're all set! The MCP server is now available in Agent mode
-
-</details>
-
-</Tab>
+<Tabs items={["Claude Code", "Codex", "Cursor", "Windsurf", "Copilot (in VSCode)", "Other MCP Clients"]}>
 
 <Tab>
 
@@ -118,6 +51,65 @@ Once added, start a Claude Code session (`claude`) and type `/mcp` to confirm th
 
 <Tab>
 
+Add Langfuse Docs MCP to Codex via the CLI:
+
+```bash
+codex mcp add langfuse-docs --url https://langfuse.com/api/mcp
+```
+
+<details>
+<summary>Manual configuration</summary>
+
+Alternatively, add the following to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.langfuse-docs]
+url = "https://langfuse.com/api/mcp"
+```
+
+Start a new Codex session, then run `codex mcp list` to confirm the server is registered.
+
+</details>
+
+</Tab>
+
+<Tab>
+
+Add Langfuse Docs MCP to Cursor via the one-click install:
+
+<div className="flex gap-2 mt-3 mb-6">
+  <Button asChild>
+    <Link
+      href="https://cursor.com/en/install-mcp?name=langfuse-docs&config=eyJ1cmwiOiJodHRwczovL2xhbmdmdXNlLmNvbS9hcGkvbWNwIn0%3D"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Install MCP Server in Cursor
+    </Link>
+  </Button>
+</div>
+
+<details>
+<summary>Manual configuration</summary>
+
+Add the following to your `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "langfuse-docs": {
+      "url": "https://langfuse.com/api/mcp"
+    }
+  }
+}
+```
+
+</details>
+
+</Tab>
+
+<Tab>
+
 Add Langfuse Docs MCP to Windsurf via the following steps:
 
 1. Open Command Palette (⌘+Shift+P)
@@ -135,6 +127,38 @@ Add Langfuse Docs MCP to Windsurf via the following steps:
      }
    }
    ```
+
+</Tab>
+
+<Tab>
+
+Add Langfuse Docs MCP to Copilot in VSCode via the one-click install:
+
+<div className="flex gap-2 mt-3 mb-6">
+  <Button asChild>
+    <Link
+      href="vscode:mcp/install?%7B%22name%22%3A%22langfuse-docs%22%2C%22url%22%3A%22https%3A%2F%2Flangfuse.com%2Fapi%2Fmcp%22%7D"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Install MCP Server in VS Code
+    </Link>
+  </Button>
+</div>
+
+<details>
+<summary>Manual configuration</summary>
+
+Add Langfuse Docs MCP to Copilot in VSCode via the following steps:
+
+1. Open Command Palette (⌘+Shift+P)
+2. Open "MCP: Add Server..."
+3. Select `HTTP`
+4. Paste `https://langfuse.com/api/mcp`
+5. Select name (e.g. `langfuse-docs`) and whether to save in user or workspace settings
+6. You're all set! The MCP server is now available in Agent mode
+
+</details>
 
 </Tab>
 


### PR DESCRIPTION
## Summary

- add installation instructions for Codex via CLI and `~/.codex/config.toml`
- make Claude Code the default install tab
- reorder install tabs: Claude Code, Codex, Cursor, Windsurf, Copilot (in VSCode), Other MCP Clients

## Validation

- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- generated Markdown output inspected
- loaded `/docs/docs-mcp` locally (HTTP 200)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Codex installation guidance to the reusable Docs MCP installation component and makes Claude Code the default tab.
- Documents Codex CLI and TOML configuration methods.
- Reorders the installation tabs to Claude Code, Codex, Cursor, Windsurf, Copilot, and other clients.
- Preserves the existing instructions for all previously documented clients.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The reordered labels remain aligned with their tab panels, and the new Codex instructions fit the existing reusable MDX component structure without introducing a concrete rendering or content failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Codex Docs MCP installation"](https://github.com/langfuse/langfuse-docs/commit/377f8590dd7952ade7231da8ae4b50c5aaf8b7c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50303020)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)

<!-- /greptile_comment -->