### PR TITLE
feat: clarify API rate-limit buckets and coverage

### DIFF
--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -24,25 +24,25 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 ### Rate Limits
 
-Rate limits are applied per-organization and shared across all projects and API keys in that organization. Metrics API v2 and the deprecated Metrics API use separate rate-limit buckets.
+Langfuse Cloud groups API requests into per-organization resource buckets shared by all projects and API keys in the organization. Resources with dedicated buckets are listed separately from the General API bucket. Closely related buckets with identical limits may be combined in one row.
 
-| Resource                                                                                                                                                                            | Hobby              | Core               | Pro/Team/Enterprise |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
-| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                                                             | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
-| **Deprecated Tracing**. Deprecated ingestion endpoints.                                                                                                                             | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
-| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                                                                | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
-| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                                                                | No limit           | No limit           | No limit            |
-| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                                                             | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
-| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)**. Deprecated `GET /api/public/metrics` endpoint.                                                          | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
-| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                                                                    | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **Deprecated read APIs**. Older trace, observation, and session read endpoints, listed below.                                                                                       | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
-| **General API**. All other public APIs, including the [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) endpoint (`GET /api/public/v2/observations`). | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| Resource bucket                                                            | Applies to                                                                                                                                            | Hobby              | Core               | Pro/Team/Enterprise |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
+| **Tracing**                                                                | Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                                            | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
+| **Deprecated tracing**                                                     | Deprecated ingestion endpoints.                                                                                                                       | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace data deletion**                                                    | Public API endpoints used to delete trace data, including traces, observations, and scores.                                                           | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
+| **Prompts**                                                                | GET APIs used to fetch prompts for use in applications.                                                                                               | No limit           | No limit           | No limit            |
+| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**                | `GET /api/public/v2/metrics` for aggregate analytics data.                                                                                            | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
+| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)** | Deprecated `GET /api/public/metrics` endpoint.                                                                                                        | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
+| **Datasets**                                                               | APIs used to work with [datasets and experiments](/docs/datasets).                                                                                    | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Deprecated read APIs**                                                   | Older trace, observation, and session read endpoints, listed below.                                                                                   | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
+| **General API**                                                            | All other public APIs, including [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) (`GET /api/public/v2/observations`). | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
 
 The deprecated read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 
 <Callout type="info">
 
-**MCP shares the General API rate-limit bucket.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API limit shown above. MCP does not have a separate rate limit.
+**MCP shares the General API resource bucket.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API limit shown above. 
 
 </Callout>
 

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -24,28 +24,27 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 ### Rate Limits
 
-Rate limits are applied per-organization. Observations API v2 shares the General API rate-limit bucket, so its listed limit is not an additional quota. Metrics API v2 uses a separate rate-limit bucket from the deprecated Metrics API.
+Rate limits are applied per-organization and shared across all projects and API keys in that organization. Metrics API v2 and the deprecated Metrics API use separate rate-limit buckets.
 
-| Resource                                                                                                                                                                 | Hobby              | Core               | Pro/Team/Enterprise |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------- |
-| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                                                  | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
-| **Deprecated Tracing**. Deprecated ingestion endpoints.                                                                                                                  | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
-| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                                                     | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
-| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                                                     | No limit           | No limit           | No limit            |
-| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                                                  | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
-| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)**. Deprecated `GET /api/public/metrics` endpoint.                                               | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
-| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                                                         | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **Deprecated read APIs**. Older trace, observation, and session read endpoints, listed below.                                                                            | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
-| **[Observations API v2](/docs/api-and-data-platform/features/observations-api#v2)**. `GET /api/public/v2/observations` requests share the General API rate-limit bucket. | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **General API**. All other APIs.                                                                                                                                         | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| Resource                                                                                                                                                                            | Hobby              | Core               | Pro/Team/Enterprise |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
+| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                                                             | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
+| **Deprecated Tracing**. Deprecated ingestion endpoints.                                                                                                                             | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                                                                | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
+| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                                                                | No limit           | No limit           | No limit            |
+| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                                                             | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
+| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)**. Deprecated `GET /api/public/metrics` endpoint.                                                          | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
+| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                                                                    | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Deprecated read APIs**. Older trace, observation, and session read endpoints, listed below.                                                                                       | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
+| **General API**. All other public APIs, including the [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) endpoint (`GET /api/public/v2/observations`). | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+
+The deprecated read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 
 <Callout type="info">
 
-**MCP uses the General API rate limit.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API quota shown above; MCP does not have a separate rate-limit bucket.
+**MCP shares the General API rate-limit bucket.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API limit shown above. MCP does not have a separate rate limit.
 
 </Callout>
