### PR TITLE
docs(experiments): link experiment ingestion options

### DIFF
--- a/content/docs/api-and-data-platform/features/experiments-api.mdx
+++ b/content/docs/api-and-data-platform/features/experiments-api.mdx
@@ -27,12 +27,13 @@ For the complete request and response contract, see the
 
 ## Choose the right API
 
-| If you want to...                                                                           | Use                                                                                                         |
-| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| List experiment runs and their summaries                                                    | `GET /api/public/experiments?fromStartTime=2026-01-01T00:00:00Z`                                            |
-| Retrieve experiment items and their inputs, outputs, expected outputs, metadata, and scores | `GET /api/public/experiment-items?fromStartTime=2026-01-01T00:00:00Z`                                       |
-| Retrieve the complete trace and observation tree for an item                                | [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2), using the item's `traceId` |
-| Query evaluation scores independently                                                       | [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)                                         |
+| If you want to...                                                                           | Use                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Run experiments and ingest experiment data                                                  | [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) or [direct OpenTelemetry ingestion](/integrations/native/opentelemetry/experiments) |
+| List experiment runs and their summaries                                                    | `GET /api/public/experiments?fromStartTime=2026-01-01T00:00:00Z`                                                                                              |
+| Retrieve experiment items and their inputs, outputs, expected outputs, metadata, and scores | `GET /api/public/experiment-items?fromStartTime=2026-01-01T00:00:00Z`                                                                                         |
+| Retrieve the complete trace and observation tree for an item                                | [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2), using the item's `traceId`                                                   |
+| Query evaluation scores independently                                                       | [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3)                                                                                           |
 
 The experiment endpoints support filtering, cursor-based pagination, and
 optional response fields. Refer to the [Experiments API reference](https://api.reference.langfuse.com/#tag/experiments)
@@ -48,6 +49,7 @@ is useful when scores are the primary data you want to query.
 ## Related resources
 
 - [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk) — run experiments with the Python or JS/TS SDK.
+- [OpenTelemetry experiment ingestion](/integrations/native/opentelemetry/experiments) — ingest experiment spans directly with OpenTelemetry.
 - [Experiments data model](/docs/evaluation/experiments/data-model) — understand how datasets, experiments, items, traces, observations, and scores relate.
 - [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) — retrieve row-level trace and observation data.
 - [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3) — retrieve evaluation and annotation scores.


### PR DESCRIPTION
## Summary
- add the experiment runner SDK and direct OpenTelemetry ingestion to the Experiments API decision table
- link the OpenTelemetry experiment-ingestion guide in Related resources

## Verification
- `pnpm run format`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Updates the Experiments API docs so readers can find **how to run and ingest** experiments, not only how to **read** them via the public API.
> 
> The **Choose the right API** table gains a top row pointing to the experiment runner SDK and direct OpenTelemetry experiment ingestion, with column widths adjusted for the longer links. **Related resources** adds a bullet for the OpenTelemetry experiment-ingestion guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376c7bccea97d80ef835913455b10f736e3ddca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the Experiments API decision table and related resources to link both SDK-based experiment execution and direct OpenTelemetry ingestion.
- Adds an experiment-ingestion row to the API selection table.
- Adds the OpenTelemetry experiment-ingestion guide to related resources.
- The new table wording does not clearly distinguish execution from ingestion.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation clarification needed to distinguish experiment execution from direct trace ingestion.

Both added links resolve correctly, but the decision-table wording can send readers seeking an experiment runner to an OpenTelemetry guide that only explains how to ingest spans from executions they orchestrate themselves.

**Files Needing Attention:** content/docs/api-and-data-platform/features/experiments-api.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/api-and-data-platform/features/experiments-api.mdx:32
**Distinguish execution from ingestion**

The table assigns both options to “Run experiments and ingest experiment data,” but direct OpenTelemetry ingestion only sends spans from item executions orchestrated by the user. Readers seeking an experiment runner are therefore directed to a guide that provides an ingestion protocol rather than task execution.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): link experiment inges..."](https://github.com/langfuse/langfuse-docs/commit/376c7bccea97d80ef835913455b10f736e3ddca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52220869)</sub>

**Context used:**

- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->