### PR TITLE
demo: use boolean negative_user_feedback score

### DIFF
--- a/components/demoLangfuseBrowserClients.ts
+++ b/components/demoLangfuseBrowserClients.ts
@@ -44,3 +44,31 @@ export const scoreDemoFeedback = (score: LangfuseBrowserScoreBody) => {
     getDemoLangfuseBrowserClients().map((client) => client.score(score)),
   );
 };
+
+export const NEGATIVE_USER_FEEDBACK_SCORE_NAME = "negative_user_feedback";
+
+/**
+ * Record thumbs up/down from a demo widget as a BOOLEAN score.
+ *
+ * `value: true` means the user gave negative feedback (thumbs down);
+ * `value: false` means positive feedback (thumbs up). The Langfuse
+ * ingestion API encodes BOOLEAN scores as 1/0.
+ */
+export const scoreDemoNegativeUserFeedback = ({
+  traceId,
+  value,
+  comment,
+}: {
+  traceId: string;
+  value: boolean;
+  comment?: string;
+}) => {
+  scoreDemoFeedback({
+    traceId,
+    id: `${NEGATIVE_USER_FEEDBACK_SCORE_NAME}-${traceId}`,
+    name: NEGATIVE_USER_FEEDBACK_SCORE_NAME,
+    value: value ? 1 : 0,
+    dataType: "BOOLEAN",
+    comment,
+  });
+};

