### PR TITLE
Add Copy page button to academy pages

### DIFF
--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -66,6 +66,7 @@ const pathsWithCopyAsMarkdownButton = [
   "/library",
   "/enterprise",
   "/resources",
+  "/academy",
 ];
 const isCustomerStory = (pathname: string) => pathname.startsWith("/users/");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes LFMKT-2200.

## Summary

Academy pages already use the same docs chrome (`DocsChromePage` → `DocBodyChrome`) as docs, but the Copy page button was gated behind a path allowlist that did not include `/academy`.

This adds `/academy` to `pathsWithCopyAsMarkdownButton`, so the button appears on English and Japanese academy pages (`/academy`, `/academy/japan`, and nested pages).

## Testing

- Verified `/academy` and `/academy/tracing` render the Copy page button
- Verified `/academy/japan` also shows the button
- Verified `/academy.md` and `/academy/japan.md` return markdown (200) for the copy action

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2200](https://linear.app/clickhouse/issue/LFMKT-2200/add-copy-button-to-academy-pages)

<div><a href="https://cursor.com/agents/bc-46e93c7c-f562-437b-bdd1-7c173994f1b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46e93c7c-f562-437b-bdd1-7c173994f1b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Academy routes to the existing copy-as-markdown button allowlist.
- Enables the shared copy-page control for English and Japanese Academy pages.
- Reuses the existing pathname matching and markdown URL generation behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new allowlist entry routes Academy pages through the existing copy-markdown behavior, and the supplied verification confirms that representative English and Japanese markdown endpoints respond successfully.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: show Copy page button on academy p..."](https://github.com/langfuse/langfuse-docs/commit/3f50522658508b10b0a3ea68fa0bbe2529f8add5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50757905)</sub>

**Context used:**

- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->