### PR TITLE
docs: add Langfuse v4 changelog link to handbook story

### DIFF
--- a/content/handbook/chapters/story.mdx
+++ b/content/handbook/chapters/story.mdx
@@ -183,7 +183,7 @@ Nothing changed for users: Langfuse stays open source under its existing MIT lic
   Scale](/images/blog/2026-03-10-simplify-langfuse-for-scale/og.jpg)
 </Frame>
 
-After 19x growth in data processed over the year, we hit the limits of the data model carried over from the Postgres era. We shifted to an observations-centric data model: a single wide, mostly immutable ClickHouse table that eliminates joins and read-time deduplication. Dashboard load times for large projects improved by at least 10x, and initial table loads went from seconds to milliseconds. This is live in beta on Langfuse Cloud and will ship as v4 for self-hosters. Learn more in our [technical blog](/blog/2026-03-10-simplify-langfuse-for-scale).
+After 19x growth in data processed over the year, we hit the limits of the data model carried over from the Postgres era. We shifted to an observations-centric data model: a single wide, mostly immutable ClickHouse table that eliminates joins and read-time deduplication. Dashboard load times for large projects improved by at least 10x, and initial table loads went from seconds to milliseconds. This shipped as [Langfuse v4](/changelog/2026-08-17-langfuse-v4) and is live on Langfuse Cloud and for self-hosters. Learn more in our [technical blog](/blog/2026-03-10-simplify-langfuse-for-scale).
 
 </Steps>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updates the **Mar 2026: Simplifying Langfuse for Scale** section in the handbook story to reflect that Langfuse v4 is live (no longer beta / upcoming).
- Adds a link to the recent v4 changelog entry: `/changelog/2026-08-17-langfuse-v4`.
- Keeps the existing technical blog link for deeper background.

## Test plan

- [x] Open `/handbook/chapters/story#mar-2026-simplifying-langfuse-for-scale`
- [x] Confirm the section mentions that v4 shipped and is live
- [x] Confirm the "Langfuse v4" link goes to `/changelog/2026-08-17-langfuse-v4`
- [x] Confirm the technical blog link still works

## Walkthrough

[Mar 2026 story section with Langfuse v4 link](https://cursor.com/agents/bc-2b278cc1-9109-4f02-a8f4-7f1b170fc81b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_mar2026_section_with_v4_link.webp)

[story_v4_changelog_link_clickthrough.mp4](https://cursor.com/agents/bc-2b278cc1-9109-4f02-a8f4-7f1b170fc81b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_v4_changelog_link_clickthrough.mp4)

[Changelog page after clicking Langfuse v4 link](https://cursor.com/agents/bc-2b278cc1-9109-4f02-a8f4-7f1b170fc81b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchangelog_v4_page_after_click.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15246](https://linear.app/clickhouse/issue/LFE-15246/add-recent-v4-changelog-link-to-this-section-in-story)

<div><a href="https://cursor.com/agents/bc-2b278cc1-9109-4f02-a8f4-7f1b170fc81b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b278cc1-9109-4f02-a8f4-7f1b170fc81b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the handbook’s March 2026 story to state that Langfuse v4 has shipped and is live for Cloud and self-hosted users.
- Adds a link to the corresponding Langfuse v4 changelog entry.
- Retains the existing technical blog link for further detail.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The updated release wording is internally consistent, and the newly linked changelog entry exists at the exact route referenced by the handbook.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: link Langfuse v4 changelog from ha..."](https://github.com/langfuse/langfuse-docs/commit/382f559563d1973ef7d5ab2f99fb692395717c3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54083787)</sub>

<!-- /greptile_comment -->