### PR TITLE
docs(agents): forbid internal ticket ids in published text

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -114,6 +114,7 @@ These run `pnpm build` followed by `pnpm link-check` / `pnpm sitemap-check`. The
 - Use sentence case for user-facing headlines, section headings, and hero copy by default. Keep title case for short standalone navigation/UI labels where it reads more naturally (for example, paired nouns like "Questions & Answers" or conventional labels like "Get Started"). Always preserve proper nouns, acronyms, and official product names.
 - Route sales and Enterprise inquiries to the [sales form](/talk-to-us) instead of directing readers to `enterprise@langfuse.com`.
 - Add an `<AvailabilityBanner />` to a feature's docs page when the feature is not available on every Langfuse plan or deployment type. Place it directly below the relevant heading: usually the H1, or an H2/H3 when availability applies only to that section.
+- Never reference internal ticket ids (`LFE-1234`, `LFINT-1234`) or Linear URLs in page content, commit messages, or PR descriptions. They mean nothing to readers of the public site or repo. Describe the change on its own terms; a ticket-prefixed branch name is the one place the identifier belongs.
 
 ### Changelog entries
 


### PR DESCRIPTION
## Why

Agents repeatedly put internal Linear ids into page content and PR descriptions. The writing guidelines didn't say not to, so the mistake kept recurring. Anything published here is read by people outside the company, for whom an internal ticket id is pure noise.

## Change

One bullet under **Writing guidelines** in `.agents/AGENTS.md`: no internal ticket ids or Linear URLs in page content, commit messages, or PR descriptions. Branch names stay the place for the identifier, so traceability is unaffected.

Mirrors the same rule added to the langfuse repo's agent setup: langfuse/langfuse#15998

## Verification

- `pnpm exec prettier --experimental-cli --check .agents/AGENTS.md` → `All matched files use Prettier code style!`
- `pnpm run agents:check` → exit 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal agent guidelines with no effect on the site build or user-facing content.
> 
> **Overview**
> Adds a **Writing guidelines** rule in `.agents/AGENTS.md` telling agents not to put internal ticket ids (e.g. `LFE-1234`) or Linear URLs in page content, commit messages, or PR descriptions. Changes should be described in plain language for public readers; ticket-prefixed branch names remain the traceability hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6c0663b5380f779f4fdb33ad1bcd8791e62f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an agent writing guideline to keep internal ticket identifiers and Linear URLs out of public-facing content and repository metadata.
- Requires changes to be described without internal references.
- Preserves ticket-prefixed branch names for traceability.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change only adds a coherent writing guideline and introduces no blocking or non-blocking defects.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): forbid internal ticket ids..."](https://github.com/langfuse/langfuse-docs/commit/5c6c0663b5380f779f4fdb33ad1bcd8791e62f52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52220263)</sub>

<!-- /greptile_comment -->