### PR TITLE
docs: add academy page on choosing what to evaluate

### DIFF
--- a/content/academy/evaluate/choosing-what-to-evaluate.mdx
+++ b/content/academy/evaluate/choosing-what-to-evaluate.mdx
@@ -31,7 +31,7 @@ export const references = [
 # Choosing what to evaluate
 
 "I have traces, how do I set up evals?" is a question we hear all the time.
-We'll tackle it here, from which qualities deserve a standing metric to what role does each metric plays.
+We'll tackle it here, from which qualities deserve a standing metric to what role each metric plays.
 
 ## Three kinds of metrics [#the-three-roles]
 
@@ -41,11 +41,11 @@ In the end, you'll end up with a set of metrics that each fall in one of the fol
 | ----------------------- | ------------------------------------------------------- | ---------------------------------------- |
 | **Goal metrics**        | Is quality improving on the things we are building for? | Error analysis, product goals            |
 | **Guardrails**          | Did we regress on something that must never break?      | Requirements, compliance, past incidents |
-| **Operational metrics** | What does it cost, how many requests per hour           | Tracing, for free                        |
+| **Operational metrics** | What does it cost, and how many requests per hour?      | Tracing, for free                        |
 
 A good setup uses a mix of the three together. Goal metrics are the ones you actively push up, guardrails catch the failures you can't afford even once, and operational metrics give you more insight into the system.
 
-**The less metrics you can keep without feeling like you're missing visibility, the better:**
+**The fewer metrics you can keep without feeling like you're missing visibility, the better:**
 
 - every metric is an extra evaluator/dataset to run and maintain
 - when everything is important, nothing is<Ref refs={references} id="hamel-field-guide" />
@@ -146,7 +146,7 @@ To start, bootstrap with two generic scores: a free-text note describing what ha
 A metric set describes your application as it is today. Three habits keep it current:
 
 - **Re-run error analysis after significant changes.** Prompt rewrites, model swaps, and new features might change the failure distribution; [when to run it](/academy/monitoring/error-analysis#when-to-run-it) is covered on the error analysis page.
-- **Retire metrics that stopped catching things.** With an exception of guardrail checks, a score that sits at 100% for months carries no information and you can most likely drop it.
+- **Retire metrics that stopped catching things.** With the exception of guardrail checks, a score that sits at 100% for months carries no information and you can most likely drop it.
 - **Watch the metrics you optimize.** Goodhart's law applies here:<Ref refs={references} id="goodhart-variants" /> when you tune prompts against certain metrics, you can overfit at some point. It's important to [re-validate against new human labels](/guides/llm-as-a-judge-calibration-skill) from time to time.
 
 ## Where to start

--- a/content/academy/evaluate/choosing-what-to-evaluate.mdx
+++ b/content/academy/evaluate/choosing-what-to-evaluate.mdx
@@ -30,8 +30,7 @@ export const references = [
 
 # Choosing what to evaluate
 
-"I have traces, how do I set up evals?" is a question we hear all the time.
-We'll tackle it here, from which qualities deserve a standing metric to what role each metric plays.
+"I have traces, how do I set up evals?" is a very common question, and an important one to get right. This page will guide you through choosing the right metrics to evaluate.
 
 ## Three kinds of metrics [#the-three-roles]
 

--- a/content/academy/evaluate/choosing-what-to-evaluate.mdx
+++ b/content/academy/evaluate/choosing-what-to-evaluate.mdx
@@ -1,0 +1,161 @@
+---
+title: Choosing what to evaluate
+sidebarTitle: Choosing what to evaluate
+description: "How to turn observed failures and product goals into a small set of metrics: where evaluation criteria come from, which candidates deserve tracking, and how many metrics you need."
+---
+
+export const references = [
+  {
+    id: "evals-faq",
+    title: "LLM evals FAQ (Hamel Husain & Shreya Shankar)",
+    url: "https://hamel.dev/blog/posts/evals-faq/",
+  },
+  {
+    id: "openai-receipt-inspection",
+    title:
+      "Eval-driven system design: from prototype to production (OpenAI Cookbook)",
+    url: "https://developers.openai.com/cookbook/examples/partners/eval_driven_system_design/receipt_inspection",
+  },
+  {
+    id: "hamel-field-guide",
+    title: "A field guide to rapidly improving AI products (Hamel Husain)",
+    url: "https://hamel.dev/blog/posts/field-guide/",
+  },
+  {
+    id: "goodhart-variants",
+    title: "Categorizing variants of Goodhart's law (Manheim & Garrabrant)",
+    url: "https://arxiv.org/abs/1803.04585",
+  },
+];
+
+# Choosing what to evaluate
+
+"I have traces, how do I set up evals?" is a question we hear all the time.
+We'll tackle it here, from which qualities deserve a standing metric to what role does each metric plays.
+
+## Three kinds of metrics [#the-three-roles]
+
+In the end, you'll end up with a set of metrics that each fall in one of the following categories:
+
+| Role                    | Question it answers                                     | Typical source                           |
+| ----------------------- | ------------------------------------------------------- | ---------------------------------------- |
+| **Goal metrics**        | Is quality improving on the things we are building for? | Error analysis, product goals            |
+| **Guardrails**          | Did we regress on something that must never break?      | Requirements, compliance, past incidents |
+| **Operational metrics** | What does it cost, how many requests per hour           | Tracing, for free                        |
+
+A good setup uses a mix of the three together. Goal metrics are the ones you actively push up, guardrails catch the failures you can't afford even once, and operational metrics give you more insight into the system.
+
+**The less metrics you can keep without feeling like you're missing visibility, the better:**
+
+- every metric is an extra evaluator/dataset to run and maintain
+- when everything is important, nothing is<Ref refs={references} id="hamel-field-guide" />
+
+<Callout>
+**Your metric set is a living artifact**
+
+Your north star changes over time. Even if you have your evals set up, it's important to keep a recurring process of looking at a sample of your traces manually. You'll discover failures your evals didn't cover yet, or notice that some metrics became less important over time.
+
+</Callout>
+
+## Where candidate metrics come from [#where-criteria-come-from]
+
+The first step towards getting a good metric set is sourcing candidate metrics. These come from two places:
+
+### 1. Observed failures [#observed-failures]
+
+Most of your metrics will come from you going through your traces, discovering how your agent behaves and how you'd like it to behave instead. There's a structured process for translating what you see into metrics to evaluate, called [Error analysis](/academy/monitoring/error-analysis). This should, in most cases, be your default way of deciding on metrics: **write evaluators for errors you discover; don't focus on imaginary ones**.<Ref refs={references} id="evals-faq" />
+
+### 2. Goals and hard constraints [#goals-and-hard-constraints]
+
+There are requirements you know you need to monitor before seeing your agent in action. Compliance rules, safety requirements, and format contracts get an evaluator from day one, even if you have never seen them break. These are often guardrail metrics.
+
+<Callout type="info">
+**Metric catalogs are good for exploration, but tailor them to your product**
+
+Evaluator libraries with ready-made metrics like hallucination, toxicity, or helpfulness measure abstract qualities that may not match how your application fails.<Ref refs={references} id="evals-faq" />
+
+</Callout>
+
+## Which candidates deserve a metric? [#which-candidates-deserve-a-metric]
+
+Not all criteria candidates should be tracked.
+
+### One-time fix or generalization problem? [#fix-first]
+
+Sometimes, an agent fails at something because you didn't specify how you wanted the agent to behave on that aspect. If a simple prompt change resolves a failure mode, just make the change and forget about it. Only keep a metric when a simple prompt change doesn't solve your problem, and you need to continuously track a failure mode over time<Ref refs={references} id="evals-faq" />.
+
+<Tabs items={["Likely one time fixes", "Generalization problems"]}>
+<Tab>
+
+- The output isn't valid JSON
+- The reply uses the wrong date format
+- The response uses markdown on a plain-text channel
+- The bot doesn't disclose it's an AI assistant
+
+</Tab>
+<Tab>
+
+- whether the answer is supported by the retrieved context
+- whether the right context was fetched to answer the question
+- whether the response actually answered the user's request
+- whether the agent picked the right tool and passed the right arguments
+
+</Tab>
+</Tabs>
+
+### Tie every metric to a decision [#tie-every-metric-to-a-decision]
+
+For each metric candidate, determine what the action changes when the metric moves: block the deploy, roll back the prompt, open an investigation. If no action changes, the metric would be noise, and should not be tracked.
+
+<Tabs items={["Conversation length is not specific enough", "Merchant-name extraction fail did not have an impact"]}>
+<Tab>
+
+Conversation length rises both when users are engaged and when they are stuck, so the number moves for unrelated reasons and you can't act on it alone.
+
+</Tab>
+<Tab>
+
+In OpenAI's receipt-processing walkthrough, merchant-name extraction was wrong 85% of the time, but those errors turned out to be uncorrelated with the audit decision the system existed to make, so the team stopped tracking it.<Ref refs={references} id="openai-receipt-inspection" />
+
+</Tab>
+</Tabs>
+
+### Mind the budget [#mind-the-budget]
+
+This one is more helpful to prune once you have set up your evaluators. Some evaluators cost more than others to run:
+
+- Code evaluators are close to free
+- An LLM-as-a-judge evaluator costs money to run, and is also harder to maintain (see [writing good evaluators](/academy/evaluate/writing-evaluators))
+
+If a metric is not that important and is expensive to track, it might be a good decision to scratch it.
+
+## Starting from zero [#starting-from-zero]
+
+Before you have your metric set, you'll need to determine your agent's failure modes. This will help you derive metrics.
+
+To start, bootstrap with two generic scores: a free-text note describing what happened and what seems wrong, and an overall pass/fail. Read 30 to 50 traces with only those, cluster the notes into named failure categories, and then create one boolean score per category. This process is called [error analysis](/academy/monitoring/error-analysis).
+
+<ManualGuideCallout
+  href="/guides/cookbook/error-analysis-llm-applications"
+  topic="Error analysis"
+  lede="The full walkthrough: sample traces, set up the two bootstrap scores in an annotation queue, cluster failure categories, and turn them into score configs."
+/>
+
+## Keeping the set alive [#keeping-the-set-alive]
+
+A metric set describes your application as it is today. Three habits keep it current:
+
+- **Re-run error analysis after significant changes.** Prompt rewrites, model swaps, and new features might change the failure distribution; [when to run it](/academy/monitoring/error-analysis#when-to-run-it) is covered on the error analysis page.
+- **Retire metrics that stopped catching things.** With an exception of guardrail checks, a score that sits at 100% for months carries no information and you can most likely drop it.
+- **Watch the metrics you optimize.** Goodhart's law applies here:<Ref refs={references} id="goodhart-variants" /> when you tune prompts against certain metrics, you can overfit at some point. It's important to [re-validate against new human labels](/guides/llm-as-a-judge-calibration-skill) from time to time.
+
+## Where to start
+
+1. Run [error analysis](/academy/monitoring/error-analysis) if you haven't.
+2. Write down the product goals and hard constraints, and turn each goal into a signal you can observe in traces.
+3. Apply the filters: fix what a prompt change fixes, keep only candidates tied to a decision, and let the judge budget push back.
+4. When you are happy with the set of metrics you assembled, implement the evaluators for it. The deep dive on [writing good evaluators](/academy/evaluate/writing-evaluators) covers how.
+
+## References
+
+<FurtherReading numbered resources={references} />

--- a/content/academy/evaluate/index.mdx
+++ b/content/academy/evaluate/index.mdx
@@ -21,7 +21,7 @@ Most of the time, you start by **manually reviewing outputs** to build intuition
 The rest of this page covers the different kinds of evaluation in detail. In practice, you'll likely end up combining all of them. But the path to a well-functioning automated evaluation setup almost always starts from manual review.
 
 <Callout type="info">
-Manual evaluation is not a one-and-done step. Good production setups incorporate continuous review by human experts to catch new failure modes and keep automated evaluators calibrated.
+Manual evaluation is not a one-and-done step. Good production setups incorporate continuous review by human experts to catch new failure modes and keep automated evaluators calibrated. [Keeping the set alive](/academy/evaluate/choosing-what-to-evaluate#keeping-the-set-alive) covers this cadence.
 </Callout>
 
 <ManualGuideCallout
@@ -82,23 +82,23 @@ The advantage of reference-free evaluators is that they can be applied to unseen
 
 ## In practice
 
-### When to set up evaluators
+### When to set up evaluators [#when-to-set-up-evaluators]
 
-[As mentioned before](#how-evaluation-typically-evolves), you always start by manually reviewing. Once you have done that, the question then becomes: should you set up an automated evaluator for what you found?
-
-Ask yourself whether the issue is a **one-time fix** or a **generalization problem**. If a simple prompt change resolves it, just make the change, there's no need for an evaluator. But if you can clearly identify a failure mode that you want to test for repeatedly across different inputs, that's when setting up an evaluator makes sense.
+[As mentioned before](#how-evaluation-typically-evolves), you always start by manually reviewing. Once you have done that, not every failure you find needs an evaluator: a **one-time fix** you can resolve with a prompt change doesn't, a **generalization problem** you need to catch repeatedly does. [Choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate#fix-first) covers this further.
 
 ### What should you evaluate?
 
 Generic qualities like "helpfulness" or "quality" are tempting starting points, but they rarely produce useful signal. An evaluator that checks a vague criterion will give vague results. The more precisely you can define what "good" or "bad" looks like for your application, the more useful your evaluators will be.
 
+This page on [choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate) explores this further.
+
 <Callout type="info">
-One practical recommendation: prefer binary scores (pass/fail) over graded scales (1-5) when designing evaluators. Binary scores force a clear definition of what separates acceptable from unacceptable. Graded scales introduce ambiguity about what a 3 means versus a 4, which makes scores harder to interpret and less consistent across evaluators and over time.
+When you do design an evaluator, prefer binary (pass/fail) scores over graded scales (1-5). [Writing good evaluators](/academy/evaluate/writing-evaluators#binary-verdicts) explains why.
 </Callout>
 
 ### Combining evaluation methods
 
-Each quality you care about gets its own evaluator.
+Each quality you care about gets [its own evaluator](/academy/evaluate/writing-evaluators#one-evaluator-per-failure-mode).
 
 **Most mature evaluation setups use [all three evaluation methods](#three-kinds-of-evaluation).** Together, they give you a view on overall quality of your application.
 

--- a/content/academy/evaluate/meta.json
+++ b/content/academy/evaluate/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Evaluation",
-  "pages": ["writing-evaluators"]
+  "pages": ["choosing-what-to-evaluate", "writing-evaluators"]
 }

--- a/content/academy/evaluate/writing-evaluators.mdx
+++ b/content/academy/evaluate/writing-evaluators.mdx
@@ -54,6 +54,7 @@ Once you know what you want to evaluate, the next question is how. What kind of 
 
 <Callout type="info">
 Haven't decided what to evaluate yet? Take a look at 
+- [Choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate), the deep dive on turning failure modes and product goals into a metric set
 - [error analysis](/academy/monitoring/error-analysis), a structured way to find the failure modes in your application worth checking
 - the evaluators on the [Langfuse demo project](/docs/demo) and [these example setups](/academy/examples), as they are good templates to start from
 </Callout>

--- a/content/academy/monitoring/error-analysis.mdx
+++ b/content/academy/monitoring/error-analysis.mdx
@@ -24,7 +24,7 @@ The process is five steps:
 
 You walk away with a prioritized list of decisions tied to your actual data: what to change today, what to measure going forward, and what to keep watching.
 
-## When to run it
+## When to run it [#when-to-run-it]
 
 - **Before designing evaluators** - so your traces define what's worth measuring, not generic criteria like "helpfulness."
 - **After a prompt rewrite, model swap, or new feature** - failure distributions shift, and new categories show up.
@@ -56,4 +56,4 @@ Please install the Langfuse skill (https://github.com/langfuse/skills/tree/main/
 
 ## What comes next
 
-Categories you can fix directly become prompt updates or bug fixes. The rest become evaluators: [datasets](/academy/datasets) hold the inputs you test against, and [evaluation](/academy/evaluate) is where you pick the method - code evaluators, LLM-as-a-judge, or human review - for each category.
+Categories you can fix directly become prompt updates or bug fixes. For the rest, [choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate) covers which categories deserve a standing metric and how to structure the set. [Datasets](/academy/datasets) hold the inputs you test against, and [evaluation](/academy/evaluate) is where you pick the method - code evaluators, LLM-as-a-judge, or human review - for each category.


### PR DESCRIPTION
Adds a new academy deep dive, **Choosing what to evaluate**, that fills the gap between the evaluation overview (which covers evaluation *methods*) and *Writing good evaluators* (which assumes the criterion is already known). It walks from "I have traces, how do I set up evals?" to a small, structured metric set.

## What's in the new page
- **Three kinds of metrics**: goal metrics, guardrails, and operational metrics, and why a healthy setup uses all three.
- **Where candidate metrics come from**: observed failures via error analysis, plus goals and hard constraints.
- **Which candidates deserve a metric**: the one-time-fix vs generalization test, tying every metric to a decision, and minding the maintenance budget, each with worked examples in tabs.
- **Starting from zero**: bootstrapping a metric set from unlabeled traces with two generic scores, then clustering into categories.
- **Keeping the set alive**: re-running error analysis, retiring stale metrics, and watching the metrics you optimize.

## Wiring and cleanup on neighboring pages
- Slots the page into the Evaluation section (`meta.json`) between the overview and writing-evaluators.
- Adds forward links from the evaluation overview, the writing-evaluators intro callout, and the error-analysis "what comes next".
- Removes duplicated content from the overview (one-time-fix vs generalization, binary vs graded) so each idea lives on the page that owns it, with links instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Academy MDX and navigation; no application code, APIs, or data handling.
> 
> **Overview**
> Adds **`choosing-what-to-evaluate.mdx`**, a new Academy deep dive between the evaluation overview and **Writing good evaluators**. It explains how to go from traces to a small metric set: goal vs guardrail vs operational metrics, sourcing candidates from error analysis and hard constraints, filters (one-time fix vs generalization, decision-linked metrics, evaluator cost), bootstrapping from unlabeled traces, and keeping the set current over time.
> 
> Registers the page in **`meta.json`** and connects the Evaluation flow with forward links from the evaluation overview, **writing-evaluators**, and **error-analysis** (plus anchor IDs like `#when-to-run-it` and `#when-to-set-up-evaluators` for deep links).
> 
> Trims duplicated guidance on **`evaluate/index.mdx`** (one-time fix vs generalization, binary vs graded scores, per-metric evaluators, ongoing manual review) in favor of links to the new page and **writing-evaluators**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cb15105da32090d9c91a134886ec1350a8a7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->