### PR TITLE
Update banner to promote Langfuse Town Hall (Aug 12)

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -4,17 +4,17 @@ import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 export function Banner() {
   return (
     <FumadocsBanner
+      id="fd-top-banner-town-hall-2026-08"
       height="2rem"
-      className="bg-black text-white [&_a]:text-white"
+      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
     >
-      <Link href="/docs/v4">
+      <Link href="https://luma.com/qahlxt9n">
         <span className="sm:hidden">
-          Langfuse v4: up to 165× faster ·{" "}
-          <span className="underline underline-offset-2">Read more</span>
+          [Virtual] Langfuse Town Hall · Aug 12 →
         </span>
         <span className="hidden sm:inline">
-          Langfuse v4 is here: real-time, up to 165× faster ·{" "}
-          <span className="underline underline-offset-2">Read more</span>
+          [Virtual] Langfuse Town Hall · Aug 12, 9am PT: New features and
+          roadmap →
         </span>
       </Link>
     </FumadocsBanner>


### PR DESCRIPTION
Swaps the top banner from the v4 announcement to the [Virtual] Langfuse Town Hall happening tomorrow, Aug 12, 2026 at 9am PT (6pm CEST).

- Links to the public event page: https://luma.com/qahlxt9n (`evt-QNaxhNhB3rnbUK9`)
- Follows the previous town hall banner pattern (#3054): dismissible via a versioned `id`, short label on mobile, date + time + topic on desktop

Remove after the event, same as #3087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and link only in the layout banner; no auth, data, or API changes.
> 
> **Overview**
> **Replaces the v4 launch top banner** with messaging for the **[Virtual] Langfuse Town Hall on Aug 12**, linking to the Luma event page instead of `/docs/v4`.
> 
> Uses a new dismissible banner **`id`** (`fd-top-banner-town-hall-2026-08`) so users who dismissed the old banner see this one. Mobile and desktop copy follow the prior town-hall pattern (short line vs date/time/topic). Adds **`[&_button]:text-white`** so the dismiss control stays visible on the black bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d5b1130db022f41af8c5f89a410fa128950675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the Langfuse v4 announcement banner with a dismissible promotion for the August 12, 2026 virtual Town Hall.
- Adds a versioned dismissal identifier for the event.
- Links the banner to the public Luma event page.
- Provides shorter mobile copy and date, time, and topic details on larger screens.
- Ensures the banner dismissal button remains visible against the black background.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

The banner uses a unique dismissal identifier, a supported absolute event URL, responsive labels, and compatible styling without breaking an established component contract.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: update banner to promote Langfuse ..."](https://github.com/langfuse/langfuse-docs/commit/f0d5b1130db022f41af8c5f89a410fa128950675) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52118992)</sub>

<!-- /greptile_comment -->