### PR TITLE
Update office attendance expectations for Europe

### DIFF
--- a/content/handbook/how-we-work/principles.mdx
+++ b/content/handbook/how-we-work/principles.mdx
@@ -20,7 +20,7 @@ We operate in two hubs: San Francisco and Berlin, with team members spread acros
 
 In San Francisco, the team is based locally and uses the office whenever it's helpful; most people come in regularly to work together.
 
-In Europe, we hire remotely with Berlin as our collaboration anchor. After onboarding (~2 weeks on-site), the expectation is one week per month in the Berlin office for everyone in Europe. Travel and accommodation are paid. The right people don't always live in the same city — EU-remote lets us hire the best people regardless of where they live.
+In Europe, we hire remotely with Berlin as our collaboration anchor. After onboarding (~2 weeks on-site), the expectation is 3-5 days every two months in the Berlin office for everyone in Europe. Travel and accommodation are paid. The right people don't always live in the same city — EU-remote lets us hire the best people regardless of where they live.
 
 Some work is simply better in person: creative exploration, fast iteration, resolving complex questions, and building relationships. The goal isn't "being in the office"; it's building momentum together. During Berlin weeks, we batch the work that benefits most from being face to face — planning, workshops, pairing, reviews, social time. Outside of those weeks, we're remote-first. For Berlin-based folks, the office is there when it's useful, not a daily obligation.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the European office attendance expectation while preserving Berlin as the collaboration hub.
- Changes attendance from one week per month to 3–5 days every two months.
- Leaves onboarding, travel reimbursement, and remote-work guidance unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change is limited to plain handbook prose and introduces no broken links, invalid MDX, structural inconsistencies, or conflicting repository requirements.
</details>

<sub>Reviews (1): Last reviewed commit: ["Update office attendance expectations fo..."](https://github.com/langfuse/langfuse-docs/commit/df58908bfe9cad7101014ec97ec844aa30527cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54000026)</sub>

**Context used:**

- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)

<!-- /greptile_comment -->