### PR TITLE
docs(self-hosting): add dedicated OSS newsletter page

### DIFF
--- a/components-mdx/self-host-update-signup.mdx
+++ b/components-mdx/self-host-update-signup.mdx
@@ -2,7 +2,7 @@ import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
 
 <Callout type="info" emoji="✉️">
 
-**Langfuse OSS updates** — get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no marketing or spam.
+**[Langfuse OSS updates](/self-hosting/oss-newsletter)** — get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no marketing or spam.
 
 <ProductUpdateSignup list="oss" source="self-host" className="mt-3 mb-1 max-w-sm" />
 

--- a/components-mdx/self-host-update-signup.mdx
+++ b/components-mdx/self-host-update-signup.mdx
@@ -2,7 +2,7 @@ import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
 
 <Callout type="info" emoji="✉️">
 
-**[Langfuse OSS updates](/self-hosting/oss-newsletter)** — get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no marketing or spam.
+**[Langfuse OSS updates](/self-hosting/oss-newsletter)** — get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no spam.
 
 <ProductUpdateSignup list="oss" source="self-host" className="mt-3 mb-1 max-w-sm" />
 

--- a/content/self-hosting/meta.json
+++ b/content/self-hosting/meta.json
@@ -5,6 +5,7 @@
     "index",
     "license-key",
     "troubleshooting-and-faq",
+    "oss-newsletter",
     "configuration",
     "deployment",
     "security",

--- a/content/self-hosting/meta.json
+++ b/content/self-hosting/meta.json
@@ -5,7 +5,6 @@
     "index",
     "license-key",
     "troubleshooting-and-faq",
-    "oss-newsletter",
     "configuration",
     "deployment",
     "security",

