### PR TITLE
docs: add usage and cost data next-steps section to token & cost tracking

### DIFF
--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -41,7 +41,13 @@ flowchart LR
   B -->|use usage| G
 ```
 
-Via the [Metrics API](/docs/metrics/features/metrics-api), you can retrieve aggregated usage and cost metrics from Langfuse for downstream use in analytics, billing, and rate-limiting. The API allows you to filter by application type, user, or tags. For a broader playbook on attributing and controlling spend, see our guide to [LLM cost management](/resources/engineering/llm-cost-management).
+## How to use usage and cost data once it's in Langfuse [#use-cost-data]
+
+Once usage and cost are tracked, you can put the data to work:
+
+- **[Create dashboards](/docs/metrics/features/custom-dashboards):** monitor cost across models, tags, or users.
+- **[Set up alerts](/docs/metrics/features/alerts):** get notified automatically when spend crosses a threshold.
+- **[Query with the Metrics API](/docs/metrics/features/metrics-api):** retrieve aggregated usage and cost, filtered by application type, user, or tags, for analytics, billing, and rate-limiting.
 
 ## Ingest usage and/or cost [#ingest]
 


### PR DESCRIPTION
Adds a scannable "How to use usage and cost data once it's in Langfuse" section to the token & cost tracking page, aimed at readers who already have cost data and want to know what to do with it.

The section replaces a single dense paragraph with a heading and three bullets, each linking to the relevant destination:

- Create dashboards → custom dashboards
- Set up alerts → alerts (the metrics alerts page, which supports cost thresholds — not spend alerts, which covers the Langfuse Cloud bill)
- Query with the Metrics API → metrics API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and link restructuring on the token & cost tracking page; no runtime or API behavior changes.
> 
> **Overview**
> On the **Token & Cost Tracking** page, the single paragraph that pointed readers to the Metrics API (and the LLM cost management guide) is replaced with **“How to use usage and cost data once it's in Langfuse”** (`#use-cost-data`).
> 
> The new section is a short intro plus three bullets: **custom dashboards** for cost monitoring, **metrics alerts** for spend thresholds, and the **Metrics API** for aggregated usage/cost in analytics, billing, and rate-limiting. The separate link to the LLM cost management engineering guide is removed from this spot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92a1d9611f56384c42503b744408ecf9102493d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces a dense Metrics API paragraph with a scannable next-steps section linking readers to dashboards, alerts, and the Metrics API.
- Adds direct links for acting on tracked usage and cost data.
- Preserves the existing Metrics API use cases in a dedicated bullet.
- Introduces terminology that should more clearly distinguish LLM cost alerts from Cloud billing spend alerts.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking terminology clarification recommended for the alert bullet.

The links resolve and generally match their stated capabilities, but “spend crosses a threshold” can conflate LLM cost-metric alerts with the separately documented Cloud billing spend-alert feature.

**Files Needing Attention:** content/docs/observability/features/token-and-cost-tracking.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/observability/features/token-and-cost-tracking.mdx:49
**Distinguish cost alerts from spend alerts**

The phrase “spend crosses a threshold” conflates the linked LLM cost-metric alerts with Cloud billing spend alerts, directing readers to expect billing-threshold behavior from the wrong feature.

```suggestion
- **[Set up alerts](/docs/metrics/features/alerts):** get notified automatically when tracked LLM cost crosses a threshold.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add usage and cost data next-steps..."](https://github.com/langfuse/langfuse-docs/commit/c92a1d9611f56384c42503b744408ecf9102493d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52792741)</sub>

<!-- /greptile_comment -->