### PR TITLE
docs: add SDK examples for fetching corrections

### DIFF
--- a/content/docs/observability/features/corrections.mdx
+++ b/content/docs/observability/features/corrections.mdx
@@ -130,17 +130,35 @@ curl -X POST https://cloud.langfuse.com/api/public/scores \
 
 ## Fetching Corrections
 
-Corrections are stored as scores and can be fetched programmatically to build datasets or analyze model performance.
+Corrections are stored as scores and can be fetched programmatically to build datasets or analyze model performance. Filter the [Scores API](/docs/api-and-data-platform/features/scores-api) by `dataType=CORRECTION`. The corrected output is in the `value` field.
 
 <Tabs items={["Python", "TypeScript", "HTTP"]}>
 <Tab>
 
-Coming soon: Fetch corrections via the SDK.
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+corrections = langfuse.api.scores_v3.get_many_v3(
+    data_type="CORRECTION",
+    fields="subject,details",
+)
+```
 
 </Tab>
 <Tab>
 
-Coming soon: Fetch corrections via the SDK.
+```typescript
+import { LangfuseClient } from "@langfuse/client";
+
+const langfuse = new LangfuseClient();
+
+const corrections = await langfuse.api.scoresV3.getManyV3({
+  dataType: "CORRECTION",
+  fields: "subject,details",
+});
+```
 
 </Tab>
 <Tab>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Both the Python and JS/TS SDKs can fetch corrections through the Scores API v3 (`get_many_v3` / `getManyV3`) by filtering on `dataType=CORRECTION`. There is no dedicated `get_corrections` helper.

This replaces the "Coming soon" placeholders on the Corrections page with working SDK examples that match the existing HTTP tab, and links to the Scores API for filters, field groups, and pagination.

The corrected output is returned in the score `value` field. Request `fields=subject,details` to include the attached trace/observation and any comment/metadata.

[Python tab: fetch corrections via scores v3](https://cursor.com/agents/bc-716a5d73-3184-4e5c-b786-09cf4976379e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffetching_corrections_python_tab.webp)
[TypeScript tab: fetch corrections via scoresV3](https://cursor.com/agents/bc-716a5d73-3184-4e5c-b786-09cf4976379e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffetching_corrections_typescript_tab.webp)
[HTTP tab: curl GET corrections](https://cursor.com/agents/bc-716a5d73-3184-4e5c-b786-09cf4976379e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffetching_corrections_http_tab.webp)
[fetching_corrections_sdk_tabs.mp4](https://cursor.com/agents/bc-716a5d73-3184-4e5c-b786-09cf4976379e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffetching_corrections_sdk_tabs.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15252](https://linear.app/clickhouse/issue/LFE-15252/update-fetching-corrections-docs)

<div><a href="https://cursor.com/agents/bc-716a5d73-3184-4e5c-b786-09cf4976379e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-716a5d73-3184-4e5c-b786-09cf4976379e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces “Coming soon” placeholders with Python and TypeScript examples for fetching corrections through Scores API v3.
- Filters scores by the `CORRECTION` data type.
- Requests the `subject` and `details` field groups.
- Clarifies that the corrected output is returned in the core `value` field.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation change appears safe to merge.

The new examples match the repository’s established Scores API v3 method names, parameter conventions, correction data type, and field-group semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add SDK examples for fetching corr..."](https://github.com/langfuse/langfuse-docs/commit/178e5710e74b240a1405a116ad7bc6f4526ef5c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54209281)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->