### PR TITLE
Simplify server-side data masking documentation

### DIFF
--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -39,7 +39,7 @@ For production and high-availability deployments, we recommend one of the follow
 - [GCP (Terraform)](/self-hosting/deployment/gcp)
 - [Railway](/self-hosting/deployment/railway)
 
-## Architecture
+## Architecture [#architecture]
 
 Langfuse only depends on open source components and can be deployed locally, on cloud infrastructure, or on-premises.
 

--- a/content/self-hosting/security/data-masking.mdx
+++ b/content/self-hosting/security/data-masking.mdx
@@ -50,13 +50,12 @@ For comprehensive documentation including code examples, advanced patterns, and 
 </Callout>
 
 Server-side ingestion masking allows self-hosted Langfuse administrators to define custom callback logic for masking or redacting sensitive data from tracing events as they are ingested.
-This feature operates at the Langfuse Worker container level, providing centralized data masking across all clients.
+This provides centralized data masking across all clients.
 
 <Callout type="warning">
 
 Server-side masking is a centralized safety net, not a replacement for client-side masking when sensitive data must never leave the application boundary.
-In the self-hosted ingestion pipeline, events are written to the event blob storage bucket before the Worker calls the masking callback.
-The callback masks data before it is processed into ClickHouse and downstream Langfuse views.
+The callback masks data before it is persisted in ClickHouse and downstream Langfuse views.
 
 </Callout>
 
@@ -68,29 +67,30 @@ The callback masks data before it is processed into ClickHouse and downstream La
 
 ### How It Works
 
-1. When a tracing event is processed on the Langfuse Worker container, it checks if a masking callback URL is configured.
+1. When a tracing event is processed, Langfuse checks if a masking callback URL is configured.
 2. If configured, Langfuse sends the OpenTelemetry trace object to your callback endpoint via HTTP POST.
 3. Your callback service processes the data and returns the masked object.
-4. Langfuse continues processing with the masked data.
+4. Langfuse persists the masked data in ClickHouse.
 
 ```mermaid
 sequenceDiagram
     participant SDK as Langfuse SDK
-    participant Web as Langfuse Web
-    participant S3 as S3 Event Bucket
-    participant Worker as Langfuse Worker
+    participant LF as Langfuse
     participant Callback as Masking Callback
+    participant CH as ClickHouse
 
-    SDK->>Web: Send trace event
-    Web->>S3: Store unmasked event in S3
-    Note over S3: Data is stored unmasked in S3.
-    Web->>Worker: Forward S3 reference to worker via Redis
-    Worker->>S3: Fetch data from S3
-    Worker->>Callback: POST (OpenTelemetry object)
+    SDK->>LF: Send trace event
+    LF->>Callback: POST (OpenTelemetry object)
     Note over Callback: Apply masking logic
-    Callback->>Worker: Return masked object
-    Note over Worker: Process masked event
+    Callback->>LF: Return masked object
+    LF->>CH: Persist masked event
 ```
+
+<Callout type="info">
+
+Scrubbing runs asynchronously in a worker. Events land in [blob storage](/self-hosting/deployment/infrastructure/blobstorage) in the interim before they are masked and written to ClickHouse. See the [self-hosting architecture](/self-hosting#architecture) for how web, worker, and storage fit together.
+
+</Callout>
 
 ### Configuration
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Simplify the server-side ingestion masking sequence diagram by collapsing Langfuse Web, Worker, and S3 into a single **Langfuse** actor that calls the masking endpoint before persisting to ClickHouse.
- Add an info callout that scrubbing still runs asynchronously in a worker, so events land in blob storage in the interim, with links to the blob storage and self-hosting architecture pages.
- Add an explicit `[#architecture]` anchor on the self-hosting Architecture heading for deep-linking.

## Test plan

- [x] Open `/self-hosting/security/data-masking` and confirm the simplified mermaid diagram renders
- [x] Confirm the async scrubbing callout and both links (`/self-hosting/deployment/infrastructure/blobstorage`, `/self-hosting#architecture`) resolve
- [x] Confirm Configuration section still documents Web vs Worker env vars

## Verification

[Simplified sequence diagram and async scrubbing callout](https://cursor.com/agents/bc-2fa8d0c9-3a09-47c2-93c1-1b52f33cfd71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_masking_simplified_diagram.webp)

[data_masking_diagram_and_links_demo.mp4](https://cursor.com/agents/bc-2fa8d0c9-3a09-47c2-93c1-1b52f33cfd71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_masking_diagram_and_links_demo.mp4)

Local checks: page and linked infra pages all returned HTTP 200; HTML contains the simplified diagram participants and scrubbing callout, and no longer mentions `S3 Event Bucket` in the diagram.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15151](https://linear.app/clickhouse/issue/LFE-15151/simplify-server-side-data-masking-documentation)

<div><a href="https://cursor.com/agents/bc-2fa8d0c9-3a09-47c2-93c1-1b52f33cfd71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa8d0c9-3a09-47c2-93c1-1b52f33cfd71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR simplifies the server-side masking documentation while retaining the asynchronous blob-storage caveat.

- Collapses Web, Worker, and object storage into one Langfuse participant in the masking sequence.
- Adds a ClickHouse persistence step and an informational callout explaining asynchronous worker processing.
- Adds an explicit Architecture heading anchor for the new cross-page link.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge with no actionable issues identified.

The explicit anchor follows established repository syntax, and the simplified masking narrative retains the important ordering that events enter blob storage before worker-side masking and ClickHouse persistence.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as Langfuse SDK
    participant LF as Langfuse
    participant Callback as Masking Callback
    participant CH as ClickHouse
    SDK->>LF: Send trace event
    Note over LF: Event temporarily enters blob storage
    LF->>Callback: POST OpenTelemetry object
    Callback-->>LF: Return masked object
    LF->>CH: Persist masked event
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Simplify server-side data masking sequen..."](https://github.com/langfuse/langfuse-docs/commit/07cc551a21762dddb0bc67aab57947e8cf1220f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53314306)</sub>

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->