### PR TITLE
feat(docs): capture PostHog events on docs feedback buttons

### DIFF
--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -386,6 +386,7 @@ export const DocsSupport = () => {
 
 export const DocsFeedback = ({ showLabel = true }: { showLabel?: boolean }) => {
   const pathname = usePathname();
+  const capture = usePostHogClientCapture();
   const [selected, setSelected] = useState<
     "positive" | "negative" | "submitted" | null
   >(null);
@@ -402,6 +403,11 @@ export const DocsFeedback = ({ showLabel = true }: { showLabel?: boolean }) => {
     setDialogOpen(true);
     setFeedbackComment("");
     setSubmitting(true);
+
+    capture("docs_feedback", {
+      rating: newSelection,
+      page: pathname ?? "",
+    });
 
     fetch("/api/feedback", {
       method: "POST",
@@ -422,6 +428,11 @@ export const DocsFeedback = ({ showLabel = true }: { showLabel?: boolean }) => {
 
   const handleFeedbackCommentSubmit = () => {
     setCommentSubmitting(true);
+
+    capture("docs_feedback_comment", {
+      rating: selected,
+      page: pathname ?? "",
+    });
 
     fetch("/api/feedback", {
       method: "POST",

--- a/src/usePostHogClientCapture.ts
+++ b/src/usePostHogClientCapture.ts
@@ -5,6 +5,11 @@ import { usePostHog } from "posthog-js/react";
 // This preserves existing PostHog event structure while adding type safety
 interface EventDefinitions {
   copy_page: { type: "copy" | "chatgpt" | "claude" | "mcp" };
+  docs_feedback: { rating: "positive" | "negative"; page: string };
+  docs_feedback_comment: {
+    rating: "positive" | "negative" | "submitted" | null;
+    page: string;
+  };
   copy_agent_prompt: {
     source: "agent_prompt_callout";
     path: string;


### PR DESCRIPTION
Clicking the thumbs up/down feedback buttons at the bottom of docs pages previously sent feedback only to Slack (via `/api/feedback`), with no analytics event. This adds PostHog capture so helpful/unhelpful rates can be tracked per page.

## Changes

In the `DocsFeedback` component (`components/MainContentWrapper.tsx`):

- Fires `docs_feedback` with `{ rating, page }` when a user clicks the "Good"/"Bad" button (`rating` is `positive` or `negative`).
- Fires `docs_feedback_comment` with `{ rating, page }` when the optional follow-up comment is submitted, so comment submissions can be distinguished from bare ratings.

This reuses the existing `usePostHogClientCapture` pattern already used for the copy-page buttons in the same file. The Slack POST to `/api/feedback` is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only additions alongside unchanged feedback API calls; no auth or data-handling changes.
> 
> **Overview**
> Docs page **Good/Bad** feedback now sends typed PostHog events in addition to the existing Slack `/api/feedback` POSTs.
> 
> `DocsFeedback` uses `usePostHogClientCapture` (same pattern as copy-page actions) to fire **`docs_feedback`** with `rating` and `page` when a thumb is clicked, and **`docs_feedback_comment`** when the follow-up comment is submitted. **`usePostHogClientCapture.ts`** extends `EventDefinitions` so both events are type-safe at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4917f1eefe0364b9a82a66635a792eacd5352c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PostHog events for documentation rating clicks and follow-up comment submissions.
- Captures positive and negative feedback with the current page pathname.
- Separately captures follow-up comment submissions.
- Leaves the existing Slack feedback requests unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until both new PostHog events are added to the typed event-definition map.

Both changed capture calls use event names that are excluded from the hook’s keyof EventDefinitions constraint, so compiling MainContentWrapper.tsx rejects the new code.

**Files Needing Attention:** components/MainContentWrapper.tsx and src/usePostHogClientCapture.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/MainContentWrapper.tsx:407
**Undefined typed analytics events**

When the Next.js TypeScript build compiles this call, `docs_feedback` is rejected because `usePostHogClientCapture` constrains event names to `keyof EventDefinitions`, which does not include either new feedback event, causing the build to fail. Add both `docs_feedback` and `docs_feedback_comment` with their payload types to the central event-definition map.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(docs): capture PostHog events on do..."](https://github.com/langfuse/langfuse-docs/commit/f790f5873921970c98a915ae3e32600aff3b8cd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53492972)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)
- Knowledge Base — [UI Components](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/ui-components.md)

<!-- /greptile_comment -->