### PR TITLE
docs: improve tracing get-started troubleshooting and next steps

### DIFF
--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -463,12 +463,20 @@ _[What does a good trace look like?](/docs/observability/best-practices)_
 
 <FaqPreview tags={["observability-get-started"]} />
 
+If your trace looks overly complicated or overwhelming, the tracing setup itself may need a second look. Compare it against our [best practices guide](/docs/observability/best-practices).
+
 ## Next steps
 
-Now that you've ingested your first trace, you can start adding on more functionality to your traces. We recommend starting with the following:
+Now that your first trace is in Langfuse, learn to make sense of your traces by reading the chapter on [Monitoring in the Langfuse Academy](/academy/monitoring).
+
+Or if you know exactly what you're looking for, here are the most common features:
 
 - [Group traces into sessions for multi-turn applications](/docs/observability/features/sessions)
-- [Split traces into environments for different stages of your application](/docs/observability/features/environments)
-- [Add attributes to your traces so you can filter them in the future](/docs/observability/features/tags)
+- [Attribute traces to individual users](/docs/observability/features/users)
+- [Add attributes to your traces so you can filter them later](/docs/observability/features/tags)
+- [Track model usage and cost](/docs/observability/features/token-and-cost-tracking)
+- [Monitor application quality with scores](/docs/evaluation/scores/overview)
+- [Get notified when a metric crosses a threshold with alerts](/docs/metrics/features/alerts)
+- [Analyze cost, latency, volume, and quality in custom dashboards](/docs/metrics/features/custom-dashboards)
 
-Already know what you want? Take a look under _Features_ for guides on specific topics.
+Take a look under [Features](#sidebar-folder-docs-observability-features) in the sidebar for guides on specific topics.


### PR DESCRIPTION
Improves the [tracing get-started page](/docs/observability/get-started) so readers know what to do after ingesting their first trace.

## Changes

- **Troubleshooting**: after the FAQ, add a pointer that an overly complicated or overwhelming trace often signals a tracing-setup issue, linking to the best practices guide.
- **Next steps**: lead with making sense of traces via the Monitoring chapter in the Langfuse Academy, then a reordered, higher-signal feature list (sessions, users, tags, cost, scores, alerts, dashboards). Swaps out environments for users based on page-view data.
- **Features link**: reuse the sidebar folder deep-link introduced in #3507 so "Features" opens the Observability → Features folder in the sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to onboarding copy and links; no application or data-handling behavior changes.
> 
> **Overview**
> Updates the tracing **get-started** page so readers have clearer guidance after their first trace lands in Langfuse.
> 
> In **Not seeing what you expected?**, a short note after the FAQ suggests that traces that feel overly complicated or overwhelming often point to tracing-setup issues, with a link to the **best practices** guide.
> 
> The **Next steps** section now leads with the Langfuse Academy **Monitoring** chapter instead of a generic feature list. It adds a reordered “most common features” list (sessions, users, tags, cost, scores, alerts, dashboards), drops **environments** in favor of **users**, and points “Features” at the Observability → Features sidebar folder via the `#sidebar-folder-docs-observability-features` deep link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33607250103cf2455351ff7cf1a741fbe2fac518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the tracing get-started page by adding troubleshooting guidance and clearer actions after ingesting a first trace.

- Directs readers with overly complex traces to tracing best practices.
- Promotes the Langfuse Academy monitoring chapter and expands the recommended feature links.
- Adds a deep link that opens the Observability Features folder in the sidebar.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge, with all added links resolving to appropriate routes and no actionable defects identified.

The revised MDX uses existing internal routes and the repository’s established sidebar-folder link format without changing runtime logic or introducing broken navigation.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: improve tracing get-started troubl..."](https://github.com/langfuse/langfuse-docs/commit/33607250103cf2455351ff7cf1a741fbe2fac518) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52778881)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->