### PR TITLE
docs: move multimodal experiments below evaluators on SDK page

### DIFF
--- a/content/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/content/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -371,6 +371,90 @@ console.log(await result.format());
 </Tab>
 </LangTabs>
 
+#### Multi-modal experiments [#multimodal-experiments]
+
+SDK-based experiments can run on datasets that include media attachments in `input`, `expectedOutput`, or `metadata`. When you fetch the dataset via the SDK, each media token is hydrated into a signed `LangfuseMediaReference` by default.
+
+<Callout type="info">
+  Multi-modal datasets are supported for SDK-based experiments with Python SDK
+  `>= 4.10.0` and JS/TS SDK `@langfuse/client >= 5.6.0`. UI-based
+  experiments do not yet support dataset items with media attachments.
+</Callout>
+
+<LangTabs items={["Python SDK", "JS/TS SDK"]}>
+<Tab>
+{/* PYTHON SDK */}
+
+```python
+from langfuse import get_client
+from langfuse.media import LangfuseMediaReference
+
+langfuse = get_client()
+
+dataset = langfuse.get_dataset("visual-qa")
+
+def my_multi_modal_task(*, item, **kwargs):
+    image = item.input["image"]
+    assert isinstance(image, LangfuseMediaReference)
+
+    # Use the format expected by your model provider.
+    image_data_uri = image.fetch_data_uri()
+
+    # Call your multi-modal application here.
+    return run_visual_qa(
+        question=item.input["question"],
+        image=image_data_uri,
+    )
+
+result = dataset.run_experiment(
+    name="Visual QA",
+    task=my_multi_modal_task,
+)
+```
+
+</Tab>
+<Tab>
+{/* JS/TS SDK */}
+
+```typescript
+import {
+  LangfuseClient,
+  LangfuseMediaReference,
+} from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+const dataset = await langfuse.dataset.get("visual-qa");
+
+const result = await dataset.runExperiment({
+  name: "Visual QA",
+  task: async (item) => {
+    const image = item.input.image as LangfuseMediaReference;
+
+    // Use the format expected by your model provider.
+    const imageDataUri = await image.fetchDataUri();
+
+    // Call your multi-modal application here.
+    return runVisualQa({
+      question: item.input.question,
+      image: imageDataUri,
+    });
+  },
+});
+```
+
+</Tab>
+</LangTabs>
+
+`LangfuseMediaReference` exposes helpers to fetch the media as raw bytes, raw base64, or a data URI:
+
+| SDK    | Bytes           | Base64           | Data URI           |
+| ------ | --------------- | ---------------- | ------------------ |
+| Python | `fetch_bytes()` | `fetch_base64()` | `fetch_data_uri()` |
+| JS/TS  | `fetchBytes()`  | `fetchBase64()`  | `fetchDataUri()`   |
+
+The resolved URLs are signed and expire. If a URL expires before your experiment uses it, fetch the dataset again to receive fresh media references.
+
 #### Async Tasks and Evaluators
 
 Both task functions and evaluators can be asynchronous.
@@ -554,90 +638,6 @@ console.log(await result.format());
 
 </Tab>
 </LangTabs>
-
-### Multi-modal experiments [#multimodal-experiments]
-
-SDK-based experiments can run on datasets that include media attachments in `input`, `expectedOutput`, or `metadata`. When you fetch the dataset via the SDK, each media token is hydrated into a signed `LangfuseMediaReference` by default.
-
-<Callout type="info">
-  Multi-modal datasets are supported for SDK-based experiments with Python SDK
-  `>= 4.10.0` and JS/TS SDK `@langfuse/client >= 5.6.0`. UI-based
-  experiments do not yet support dataset items with media attachments.
-</Callout>
-
-<LangTabs items={["Python SDK", "JS/TS SDK"]}>
-<Tab>
-{/* PYTHON SDK */}
-
-```python
-from langfuse import get_client
-from langfuse.media import LangfuseMediaReference
-
-langfuse = get_client()
-
-dataset = langfuse.get_dataset("visual-qa")
-
-def my_multi_modal_task(*, item, **kwargs):
-    image = item.input["image"]
-    assert isinstance(image, LangfuseMediaReference)
-
-    # Use the format expected by your model provider.
-    image_data_uri = image.fetch_data_uri()
-
-    # Call your multi-modal application here.
-    return run_visual_qa(
-        question=item.input["question"],
-        image=image_data_uri,
-    )
-
-result = dataset.run_experiment(
-    name="Visual QA",
-    task=my_multi_modal_task,
-)
-```
-
-</Tab>
-<Tab>
-{/* JS/TS SDK */}
-
-```typescript
-import {
-  LangfuseClient,
-  LangfuseMediaReference,
-} from "@langfuse/client";
-
-const langfuse = new LangfuseClient();
-
-const dataset = await langfuse.dataset.get("visual-qa");
-
-const result = await dataset.runExperiment({
-  name: "Visual QA",
-  task: async (item) => {
-    const image = item.input.image as LangfuseMediaReference;
-
-    // Use the format expected by your model provider.
-    const imageDataUri = await image.fetchDataUri();
-
-    // Call your multi-modal application here.
-    return runVisualQa({
-      question: item.input.question,
-      image: imageDataUri,
-    });
-  },
-});
-```
-
-</Tab>
-</LangTabs>
-
-`LangfuseMediaReference` exposes helpers to fetch the media as raw bytes, raw base64, or a data URI:
-
-| SDK    | Bytes           | Base64           | Data URI           |
-| ------ | --------------- | ---------------- | ------------------ |
-| Python | `fetch_bytes()` | `fetch_base64()` | `fetch_data_uri()` |
-| JS/TS  | `fetchBytes()`  | `fetchBase64()`  | `fetchDataUri()`   |
-
-The resolved URLs are signed and expire. If a URL expires before your experiment uses it, fetch the dataset again to receive fresh media references.
 
 ## Optional: Trigger SDK Experiment from UI
 

