### PR TITLE
fix(home): improve Onboard with AI prompt text wrapping

### DIFF
--- a/components/home/OnboardWithAIButton.tsx
+++ b/components/home/OnboardWithAIButton.tsx
@@ -13,9 +13,8 @@ import {
 } from "@/components/ui";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
 
-const AI_ONBOARDING_PROMPT = `Install the Langfuse Agent Skill from github.com/langfuse/skills
-and use it to add tracing to this application with Langfuse
-following best practices.`;
+const AI_ONBOARDING_PROMPT =
+  "Install the Langfuse Agent Skill from github.com/langfuse/skills and use it to add tracing to this application with Langfuse following best practices.";
 
 async function copyPromptToClipboard(sourceElement: HTMLElement) {
   if (typeof navigator !== "undefined" && navigator.clipboard) {
@@ -108,7 +107,7 @@ export function OnboardWithAIButton() {
             </Button>
           </div>
 
-          <pre className="max-h-[220px] overflow-auto whitespace-pre-wrap rounded-[2px] border border-line-structure bg-surface-1 p-3 font-mono text-[12px] leading-[160%] text-text-secondary">
+          <pre className="max-h-[220px] overflow-auto whitespace-pre-wrap text-pretty break-words rounded-[2px] border border-line-structure bg-surface-1 p-3 font-mono text-[12px] leading-[160%] text-text-secondary">
             <code ref={promptRef}>{AI_ONBOARDING_PROMPT}</code>
           </pre>
         </div>


### PR DESCRIPTION
## Summary

* Fixes awkward line wrapping in the home hero **Onboard with AI** popover ([LFMKT-2195](<https://linear.app/langfuse/issue/LFMKT-2195>)).
* The prompt previously included hard newlines, which combined with `whitespace-pre-wrap` left short orphan lines (e.g. `Langfuse` alone).
* Uses a single-line prompt (matching the Get Started section copy) and adds `text-pretty` / `break-words` so wrapping follows the container width more evenly.

## Before

Hard breaks left `Langfuse` on its own line before `following best practices.`

## After

Desktop:

[Onboard with AI popover wrapping on desktop](<https://cursor.com/agents/bc-937dc972-5ada-4185-a1e1-297725f4715c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboard-ai-desktop.webp>)

Mobile (\~400px):

[Onboard with AI popover wrapping on mobile](<https://cursor.com/agents/bc-937dc972-5ada-4185-a1e1-297725f4715c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboard-ai-mobile.webp>)

## Test plan

- [X] Open the home page and click **Onboard with AI**
- [X] Confirm the prompt text wraps evenly in the popover (no orphan single-word lines)
- [X] Spot-check at a narrow viewport (\~400px) and desktop width
- [X] Confirm **Copy** still copies the full prompt text

To show artifacts inline, [enable](<https://cursor.com/dashboard/cloud-agents#team-pull-requests>) in settings.

Linear Issue: [LFMKT-2195](https://linear.app/clickhouse/issue/LFMKT-2195/text-wrap-looks-off)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

<details><summary>Greptile Summary</summary>

The PR removes hard-coded line breaks from the “Onboard with AI” prompt and adds balanced, word-safe wrapping styles to its popover.

* Converts the onboarding prompt to a single-line string matching the related Get Started copy.
* Adds `text-pretty` and `break-words` while preserving the full prompt in both clipboard paths.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge with no actionable issues identified.

The visual wrapping changes do not alter the underlying prompt, and both the Clipboard API and fallback selection path continue to copy the complete single-line text.

</details>

Reviews (1): Last reviewed commit: ["fix(home): improve Onboard with AI promp..."](<https://github.com/langfuse/langfuse-docs/commit/5ab4367b1daab8afcf09aa236d7e95cd0ebdf0bd>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=51731005>)