### PR TITLE
docs: add FAQ on Vapi integration and Langfuse v4 upgrade process

### DIFF
--- a/content/faq/all/partner-integration-v4-upgrade.mdx
+++ b/content/faq/all/partner-integration-v4-upgrade.mdx
@@ -1,0 +1,33 @@
+---
+title: Why is my Vapi project still on the Langfuse v3 experience?
+sidebarTitle: Vapi and the v4 upgrade
+description: Projects ingesting via the Vapi integration stay on the Langfuse v3 experience until the integration is upgraded — what this means for dashboards, tables, and evaluators.
+tags: [observability, integration]
+---
+
+# Vapi and the Langfuse v4 upgrade
+
+Vapi sends data to Langfuse through the [Vapi integration](/integrations/no-code/vapi), which the Vapi team operates. Projects relying on this integration are currently opted into the Langfuse v3 experience because the integration does not yet ingest data on the [Langfuse v4](/docs/v4) data model.
+
+We are working with the Vapi team to upgrade the integration. As soon as the upgrade ships, affected projects see the v4 experience automatically — no action is needed on your side.
+
+## Switching to v4 early [#switch-early]
+
+You can opt into the v4 experience yourself at any time via the **Langfuse v4 preview** toggle (bottom-left in the UI). This gives you the significantly faster dashboards and tables of the v4 experience. You may opt-out again at any time.
+
+<Callout type="warning">
+  Until the Vapi integration is upgraded, data ingested via Vapi appears in the
+  v4 experience with a delay of approximately 15 minutes. If you need real-time
+  data, keep the toggle off and switch after the integration upgrade.
+</Callout>
+
+## Keep managing trace-level evaluators [#trace-level-evaluators]
+
+Trace-level LLM-as-a-Judge evaluators are deprecated as part of Langfuse v4, and most projects should [upgrade them to observation-level evaluators](/faq/all/llm-as-a-judge-migration). Observation-level evaluators require the upgraded ingestion path, so for projects ingesting via Vapi this upgrade is currently blocked until the Vapi integration upgrade ships.
+
+Continue creating and managing trace-level evaluators as before — they keep running throughout the transition. Once the integration is upgraded, follow the [evaluator upgrade guide](/faq/all/llm-as-a-judge-migration) to move to observation-level evaluators.
+
+## Getting help
+
+- **Questions on Langfuse v4**: Ask in the dedicated [GitHub Discussion](https://github.com/orgs/langfuse/discussions/12518)
+- **Support**: Contact support@langfuse.com for enterprise customers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application, API, or data-path changes.
> 
> **Overview**
> Adds a new FAQ page **`partner-integration-v4-upgrade.mdx`** explaining why Vapi-backed projects remain on the Langfuse **v3 experience** until the partner integration supports the v4 data model, and that v4 rolls out automatically once that upgrade ships.
> 
> The page documents how to use the **Langfuse v4 preview** toggle early, including a warning that Vapi-ingested data can lag by ~15 minutes in v4 until the integration is updated. It also clarifies that **observation-level evaluator** migration stays blocked for Vapi ingestion for now, while **trace-level evaluators** can still be used during the transition, with pointers to the existing evaluator migration FAQ and support channels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bd30b0f68e2f9fa48c1891e6ad5b4f80c04527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Vapi-specific FAQ explaining why affected projects remain on the Langfuse v3 experience and how users can navigate the transition to v4.

- Documents early v4 opt-in behavior and the temporary ingestion delay.
- Explains how to manage trace-level evaluators until Vapi supports the upgraded ingestion path.
- Links to the Vapi integration, v4 overview, evaluator migration guide, and support channels.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new FAQ follows existing MDX and FAQ conventions, and its internal links resolve to canonical repository routes.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add FAQ on Vapi integration and La..."](https://github.com/langfuse/langfuse-docs/commit/29bd30b0f68e2f9fa48c1891e6ad5b4f80c04527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52904002)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->