### PR TITLE
docs: redirect old v4 changelog date to final URL

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1766,6 +1766,12 @@ const permanentRedirects = [
   ["/blog/2026-08-13-langfuse-v4", "/changelog/2026-08-17-langfuse-v4"],
   // Also redirect the .md variant so the markdown URL does not 404
   ["/blog/2026-08-13-langfuse-v4.md", "/changelog/2026-08-17-langfuse-v4.md"],
+  // The changelog entry was republished under its final date (2026-08-17)
+  ["/changelog/2026-08-13-langfuse-v4", "/changelog/2026-08-17-langfuse-v4"],
+  [
+    "/changelog/2026-08-13-langfuse-v4.md",
+    "/changelog/2026-08-17-langfuse-v4.md",
+  ],
   // llm-evaluation blog consolidation (2026-07): 101 post merged into the evals leader post
   [
     "/blog/2025-03-04-llm-evaluation-101-best-practices-and-challenges",


### PR DESCRIPTION
The Langfuse v4 changelog entry was republished under its final date (`2026-08-17`), which left `/changelog/2026-08-13-langfuse-v4` returning a 404.

Adds permanent redirects for the old changelog URL and its `.md` variant to `/changelog/2026-08-17-langfuse-v4`, next to the existing blog → changelog redirects for the same post.

Only `lib/redirects.js` is touched — no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Redirect-only change in site routing config; no application logic, auth, or data handling.
> 
> **Overview**
> Fixes **404s** for bookmarks and links that still use the pre-republish Langfuse v4 changelog slug (`2026-08-13`).
> 
> Adds two **permanent redirects** in `lib/redirects.js` next to the existing blog → changelog rules: `/changelog/2026-08-13-langfuse-v4` and its `.md` variant now point at `/changelog/2026-08-17-langfuse-v4` (and `.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d79088c3141af27741b379abcdf9198b6fa188a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds permanent redirects from the former Langfuse v4 changelog date to its final publication date.
- Redirects the old changelog page URL to the current page.
- Preserves access to the corresponding `.md` URL.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

Both new redirect sources represent obsolete URLs, and their destinations resolve through the existing changelog content and markdown-serving paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect old v4 changelog date to ..."](https://github.com/langfuse/langfuse-docs/commit/5d79088c3141af27741b379abcdf9198b6fa188a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53955666)</sub>

<!-- /greptile_comment -->