### PR TITLE
docs: add ClickHouse Agents integration page

### DIFF
--- a/components/home/Integrations.tsx
+++ b/components/home/Integrations.tsx
@@ -353,6 +353,11 @@ const marqueeRow2: MarqueeItem[] = [
     icon: "/images/integrations/temporal.svg",
   },
   {
+    label: "ClickHouse Agents",
+    href: "/integrations/other/clickhouse-agents",
+    icon: "/images/integrations/clickhouse_icon.svg",
+  },
+  {
     label: "ClickHouse Agentic Data Stack",
     href: "/integrations/other/agentic-data-stack",
     icon: "/images/integrations/clickhouse_icon.svg",

--- a/content/integrations/other/agentic-data-stack.mdx
+++ b/content/integrations/other/agentic-data-stack.mdx
@@ -157,6 +157,7 @@ docker compose up -d
 
 ## Learn More
 
+- [ClickHouse Agents](/integrations/other/clickhouse-agents) — Langfuse tracing for the managed agentic analytics service in ClickHouse Cloud
 - [Agentic Data Stack repository](https://github.com/ClickHouse/agentic-data-stack) — Source code and full documentation
 - [clickhouse.com/ai](https://clickhouse.com/ai) — The Agentic Data Stack
 - [LibreChat documentation](https://www.librechat.ai/docs) — LibreChat setup and configuration

--- a/content/integrations/other/clickhouse-agents.mdx
+++ b/content/integrations/other/clickhouse-agents.mdx
@@ -1,0 +1,103 @@
+---
+title: "ClickHouse Agents Observability with Langfuse"
+sidebarTitle: ClickHouse Agents
+logo: /images/integrations/clickhouse_icon.svg
+description: "Send traces and user feedback from ClickHouse Agents to your own Langfuse project to debug agent runs, monitor cost and latency, and evaluate response quality."
+category: Integrations
+---
+
+# ClickHouse Agents tracing with Langfuse
+
+> **What is ClickHouse Agents?** [ClickHouse Agents](https://clickhouse.com/docs/cloud/features/ai-ml/agents) is a fully managed agentic analytics service in [ClickHouse Cloud](https://clickhouse.com/cloud). Built on [LibreChat](https://www.librechat.ai/), it lets anyone define no-code agents that are grounded in live ClickHouse data via [MCP](https://modelcontextprotocol.io) and query them in natural language.
+
+> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source LLM engineering platform that helps teams trace, debug, and evaluate their LLM applications.
+
+ClickHouse Agents has a built-in Langfuse connection. An organization admin adds Langfuse API keys once, and from then on every agent run in that organization is traced to your own Langfuse project — no code, no deployment changes.
+
+## What gets traced
+
+- **Agent runs** — one trace per assistant message, with the full call hierarchy from the incoming prompt to the final response
+- **Model calls** — generations with model name, prompt, completion, token usage, cost, and latency
+- **Tool calls** — ClickHouse MCP queries, code interpreter runs (Bash, Python, JavaScript), and any other MCP tools the agent has access to
+- **User feedback** — the thumbs up / thumbs down on an assistant message, plus its reason tag and comment, arrives as a `user-feedback` [score](/docs/evaluation/evaluation-methods/scores-via-ui) on that message's trace
+- **Organization attribution** — traces carry a `tenant:<organizationId>` tag and `librechat.tenant.id` in metadata, so you can slice them via the [Metrics API](/docs/metrics/features/metrics-api)
+
+## How it works
+
+ClickHouse Agents emits agent traces as OpenTelemetry spans and exports them to Langfuse's OTLP endpoint. When you enable the Langfuse connection for your organization, ClickHouse Cloud routes your organization's spans to the Langfuse project belonging to the keys you configured. Feedback scores are sent separately through the Langfuse API and attached to the matching trace.
+
+The connection is scoped to the **organization**, so it applies to all agents in it. Only new conversations are traced — enabling the connection does not backfill existing chat history.
+
+## Connect Langfuse
+
+<Steps>
+
+### Create a Langfuse project
+
+Sign up for [Langfuse Cloud](https://cloud.langfuse.com) or [self-host Langfuse](/self-hosting), then create a project. Copy the **public key** and **secret key** from the project settings.
+
+### Open the Langfuse settings in ClickHouse Agents
+
+In ClickHouse Agents, go to **Settings → Langfuse** and find the **Langfuse connection** panel. This setting is only visible to organization admins.
+
+### Select your destination
+
+Pick the **Destination** that matches the region of your Langfuse project:
+
+| Destination | Langfuse URL                    |
+| ----------- | ------------------------------- |
+| EU          | `https://cloud.langfuse.com`    |
+| US          | `https://us.cloud.langfuse.com` |
+| Japan       | `https://jp.cloud.langfuse.com` |
+
+<Callout type="info">
+  The destination must match the region your project lives in. Keys from an EU project are rejected against the US or Japan destination.
+</Callout>
+
+### Add your keys and enable the connection
+
+Paste the public and secret key, then choose **Save & enable**. ClickHouse Agents verifies the keys against Langfuse before storing them, and the status changes to **Verified with Langfuse** once the connection is live. The secret key is stored encrypted and shown masked afterwards.
+
+### Chat with your agents
+
+Run a conversation with any agent in the organization. Each assistant message produces a trace in your Langfuse project.
+
+### View traces in Langfuse
+
+Open your Langfuse project to work with the incoming data:
+
+- Follow an agent run step by step in the trace tree — prompts, completions, SQL generated against ClickHouse, and tool results
+- Group the messages of a conversation with [sessions](/docs/observability/features/sessions) to review a full chat rather than a single turn
+- Track token usage, cost, and latency per model and per agent
+- Turn thumbs up / thumbs down into response-quality analysis using the `user-feedback` scores on your traces
+- Score outputs with [LLM-as-a-judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) evaluators or [human annotations](/docs/evaluation/evaluation-methods/annotation-queues)
+- Build [datasets](/docs/evaluation/experiments/datasets) from real conversations and run [experiments](/docs/evaluation/experiments/experiments-via-ui) against them
+
+</Steps>
+
+## Manage the connection
+
+- **Disable** pauses trace and score export while keeping the stored keys, and **Enable** resumes it. Neither action re-runs verification.
+- **Rotating keys**: click a stored key to replace it, paste the new pair, and choose **Save & enable** to verify and persist it.
+- ClickHouse Agents re-verifies the saved credentials when the settings page loads and whenever you change the destination, so a revoked key surfaces as a failed connection.
+
+## Troubleshooting
+
+**There is no Langfuse section in Settings.** The setting is admin-only, so check that your user is an organization admin.
+
+**"Langfuse rejected these keys."** Either the destination does not match your project's region, or the public and secret key are not from the same project. Copy both keys again from the project settings page and confirm the region.
+
+**"Langfuse denied access."** The keys reached Langfuse but were refused. Check that you are using project API keys (`pk-lf-…` / `sk-lf-…`) rather than an organization-level key, and that the project is still active.
+
+**"Connection failed" but traces are arriving.** The status reflects a one-time verification ping. If traces continue to show up in Langfuse, the export path is healthy — retry the check later.
+
+**No traces after enabling.** Only conversations started after you enabled the connection are traced. Send a new message and reload the Langfuse **Tracing** view.
+
+**Feedback does not show up as a score.** Feedback scores are attached to the trace of the assistant message that was rated. Open that trace and check its **Scores** tab rather than looking for a separate trace.
+
+## Learn more
+
+- [ClickHouse Agents documentation](https://clickhouse.com/docs/cloud/features/ai-ml/agents) — Building and running agents in ClickHouse Cloud
+- [Agentic Data Stack](/integrations/other/agentic-data-stack) — Self-host LibreChat, ClickHouse, and Langfuse together
+- [LibreChat integration](/integrations/other/librechat) — Add Langfuse to a self-managed LibreChat instance
+- [Self-host Langfuse](/self-hosting) — Deploy Langfuse on your own infrastructure

--- a/content/integrations/other/meta.json
+++ b/content/integrations/other/meta.json
@@ -2,6 +2,7 @@
   "title": "Other",
   "pages": [
     "agentic-data-stack",
+    "clickhouse-agents",
     "cognee",
     "everos",
     "exa",


### PR DESCRIPTION
Adds a dedicated integration page for **ClickHouse Agents** — the managed LibreChat / agentic analytics service in ClickHouse Cloud — covering its built-in Langfuse connection.

Requested by Marc in the `#langfuse` thread on the ClickHouse Agents ↔ Langfuse rollout: a page focused on ClickHouse Agents, separate from LibreChat.

## Why

An org admin adds Langfuse keys under **Settings → Langfuse** and every agent run in that org is traced to their own project — no code, no deployment changes. That flow wasn't documented anywhere. The existing [LibreChat](https://langfuse.com/integrations/other/librechat) and [Agentic Data Stack](https://langfuse.com/integrations/other/agentic-data-stack) pages only cover self-managed setups configured with env vars, which doesn't apply to a managed multi-tenant deployment.

## What changed

- **New page** `content/integrations/other/clickhouse-agents.mdx` — what gets traced (agent runs, model calls, ClickHouse MCP / code-interpreter tool calls, thumbs up/down as `user-feedback` scores, org attribution tags), how it works, the admin settings flow with the three Langfuse Cloud destinations, connection management, and troubleshooting keyed to the actual in-app error strings.
- **Registered** in `content/integrations/other/meta.json` (MDX page — no `_routes.json` entry, no cookbook build needed).
- **Cross-links**: added to the Learn More list on the Agentic Data Stack page and to the homepage integrations grid.
- **Logo**: reuses the existing `/images/integrations/clickhouse_icon.svg`.

## Where the content came from

clickhouse.com/docs has no Langfuse section yet, so every step is sourced from the merged LibreChat implementation rather than partner docs:

| Detail | Source |
| --- | --- |
| UI flow, status + error strings | `danny-avila/LibreChat#14108`, `client/src/locales/en/translation.json` |
| `eu` / `us` / `jp` destinations | `packages/api/src/langfuse/tenantDestinations.ts` |
| Admin-only visibility conditions | `packages/api/src/langfuse/policy.ts` |
| Encrypted secret storage, masked keys | `danny-avila/LibreChat#14107` |
| `user-feedback` score from thumbs up/down | `danny-avila/LibreChat#13544` |
| `tenant:<id>` tag + `librechat.tenant.id` metadata | `danny-avila/LibreChat#13808` |
| Fanout / OTLP export mechanism | `danny-avila/LibreChat#13872`, `otel/langfuse-fanout/README.md` |

## Reviewer notes

**The page is written as generally available, with no beta or gating language.** That was a deliberate call, but two things point the other way: the feature is still behind a sysadmin feature toggle on prod as of this week, and the in-app panel itself says *"This feature is in beta."* ClickHouse's own Agents docs also carry a beta banner. Worth timing the merge with the rollout, or adding a one-line callout if it slips.

No screenshots or example-trace link — I couldn't run this end-to-end (needs an org with the toggle on), so the trace structure is described in prose, matching the existing developer-tools pages. This also avoids the missing-image `link-check` failure.

The LibreChat page has no link to this one: `content/integrations/other/librechat.mdx` is generated from `cookbook/integration_librechat.ipynb`, so adding it means editing the notebook and running the ~10 min `scripts/update_cookbook_docs.sh`. Left out of this PR — happy to do it as a follow-up.

## Verification

- Renders clean on the dev server — `<Steps>`, `<Callout>`, and the region table all fine, no console errors, sidebar entry appears under **Other**
- All 10 internal links return 200
- `prettier --check` passes on all four files
- `scripts/check-h1-headings.js` passes
- `scripts/copy_md_sources.js` confirms the Callout text survives into `public/md-src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no application logic, auth, or data handling changes.
> 
> **Overview**
> Adds documentation for **ClickHouse Cloud’s managed ClickHouse Agents** product and its built-in Langfuse connection (admin UI + OTLP), distinct from self-hosted LibreChat / Agentic Data Stack env-var setup.
> 
> A new **`clickhouse-agents.mdx`** page covers what is traced (runs, model/tool calls, `user-feedback` scores, org tags), EU/US/Japan destinations, connection management, and troubleshooting aligned with in-app errors. The page is registered in **`meta.json`**, linked from **Agentic Data Stack** Learn More, and surfaced on the homepage integrations marquee as **ClickHouse Agents**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58933d77d9d1c844602b9814673d1220cf7e891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated ClickHouse Agents integration guide and registers it in the integration sidebar, homepage grid, and related Agentic Data Stack documentation.

- Documents traced data, organization-level setup, connection management, and troubleshooting.
- Adds navigation and cross-links for the new integration page.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation should be corrected before merging because it currently directs self-hosted users into a setup flow they cannot complete.

The new page offers self-hosting in its project-creation step, but the following destination selector documents only fixed Langfuse Cloud endpoints and no custom URL.

**Files Needing Attention:** content/integrations/other/clickhouse-agents.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/integrations/other/clickhouse-agents.mdx:37
**Self-hosted setup has no destination**

When an organization admin follows the documented self-hosting option, the subsequent destination step offers only EU, US, and Japan Langfuse Cloud endpoints and no custom URL, so the admin cannot connect the self-hosted instance or complete the documented setup flow.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add ClickHouse Agents integration ..."](https://github.com/langfuse/langfuse-docs/commit/b58933d77d9d1c844602b9814673d1220cf7e891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51085287)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Cookbook and Integrations Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/cookbook-integrations.md)

<!-- /greptile_comment -->