### PR TITLE
Replace LLM engineering loop with AI engineering loop on homepage

### DIFF
--- a/components/home/RiveSection.tsx
+++ b/components/home/RiveSection.tsx
@@ -29,7 +29,7 @@ type RiveLabel = {
 };
 
 const OVERVIEW: RiveLabel = {
-  heading: "The full LLM engineering loop",
+  heading: "The full AI engineering loop",
   body: "See how observability, prompts, evals, experiments, and human feedback work together.",
 };
 

--- a/components/home/layout/HomeAside.tsx
+++ b/components/home/layout/HomeAside.tsx
@@ -19,7 +19,7 @@ const HOME_SECTIONS: TocItem[] = [
   { id: "overview", title: "Overview", depth: 2, url: "#overview" },
   {
     id: "llm-engineering-loop",
-    title: "LLM engineering loop",
+    title: "AI engineering loop",
     depth: 2,
     url: "#llm-engineering-loop",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the homepage "On this page" sidebar TOC entry from **LLM engineering loop** to **AI engineering loop**
- Update the matching section header from **The full LLM engineering loop** to **The full AI engineering loop**

Section anchor `#llm-engineering-loop` is unchanged for existing link stability.

## Screenshots
Sidebar TOC:
[Sidebar shows AI engineering loop](https://cursor.com/agents/bc-4c89b09b-1a61-44fd-b1c8-0094e220653c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsidebar-ai-engineering-loop.webp)

Section header:
[Header shows The full AI engineering loop](https://cursor.com/agents/bc-4c89b09b-1a61-44fd-b1c8-0094e220653c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fheader-ai-engineering-loop.webp)

## Test plan
- [x] Open the homepage and confirm the sidebar TOC shows "AI engineering loop"
- [x] Confirm the Rive section header shows "The full AI engineering loop"
- [x] Confirm no remaining "LLM engineering loop" strings on the homepage for these UI locations

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-89](https://linear.app/clickhouse/issue/LF-89/replace-llm-engineering-loop-with-ai-engineering-loop)

<div><a href="https://cursor.com/agents/bc-4c89b09b-1a61-44fd-b1c8-0094e220653c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c89b09b-1a61-44fd-b1c8-0094e220653c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently renames the homepage’s “LLM engineering loop” display text to “AI engineering loop” while preserving the existing stable anchor.

- Updates the Rive section heading.
- Updates the corresponding homepage sidebar entry.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The two display-text changes are consistent, and the existing section anchor remains unchanged for link compatibility.
</details>

<sub>Reviews (1): Last reviewed commit: ["Replace LLM engineering loop with AI eng..."](https://github.com/langfuse/langfuse-docs/commit/ae13f2472cd7c63f9dc2b4859858107f747bfa1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51899132)</sub>

<!-- /greptile_comment -->