--- a/components/imageGenerator/index.tsx
+++ b/components/imageGenerator/index.tsx
@@ -40,9 +40,7 @@ export const ImageGenerator = ({
   const [loading, setLoading] = useState(false);
   const [currentImage, setCurrentImage] = useState<GeneratedImage | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<"positive" | "negative" | null>(
-    null,
-  );
+  const [feedback, setFeedback] = useState<boolean | null>(null);
 
   const userId = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -106,12 +104,12 @@ export const ImageGenerator = ({
     link.click();
   };
 
-  const handleFeedback = (feedbackType: "positive" | "negative") => {
+  const handleFeedback = (value: boolean) => {
     if (!currentImage) return;
-    setFeedback(feedbackType);
+    setFeedback(value);
     scoreDemoNegativeUserFeedback({
       traceId: currentImage.traceId,
-      value: feedbackType === "negative",
+      value,
     });
   };
 
@@ -223,10 +221,10 @@ export const ImageGenerator = ({
                   Rate this:
                 </span>
                 <button
-                  onClick={() => handleFeedback("positive")}
+                  onClick={() => handleFeedback(false)}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === "positive"
+                    feedback === false
                       ? "text-green-700 dark:text-green-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}
@@ -234,10 +232,10 @@ export const ImageGenerator = ({
                   <ThumbsUpIcon className="size-3.5" />
                 </button>
                 <button
-                  onClick={() => handleFeedback("negative")}
+                  onClick={() => handleFeedback(true)}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === "negative"
+                    feedback === true
                       ? "text-red-700 dark:text-red-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}

--- a/components/imageGenerator/index.tsx
+++ b/components/imageGenerator/index.tsx
@@ -7,7 +7,7 @@ import { Loader } from "@/components/ai-elements/loader";
 import { Suggestions, Suggestion } from "@/components/ai-elements/suggestion";
 import { Image as AiImage } from "@/components/ai-elements/image";
 import { getPersistedNanoId } from "@/components/qaChatbot/utils/persistedNanoId";
-import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
+import { scoreDemoNegativeUserFeedback } from "@/components/demoLangfuseBrowserClients";
 import {
   SendIcon,
   DownloadIcon,
@@ -40,7 +40,9 @@ export const ImageGenerator = ({
   const [loading, setLoading] = useState(false);
   const [currentImage, setCurrentImage] = useState<GeneratedImage | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState<"positive" | "negative" | null>(
+    null,
+  );
 
   const userId = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -104,14 +106,12 @@ export const ImageGenerator = ({
     link.click();
   };
 
-  const handleFeedback = (value: number) => {
+  const handleFeedback = (feedbackType: "positive" | "negative") => {
     if (!currentImage) return;
-    setFeedback(value);
-    scoreDemoFeedback({
+    setFeedback(feedbackType);
+    scoreDemoNegativeUserFeedback({
       traceId: currentImage.traceId,
-      id: `user-feedback-${currentImage.traceId}`,
-      name: "user-feedback",
-      value,
+      value: feedbackType === "negative",
     });
   };
 
@@ -223,10 +223,10 @@ export const ImageGenerator = ({
                   Rate this:
                 </span>
                 <button
-                  onClick={() => handleFeedback(1)}
+                  onClick={() => handleFeedback("positive")}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === 1
+                    feedback === "positive"
                       ? "text-green-700 dark:text-green-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}
@@ -234,10 +234,10 @@ export const ImageGenerator = ({
                   <ThumbsUpIcon className="size-3.5" />
                 </button>
                 <button
-                  onClick={() => handleFeedback(0)}
+                  onClick={() => handleFeedback("negative")}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === 0
+                    feedback === "negative"
                       ? "text-red-700 dark:text-red-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}

--- a/components/qaChatbot/FeedbackPopover.tsx
+++ b/components/qaChatbot/FeedbackPopover.tsx
@@ -19,8 +19,12 @@ import { Textarea } from "../ui/textarea";
 interface FeedbackDialogProps {
   messageId: string;
   feedbackType: "positive" | "negative";
-  currentFeedback: number | null;
-  onFeedback: (messageId: string, value: number, comment?: string) => void;
+  currentFeedback: "positive" | "negative" | null;
+  onFeedback: (
+    messageId: string,
+    feedbackType: "positive" | "negative",
+    comment?: string,
+  ) => void;
 }
 
 export const FeedbackDialog = ({
@@ -32,12 +36,10 @@ export const FeedbackDialog = ({
   const [comment, setComment] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const feedbackValue = feedbackType === "positive" ? 1 : 0;
-  const isActive = currentFeedback === feedbackValue;
+  const isActive = currentFeedback === feedbackType;
 
   const handleSubmit = () => {
-    // Update feedback with comment
-    onFeedback(messageId, feedbackValue, comment.trim() || undefined);
+    onFeedback(messageId, feedbackType, comment.trim() || undefined);
     setComment("");
     setIsOpen(false);
   };
@@ -45,7 +47,7 @@ export const FeedbackDialog = ({
   const handleOpenChange = (open: boolean) => {
     if (open && !isActive) {
       // Submit feedback when popover opens (only if not already active)
-      onFeedback(messageId, feedbackValue);
+      onFeedback(messageId, feedbackType);
     }
     setIsOpen(open);
   };

--- a/components/qaChatbot/FeedbackPopover.tsx
+++ b/components/qaChatbot/FeedbackPopover.tsx
@@ -19,12 +19,8 @@ import { Textarea } from "../ui/textarea";
 interface FeedbackDialogProps {
   messageId: string;
   feedbackType: "positive" | "negative";
-  currentFeedback: "positive" | "negative" | null;
-  onFeedback: (
-    messageId: string,
-    feedbackType: "positive" | "negative",
-    comment?: string,
-  ) => void;
+  currentFeedback: boolean | null;
+  onFeedback: (messageId: string, value: boolean, comment?: string) => void;
 }
 
 export const FeedbackDialog = ({
@@ -36,10 +32,11 @@ export const FeedbackDialog = ({
   const [comment, setComment] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const isActive = currentFeedback === feedbackType;
+  const value = feedbackType === "negative";
+  const isActive = currentFeedback === value;
 
   const handleSubmit = () => {
-    onFeedback(messageId, feedbackType, comment.trim() || undefined);
+    onFeedback(messageId, value, comment.trim() || undefined);
     setComment("");
     setIsOpen(false);
   };
@@ -47,7 +44,7 @@ export const FeedbackDialog = ({
   const handleOpenChange = (open: boolean) => {
     if (open && !isActive) {
       // Submit feedback when popover opens (only if not already active)
-      onFeedback(messageId, feedbackType);
+      onFeedback(messageId, value);
     }
     setIsOpen(open);
   };

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -39,7 +39,7 @@ import {
   ToolOutput,
   ToolInput,
 } from "@/components/ai-elements/tool";
-import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
+import { scoreDemoNegativeUserFeedback } from "@/components/demoLangfuseBrowserClients";
 import { FeedbackDialog } from "./FeedbackPopover";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
@@ -51,10 +51,10 @@ type ChatProps = HTMLAttributes<HTMLDivElement>;
 export const Chat = ({ className, ...props }: ChatProps) => {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  // Track user feedback for each message ID (1 = thumbs up, 0 = thumbs down, null = no feedback)
-  const [userFeedback, setUserFeedback] = useState<Map<string, number | null>>(
-    new Map(),
-  );
+  // Track user feedback for each message ID (null = no feedback)
+  const [userFeedback, setUserFeedback] = useState<
+    Map<string, "positive" | "negative" | null>
+  >(new Map());
 
   // Auto-resize and scroll textarea to bottom when content changes
   useEffect(() => {
@@ -107,17 +107,14 @@ export const Chat = ({ className, ...props }: ChatProps) => {
 
   const handleFeedback = (
     messageId: string,
-    value: number,
+    feedbackType: "positive" | "negative",
     comment?: string,
   ) => {
-    // Update the local state
-    setUserFeedback((prev) => new Map([...prev, [messageId, value]]));
+    setUserFeedback((prev) => new Map([...prev, [messageId, feedbackType]]));
 
-    scoreDemoFeedback({
+    scoreDemoNegativeUserFeedback({
       traceId: messageId,
-      id: `user-feedback-${messageId}`,
-      name: "user-feedback",
-      value,
+      value: feedbackType === "negative",
       comment,
     });
   };

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -51,10 +51,10 @@ type ChatProps = HTMLAttributes<HTMLDivElement>;
 export const Chat = ({ className, ...props }: ChatProps) => {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  // Track user feedback for each message ID (null = no feedback)
-  const [userFeedback, setUserFeedback] = useState<
-    Map<string, "positive" | "negative" | null>
-  >(new Map());
+  // Track negative_user_feedback per message (true/false, null = none)
+  const [userFeedback, setUserFeedback] = useState<Map<string, boolean | null>>(
+    new Map(),
+  );
 
   // Auto-resize and scroll textarea to bottom when content changes
   useEffect(() => {
@@ -107,14 +107,14 @@ export const Chat = ({ className, ...props }: ChatProps) => {
 
   const handleFeedback = (
     messageId: string,
-    feedbackType: "positive" | "negative",
+    value: boolean,
     comment?: string,
   ) => {
-    setUserFeedback((prev) => new Map([...prev, [messageId, feedbackType]]));
+    setUserFeedback((prev) => new Map([...prev, [messageId, value]]));
 
     scoreDemoNegativeUserFeedback({
       traceId: messageId,
-      value: feedbackType === "negative",
+      value,
       comment,
     });
   };

--- a/components/sentimentClassifier/index.tsx
+++ b/components/sentimentClassifier/index.tsx
@@ -54,9 +54,7 @@ export const SentimentClassifier = ({
     inputText: string;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<"positive" | "negative" | null>(
-    null,
-  );
+  const [feedback, setFeedback] = useState<boolean | null>(null);
 
   const userId = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -102,12 +100,12 @@ export const SentimentClassifier = ({
     }
   };
 
-  const handleFeedback = (feedbackType: "positive" | "negative") => {
+  const handleFeedback = (value: boolean) => {
     if (!result) return;
-    setFeedback(feedbackType);
+    setFeedback(value);
     scoreDemoNegativeUserFeedback({
       traceId: result.traceId,
-      value: feedbackType === "negative",
+      value,
     });
   };
 
@@ -249,10 +247,10 @@ export const SentimentClassifier = ({
                   Was this classification accurate?
                 </span>
                 <button
-                  onClick={() => handleFeedback("positive")}
+                  onClick={() => handleFeedback(false)}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === "positive"
+                    feedback === false
                       ? "text-green-700 dark:text-green-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}
@@ -260,10 +258,10 @@ export const SentimentClassifier = ({
                   <ThumbsUpIcon className="size-3.5" />
                 </button>
                 <button
-                  onClick={() => handleFeedback("negative")}
+                  onClick={() => handleFeedback(true)}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === "negative"
+                    feedback === true
                       ? "text-red-700 dark:text-red-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}

--- a/components/sentimentClassifier/index.tsx
+++ b/components/sentimentClassifier/index.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { Loader } from "@/components/ai-elements/loader";
 import { Suggestions, Suggestion } from "@/components/ai-elements/suggestion";
 import { getPersistedNanoId } from "@/components/qaChatbot/utils/persistedNanoId";
-import { scoreDemoFeedback } from "@/components/demoLangfuseBrowserClients";
+import { scoreDemoNegativeUserFeedback } from "@/components/demoLangfuseBrowserClients";
 import { SendIcon, ThumbsUpIcon, ThumbsDownIcon } from "lucide-react";
 
 type SentimentResult = {
@@ -54,7 +54,9 @@ export const SentimentClassifier = ({
     inputText: string;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState<"positive" | "negative" | null>(
+    null,
+  );
 
   const userId = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -100,14 +102,12 @@ export const SentimentClassifier = ({
     }
   };
 
-  const handleFeedback = (value: number) => {
+  const handleFeedback = (feedbackType: "positive" | "negative") => {
     if (!result) return;
-    setFeedback(value);
-    scoreDemoFeedback({
+    setFeedback(feedbackType);
+    scoreDemoNegativeUserFeedback({
       traceId: result.traceId,
-      id: `user-feedback-${result.traceId}`,
-      name: "user-feedback",
-      value,
+      value: feedbackType === "negative",
     });
   };
 
@@ -249,10 +249,10 @@ export const SentimentClassifier = ({
                   Was this classification accurate?
                 </span>
                 <button
-                  onClick={() => handleFeedback(1)}
+                  onClick={() => handleFeedback("positive")}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === 1
+                    feedback === "positive"
                       ? "text-green-700 dark:text-green-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}
@@ -260,10 +260,10 @@ export const SentimentClassifier = ({
                   <ThumbsUpIcon className="size-3.5" />
                 </button>
                 <button
-                  onClick={() => handleFeedback(0)}
+                  onClick={() => handleFeedback("negative")}
                   className={cn(
                     "p-1.5 rounded-[2px] transition-colors",
-                    feedback === 0
+                    feedback === "negative"
                       ? "text-red-700 dark:text-red-400"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                   )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Demo widgets on the docs site currently ingest thumbs up/down as a numeric `user-feedback` score (`1`/`0`). That lands in the public example project as a numeric score, which is harder to filter and less descriptive than a boolean.

This change records feedback as a BOOLEAN score named `negative_user_feedback`:

- thumbs down → `true`
- thumbs up → `false`

Widgets pass those booleans through. The Langfuse ingestion API still encodes BOOLEAN scores as `1`/`0` on the wire; `dataType: "BOOLEAN"` is what makes the score filterable as true/false in Langfuse.

Updated widgets: QA chatbot, sentiment classifier, and image generator.

Linear Issue: [LFE-15102](https://linear.app/clickhouse/issue/LFE-15102/use-boolean-user-feedback-score-in-demo-project)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15102](https://linear.app/clickhouse/issue/LFE-15102/use-boolean-user-feedback-score-in-demo-project)

<div><a href="https://cursor.com/agents/bc-5bdb0a28-5939-4384-a3d3-b911ce506f5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bdb0a28-5939-4384-a3d3-b911ce506f5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes feedback emitted by three demo widgets from a numeric `user-feedback` score to a BOOLEAN `negative_user_feedback` score.

- Adds a shared helper that maps negative feedback to `1` and positive feedback to `0` using the BOOLEAN score type.
- Updates the QA chatbot, sentiment classifier, and image generator to use semantic positive/negative UI state.
- Preserves stable per-trace score IDs so subsequent feedback submissions update the same score.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The shared helper uses the expected 1/0 encoding for BOOLEAN scores, all three widgets apply the intended negative-feedback mapping consistently, and the QA chatbot retains its existing idempotent update behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["demo: ingest user feedback as boolean ne..."](https://github.com/langfuse/langfuse-docs/commit/faa21de83c61c272902b5a46a84931f685e337f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53034326)</sub>

**Context used:**

- Knowledge Base — [QA Chatbot](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/qa-chatbot.md)

<!-- /greptile_comment -->