-
-The deprecated read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 
 On the Enterprise plan, you can request custom rate limits by contacting [support](/support).
 

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -42,7 +42,7 @@ The deprecated read APIs are `GET /api/public/traces`, `GET /api/public/traces/{
 
 <Callout type="info">
 
-**MCP shares the General API resource bucket.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API limit shown above. 
+**MCP shares the General API resource bucket.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API limit shown above.
 
 </Callout>
 

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -24,19 +24,26 @@ While the [Langfuse API](/docs/api) is extremely open and flexible, there are so
 
 ### Rate Limits
 
-Rate limits are applied per-organization. Metrics API v2 uses a separate rate-limit bucket from the deprecated Metrics API.
+Rate limits are applied per-organization. Observations API v2 shares the General API rate-limit bucket, so its listed limit is not an additional quota. Metrics API v2 uses a separate rate-limit bucket from the deprecated Metrics API.
 
-| Resource                                                                                                                   | Hobby              | Core               | Pro/Team/Enterprise |
-| -------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ | ------------------- |
-| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                    | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
-| **Deprecated Tracing**. Deprecated ingestion endpoints.                                                                    | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
-| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.       | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
-| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                       | No limit           | No limit           | No limit            |
-| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.    | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
-| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)**. Deprecated `GET /api/public/metrics` endpoint. | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
-| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                           | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
-| **Deprecated read APIs**. Older trace, observation, and session read endpoints, listed below.                              | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
-| **API**. All other APIs.                                                                                                   | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| Resource                                                                                                                                                                 | Hobby              | Core               | Pro/Team/Enterprise |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------- |
+| **Tracing**. Batched `/ingestion` and `/otel` endpoints used by SDKs and integrations to ingest traces.                                                                  | 1,000&nbsp;req/min | 4,000&nbsp;req/min | 20,000&nbsp;req/min |
+| **Deprecated Tracing**. Deprecated ingestion endpoints.                                                                                                                  | 100&nbsp;req/min   | 400&nbsp;req/min   | 400&nbsp;req/min    |
+| **Trace Data Deletion**. Public API endpoints used to delete trace data, including traces, observations, and scores.                                                     | 50&nbsp;req/day    | 200&nbsp;req/day   | 1,000&nbsp;req/day  |
+| **Prompts**. GET APIs used to fetch prompts for use in applications.                                                                                                     | No limit           | No limit           | No limit            |
+| **[Metrics API v2](/docs/metrics/features/metrics-api#v2)**. `GET /api/public/v2/metrics` for aggregate analytics data.                                                  | 100&nbsp;req/day   | 100&nbsp;req/hour  | 500&nbsp;req/hour   |
+| **[Deprecated Metrics API](/faq/all/deprecated-api-migration#metrics-v1)**. Deprecated `GET /api/public/metrics` endpoint.                                               | 100&nbsp;req/day   | 2,000&nbsp;req/day | 2,000&nbsp;req/day  |
+| **Datasets**. APIs used to work with [datasets and experiments](/docs/datasets).                                                                                         | 100&nbsp;req/min   | 200&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **Deprecated read APIs**. Older trace, observation, and session read endpoints, listed below.                                                                            | 15&nbsp;req/min    | 30&nbsp;req/min    | 100&nbsp;req/min    |
+| **[Observations API v2](/docs/api-and-data-platform/features/observations-api#v2)**. `GET /api/public/v2/observations` requests share the General API rate-limit bucket. | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+| **General API**. All other APIs.                                                                                                                                         | 30&nbsp;req/min    | 100&nbsp;req/min   | 1,000&nbsp;req/min  |
+
+<Callout type="info">
+
+**MCP uses the General API rate limit.** Authenticated requests to the [Langfuse MCP server](/docs/api-and-data-platform/features/mcp-server) at `/api/public/mcp` count toward the General API quota shown above; MCP does not have a separate rate-limit bucket.
+
+</Callout>
 
 The deprecated read APIs are `GET /api/public/traces`, `GET /api/public/traces/{traceId}`, `GET /api/public/observations`, `GET /api/public/observations/{observationId}`, `GET /api/public/sessions`, and `GET /api/public/sessions/{sessionId}`.
 


### PR DESCRIPTION
## Summary

- Clarify that rate limits are shared across organizations, projects, and API keys.
- Document the General API bucket, including Observations API v2.
- Explain that MCP requests share the General API rate limit.
- Update table formatting for the expanded resource descriptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only FAQ update with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Langfuse Cloud API limits** FAQ to explain how rate limits are scoped and which endpoints share buckets.
> 
> Adds prose that limits are **per-organization resource buckets** shared across all projects and API keys, with dedicated buckets called out separately from a catch-all **General API** bucket. The rate-limit table is restructured with **Resource bucket** and **Applies to** columns; the former “API” row is renamed **General API** and now explicitly includes **Observations API v2** (`GET /api/public/v2/observations`). A new info callout states that authenticated **MCP** traffic at `/api/public/mcp` counts against the General API limit. Numeric limits per plan are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2029cee61fe2cff23eaecbee6dba22a22b9da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies that API rate limits are shared organization-wide and documents which requests consume the General API bucket.

- Renames the catch-all API category to “General API” and explicitly includes Observations API v2.
- Documents that authenticated MCP requests share the General API bucket.
- Expands the rate-limit table formatting to accommodate the clarified descriptions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The updated MDX is consistent with sibling Observations API documentation, uses an existing registered Callout component, and contains no established incorrect links, rendering problems, or contradictory rate-limit guidance.
</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify API rate-limit buckets and scope"](https://github.com/langfuse/langfuse-docs/commit/b7ba65f044f31f77b7d73dc1a891c0cac22a1418) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52134092)</sub>

<!-- /greptile_comment -->