### PR TITLE
docs: improve observability overview discovery

### DIFF
--- a/app/api/md-to-pdf/route.ts
+++ b/app/api/md-to-pdf/route.ts
@@ -55,8 +55,11 @@ async function runtimeImport(moduleName: string): Promise<any> {
   return importAtRuntime(moduleName);
 }
 
-function removeAnchorTags(content: string): string {
-  return content.replace(/\s*\[#[\w-]+\]/g, "");
+function renderAnchorTags(content: string): string {
+  return content.replace(
+    /^(#{1,6}\s+)(.*?)(?:\s+\[#([\w-]+)\])\s*$/gm,
+    (_, prefix, title, id) => `${prefix}<span id="${id}"></span>${title}`,
+  );
 }
 
 function processCallouts(content: string): string {
@@ -165,7 +168,7 @@ export async function GET(request: NextRequest) {
     markdownContent = stripMdxForPlainMarkdown(markdownContent, {
       unwrapCalloutsForPlainMd: false,
     });
-    markdownContent = removeAnchorTags(markdownContent);
+    markdownContent = renderAnchorTags(markdownContent);
     let htmlContent = await marked.parse(markdownContent);
     htmlContent = processCallouts(htmlContent);
 

--- a/components/docs-sidebar/SidebarFolderDeepLinkHandler.tsx
+++ b/components/docs-sidebar/SidebarFolderDeepLinkHandler.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const SIDEBAR_FOLDER_HASH_PREFIX = "#sidebar-folder-";
+
+function openSidebarFolder(hash: string) {
+  if (!hash.startsWith(SIDEBAR_FOLDER_HASH_PREFIX)) return;
+
+  const anchorId = hash.slice(1);
+  const trigger = Array.from(
+    document.querySelectorAll<HTMLButtonElement>(
+      "button[data-sidebar-folder-anchor]",
+    ),
+  ).find(
+    (element) =>
+      element.getAttribute("data-sidebar-folder-anchor") === anchorId,
+  );
+  if (!trigger) return;
+
+  if (trigger.getAttribute("aria-expanded") === "false") {
+    trigger.click();
+  }
+  trigger.scrollIntoView({ block: "nearest" });
+}
+
+export function SidebarFolderDeepLinkHandler() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const openFolderFromLocation = () => {
+      openSidebarFolder(window.location.hash);
+    };
+    const openFolderFromLink = (event: MouseEvent) => {
+      if (
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
+        !(event.target instanceof Element)
+      ) {
+        return;
+      }
+
+      const link = event.target.closest<HTMLAnchorElement>("a[href]");
+      if (
+        !link?.hash.startsWith(SIDEBAR_FOLDER_HASH_PREFIX) ||
+        link.origin !== window.location.origin ||
+        link.pathname !== window.location.pathname
+      ) {
+        return;
+      }
+
+      window.setTimeout(() => openSidebarFolder(link.hash));
+    };
+
+    openFolderFromLocation();
+    window.addEventListener("hashchange", openFolderFromLocation);
+    document.addEventListener("click", openFolderFromLink);
+    return () => {
+      window.removeEventListener("hashchange", openFolderFromLocation);
+      document.removeEventListener("click", openFolderFromLink);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/components/docs-sidebar/SidebarFolderItem.tsx
+++ b/components/docs-sidebar/SidebarFolderItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import {
   SidebarFolder,
@@ -65,41 +65,6 @@ export function SidebarFolderItem({
   const depth = useFolderDepth();
   const folderAnchorId = item.index ? undefined : getFolderAnchorId(item.$id);
 
-  useEffect(() => {
-    if (!folderAnchorId) return;
-
-    const folderHash = `#${folderAnchorId}`;
-    const openFolder = () => {
-      const trigger = document.querySelector<HTMLButtonElement>(
-        `[data-sidebar-folder-anchor="${folderAnchorId}"]`,
-      );
-      if (trigger?.getAttribute("aria-expanded") === "false") {
-        trigger.click();
-      }
-      trigger?.scrollIntoView({ block: "nearest" });
-    };
-    const openFolderFromHash = () => {
-      if (window.location.hash === folderHash) openFolder();
-    };
-    const handleFolderLinkClick = (event: MouseEvent) => {
-      if (!(event.target instanceof Element)) return;
-      const link = event.target.closest<HTMLAnchorElement>("a[href]");
-      if (link?.hash !== folderHash) return;
-
-      event.preventDefault();
-      window.history.replaceState(null, "", folderHash);
-      openFolder();
-    };
-
-    openFolderFromHash();
-    window.addEventListener("hashchange", openFolderFromHash);
-    document.addEventListener("click", handleFolderLinkClick, true);
-    return () => {
-      window.removeEventListener("hashchange", openFolderFromHash);
-      document.removeEventListener("click", handleFolderLinkClick, true);
-    };
-  }, [folderAnchorId]);
-
   const rowStyle = { paddingInlineStart: sidebarNavPaddingInlineStart(depth) };
 
   return (
@@ -121,7 +86,6 @@ export function SidebarFolderItem({
         </SidebarFolderLink>
       ) : (
         <SidebarFolderTrigger
-          id={folderAnchorId}
           data-sidebar-folder-anchor={folderAnchorId}
           className={SIDEBAR_NAV_ROW_CLASS}
           style={rowStyle}

--- a/components/docs-sidebar/SidebarFolderItem.tsx
+++ b/components/docs-sidebar/SidebarFolderItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import {
   SidebarFolder,
@@ -20,6 +20,11 @@ export const SIDEBAR_NAV_ROW_CLASS =
 
 export function sidebarNavPaddingInlineStart(depth: number) {
   return `calc(${2 * depth} * var(--spacing) + 6px)`;
+}
+
+function getFolderAnchorId(itemId?: string) {
+  if (!itemId) return undefined;
+  return `sidebar-folder-${itemId.replace(/[^a-zA-Z0-9_-]+/g, "-")}`;
 }
 
 /**
@@ -58,6 +63,42 @@ export function SidebarFolderItem({
   const pathname = usePathname();
   /** Parent depth: folder row aligns with `SidebarItem` at the same tree level. */
   const depth = useFolderDepth();
+  const folderAnchorId = item.index ? undefined : getFolderAnchorId(item.$id);
+
+  useEffect(() => {
+    if (!folderAnchorId) return;
+
+    const folderHash = `#${folderAnchorId}`;
+    const openFolder = () => {
+      const trigger = document.querySelector<HTMLButtonElement>(
+        `[data-sidebar-folder-anchor="${folderAnchorId}"]`,
+      );
+      if (trigger?.getAttribute("aria-expanded") === "false") {
+        trigger.click();
+      }
+      trigger?.scrollIntoView({ block: "nearest" });
+    };
+    const openFolderFromHash = () => {
+      if (window.location.hash === folderHash) openFolder();
+    };
+    const handleFolderLinkClick = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return;
+      const link = event.target.closest<HTMLAnchorElement>("a[href]");
+      if (link?.hash !== folderHash) return;
+
+      event.preventDefault();
+      window.history.replaceState(null, "", folderHash);
+      openFolder();
+    };
+
+    openFolderFromHash();
+    window.addEventListener("hashchange", openFolderFromHash);
+    document.addEventListener("click", handleFolderLinkClick, true);
+    return () => {
+      window.removeEventListener("hashchange", openFolderFromHash);
+      document.removeEventListener("click", handleFolderLinkClick, true);
+    };
+  }, [folderAnchorId]);
 
   const rowStyle = { paddingInlineStart: sidebarNavPaddingInlineStart(depth) };
 
@@ -80,6 +121,8 @@ export function SidebarFolderItem({
         </SidebarFolderLink>
       ) : (
         <SidebarFolderTrigger
+          id={folderAnchorId}
+          data-sidebar-folder-anchor={folderAnchorId}
           className={SIDEBAR_NAV_ROW_CLASS}
           style={rowStyle}
         >

--- a/components/layout/SharedDocsLayout.tsx
+++ b/components/layout/SharedDocsLayout.tsx
@@ -11,6 +11,7 @@ import {
   FloatingAskAI,
 } from "@/components/inkeep/search";
 import { SidebarFolderItem } from "@/components/docs-sidebar/SidebarFolderItem";
+import { SidebarFolderDeepLinkHandler } from "@/components/docs-sidebar/SidebarFolderDeepLinkHandler";
 import { SidebarItem } from "@/components/docs-sidebar/SidebarItem";
 import { SidebarSeparatorItem } from "@/components/docs-sidebar/SidebarSeparatorItem";
 import { Banner } from "./Banner";
@@ -57,6 +58,7 @@ export function SharedDocsLayout({
             : undefined
         }
       >
+        <SidebarFolderDeepLinkHandler />
         <DocsPatternTracker />
         <Banner />
         <NavbarDocs sectionLabel={sectionLabel} />

--- a/content/docs/observability/overview.mdx
+++ b/content/docs/observability/overview.mdx
@@ -27,10 +27,10 @@ Want to see it in action? [**Create a free account**](/cloud) and explore Langfu
 
 ## Getting Started
 
-Start by [setting up your first trace](/docs/observability/get-started), compare it against our
+Start by [setting up your first trace](/docs/observability/get-started), and compare it against our
 [best practices guide](/docs/observability/best-practices) so you're set up for success. If you're new to AI observability, take a look at the [core concepts](/docs/observability/data-model) too.
 
-## Use Your Traces
+## Use your traces [#sidebar-folder-docs-observability-features]
 
 Once traces are coming in, the next step is to make sense of them and use what you learn to improve your agent. Read the chapter on [Monitoring in the Langfuse Academy](/academy/monitoring) to learn how to utilize your traces well.
 

--- a/content/docs/observability/overview.mdx
+++ b/content/docs/observability/overview.mdx
@@ -27,19 +27,21 @@ Want to see it in action? [**Create a free account**](/cloud) and explore Langfu
 
 ## Getting Started
 
-Start by [setting up your first trace](/docs/observability/get-started).
+Start by [setting up your first trace](/docs/observability/get-started), compare it against our
+[best practices guide](/docs/observability/best-practices) so you're set up for success. If you're new to AI observability, take a look at the [core concepts](/docs/observability/data-model) too.
 
-Take a moment to understand the core concepts of tracing in Langfuse: [traces, sessions, and observations](/docs/observability/data-model).
+## Use Your Traces
 
-Once you're up and running, you can start adding on more functionality to your traces. We recommend starting with the following:
+Once traces are coming in, the next step is to make sense of them and use what you learn to improve your agent. Read the chapter on [Monitoring in the Langfuse Academy](/academy/monitoring) to learn how to utilize your traces well.
 
-- [Group traces into sessions for multi-turn applications](/docs/observability/features/sessions)
-- [Split traces into environments for different stages of your application](/docs/observability/features/environments)
-- [Add attributes to your traces so you can filter them in the future](/docs/observability/features/tags)
-- [Use custom trace IDs for distributed tracing](/docs/observability/features/trace-ids-and-distributed-tracing)
-- [Track costs and token usage](/docs/observability/features/token-and-cost-tracking)
+For feature-specific implementation guidance, these are the most common ones to start with:
 
-Already know what you want? Take a look under _Features_ for guides on specific topics.
+- Track [model usage and cost](/docs/observability/features/token-and-cost-tracking)
+- Monitor application quality with [scores](/docs/evaluation/scores/overview)
+- Analyze cost, latency, volume, and quality in [custom dashboards](/docs/metrics/features/custom-dashboards)
+- Get notified when a metric crosses a threshold with [alerts](/docs/metrics/features/alerts)
+
+Browse the [Features section](#sidebar-folder-docs-observability-features) in the sidebar for a complete list of observability features.
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

- guide readers from tracing setup to monitoring and common observability workflows
- link each recommended next step to its relevant documentation
- make sidebar folders deep-linkable without overriding native link behavior
- preserve explicit heading anchors in generated PDFs

## Validation

- pnpm run format
- pnpm run format:check
- pnpm exec tsc --noEmit
- node scripts/check-h1-headings.js
- node scripts/copy_md_sources.js
- git diff --check
- verified the overview and linked destinations return HTTP 200 locally
- verified the feature fragment has one content anchor and one matching sidebar target