### PR TITLE
Add instance switcher screenshot to changelog

### DIFF
--- a/content/changelog/2026-08-11-self-hosted-instance-switcher.mdx
+++ b/content/changelog/2026-08-11-self-hosted-instance-switcher.mdx
@@ -15,7 +15,7 @@ This feature is available in the [Enterprise Edition](/open-source) (self-host).
 
 If you run more than one Langfuse deployment — development, staging, and production, or one per business unit — you can now configure them as a list and switch between them from the sidebar user menu. This mirrors the region switcher on Langfuse Cloud, so nobody has to keep deployment URLs in a spreadsheet.
 
-<Frame>
+<Frame fullWidth className="w-full">
   ![Instance switcher in the Langfuse sidebar user
   menu](/images/docs/ui-customization-instance-switcher.png)
 </Frame>

--- a/content/changelog/2026-08-11-self-hosted-instance-switcher.mdx
+++ b/content/changelog/2026-08-11-self-hosted-instance-switcher.mdx
@@ -15,6 +15,11 @@ This feature is available in the [Enterprise Edition](/open-source) (self-host).
 
 If you run more than one Langfuse deployment — development, staging, and production, or one per business unit — you can now configure them as a list and switch between them from the sidebar user menu. This mirrors the region switcher on Langfuse Cloud, so nobody has to keep deployment URLs in a spreadsheet.
 
+<Frame>
+  ![Instance switcher in the Langfuse sidebar user
+  menu](/images/docs/ui-customization-instance-switcher.png)
+</Frame>
+
 ```bash filename=".env"
 LANGFUSE_UI_INSTANCE_LINKS='[{"name":"Staging","url":"https://langfuse-staging.example.com"},{"name":"Production","url":"https://langfuse.example.com"}]'
 ```

--- a/content/self-hosting/administration/ui-customization.mdx
+++ b/content/self-hosting/administration/ui-customization.mdx
@@ -47,7 +47,7 @@ Langfuse adapts to the logo width, with a maximum aspect ratio of 1:3. Narrower 
 
 Organizations that operate multiple Langfuse deployments (e.g. for development, staging, and production, or per business unit) can configure a list of instances. It is rendered as an instance switcher in the sidebar user menu so users can quickly move between deployments, similar to the region switcher on Langfuse Cloud.
 
-<Frame>
+<Frame fullWidth className="w-full">
   ![UI Customization Instance
   Switcher](/images/docs/ui-customization-instance-switcher.png)
 </Frame>


### PR DESCRIPTION
## Summary

- Add a sidebar instance switcher screenshot to the self-hosted instance switcher changelog entry

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX and image framing changes with no application or runtime impact.
> 
> **Overview**
> Adds a **full-width `Frame` screenshot** of the sidebar instance switcher to the self-hosted instance switcher **changelog** entry, using the same asset as the UI customization docs (`/images/docs/ui-customization-instance-switcher.png`).
> 
> Aligns the **instance switcher** section in `ui-customization.mdx` by changing the existing screenshot wrapper from `<Frame>` to `<Frame fullWidth className="w-full">` so layout matches the new changelog and other wide doc images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7402e6f1d94833fbe3d4011824f506f565736def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a screenshot of the sidebar instance switcher to its self-hosted changelog entry.

- Wraps the screenshot in the existing `Frame` MDX component.
- Uses an existing image asset from the public documentation images directory.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The referenced image exists at the exact public path, and the Frame-wrapped image syntax is supported by the shared MDX pipeline and established changelog patterns.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add instance switcher screenshot to chan..."](https://github.com/langfuse/langfuse-docs/commit/5533d8dd912a7dfc33f690f2f56266bf013aa562) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53034732)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)

<!-- /greptile_comment -->