--- a/content/docs/evaluation/experiments/experiments-via-sdk.mdx
+++ b/content/docs/evaluation/experiments/experiments-via-sdk.mdx
@@ -211,90 +211,6 @@ When using Langfuse datasets, dataset runs are automatically created in Langfuse
 
 Experiments always run on the latest dataset version at experiment time. Support for running experiments on specific dataset versions will be added to the SDK shortly.
 
-### Multi-modal experiments [#multimodal-experiments]
-
-SDK-based experiments can run on datasets that include media attachments in `input`, `expectedOutput`, or `metadata`. When you fetch the dataset via the SDK, each media token is hydrated into a signed `LangfuseMediaReference` by default.
-
-<Callout type="info">
-  Multi-modal datasets are supported for SDK-based experiments with Python SDK
-  `>= 4.10.0` and JS/TS SDK `@langfuse/client >= 5.6.0`. UI-based
-  experiments do not yet support dataset items with media attachments.
-</Callout>
-
-<LangTabs items={["Python SDK", "JS/TS SDK"]}>
-<Tab>
-{/* PYTHON SDK */}
-
-```python
-from langfuse import get_client
-from langfuse.media import LangfuseMediaReference
-
-langfuse = get_client()
-
-dataset = langfuse.get_dataset("visual-qa")
-
-def my_multi_modal_task(*, item, **kwargs):
-    image = item.input["image"]
-    assert isinstance(image, LangfuseMediaReference)
-
-    # Use the format expected by your model provider.
-    image_data_uri = image.fetch_data_uri()
-
-    # Call your multi-modal application here.
-    return run_visual_qa(
-        question=item.input["question"],
-        image=image_data_uri,
-    )
-
-result = dataset.run_experiment(
-    name="Visual QA",
-    task=my_multi_modal_task,
-)
-```
-
-</Tab>
-<Tab>
-{/* JS/TS SDK */}
-
-```typescript
-import {
-  LangfuseClient,
-  LangfuseMediaReference,
-} from "@langfuse/client";
-
-const langfuse = new LangfuseClient();
-
-const dataset = await langfuse.dataset.get("visual-qa");
-
-const result = await dataset.runExperiment({
-  name: "Visual QA",
-  task: async (item) => {
-    const image = item.input.image as LangfuseMediaReference;
-
-    // Use the format expected by your model provider.
-    const imageDataUri = await image.fetchDataUri();
-
-    // Call your multi-modal application here.
-    return runVisualQa({
-      question: item.input.question,
-      image: imageDataUri,
-    });
-  },
-});
-```
-
-</Tab>
-</LangTabs>
-
-`LangfuseMediaReference` exposes helpers to fetch the media as raw bytes, raw base64, or a data URI:
-
-| SDK    | Bytes           | Base64           | Data URI           |
-| ------ | --------------- | ---------------- | ------------------ |
-| Python | `fetch_bytes()` | `fetch_base64()` | `fetch_data_uri()` |
-| JS/TS  | `fetchBytes()`  | `fetchBase64()`  | `fetchDataUri()`   |
-
-The resolved URLs are signed and expire. If a URL expires before your experiment uses it, fetch the dataset again to receive fresh media references.
-
 ### Advanced Features
 
 Enhance your experiments with evaluators and advanced configuration options.
@@ -638,6 +554,90 @@ console.log(await result.format());
 
 </Tab>
 </LangTabs>
