### PR TITLE
Improve wording in OpenAI Agents example

### DIFF
--- a/content/integrations/frameworks/openai-agents.mdx
+++ b/content/integrations/frameworks/openai-agents.mdx
@@ -10,9 +10,9 @@ category: Integrations
 
 # Trace the OpenAI Agents SDK with Langfuse
 
-This notebook demonstrates how to **integrate Langfuse** into your **OpenAI Agents** workflow to monitor, debug and evaluate your AI agents.
+This notebook demonstrates how to **integrate Langfuse** into your **OpenAI Agents** workflow to monitor, debug, and evaluate your AI agents.
 
-> **What is the OpenAI Agents SDK?**: The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) is a lightweight, open-source framework that lets developers build AI agents and orchestrate multi-agent workflows. It provides building blocks—such as tools, handoffs, and guardrails to configure large language models with custom instructions and integrated tools. Its Python-first design supports dynamic instructions and function tools for rapid prototyping and integration with external systems.
+> **What is the OpenAI Agents SDK?**: The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) is a lightweight, open-source framework that lets developers build AI agents and orchestrate multi-agent workflows. It provides building blocks—such as tools, handoffs, and guardrails—to configure large language models (LLMs) with custom instructions and integrated tools. Its Python-first design supports dynamic instructions and function tools for rapid prototyping and integration with external systems.
 
 > **What is Langfuse?**: [Langfuse](https://langfuse.com/) is an open-source observability platform for AI agents. It helps you visualize and monitor LLM calls, tool usage, cost, latency, and more.
 
@@ -37,7 +37,7 @@ os.environ.setdefault("LANGFUSE_SECRET_KEY", "sk-lf-...");
 os.environ.setdefault("LANGFUSE_BASE_URL", "https://cloud.langfuse.com"); # 🇪🇺 EU region
 # Other Langfuse data regions include 🇺🇸 US: https://us.cloud.langfuse.com, 🇯🇵 Japan: https://jp.cloud.langfuse.com and ⚕️ HIPAA: https://hipaa.cloud.langfuse.com
 
-# Your openai key
+# Your OpenAI API key
 os.environ.setdefault("OPENAI_API_KEY", "sk-proj-...");
 ```
 
@@ -118,7 +118,7 @@ spanish_agent = Agent(
 
 english_agent = Agent(
     name="English agent",
-    instructions="You only speak English",
+    instructions="You only speak English.",
 )
 
 triage_agent = Agent(
@@ -197,7 +197,7 @@ Each child call is represented as a sub-span under the top-level **Joke workflow
 
 ## Link Langfuse Prompt
 
-If you manage your prompt with [Langfuse Prompt Management](https://langfuse.com/docs/prompt-management/overview), you can link the used prompt to the trace by setting up an OTel Span processor.
+If you manage your prompt with [Langfuse Prompt Management](https://langfuse.com/docs/prompt-management/overview), you can link the used prompt to the trace by setting up an OTel span processor.
 
 <Callout type="info" emoji="⚠️">
 **Limitation:** This method links the Langfuse Prompt to all generation spans in the trace that start with the defined string (see next cell).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Text-only MDX changes with no runtime, API, or security impact.
> 
> **Overview**
> Polishes copy in the **OpenAI Agents** integration doc (`openai-agents.mdx`) without changing behavior or code samples beyond punctuation.
> 
> Edits include Oxford comma in the intro (“debug, and evaluate”), clearer SDK description (em dash around “guardrails”, **LLMs** acronym), capitalization of “OpenAI API key” in env setup, a trailing period on the English agent instructions, and lowercasing “OTel span processor” in the prompt-linking section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09a7cce62c5b5fca31a4ec05735b53ddb9ff18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves wording, punctuation, capitalization, and terminology in the OpenAI Agents integration example.
- Clarifies the OpenAI Agents SDK description and expands the LLM acronym.
- Improves comments and punctuation in the Python example.
- Standardizes “OTel span processor” terminology.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The changes are limited to clear editorial refinements and punctuation that preserve the MDX structure and executable example behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["Improve wording in OpenAI Agents example"](https://github.com/langfuse/langfuse-docs/commit/b09a7cce62c5b5fca31a4ec05735b53ddb9ff18a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51171228)</sub>

<!-- /greptile_comment -->