### PR TITLE
docs: move pricing tiers higher on cost tracking page

### DIFF
--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -23,7 +23,7 @@ In the UI, Langfuse summarizes all usage types that include the string `input` a
 Both usage details and cost details can be either
 
 - [**ingested**](#ingest) via API, SDKs or integrations
-- or [**inferred**](#infer) based on the `model` parameter of the generation. Langfuse comes with a list of predefined popular models and their tokenizers including OpenAI, Anthropic, and Google models. You can also add your own [custom model definitions](#custom-model-definitions) or request official support for new models via [GitHub](/issue). Inferred cost are calculated at the time of ingestion with the model and price information available at that point in time.
+- or [**inferred**](#infer) based on the `model` parameter of the generation. Langfuse comes with a list of predefined popular models and their tokenizers including OpenAI, Anthropic, and Google models. You can also add your own [custom model definitions](#custom-model-definitions) or request official support for new models via [GitHub](/issue). Inferred cost are calculated at the time of ingestion with the model and price information available at that point in time. Models with context-dependent pricing use [pricing tiers](#pricing-tiers) so the correct rate is applied based on token volume.
 
 Ingested usage and cost are prioritized over inferred usage and cost:
 
@@ -48,6 +48,32 @@ Once usage and cost are tracked, you can put the data to work:
 - **[Create dashboards](/docs/metrics/features/custom-dashboards):** monitor cost across models, tags, or users.
 - **[Set up alerts](/docs/metrics/features/alerts):** get notified automatically when spend crosses a threshold.
 - **[Query with the Metrics API](/docs/metrics/features/metrics-api):** retrieve aggregated usage and cost, filtered by application type, user, or tags, for analytics, billing, and rate-limiting.
+
+## Pricing tiers [#pricing-tiers]
+
+Some model providers charge different rates depending on the number of input tokens used. For example, Anthropic's Claude Sonnet 4.5 and Google's Gemini 2.5 Pro apply higher pricing when more than 200K input tokens are used.
+
+Langfuse supports **pricing tiers** for models, enabling accurate cost calculation for these context-dependent pricing structures.
+
+### How tier matching works
+
+Each model can have multiple pricing tiers, each with:
+
+- **Name**: A descriptive name (e.g., "Standard", "Large Context")
+- **Priority**: Evaluation order (0 is reserved for default tier)
+- **Conditions**: Rules that determine when the tier applies
+- **Prices**: Cost per usage type for this tier
+
+When calculating cost, Langfuse evaluates tiers in priority order (excluding the default tier). The first tier whose conditions are satisfied is used. If no conditional tier matches, the default tier is applied.
+
+**Condition format:**
+
+- `usageDetailPattern`: A regex pattern to match usage detail keys (e.g., `input` matches `input_tokens`, `input_cached_tokens`, etc.)
+- `operator`: Comparison operator (`gt`, `gte`, `lt`, `lte`, `eq`, `neq`)
+- `value`: The threshold value to compare against
+- `caseSensitive`: Whether the pattern matching is case-sensitive (default: false)
+
+For example, the "Large Context" tier for Claude Sonnet 4.5 has a condition: `input > 200000`, meaning it applies when the sum of all usage details matching the pattern "input" exceeds 200,000 tokens.
 
 ## Ingest usage and/or cost [#ingest]
 
@@ -445,32 +471,6 @@ The audit follows an evidence-first workflow:
 4. When changes are needed, a pull request is opened, and the updated prices are deployed shortly after approval.
 
 This process keeps the default definitions current without relying on a third-party pricing aggregator. Because inferred costs are calculated at ingestion time, updated defaults apply only to new generations. If you need support for a model immediately or use private pricing, add a [custom model definition](#custom-model-definitions) or [ingest the cost directly](#ingest).
-
-### Pricing Tiers [#pricing-tiers]
-
-Some model providers charge different rates depending on the number of input tokens used. For example, Anthropic's Claude Sonnet 4.5 and Google's Gemini 2.5 Pro apply higher pricing when more than 200K input tokens are used.
-
-Langfuse supports **pricing tiers** for models, enabling accurate cost calculation for these context-dependent pricing structures.
-
-#### How tier matching works
-
-Each model can have multiple pricing tiers, each with:
-
-- **Name**: A descriptive name (e.g., "Standard", "Large Context")
-- **Priority**: Evaluation order (0 is reserved for default tier)
-- **Conditions**: Rules that determine when the tier applies
-- **Prices**: Cost per usage type for this tier
-
-When calculating cost, Langfuse evaluates tiers in priority order (excluding the default tier). The first tier whose conditions are satisfied is used. If no conditional tier matches, the default tier is applied.
-
-**Condition format:**
-
-- `usageDetailPattern`: A regex pattern to match usage detail keys (e.g., `input` matches `input_tokens`, `input_cached_tokens`, etc.)
-- `operator`: Comparison operator (`gt`, `gte`, `lt`, `lte`, `eq`, `neq`)
-- `value`: The threshold value to compare against
-- `caseSensitive`: Whether the pattern matching is case-sensitive (default: false)
-
-For example, the "Large Context" tier for Claude Sonnet 4.5 has a condition: `input > 200000`, meaning it applies when the sum of all usage details matching the pattern "input" exceeds 200,000 tokens.
 
 ### Custom model definitions [#custom-model-definitions]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the **Pricing tiers** section higher on the [Token & Cost Tracking](/docs/observability/features/token-and-cost-tracking) docs page so context-dependent model pricing is easier to find.

- Promotes Pricing tiers from a buried `###` under Infer (after ingest examples, tokenizers, and default-price maintenance) to a top-level `##` section, placed after “How to use usage and cost data” and before ingest.
- Adds a short intro mention with a link to `#pricing-tiers`.
- Keeps the existing `#pricing-tiers` anchor so changelog, blog, and other inbound links still work.

## Test plan

- [x] Open `/docs/observability/features/token-and-cost-tracking` and confirm Pricing tiers appears near the top (after How to use, before Ingest).
- [x] Confirm `#pricing-tiers` still jumps to the section.
- [x] Confirm the intro link to pricing tiers works.
- [x] Confirm heading hierarchy (`##` / `###`) and that there is still a single H1.

[TOC shows Pricing tiers near the top](https://cursor.com/agents/bc-1d470759-46e5-4662-807f-7a027717265d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_tracking_toc_pricing_tiers_near_top.webp)

[Pricing tiers section above Ingest](https://cursor.com/agents/bc-1d470759-46e5-4662-807f-7a027717265d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_tracking_pricing_tiers_section.webp)

[cost_tracking_pricing_tiers_higher_walkthrough.mp4](https://cursor.com/agents/bc-1d470759-46e5-4662-807f-7a027717265d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_tracking_pricing_tiers_higher_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-122](https://linear.app/clickhouse/issue/LF-122/put-pricing-tiers-higher-on-cost-tracking-docs-page)

<div><a href="https://cursor.com/agents/bc-1d470759-46e5-4662-807f-7a027717265d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d470759-46e5-4662-807f-7a027717265d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

