### PR TITLE
docs(v4): document experiment instrumentation migration

### DIFF
--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -143,7 +143,14 @@ Dataset runs, replaced by the [experiments API](https://api.reference.langfuse.c
 | `GET /api/public/datasets/:name/runs/:runName`    | Returns `404`                                                         |
 | `DELETE /api/public/datasets/:name/runs/:runName` | Returns `404`                                                         |
 
-Create experiment data with the Experiment runner SDK (Python and JS/TS), which applies the required experiment semantics automatically; from other languages, send experiment traces to `POST /api/public/otel/v1/traces` with the [experiment attributes](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans) set.
+### Experiment instrumentation [#experiment-instrumentation]
+
+If your application creates experiment data, replace `POST /api/public/dataset-run-items` as part of the migration:
+
+- **Python or JS/TS:** use the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk). It creates the required experiment traces and attributes automatically.
+- **Other languages or direct integrations:** send each experiment item as one trace to [`POST /api/public/otel/v1/traces`](https://api.reference.langfuse.com/#tag/opentelemetry/POST/api/public/otel/v1/traces) and follow the [experiment attribute propagation guide](/integrations/native/opentelemetry#experiments-ingesting-experiment-spans).
+
+Do not create new experiment data through `POST /api/public/dataset-run-items`; it is retained only as a compatibility path for older SDKs and is not part of the v4 write path.
 
 ### Evaluations [#evaluations]
 


### PR DESCRIPTION
## Summary

- Add a dedicated experiment instrumentation subsection to the v3 → v4 migration guide.
- Direct Python and JS/TS users to the Experiment Runner SDK.
- Direct other languages and API integrations to OTEL traces with the experiment attribute propagation guide.
- Explicitly explain that new use of `POST /api/public/dataset-run-items` is not part of the v4 write path.

## Verification

- `pnpm run format:check`
- `pnpm exec node scripts/check-h1-headings.js`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the v3-to-v4 migration guide with dedicated experiment-instrumentation guidance.
- Directs Python and JS/TS users to the Experiment Runner SDK.
- Directs other integrations to one OTEL trace per experiment item and the attribute-propagation guide.
- Clarifies that `POST /api/public/dataset-run-items` is retained only for legacy compatibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge, with no concrete broken links, rendering problems, or inaccurate migration instructions identified.

The new internal routes and explicit anchors exist, the heading syntax follows established repository conventions, and the migration instructions agree with the detailed SDK and OpenTelemetry experiment documentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(v4): document experiment instrument..."](https://github.com/langfuse/langfuse-docs/commit/07e31ddab92e796a8fab6bd06886280edc58a78a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50821976)</sub>

<!-- /greptile_comment -->