### PR TITLE
docs(experiments): clarify dataset run item reads

### DIFF
--- a/content/docs/evaluation/experiments/data-model.mdx
+++ b/content/docs/evaluation/experiments/data-model.mdx
@@ -131,7 +131,7 @@ direction LR
 | `traceId`       | string | Yes      | ID of the trace to link to this run        |
 | `observationId` | string | No       | ID of the observation to link to this run  |
 
-Langfuse currently assumes that experiments do not contain repetitions: each dataset item appears once per experiment. Accordingly, reads surface at most one `DatasetRunItem` per `datasetItemId` within a dataset run. Repetition support is tracked in [#5855](https://github.com/langfuse/langfuse/issues/5855).
+Langfuse currently assumes that experiments do not contain repetitions: each dataset item appears once per experiment. Accordingly, reads surface at most one experiment item per dataset item within an experiment. Repetition support is tracked in [#5855](https://github.com/langfuse/langfuse/issues/5855).
 
 <Callout type="info">
 Most of the time, we recommend that DatasetRunItems reference TraceIDs directly. The reference to ObservationID exists for backwards compatibility with older SDK versions.

--- a/content/docs/evaluation/experiments/data-model.mdx
+++ b/content/docs/evaluation/experiments/data-model.mdx
@@ -131,6 +131,8 @@ direction LR
 | `traceId`       | string | Yes      | ID of the trace to link to this run        |
 | `observationId` | string | No       | ID of the observation to link to this run  |
 
+Within a dataset run, Langfuse currently exposes at most one `DatasetRunItem` per `datasetItemId`. Multiple run items for the same dataset item may be accepted on write, but only one is returned when reading the run.
+
 <Callout type="info">
 Most of the time, we recommend that DatasetRunItems reference TraceIDs directly. The reference to ObservationID exists for backwards compatibility with older SDK versions.
 </Callout>

--- a/content/docs/evaluation/experiments/data-model.mdx
+++ b/content/docs/evaluation/experiments/data-model.mdx
@@ -131,7 +131,7 @@ direction LR
 | `traceId`       | string | Yes      | ID of the trace to link to this run        |
 | `observationId` | string | No       | ID of the observation to link to this run  |
 
-Within a dataset run, Langfuse currently exposes at most one `DatasetRunItem` per `datasetItemId`. Multiple run items for the same dataset item may be accepted on write, but only one is returned when reading the run.
+Within a dataset run, Langfuse currently exposes at most one `DatasetRunItem` per `datasetItemId`. Multiple run items for the same dataset item may be accepted on write, but only one is returned when reading the run; repeated executions are not currently supported ([#5855](https://github.com/langfuse/langfuse/issues/5855)).
 
 <Callout type="info">
 Most of the time, we recommend that DatasetRunItems reference TraceIDs directly. The reference to ObservationID exists for backwards compatibility with older SDK versions.

--- a/content/docs/evaluation/experiments/data-model.mdx
+++ b/content/docs/evaluation/experiments/data-model.mdx
@@ -131,7 +131,7 @@ direction LR
 | `traceId`       | string | Yes      | ID of the trace to link to this run        |
 | `observationId` | string | No       | ID of the observation to link to this run  |
 
-Within a dataset run, Langfuse currently exposes at most one `DatasetRunItem` per `datasetItemId`. Multiple run items for the same dataset item may be accepted on write, but only one is returned when reading the run; repeated executions are not currently supported ([#5855](https://github.com/langfuse/langfuse/issues/5855)).
+Langfuse currently assumes that experiments do not contain repetitions: each dataset item appears once per experiment. Accordingly, reads surface at most one `DatasetRunItem` per `datasetItemId` within a dataset run. Repetition support is tracked in [#5855](https://github.com/langfuse/langfuse/issues/5855).
 
 <Callout type="info">
 Most of the time, we recommend that DatasetRunItems reference TraceIDs directly. The reference to ObservationID exists for backwards compatibility with older SDK versions.


### PR DESCRIPTION
## Summary
- Document that a dataset run exposes at most one `DatasetRunItem` per `datasetItemId`.
- Clarify that duplicate run items may be accepted on write but only one is returned when reading the run.

Fixes LFE-14919.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or API behavior changes in this PR.
> 
> **Overview**
> **Documents experiment repetition behavior** for `DatasetRunItem` in the experiments data model page.
> 
> Adds a note after the `DatasetRunItem` attribute table stating that Langfuse currently treats experiments as **one run item per dataset item**—reads return **at most one** experiment item per `datasetItemId` within a run—and points to [#5855](https://github.com/langfuse/langfuse/issues/5855) for future repetition support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee8c992d60789ef62236aade4abee4b90e2bda1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the one-item-per-dataset-item behavior of experiment reads and links to the repetition-support request.
- Adds the current no-repetition assumption to the DatasetRunItem data model.
- States that reads expose at most one experiment item for each dataset item.
- Links to the issue tracking repetition support.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge, though it should explicitly mention that duplicate writes may be accepted before reads collapse them to one visible item.

The added text accurately describes the read result but leaves readers with the misleading impression that repetition is prevented when items are written.

**Files Needing Attention:** content/docs/evaluation/experiments/data-model.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/evaluation/experiments/data-model.mdx:134
**Duplicate writes remain undocumented**

The paragraph describes read-side deduplication but omits that multiple `DatasetRunItem` writes for the same dataset item can be accepted. Readers can therefore mistake this for write-time uniqueness and remain unaware that only one accepted item will be visible when the run is read.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): use experiment item t..."](https://github.com/langfuse/langfuse-docs/commit/9ee8c992d60789ef62236aade4abee4b90e2bda1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51765377)</sub>

**Context used:**

- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->