### PR TITLE
Document masking options for OpenTelemetry traces

### DIFF
--- a/content/docs/observability/features/masking.mdx
+++ b/content/docs/observability/features/masking.mdx
@@ -290,7 +290,7 @@ const handler = new CallbackHandler();
 In a pure OpenTelemetry tracing setup, mask sensitive span attributes before they reach Langfuse. You can apply masking in two places:
 
 - **In the application:** Avoid recording sensitive attributes where possible. Otherwise, use a language-specific or custom span processor or export layer to transform them before OTLP export. Choose this approach when sensitive data must not leave the application.
-- **In an OpenTelemetry Collector:** Route traces through an optional Collector and use processors to delete, filter, redact, or transform attributes centrally. This is useful for applying a consistent policy across multiple services.
+- **In an OpenTelemetry Collector:** Route traces through an optional Collector and use the attributes, redaction, or transform processors to mask attributes centrally. The filter processor drops entire spans, so use it only when you intentionally want to remove spans. This approach is useful for applying a consistent policy across multiple services.
 
 ```mermaid
 flowchart LR

--- a/content/docs/observability/features/masking.mdx
+++ b/content/docs/observability/features/masking.mdx
@@ -285,6 +285,23 @@ const handler = new CallbackHandler();
 </Tab>
 </LangTabs>
 
+## Masking with OpenTelemetry
+
+In a pure OpenTelemetry tracing setup, mask sensitive span attributes before they reach Langfuse. You can apply masking in two places:
+
+- **In the application:** Avoid recording sensitive attributes where possible. Otherwise, use a language-specific or custom span processor or export layer to transform them before OTLP export. Choose this approach when sensitive data must not leave the application.
+- **In an OpenTelemetry Collector:** Route traces through an optional Collector and use processors to delete, filter, redact, or transform attributes centrally. This is useful for applying a consistent policy across multiple services.
+
+```mermaid
+flowchart LR
+  App["Application (OpenTelemetry SDK)"] -->|"OTLP traces"| Collector["OpenTelemetry Collector<br/>(masking processors)"]
+  Collector -->|"OTLP/HTTP"| Langfuse["Langfuse"]
+```
+
+Collector-side masking happens after telemetry leaves the application. Deploy the Collector within the appropriate trust boundary and secure the connection between the application and Collector.
+
+See OpenTelemetry's guide to [handling sensitive data](https://opentelemetry.io/docs/security/handling-sensitive-data/) for common Collector processor patterns, and the [Langfuse OpenTelemetry integration guide](/integrations/native/opentelemetry) for export setup.
+
 ## Related resources
 
 - [Data Retention](/docs/administration/data-retention) - Automatically delete traces, observations, scores, and media assets after a configured retention period.


### PR DESCRIPTION
## Summary

- Add guidance for masking sensitive OpenTelemetry span attributes before they reach Langfuse.
- Explain application-side and OpenTelemetry Collector masking approaches.
- Include a Mermaid flowchart and links to relevant OpenTelemetry and Langfuse documentation.

## Testing

Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `masking.mdx`; no runtime or security behavior changes.
> 
> **Overview**
> Extends the masking page with a **Masking with OpenTelemetry** section for setups that are not using Langfuse SDK hooks alone.
> 
> It contrasts **application-side** masking (avoid recording sensitive attributes, or transform via span processors/export before OTLP) with **Collector-side** masking (attributes/redaction/transform processors; notes that the filter processor drops whole spans). A Mermaid diagram shows App → Collector (masking) → Langfuse over OTLP/HTTP, plus a short note on trust boundaries and securing App–Collector links.
> 
> Links point to OpenTelemetry’s sensitive-data handling guide and the Langfuse native OpenTelemetry integration doc for export setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9038cd2e6092479e637676b666c592921450a538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents how to mask sensitive OpenTelemetry span attributes before Langfuse ingestion.

- Describes application-side and OpenTelemetry Collector masking approaches.
- Clarifies the Collector trust boundary and transport-security considerations.
- Adds a flowchart and links to the relevant OpenTelemetry and Langfuse guides.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The Mermaid syntax follows established repository patterns, the linked Langfuse integration route exists, and no concrete incorrect or unsafe guidance was identified.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  App["Application<br/>OpenTelemetry SDK"] -->|"Mask before export"| Export["OTLP export"]
  App -->|"Unmasked OTLP within secured trust boundary"| Collector["OpenTelemetry Collector<br/>masking processors"]
  Export --> Langfuse["Langfuse"]
  Collector -->|"Masked OTLP/HTTP"| Langfuse
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Document masking options for OpenTelemet..."](https://github.com/langfuse/langfuse-docs/commit/889e415ef97a49171591c55deff20b6930bbe8e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52605685)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->