+
+### Multi-modal experiments [#multimodal-experiments]
+
+SDK-based experiments can run on datasets that include media attachments in `input`, `expectedOutput`, or `metadata`. When you fetch the dataset via the SDK, each media token is hydrated into a signed `LangfuseMediaReference` by default.
+
+<Callout type="info">
+  Multi-modal datasets are supported for SDK-based experiments with Python SDK
+  `>= 4.10.0` and JS/TS SDK `@langfuse/client >= 5.6.0`. UI-based
+  experiments do not yet support dataset items with media attachments.
+</Callout>
+
+<LangTabs items={["Python SDK", "JS/TS SDK"]}>
+<Tab>
+{/* PYTHON SDK */}
+
+```python
+from langfuse import get_client
+from langfuse.media import LangfuseMediaReference
+
+langfuse = get_client()
+
+dataset = langfuse.get_dataset("visual-qa")
+
+def my_multi_modal_task(*, item, **kwargs):
+    image = item.input["image"]
+    assert isinstance(image, LangfuseMediaReference)
+
+    # Use the format expected by your model provider.
+    image_data_uri = image.fetch_data_uri()
+
+    # Call your multi-modal application here.
+    return run_visual_qa(
+        question=item.input["question"],
+        image=image_data_uri,
+    )
+
+result = dataset.run_experiment(
+    name="Visual QA",
+    task=my_multi_modal_task,
+)
+```
+
+</Tab>
+<Tab>
+{/* JS/TS SDK */}
+
+```typescript
+import {
+  LangfuseClient,
+  LangfuseMediaReference,
+} from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+const dataset = await langfuse.dataset.get("visual-qa");
+
+const result = await dataset.runExperiment({
+  name: "Visual QA",
+  task: async (item) => {
+    const image = item.input.image as LangfuseMediaReference;
+
+    // Use the format expected by your model provider.
+    const imageDataUri = await image.fetchDataUri();
+
+    // Call your multi-modal application here.
+    return runVisualQa({
+      question: item.input.question,
+      image: imageDataUri,
+    });
+  },
+});
+```
+
+</Tab>
+</LangTabs>
+
+`LangfuseMediaReference` exposes helpers to fetch the media as raw bytes, raw base64, or a data URI:
+
+| SDK    | Bytes           | Base64           | Data URI           |
+| ------ | --------------- | ---------------- | ------------------ |
+| Python | `fetch_bytes()` | `fetch_base64()` | `fetch_data_uri()` |
+| JS/TS  | `fetchBytes()`  | `fetchBase64()`  | `fetchDataUri()`   |
+
+The resolved URLs are signed and expire. If a URL expires before your experiment uses it, fetch the dataset again to receive fresh media references.
 
 ## Optional: Trigger SDK Experiment from UI
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Moves **Multi-modal experiments** into **Advanced Features** on [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk), after Run-level Evaluators and before Async Tasks and Evaluators.
- Addresses LFE-15112 feedback that the multimodal segment was confusingly placed above evals.

### Section order under Advanced Features

1. Evaluators  
2. Run-level Evaluators  
3. **Multi-modal experiments** ← here  
4. Async Tasks and Evaluators  
5. Configuration Options  

The `#multimodal-experiments` anchor is unchanged, so existing links from the datasets and multi-modality docs still work.

## Test plan

- [ ] Confirm TOC on `/docs/evaluation/experiments/experiments-via-sdk` nests Multimodal under Advanced Features, before Async
- [ ] Confirm `/docs/evaluation/experiments/experiments-via-sdk#multimodal-experiments` still jumps to the section
- [ ] Spot-check links from `/docs/evaluation/experiments/datasets` and `/docs/observability/features/multi-modality`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15112](https://linear.app/clickhouse/issue/LFE-15112/update-the-multimodal-experiments-section-in-the-langfuse-docs)

<div><a href="https://cursor.com/agents/bc-e424a7d6-a7c4-46f2-ae2d-40fb9808880c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e424a7d6-a7c4-46f2-ae2d-40fb9808880c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Moves the existing Multi-modal experiments section into Advanced Features, between Run-level Evaluators and Async Tasks and Evaluators.

- Preserves the `#multimodal-experiments` anchor and all section content.
- Changes the heading level to nest the section correctly in the table of contents.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only reorders existing documentation while preserving its content and deep-link anchor.

The moved section remains intact, is correctly nested under Advanced Features, and retains the explicit multimodal-experiments anchor used by existing links.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: nest multimodal experiments under ..."](https://github.com/langfuse/langfuse-docs/commit/3a4008f094bead85e7f1bda1d4c39d3cf1621aed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53039597)</sub>

<!-- /greptile_comment -->