### PR TITLE
docs(scim): remove password provisioning guidance

### DIFF
--- a/content/docs/administration/scim-and-org-api.mdx
+++ b/content/docs/administration/scim-and-org-api.mdx
@@ -77,8 +77,11 @@ Afterward, the role can be updated using the membership endpoints either on an o
 To remove a user from an organization, call the `DELETE /Users/{id}` endpoint.
 This will not delete the user itself, only its membership with the organization.
 
-You can either supply an initial password for users via the API and share it with them, or use Single Sign-On (SSO) to authenticate users.
-In the latter case, you need to:
+SCIM provisioning does not set a password.
+A `password` attribute in the request body is accepted for compatibility — Okta sends a placeholder value on every user create, even when password sync is disabled — but Langfuse ignores it, so provisioned users never receive a credential from SCIM.
+Provisioned users sign in via Single Sign-On (SSO), or set their own password through the "Forgot password" flow, which confirms that they control the email address.
+
+To authenticate provisioned users via SSO, you need to:
 
 - Langfuse Cloud: configure an Enterprise SSO provider ([docs](/security/auth)).
 - Self-hosted: configure `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING` for your SSO provider to ensure that the user accounts are linked correctly [SSO Docs](/self-hosting/security/authentication-and-sso#additional-configuration).


### PR DESCRIPTION
Docs counterpart to langfuse/langfuse#15997 — **merge after that ships**.

## Why

The SCIM page told users they could "supply an initial password for users via the API and share it with them". That path let an org-scoped API key establish a usable login credential for an email address nobody had verified, so langfuse/langfuse#15997 makes `POST /Users` ignore the `password` attribute (accepted for compatibility, never stored) and drops it from the `/Schemas` response.

## What changed

The password sentence is replaced with what the API now does, plus the two paths a provisioned user actually gets access by:

- SSO, or
- the "Forgot password" flow, which confirms they control the email address.

It also states explicitly that a `password` attribute is still accepted so integrators aren't surprised — worth calling out because Okta [sends a placeholder password on every user create even when password sync is disabled](https://support.okta.com/help/s/article/password-sent-during-user-creation-to-custom-scim-integration-even-with-password-sync-disabled?language=en_US), which measurement showed is the source of ~100% of password-bearing requests in production.

The surrounding SSO bullets are unchanged; only the lead-in sentence was rewritten so it still reads correctly ("To authenticate provisioned users via SSO, you need to:").

## Verification

- `pnpm exec prettier --experimental-cli --check content/docs/administration/scim-and-org-api.mdx` → `All matched files use Prettier code style!`
- Prose-only change to one page; no components, links, or frontmatter touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only documentation on one page; no runtime, auth, or API behavior changes in this repo.
> 
> **Overview**
> Updates **User Management via SCIM** in `scim-and-org-api.mdx` to match the API change that ignores `password` on `POST /Users`.
> 
> The old guidance about supplying an initial password via the API is removed. The page now states that SCIM never sets credentials, that a `password` body field is only accepted for compatibility (including Okta’s placeholder on user create) and is ignored, and that provisioned users get access via **SSO** or the **Forgot password** flow.
> 
> The existing SSO configuration bullets are unchanged; the lead-in is reworded to **“To authenticate provisioned users via SSO, you need to:”** so it still fits the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bba60708f520cc3538a904849804d865cbe1c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->