### PR TITLE
Changelog: Bulk import and export for prompts

### DIFF
--- a/content/changelog/2026-08-06-bulk-import-export-prompts.mdx
+++ b/content/changelog/2026-08-06-bulk-import-export-prompts.mdx
@@ -1,0 +1,18 @@
+---
+date: 2026-08-06
+title: Bulk import and export for prompts
+description: Export prompt versions as JSON and import them in bulk.
+author: Ben
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+You can now move versioned prompts between Langfuse projects using bulk JSON export and import. Use it to promote prompts across environments, create backups, or restore complete prompt histories without recreating versions manually.
+
+To export prompts, open the [Prompts page](https://cloud.langfuse.com/project/~/prompts) and click **Export**. Langfuse downloads a JSON file containing the selected prompts.
+
+To import prompts, click **Import** and upload an exported file or a compatible JSON array. Each imported prompt is created as a new version, including when a prompt with the same name already exists. The `latest` and `production` labels are omitted during import to avoid changing deployments in the destination project. Once the import finishes, the dialog shows the result for each prompt.
+
+Thanks to [@rkdhanda](https://github.com/rkdhanda) for the contribution!


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a changelog announcement for bulk prompt import and export.

- Explains moving prompt histories between projects through JSON export and import.
- Describes version creation, deployment-label handling, and per-prompt import results.
- Credits the feature contributor.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation gap around the supported JSON import schema.

The changelog should define or link the compatible JSON-array format so users can construct valid import payloads without trial and error.

**Files Needing Attention:** content/changelog/2026-08-06-bulk-import-export-prompts.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/changelog/2026-08-06-bulk-import-export-prompts.mdx:16
**Undefined compatible JSON format**

The entry presents a “compatible JSON array” as a supported upload option without defining or linking its required schema, leaving users who create their own payloads unable to determine the required fields and values without trial and error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changelog: Bulk import and export for pr..."](https://github.com/langfuse/langfuse-docs/commit/9d6ddd751df7125659b99c3435157769a71edf8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50759840)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)

<!-- /greptile_comment -->