### PR TITLE
docs: add deterministic evaluator sampling changelog

### DIFF
--- a/content/changelog/2026-08-05-deterministic-evaluator-sampling.mdx
+++ b/content/changelog/2026-08-05-deterministic-evaluator-sampling.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-05
 title: Consistent evaluator sampling
-description: Compare evaluators on the same sample of matching traces or observations.
+description: Compare evaluators on the same sample of matching observations.
 author: Tobias Wochinger
 canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
 ---
@@ -11,12 +11,18 @@ import { Book } from "lucide-react";
 
 <ChangelogHeader />
 
-Evaluator sampling is now consistent across evaluator configurations. Two evaluators with the same filters and a 10% sampling rate now evaluate the same 10% of matching traces or observations, making their results directly comparable.
+Evaluator sampling is now consistent across evaluator configurations. Two evaluators with the same filters and a 10% sampling rate now evaluate the same 10% of matching observations, making their results directly comparable.
 
-<Cards num={1}>
+<Cards num={2}>
   <Card
     title="LLM-as-a-Judge"
     href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
+    icon={<Book />}
+    arrow
+  />
+  <Card
+    title="Code evaluators"
+    href="/docs/evaluation/evaluation-methods/code-evaluators"
     icon={<Book />}
     arrow
   />

--- a/content/changelog/2026-08-05-deterministic-evaluator-sampling.mdx
+++ b/content/changelog/2026-08-05-deterministic-evaluator-sampling.mdx
@@ -1,0 +1,23 @@
+---
+date: 2026-08-05
+title: Consistent evaluator sampling
+description: Compare evaluators on the same sample of matching traces or observations.
+author: Tobias Wochinger
+canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book } from "lucide-react";
+
+<ChangelogHeader />
+
+Evaluator sampling is now consistent across evaluator configurations. Two evaluators with the same filters and a 10% sampling rate now evaluate the same 10% of matching traces or observations, making their results directly comparable.
+
+<Cards num={1}>
+  <Card
+    title="LLM-as-a-Judge"
+    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
+    icon={<Book />}
+    arrow
+  />
+</Cards>

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -243,7 +243,7 @@ With your evaluator and model selected, configure which data to run the evaluati
 </Callout>
 
 <Callout type="info">
-**Sampling is applied per evaluator.** Each evaluator draws its own random sample, so two evaluators configured with the same sampling percentage will generally score different subsets of your traffic. If several evaluators must score the same items, set their sampling to 100% and use identical filters, for example by making the sampling decision in your application and applying a [tag](/docs/observability/features/tags) that the evaluators filter on.
+**Sampling is deterministic per trace or observation.** Evaluators with the same sampling percentage select the same subset of matching traffic.
 </Callout>
 
 </Tab>

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -243,7 +243,7 @@ With your evaluator and model selected, configure which data to run the evaluati
 </Callout>
 
 <Callout type="info">
-**Sampling is deterministic per trace or observation.** Evaluators with the same sampling percentage select the same subset of matching traffic.
+**Sampling is deterministic per observation.** Evaluators with the same sampling percentage select the same subset of matching traffic.
 </Callout>
 
 </Tab>


### PR DESCRIPTION
## Summary

- Add a concise changelog explaining that matching evaluator configurations now sample the same observations.
- Update the LLM-as-a-Judge documentation to reflect deterministic evaluator sampling.
- Link both LLM-as-a-Judge and code evaluator documentation.

## Linear

- [LF-72](https://linear.app/clickhouse/issue/LF-72/deterministic-eval-sampling)

## Implementation

- [langfuse/langfuse#15798](https://github.com/langfuse/langfuse/pull/15798)