### PR TITLE
docs(glossary): add scorer, grader, judge synonyms to Evaluator

### DIFF
--- a/lib/glossary-data.js
+++ b/lib/glossary-data.js
@@ -199,7 +199,7 @@ const TERMS = [
       "Observation",
       "Evaluation Method",
     ],
-    synonyms: ["Observation Type"],
+    synonyms: ["Scorer", "Grader", "Judge"],
   },
   {
     term: "Event",


### PR DESCRIPTION
Adds `Scorer`, `Grader`, and `Judge` as synonyms on the Evaluator glossary entry (`lib/glossary-data.js`), replacing the inaccurate `Observation Type` synonym.

"Observation Type" is the category the term belongs to, not a synonym, and the definition already states "An observation type...". The three added terms are genuine synonyms readers use, so searches for scorer, grader, or judge now surface the Evaluator entry. They also render beside the term in the UI and as "Also known as:" in the Markdown/PDF output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only glossary metadata with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Evaluator** glossary entry so its `synonyms` list uses **Scorer**, **Grader**, and **Judge** instead of **Observation Type**.
> 
> That swap improves glossary search and the “Also known as” UI/export for terms readers actually use, without changing definitions or other entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6767c5b26bea2204b49173fc96674731f7da72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Evaluator glossary entry to use accurate synonyms so users searching for scorer, grader, or judge can discover it.
- Replaces the inaccurate “Observation Type” synonym with “Scorer,” “Grader,” and “Judge.”
- Updates synonym text rendered in the glossary UI and Markdown/PDF output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new synonym strings match the existing glossary data shape, are handled correctly by search and output rendering, and do not collide with other glossary terms or synonyms.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(glossary): add scorer, grader, judg..."](https://github.com/langfuse/langfuse-docs/commit/cf6767c5b26bea2204b49173fc96674731f7da72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51251187)</sub>

**Context used:**

- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->