### PR TITLE
Restore Langfuse v4 top banner after Town Hall

### DIFF
--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -4,17 +4,17 @@ import { Banner as FumadocsBanner } from "fumadocs-ui/components/banner";
 export function Banner() {
   return (
     <FumadocsBanner
-      id="fd-top-banner-town-hall-2026-08"
       height="2rem"
-      className="bg-black text-white [&_a]:text-white [&_button]:text-white"
+      className="bg-black text-white [&_a]:text-white"
     >
-      <Link href="https://luma.com/qahlxt9n">
+      <Link href="/docs/v4">
         <span className="sm:hidden">
-          [Virtual] Langfuse Town Hall · Aug 12 →
+          Langfuse v4: up to 165× faster ·{" "}
+          <span className="underline underline-offset-2">Read more</span>
         </span>
         <span className="hidden sm:inline">
-          [Virtual] Langfuse Town Hall · Aug 12, 9am PT: New features and
-          roadmap →
+          Langfuse v4 is here: real-time, up to 165× faster ·{" "}
+          <span className="underline underline-offset-2">Read more</span>
         </span>
       </Link>
     </FumadocsBanner>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restores the site top banner to the Langfuse v4 launch message that was live before the Aug 12 Town Hall promo (#3498).

### Changes
- Replaces Town Hall copy and Luma link with the prior v4 announcement
- Links to `/docs/v4` again
- Mobile: `Langfuse v4: up to 165× faster · Read more`
- Desktop: `Langfuse v4 is here: real-time, up to 165× faster · Read more`

This matches the banner state introduced in #3431.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15114](https://linear.app/clickhouse/issue/LFE-15114/update-banner-on-website-again-back-to-v4-previous-state-before)

<div><a href="https://cursor.com/agents/bc-ca41e52c-38b9-46bb-aec2-c00a604217d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca41e52c-38b9-46bb-aec2-c00a604217d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores the site-wide top banner from the expired Town Hall promotion to the previous Langfuse v4 announcement.
- Replaces the external event link with `/docs/v4`.
- Restores responsive v4 launch copy for mobile and desktop.
- Returns the banner configuration to the state introduced for the original v4 campaign.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the banner restored consistently to its previous v4 campaign state.

The changed component uses a valid internal route, retains responsive copy variants and contrasting link text, and introduces no supported blocking or non-blocking failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["Restore Langfuse v4 top banner after Tow..."](https://github.com/langfuse/langfuse-docs/commit/fee5d531f4d9109f4878f3faea61ceafcf0541dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53040905)</sub>

**Context used:**

- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->