--- a/content/self-hosting/oss-newsletter.mdx
+++ b/content/self-hosting/oss-newsletter.mdx
@@ -1,0 +1,37 @@
+---
+title: Langfuse OSS newsletter (self-hosting updates)
+sidebarTitle: OSS Newsletter
+description: Subscribe to the Langfuse OSS newsletter to get an email when we ship new releases, breaking changes, and upgrade guides for self-hosted Langfuse.
+label: "Version: v4"
+---
+
+# Langfuse OSS newsletter
+
+Get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no marketing or spam.
+
+import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
+
+<ProductUpdateSignup
+  list="oss"
+  source="oss-newsletter-page"
+  className="mt-6 mb-8"
+/>
+
+## What you get
+
+- **New releases**: notable features and improvements that are relevant when you run Langfuse yourself.
+- **Breaking changes and upgrade guides**: heads-up before a major version, with a pointer to the [migration guide](/self-hosting/upgrade).
+- **Deployment changes**: updates to the [Helm chart](/self-hosting/deployment/kubernetes-helm), Docker Compose, and Terraform modules, as well as new configuration options.
+
+Emails are sent when there is something worth sharing, not on a fixed schedule. You can unsubscribe from any email.
+
+## Other ways to follow releases
+
+If you prefer not to receive emails, you can follow self-hosting releases through these channels instead:
+
+- **GitHub releases**: watch the [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) repository or subscribe to the [releases Atom feed](https://github.com/langfuse/langfuse/releases.atom). Langfuse uses tagged semver releases ([versioning policy](/self-hosting/upgrade/versioning)).
+- **Changelog**: all product updates are published on the [Langfuse changelog](/changelog).
+
+## Looking for the product newsletter?
+
+The OSS newsletter covers self-hosting. If you are looking for the monthly Langfuse product update instead, which covers all Langfuse features including Langfuse Cloud, subscribe on the [changelog page](/changelog).

--- a/content/self-hosting/oss-newsletter.mdx
+++ b/content/self-hosting/oss-newsletter.mdx
@@ -7,7 +7,7 @@ label: "Version: v4"
 
 # Langfuse OSS newsletter
 
-Get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no marketing or spam.
+Get an email when we ship important features and new releases for self-hosted (open source) Langfuse. Self-hosting updates only, no spam.
 
 import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
 
@@ -16,22 +16,3 @@ import { ProductUpdateSignup } from "@/components/ProductUpdateSignup";
   source="oss-newsletter-page"
   className="mt-6 mb-8"
 />
-
-## What you get
-
-- **New releases**: notable features and improvements that are relevant when you run Langfuse yourself.
-- **Breaking changes and upgrade guides**: heads-up before a major version, with a pointer to the [migration guide](/self-hosting/upgrade).
-- **Deployment changes**: updates to the [Helm chart](/self-hosting/deployment/kubernetes-helm), Docker Compose, and Terraform modules, as well as new configuration options.
-
-Emails are sent when there is something worth sharing, not on a fixed schedule. You can unsubscribe from any email.
-
-## Other ways to follow releases
-
-If you prefer not to receive emails, you can follow self-hosting releases through these channels instead:
-
-- **GitHub releases**: watch the [langfuse/langfuse](https://github.com/langfuse/langfuse/releases) repository or subscribe to the [releases Atom feed](https://github.com/langfuse/langfuse/releases.atom). Langfuse uses tagged semver releases ([versioning policy](/self-hosting/upgrade/versioning)).
-- **Changelog**: all product updates are published on the [Langfuse changelog](/changelog).
-
-## Looking for the product newsletter?
-
-The OSS newsletter covers self-hosting. If you are looking for the monthly Langfuse product update instead, which covers all Langfuse features including Langfuse Cloud, subscribe on the [changelog page](/changelog).

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -18,6 +18,10 @@ function replaceComponentsWithMarkdown(fileContent) {
       /<ManualGuideList\b([\s\S]*?)\/>/g,
       (_, attributes) => `\n${renderManualGuideList(attributes)}\n`,
     )
+    .replace(
+      /<ProductUpdateSignup\b([\s\S]*?)\/>/g,
+      (_, attributes) => `\n${renderProductUpdateSignup(attributes)}\n`,
+    )
     .replace(/<Glossary\s*\/>/g, () => `\n${renderGlossary()}\n`)
     .replace(
       /<JudgePromptExample\s*\/>/g,
@@ -188,6 +192,15 @@ function renderJudgePromptExample() {
     "one of: pass, fail, unknown.",
     "```",
   ].join("\n");
+}
+
+// The email sign-up form has no Markdown equivalent, so point Markdown/PDF
+// readers to the page where they can subscribe.
+function renderProductUpdateSignup(attributes) {
+  const list = extractAttributeString(attributes, "list");
+  return list === "oss"
+    ? "Subscribe to the Langfuse OSS newsletter at https://langfuse.com/self-hosting/oss-newsletter."
+    : "Subscribe to the Langfuse product update newsletter at https://langfuse.com/changelog.";
 }
 
 function renderManualGuideCallout(attributes, isJapanese) {


### PR DESCRIPTION
Adds a standalone docs page for the OSS (self-hosting) newsletter at `/self-hosting/oss-newsletter`, in addition to the sign-up boxes already embedded in the self-hosting docs.

## What changed

- **`content/self-hosting/oss-newsletter.mdx`** (new) — the page itself: intro, the sign-up form, "What you get", and other ways to follow releases (GitHub releases + Atom feed, changelog, versioning policy), plus a pointer to the general product newsletter for readers who land here by mistake. Uses `source="oss-newsletter-page"` so signups from this page are attributable in Loops. No `.gif` — I left out the GitHub-watch animation that the older self-hosting pages still embed.
- **`content/self-hosting/meta.json`** — registered as the last flat page in the section, so it sits after "Troubleshooting & FAQ" and above the folder groups. Sidebar label is "OSS Newsletter".
- **`components-mdx/self-host-update-signup.mdx`** — the shared callout's "Langfuse OSS updates" lead-in now links to the new page. The three pages that embed the box (self-hosting overview, upgrade overview, versioning) become discovery paths rather than duplicating the explanation.
- **`lib/markdown-component-renderers.js`** — adds a renderer for `ProductUpdateSignup`. The form previously disappeared entirely from `public/md-src/` and PDF output, so markdown consumers had no way to subscribe. It now renders as a subscribe URL, list-aware (`list="oss"` → the new page, otherwise the changelog). This affects every page using the component, including `/docs`, `/docs/roadmap`, and the changelog.

## Notes for reviewers

- The renderer change touches markdown output for ~8 pages beyond self-hosting. Worth a glance at whether the wording fits on the general-newsletter pages too.
- The page has no `<AvailabilityBanner />` — it isn't a product feature, so plan/deployment availability doesn't apply.

## Verified

- `/self-hosting/oss-newsletter`, `/self-hosting`, `/self-hosting/upgrade`, `/self-hosting/upgrade/versioning` all return 200 on the dev server; new page renders with correct sidebar placement, prev/next, and no console errors.
- `node scripts/copy_md_sources.js` output checked for the new page and `self-hosting/upgrade.md` — all copy and links preserved.
- `node scripts/check-h1-headings.js` and `pnpm run format:check` pass.
- The form was not submitted — that would create a real contact in the Loops OSS list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and static export text only; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds a standalone **OSS newsletter** docs page at `/self-hosting/oss-newsletter` with the existing `ProductUpdateSignup` form (`list="oss"`, `source="oss-newsletter-page"`).
> 
> The shared self-hosting signup callout now links **Langfuse OSS updates** to that page and tightens the copy (drops “marketing” wording).
> 
> For **Markdown/PDF** exports, `ProductUpdateSignup` is no longer stripped: it becomes a subscribe link—OSS list → the new page, otherwise → the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3a3a5be25e9f89b7dcdfb34587c941bced4a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a dedicated self-hosted OSS newsletter page and links existing self-hosting signup callouts to it.

- Registers the page in the self-hosting sidebar.
- Adds release-following and product-newsletter guidance.
- Preserves newsletter signup information in generated Markdown and PDF content by rendering signup components as destination URLs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete defects identified in the changed paths.

The new page is registered consistently, current signup usages map to the correct newsletter destinations, and the renderer handles every existing ProductUpdateSignup syntax used by the generated Markdown pipeline.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): add dedicated OSS ne..."](https://github.com/langfuse/langfuse-docs/commit/b00cc2567abdaa0af20c7776413f7b20c2119606) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51777052)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->