### PR TITLE
docs: redirect /docs/v4 to the v4 changelog

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1772,6 +1772,7 @@ const permanentRedirects = [
     "/changelog/2026-08-13-langfuse-v4.md",
     "/changelog/2026-08-17-langfuse-v4.md",
   ],
+  ["/docs/v4", "/changelog/2026-08-17-langfuse-v4"],
   // llm-evaluation blog consolidation (2026-07): 101 post merged into the evals leader post
   [
     "/blog/2025-03-04-llm-evaluation-101-best-practices-and-challenges",


### PR DESCRIPTION
## Summary
- Permanently redirect `/docs/v4` to `/changelog/2026-08-17-langfuse-v4` (same destination as https://langfuse.com/changelog/2026-08-17-langfuse-v4).

## Test plan
- [ ] Confirm `/docs/v4` redirects to the v4 changelog announcement after deploy.
- [ ] Confirm `/docs/v4` no longer serves the old preview docs page.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a permanent redirect from the retired Langfuse v4 preview documentation page to the published v4 changelog announcement.

- Adds `/docs/v4` to the permanent redirect list.
- Targets the existing `/changelog/2026-08-17-langfuse-v4` page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the redirect intentionally retires the existing preview route and points to a valid changelog page.

The added redirect uses the repository’s established permanent-redirect structure, its source behavior matches the stated migration plan, and its destination resolves through the existing changelog content route.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect /docs/v4 to the v4 change..."](https://github.com/langfuse/langfuse-docs/commit/745c1b7fde53fc03877d8e3aae08975bb8690d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54287246)</sub>

**Context used:**

- Knowledge Base — [Docs Search and Link Integrity](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/search-and-link-integrity.md)

<!-- /greptile_comment -->