### PR TITLE
update Arize comparison page

### DIFF
--- a/content/resources/engineering/best-phoenix-arize-alternatives.mdx
+++ b/content/resources/engineering/best-phoenix-arize-alternatives.mdx
@@ -14,7 +14,7 @@ In August 2026, Dynatrace [announced a definitive agreement to acquire Arize](ht
 
 **TL;DR:**
 
-- **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation, [self-hosted](/self-hosting) or on Cloud, with usage-based pricing and no vendor lock-in. It is the open-source AI engineering platform with the most public adoption.
+- **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation, [self-hosted](/self-hosting) or on Cloud, with usage-based Cloud pricing and no vendor lock-in. It is the open-source AI engineering platform with the most public adoption.
 - **Choose Phoenix** if you want an Elastic License 2.0, local-first platform for tracing, evaluations, datasets, experiments, and prompt management. It can run as one container (SQLite) or multi-instance deployments (PostgreSQL).
 - **Choose Arize AX** if you want Arize's managed production platform, including Data Fabric, listed PCI DSS 4.0, and the AX Enterprise self-hosted option.
 

--- a/content/resources/engineering/best-phoenix-arize-alternatives.mdx
+++ b/content/resources/engineering/best-phoenix-arize-alternatives.mdx
@@ -14,7 +14,7 @@ In August 2026, Dynatrace [announced a definitive agreement to acquire Arize](ht
 
 **TL;DR:**
 
-- **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation you can [self-host](/self-hosting) or leave, usage-based Cloud pricing, and the open-source LLM observability and evaluation platform with the most public adoption.
+- **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation, [self-hosted](/self-hosting) or on Cloud, with usage-based pricing and no vendor lock-in. It is the open-source AI engineering platform with the most public adoption.
 - **Choose Phoenix** if you want an Elastic License 2.0, local-first platform for tracing, evaluations, datasets, experiments, and prompt management. It can run as one container (SQLite) or multi-instance deployments (PostgreSQL).
 - **Choose Arize AX** if you want Arize's managed production platform, including Data Fabric, listed PCI DSS 4.0, and the AX Enterprise self-hosted option.
 
@@ -33,7 +33,7 @@ Langfuse is [MIT-licensed](https://github.com/langfuse/langfuse) across tracing,
 
 Arize ships two products. [Phoenix](https://docs.arize.com/phoenix) is source-available under the Elastic License 2.0 (not an OSI-approved open-source license) and self-hosts on SQLite or PostgreSQL. [Arize AX](https://arize.com/llm-observability/) is proprietary SaaS (self-hosting is an Enterprise option). Phoenix and AX do not share a storage engine: Phoenix uses Postgres/SQLite; AX Cloud uses [adb](https://arize.com/blog/introducing-adb-arizes-proprietary-olap-database).
 
-Dynatrace's [acquisition announcement](https://www.dynatrace.com/news/press-release/dynatrace-to-acquire-arize/) is an enterprise AI observability deal. It mentions a developer community and calls Arize OSS-native. It does not name Phoenix, and it does not state a license or a commitment that a standalone open-source product continues.
+Dynatrace's [acquisition announcement](https://www.dynatrace.com/news/press-release/dynatrace-to-acquire-arize/) is an enterprise AI observability deal. It refers to Arize as “OSS-native” and highlights its open-source developer community but it does not name Phoenix, and it does not state a license or a commitment that a standalone open-source product continues. For current Phoenix licensing and availability, see the Phoenix license and self-hosting documentation.
 
 | Feature            | Langfuse                                                                                                                                                                                  | Arize AX                                                                                                                                                                                               |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/content/resources/engineering/best-phoenix-arize-alternatives.mdx
+++ b/content/resources/engineering/best-phoenix-arize-alternatives.mdx
@@ -16,7 +16,7 @@ In August 2026, Dynatrace [announced a definitive agreement to acquire Arize](ht
 
 - **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation, [self-hosted](/self-hosting) or on Cloud, with usage-based Cloud pricing and no vendor lock-in. It is the open-source AI engineering platform with the most public adoption.
 - **Choose Phoenix** if you want an Elastic License 2.0, local-first platform for tracing, evaluations, datasets, experiments, and prompt management. It can run as one container (SQLite) or multi-instance deployments (PostgreSQL).
-- **Choose Arize AX** if you want Arize’s managed production platform, listed PCI DSS 4.0 status, an Enterprise self-hosted option, and Enterprise Data Fabric access, which is currently waitlisted.
+- **Choose Arize AX** if you want Arize's managed production platform, listed PCI DSS 4.0 status, an Enterprise self-hosted option, and Enterprise Data Fabric access, which is currently waitlisted.
 
 Already on Phoenix or AX? See [Migrate from Arize Phoenix to Langfuse](/resources/engineering/migrate-from-phoenix).
 
@@ -33,7 +33,7 @@ Langfuse is [MIT-licensed](https://github.com/langfuse/langfuse) across tracing,
 
 Arize ships two products. [Phoenix](https://docs.arize.com/phoenix) is source-available under the Elastic License 2.0 (not an OSI-approved open-source license) and self-hosts on SQLite or PostgreSQL. [Arize AX](https://arize.com/llm-observability/) is proprietary SaaS (self-hosting is an Enterprise option). Phoenix and AX do not share a storage engine: Phoenix uses Postgres/SQLite; AX Cloud uses [adb](https://arize.com/blog/introducing-adb-arizes-proprietary-olap-database).
 
-Dynatrace's [acquisition announcement](https://www.dynatrace.com/news/press-release/dynatrace-to-acquire-arize/) is an enterprise AI observability deal. It refers to Arize as “OSS-native” and highlights its open-source developer community but it does not name Phoenix, and it does not state a license or a commitment that a standalone open-source product continues. For current Phoenix licensing and availability, see the Phoenix license and self-hosting documentation.
+Dynatrace's [acquisition announcement](https://www.dynatrace.com/news/press-release/dynatrace-to-acquire-arize/) is an enterprise AI observability deal. It refers to Arize as "OSS-native" and highlights its open-source developer community, but it does not name Phoenix, and it does not state a license or a commitment that a standalone open-source product continues. For current Phoenix licensing and availability, see the [Phoenix license](https://github.com/Arize-ai/phoenix/blob/main/LICENSE) and [self-hosting documentation](https://docs.arize.com/phoenix/deployment).
 
 | Feature            | Langfuse                                                                                                                                                                                  | Arize AX                                                                                                                                                                                               |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/content/resources/engineering/best-phoenix-arize-alternatives.mdx
+++ b/content/resources/engineering/best-phoenix-arize-alternatives.mdx
@@ -16,7 +16,7 @@ In August 2026, Dynatrace [announced a definitive agreement to acquire Arize](ht
 
 - **Choose Langfuse** if you want [MIT-licensed](https://github.com/langfuse/langfuse) tracing and evaluation, [self-hosted](/self-hosting) or on Cloud, with usage-based Cloud pricing and no vendor lock-in. It is the open-source AI engineering platform with the most public adoption.
 - **Choose Phoenix** if you want an Elastic License 2.0, local-first platform for tracing, evaluations, datasets, experiments, and prompt management. It can run as one container (SQLite) or multi-instance deployments (PostgreSQL).
-- **Choose Arize AX** if you want Arize's managed production platform, including Data Fabric, listed PCI DSS 4.0, and the AX Enterprise self-hosted option.
+- **Choose Arize AX** if you want Arize’s managed production platform, listed PCI DSS 4.0 status, an Enterprise self-hosted option, and Enterprise Data Fabric access, which is currently waitlisted.
 
 Already on Phoenix or AX? See [Migrate from Arize Phoenix to Langfuse](/resources/engineering/migrate-from-phoenix).
 
@@ -107,7 +107,7 @@ Both platforms serve large enterprises. Arize AX lists PCI DSS 4.0 among its cer
 **Arize AX:**
 
 - **[Agentic Visualization](https://arize.com/docs/ax/instrument/agent-trajectory):** Specialized views for multi-agent conversation flows.
-- **[Data Fabric](https://arize.com/docs/ax/security-and-settings/data-fabric):** Sync with enterprise data lakes (Snowflake/BigQuery).
+- **[Data Fabric](https://arize.com/docs/ax/security-and-settings/data-fabric):** Sync with enterprise data lakes (Enterprise feature, currently waitlisted).
 - **Evaluation:** Session-level evaluation and retrieval diagnosis (RAG). AX also includes Signal and Alyx, with availability depending on plan.
 
 Already instrumented with OpenInference? Keep it and [repoint traces to Langfuse](/resources/engineering/migrate-from-phoenix). For a migration plan on Cloud or self-hosted, [talk to us](/talk-to-us).


### PR DESCRIPTION
## Summary
- Fresh PR from current `main` (after #3517) with only the leftover Arize comparison copy edits.
- Clarifies the Choose Langfuse TL;DR (self-hosted or Cloud, no vendor lock-in) and ties the Dynatrace OSS wording to what the announcement actually says.

## Test plan
- [ ] Prettier / H1: only `content/resources/engineering/best-phoenix-arize-alternatives.mdx` changed
- [ ] Confirm this PR shows a single commit on top of `main`
- [ ] Close #3525 (old `update-comparison-pages` branch; its history predates the #3517 merge)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refines the Arize comparison copy to distinguish Langfuse Cloud pricing from self-hosting and more precisely describe Arize licensing, acquisition language, and Data Fabric availability.
- Qualifies usage-based pricing as Cloud-specific while emphasizing self-hosting and portability.
- Updates Arize AX and Dynatrace acquisition wording with licensing and availability references.
- Marks Enterprise Data Fabric access as currently waitlisted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: fix Arize acquisition copy punctua..."](https://github.com/langfuse/langfuse-docs/commit/c89b9b1d5eb9ddfa17bae3c30bc992604126f91e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53280373)</sub>

<!-- /greptile_comment -->