### PR TITLE
docs: restore the legacy observations schema in the blob storage field reference

### DIFF
--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -100,9 +100,9 @@ Scores are always exported. Their fields are not configurable.
 | `created_at`     | string (timestamp) | Row creation time.                                     |
 | `updated_at`     | string (timestamp) | Last row update time.                                  |
 
-## Legacy export differences [#legacy-export-paths]
+## Legacy exports [#legacy-export-paths]
 
-Legacy exports are deprecated. They split trace context into `traces/` and observation data into `observations/`; consumers join them on `trace_id`.
+Legacy exports are deprecated. They split trace context into `traces/` and observation data into `observations/`; consumers join them on `trace_id`. See [upgrade a legacy export](/docs/api-and-data-platform/features/export-to-blob-storage#legacy-export-sources) before changing a consumer.
 
 ### Traces (`traces/`) [#traces]
 
@@ -136,19 +136,52 @@ The trace file does not include `total_cost`, `latency`, `observations`, `scores
 
 ### Observations (`observations/`) [#observations]
 
-Legacy observations use the same observation field groups, with these differences:
-
 <span id="enriched-vs-legacy-differences" />
 
-| Group           | Difference in the legacy file                                                                      |
-| --------------- | -------------------------------------------------------------------------------------------------- |
-| `basic`         | Does not include `bookmarked`, `is_root_observation`, `public`, `session_id`, or `user_id`.        |
-| `usage`         | Does not include `usage_pricing_tier_id`.                                                          |
-| `trace_context` | Has no effect; `release`, `tags`, and the trace name are available in the separate `traces/` file. |
+Each row represents one observation without its trace context; join `trace_id` to the `traces/` file to add it. Only the [selected field groups](/docs/api-and-data-platform/features/export-to-blob-storage#export-field-groups) appear; `core` is always included.
 
-All other field groups use the same field names as `observations_v2/`. Some nullable values appear as empty strings in enriched JSON/JSONL output.
+| Field                     | Type                       | Description                                                                                                                       |
+| ------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                      | string                     | Unique observation identifier.                                                                                                    |
+| `trace_id`                | string                     | Trace identifier shared by related observations and scores.                                                                       |
+| `project_id`              | string                     | Langfuse project identifier.                                                                                                      |
+| `environment`             | string                     | Environment label.                                                                                                                |
+| `type`                    | string                     | Observation type: `SPAN`, `GENERATION`, `EVENT`, `AGENT`, `TOOL`, `CHAIN`, `RETRIEVER`, `EVALUATOR`, `EMBEDDING`, or `GUARDRAIL`. |
+| `parent_observation_id`   | string or null             | Parent observation identifier; null for a root observation.                                                                       |
+| `start_time`              | string (timestamp)         | When the observation started.                                                                                                     |
+| `end_time`                | string (timestamp) or null | When the observation ended.                                                                                                       |
+| `name`                    | string                     | User-defined observation name.                                                                                                    |
+| `metadata`                | object                     | User-supplied observation metadata.                                                                                               |
+| `level`                   | string                     | `DEBUG`, `DEFAULT`, `WARNING`, or `ERROR`.                                                                                        |
+| `status_message`          | string or null             | Status or error message.                                                                                                          |
+| `version`                 | string or null             | User-defined version.                                                                                                             |
+| `input`                   | string or null             | Observation input; may contain plain text or JSON.                                                                                |
+| `output`                  | string or null             | Observation output; may contain plain text or JSON.                                                                               |
+| `provided_model_name`     | string or null             | Model name supplied by the SDK or user.                                                                                           |
+| `model_parameters`        | string or null             | Model parameters encoded as JSON.                                                                                                 |
+| `usage_details`           | object (string → integer)  | Token usage by category, such as `input`, `output`, and `total`.                                                                  |
+| `cost_details`            | object (string → number)   | Cost in USD by category.                                                                                                          |
+| `completion_start_time`   | string (timestamp) or null | When the first streamed token was generated.                                                                                      |
+| `prompt_name`             | string or null             | Langfuse prompt name.                                                                                                             |
+| `prompt_version`          | integer or null            | Langfuse prompt version.                                                                                                          |
+| `total_cost`              | number or null             | Total observation cost in USD.                                                                                                    |
+| `latency`                 | number or null             | Duration in seconds.                                                                                                              |
+| `time_to_first_token`     | number or null             | Time to first token in seconds.                                                                                                   |
+| `model_id`                | string or null             | Matched Langfuse model definition identifier.                                                                                     |
+| `created_at`              | string (timestamp)         | Row creation time.                                                                                                                |
+| `updated_at`              | string (timestamp)         | Last row update time.                                                                                                             |
+| `prompt_id`               | string or null             | Langfuse prompt identifier.                                                                                                       |
+| `tool_calls`              | array of strings           | Tool calls encoded as JSON strings.                                                                                               |
+| `tool_call_names`         | array of strings           | Names of called tools.                                                                                                            |
+| `tool_definitions`        | object                     | Tool or function schemas supplied to the model.                                                                                   |
+| `usage_pricing_tier_name` | string or null             | Pricing tier name used for cost calculation.                                                                                      |
+| `input_price`             | string or null             | Matched per-unit input price; omitted from Parquet.                                                                               |
+| `output_price`            | string or null             | Matched per-unit output price; omitted from Parquet.                                                                              |
+| `total_price`             | string or null             | Matched flat per-call price; omitted from Parquet.                                                                                |
 
-See [upgrade a legacy export](/docs/api-and-data-platform/features/export-to-blob-storage#legacy-export-sources) before changing a consumer.
+Where a field appears in both observation files it carries the same meaning. Values that are null here are exported as empty strings in `observations_v2/` JSON and JSONL output.
+
+For the field groups that select these columns and how they differ from the enriched export, see [what changes in the exported data](/docs/api-and-data-platform/features/export-to-blob-storage#legacy-field-differences).
 
 ## Parquet differences [#parquet-exports]
 

--- a/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
+++ b/content/docs/api-and-data-platform/features/blob-storage-export-fields.mdx
@@ -48,7 +48,7 @@ Each row represents one observation and includes its trace context. Only the [se
 | `completion_start_time`   | string (timestamp) or null | When the first streamed token was generated.                                                                                      |
 | `prompt_name`             | string                     | Langfuse prompt name.                                                                                                             |
 | `prompt_version`          | integer or null            | Langfuse prompt version.                                                                                                          |
-| `total_cost`              | number                     | Total observation cost in USD.                                                                                                    |
+| `total_cost`              | number                     | Total observation cost in USD; `0` when no cost was recorded.                                                                     |
 | `latency`                 | number or null             | Duration in seconds.                                                                                                              |
 | `time_to_first_token`     | number or null             | Time to first token in seconds.                                                                                                   |
 | `model_id`                | string                     | Matched Langfuse model definition identifier.                                                                                     |
@@ -179,7 +179,15 @@ Each row represents one observation without its trace context; join `trace_id` t
 | `output_price`            | string or null             | Matched per-unit output price; omitted from Parquet.                                                                              |
 | `total_price`             | string or null             | Matched flat per-call price; omitted from Parquet.                                                                                |
 
-Where a field appears in both observation files it carries the same meaning. Values that are null here are exported as empty strings in `observations_v2/` JSON and JSONL output.
+Where a field appears in both observation files it carries the same meaning. Unset values are encoded differently, though: a field that is `null` above maps to one of three values in `observations_v2/` JSON and JSONL output.
+
+| Value in `observations_v2/` | Fields                                                                                                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `""` (empty string)         | `input`, `model_id`, `model_parameters`, `output`, `parent_observation_id`, `prompt_id`, `prompt_name`, `provided_model_name`, `status_message`, `version`       |
+| `null`                      | `completion_start_time`, `end_time`, `input_price`, `latency`, `output_price`, `prompt_version`, `time_to_first_token`, `total_price`, `usage_pricing_tier_name` |
+| `0`                         | `total_cost`                                                                                                                                                     |
+
+Empty strings appear where the v4 events table stores the column as non-nullable. `total_cost` reads from `cost_details['total']`, so a `0` there cannot be told apart from a genuine zero cost.
 
 For the field groups that select these columns and how they differ from the enriched export, see [what changes in the exported data](/docs/api-and-data-platform/features/export-to-blob-storage#legacy-field-differences).
 

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -175,6 +175,22 @@ Make manifest processing idempotent. Provider events can be delivered more than 
   producing data after the server switches to `events_only`.
 </Callout>
 
+### What changes in the exported data [#legacy-field-differences]
+
+The legacy source writes observation data to `observations/` and trace context to a separate `traces/` file, which consumers join on `trace_id`. The enriched source writes a single `observations_v2/` file in which each observation row already carries its trace context.
+
+[Field groups](#export-field-groups) select columns in both observation files. Three groups contain fewer fields in the legacy `observations/` file; the rest are identical:
+
+| Group           | `observations_v2/`                                                                                                                  | `observations/`                                                             |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `basic`         | `bookmarked`, `environment`, `is_root_observation`, `level`, `name`, `public`, `session_id`, `status_message`, `user_id`, `version` | `environment`, `level`, `name`, `status_message`, `version`                 |
+| `usage`         | `cost_details`, `total_cost`, `usage_details`, `usage_pricing_tier_id`, `usage_pricing_tier_name`                                   | Same, without `usage_pricing_tier_id`                                       |
+| `trace_context` | `release`, `tags`, `trace_name`                                                                                                     | No effect; these fields are in the `traces/` file (`name` for `trace_name`) |
+
+The `traces/` file itself has a fixed schema that field groups do not apply to. Its trace-level `input`, `output`, `metadata`, `timestamp`, and `version` have no direct equivalent in `observations_v2/`, where identically named fields hold observation-level data.
+
+For every column in each file, see the [legacy field reference](/docs/api-and-data-platform/features/blob-storage-export-fields#legacy-export-paths).
+
 ### Switch to enriched observations [#upgrade-path]
 
 Most integrations can switch directly once their consumer supports the enriched layout:


### PR DESCRIPTION
## Problem

The [blob storage export field reference](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields) documents full field tables for `observations_v2/` (45 fields), `scores/` (16), and `traces/` (17), but the `### Observations (observations/)` section carried only a three-row field-group difference table. Anyone building or maintaining a legacy consumer had no column list to work from.

## Changes

**`blob-storage-export-fields.mdx`**

- Add the 36-field schema for legacy `observations/`, in the same column order as the enriched table so the two can be compared directly.
- Move the enriched vs. legacy field-group comparison out to the export page (see below) and link to it.
- Rename the H2 from "Legacy export differences" to "Legacy exports", since it now holds schemas rather than only differences.

**`export-to-blob-storage.mdx`**

- New `### What changes in the exported data [#legacy-field-differences]` under `## Upgrade a legacy export`, holding the `traces/` + `observations/` vs. `observations_v2/` field-group comparison, the `traces/` fixed-schema note, and the caveat that trace-level `input`, `output`, `metadata`, `timestamp`, and `version` have no direct equivalent in the enriched file. This puts the field-level diff next to the migration steps that depend on it.

The existing `#enriched-vs-legacy-differences` and `#traces-derived-fields` anchors are preserved, so inbound deep links keep working.

## Verification

Rendered locally against a dev server:

- Field reference renders 5 tables — 4 / 45 / 16 / 17 / 36 rows. The 45 to 36 delta is exactly the nine fields the field-group comparison documents as absent from the legacy file (`bookmarked`, `is_root_observation`, `public`, `session_id`, `user_id`, `release`, `tags`, `trace_name`, `usage_pricing_tier_id`).
- `#legacy-field-differences` resolves and appears in the export page's table of contents; both cross-links between the pages work.
- `pnpm run format` and `node scripts/check-h1-headings.js` pass.

## Note for review

The legacy `observations/` field list was derived from the enriched table minus the documented group differences, then cross-checked against the version of this page that preceded #3419, which listed the same 36 fields. Worth a sanity check against the exporter itself in case anything shifted in the interim.

## Scope

Deliberately limited to the schema restore. Other details dropped by #3419 — the `Export Mode` field name, the self-hosted preview flag, the status badge table, the credentials link, the score data types, and the page's sidebar visibility — are in the stacked follow-up #3552 for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to blob export field reference and migration pages; no runtime or API behavior.
> 
> **Overview**
> Restores a **full 36-column schema** for deprecated `observations/` in the blob storage field reference so legacy consumers have a column list comparable to `observations_v2/`. The section is renamed to **Legacy exports**, `total_cost` on enriched rows is clarified as `0` when no cost was recorded, and legacy intro text links to the upgrade guide.
> 
> The **enriched vs legacy field-group comparison** moves from the field reference to **Upgrade a legacy export** (`#legacy-field-differences`) on the export page, next to migration steps. The field reference keeps **null vs empty string vs `0`** encoding differences between legacy and `observations_v2/` JSON/JSONL and points readers to that section for group-level diffs. Existing anchors `#enriched-vs-legacy-differences` and `#traces-derived-fields` are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3905fc2e741b05722b7ef9a0ef72be4e731fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->