### PR TITLE
chore(docs): Remove beta notice from agent graphs

### DIFF
--- a/content/docs/observability/features/agent-graphs.mdx
+++ b/content/docs/observability/features/agent-graphs.mdx
@@ -20,12 +20,6 @@ _Example trace with agent graph view ([public link](https://cloud.langfuse.com/p
 
 ## Get Started
 
-<Callout type="info">
-
-The graph view is currently in beta, please feel free to share feedback.
-
-</Callout>
-
 There are two ways a graph appears for a trace:
 
 1. **Inferred from observations.** Have an observation with any observation type except `span`, `event`, or `generation` in your trace. Langfuse then interprets the trace as agentic and shows a graph, inferred automatically from the observations' timings and nesting.


### PR DESCRIPTION
## Summary

Remove the outdated beta notice from the Agent Graphs documentation.

## Impact

The documentation now reflects that agent graphs are stable.

## Checks

- `pnpm run format:check`
- `pnpm run format`
- `node scripts/check-h1-headings.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit with no product or API behavior changes.
> 
> **Overview**
> Removes the **info** `Callout` under **Get Started** in `agent-graphs.mdx` that said the graph view was in beta and invited feedback.
> 
> Docs now present agent graphs as a stable feature with no beta disclaimer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bdb7598e5cf80088785a7126f7fb140abc92b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the outdated beta notice from the Agent Graphs documentation so the page reflects the feature's stable status.

- Deletes the informational beta callout from the “Get Started” section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only removes an outdated informational callout and leaves the surrounding MDX content valid and intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove beta notice from agent graphs"](https://github.com/langfuse/langfuse-docs/commit/3af2c409eaac1a134ef9b2876d015613677c7a40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52906236)</sub>

<!-- /greptile_comment -->