### PR TITLE
feat: add Spotify Ad Analytics pixel

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { Hubspot } from "@/components/analytics/hubspot";
 import { GoogleAds } from "@/components/analytics/google-ads";
 import { LinkedInInsightTag } from "@/components/analytics/linkedin-ads";
 import { RedditPixel } from "@/components/analytics/reddit-ads";
+import { SpotifyPixel } from "@/components/analytics/spotify-ads";
 import { TwitterPixel } from "@/components/analytics/twitter-ads";
 import { ConversionTracker } from "@/components/analytics/ConversionTracker";
 import { CommonRoom } from "@/components/analytics/common-room";
@@ -100,6 +101,7 @@ export default function RootLayout({
             <GoogleAds />
             <LinkedInInsightTag />
             <RedditPixel />
+            <SpotifyPixel />
             <TwitterPixel />
             <ConversionTracker />
             <Hubspot />

--- a/components/analytics/PostHogProvider.tsx
+++ b/components/analytics/PostHogProvider.tsx
@@ -6,6 +6,7 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { hsPageView } from "@/components/analytics/hubspot";
 import { crPageView } from "@/components/analytics/common-room";
+import { spotifyPageView } from "@/lib/spotify-ads";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
 
@@ -38,12 +39,13 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     if (pathname) {
       posthog.capture("$pageview");
       hsPageView(pathname);
-      // Common Room's snippet auto-tracks the first page load, so only report
-      // subsequent client-side navigations to avoid double counting.
+      // The Common Room and Spotify snippets auto-track the first page load, so
+      // only report subsequent client-side navigations to avoid double counting.
       if (isInitialPageView.current) {
         isInitialPageView.current = false;
       } else {
         crPageView();
+        spotifyPageView();
       }
     }
   }, [pathname]);

--- a/components/analytics/spotify-ads.tsx
+++ b/components/analytics/spotify-ads.tsx
@@ -1,0 +1,27 @@
+import Script from "next/script";
+import { SPOTIFY_PIXEL_ID, isSpotifyEnabled } from "@/lib/spotify-ads";
+
+// Spotify Ad Analytics (SpAA) base pixel. Tracks the initial page view; because
+// the docs site is a single-page app, subsequent client-side navigations are
+// reported manually via `spotifyPageView` (see PostHogProvider). Conversions are
+// reported via `reportSpotifyLead` (see lib/ad-conversions.ts).
+export function SpotifyPixel() {
+  if (!isSpotifyEnabled) return null;
+
+  return (
+    <Script id="spotify-pixel" strategy="afterInteractive">
+      {`(function(w, d){
+  var id='spdt-capture', n='script';
+  if (!d.getElementById(id)) {
+    w.spdt = w.spdt || function() { (w.spdt.q = w.spdt.q || []).push(arguments); };
+    var e = d.createElement(n); e.id = id; e.async=1;
+    e.src = 'https://pixel.byspotify.com/ping.min.js';
+    var s = d.getElementsByTagName(n)[0];
+    s.parentNode.insertBefore(e, s);
+  }
+  w.spdt('conf', { key: '${SPOTIFY_PIXEL_ID}' });
+  w.spdt('view');
+})(window, document);`}
+    </Script>
+  );
+}

--- a/content/marketing/privacy.mdx
+++ b/content/marketing/privacy.mdx
@@ -4,7 +4,7 @@ title: Privacy Policy
 
 # Privacy Policy
 
-**Last updated: July 29, 2026 | <a href="/api/md-to-pdf?url=/privacy.md" target="_blank">download as PDF</a>**
+**Last updated: August 21, 2026 | <a href="/api/md-to-pdf?url=/privacy.md" target="_blank">download as PDF</a>**
 
 This privacy notice for **ClickHouse, Inc.** ("**we**," "**us**," or "**our**"), describes how and why we might collect, store, use, and/or share ("**process**") your information when you interact with our Langfuse-branded services ("**Services**"), such as when you:
 
@@ -187,6 +187,7 @@ We may share your data with third-party vendors, service providers, contractors,
   - Reo.dev
   - LinkedIn
   - Reddit
+  - Spotify
   - X (formerly Twitter)
 - **Allow Users to Connect to Their Third-Party Accounts**
   - Google Authentication, GitHub, AzureAD

--- a/global.d.ts
+++ b/global.d.ts
@@ -5,6 +5,7 @@ interface Window {
   lintrk?: (...args: any[]) => void;
   _linkedin_data_partner_ids?: any[];
   rdt?: (...args: any[]) => void;
+  spdt?: (...args: any[]) => void;
   twq?: (...args: any[]) => void;
   signals?: any[] & {
     page: (...args: any[]) => void;

--- a/lib/ad-conversions.ts
+++ b/lib/ad-conversions.ts
@@ -7,6 +7,7 @@ import {
   reportLinkedInConversion,
 } from "@/lib/linkedin-ads";
 import { REDDIT_EVENTS, reportRedditConversion } from "@/lib/reddit-ads";
+import { SPOTIFY_LEADS, reportSpotifyLead } from "@/lib/spotify-ads";
 import {
   TWITTER_CONVERSIONS,
   reportTwitterConversion,
@@ -24,6 +25,7 @@ export function reportLaunchAppConversion() {
   });
   reportLinkedInConversion(LINKEDIN_CONVERSIONS.launchApp);
   reportRedditConversion(REDDIT_EVENTS.launchApp);
+  reportSpotifyLead(SPOTIFY_LEADS.launchApp);
   reportTwitterConversion(TWITTER_CONVERSIONS.launchApp, {
     value: 1.0,
     currency: "USD",
@@ -35,5 +37,6 @@ export function reportTalkToUsConversion() {
   reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.talkToUsFormSubmit);
   reportLinkedInConversion(LINKEDIN_CONVERSIONS.talkToUs);
   reportRedditConversion(REDDIT_EVENTS.talkToUs);
+  reportSpotifyLead(SPOTIFY_LEADS.talkToUs);
   reportTwitterConversion(TWITTER_CONVERSIONS.talkToUs);
 }

--- a/lib/ad-conversions.ts
+++ b/lib/ad-conversions.ts
@@ -7,7 +7,7 @@ import {
   reportLinkedInConversion,
 } from "@/lib/linkedin-ads";
 import { REDDIT_EVENTS, reportRedditConversion } from "@/lib/reddit-ads";
-import { SPOTIFY_LEADS, reportSpotifyLead } from "@/lib/spotify-ads";
+import { SPOTIFY_LEAD_CATEGORIES, reportSpotifyLead } from "@/lib/spotify-ads";
 import {
   TWITTER_CONVERSIONS,
   reportTwitterConversion,
@@ -25,7 +25,7 @@ export function reportLaunchAppConversion() {
   });
   reportLinkedInConversion(LINKEDIN_CONVERSIONS.launchApp);
   reportRedditConversion(REDDIT_EVENTS.launchApp);
-  reportSpotifyLead(SPOTIFY_LEADS.launchApp);
+  reportSpotifyLead(SPOTIFY_LEAD_CATEGORIES.launchApp);
   reportTwitterConversion(TWITTER_CONVERSIONS.launchApp, {
     value: 1.0,
     currency: "USD",
@@ -37,6 +37,6 @@ export function reportTalkToUsConversion() {
   reportGoogleAdsConversion(GOOGLE_ADS_CONVERSIONS.talkToUsFormSubmit);
   reportLinkedInConversion(LINKEDIN_CONVERSIONS.talkToUs);
   reportRedditConversion(REDDIT_EVENTS.talkToUs);
-  reportSpotifyLead(SPOTIFY_LEADS.talkToUs);
+  reportSpotifyLead(SPOTIFY_LEAD_CATEGORIES.talkToUs);
   reportTwitterConversion(TWITTER_CONVERSIONS.talkToUs);
 }

--- a/lib/spotify-ads.ts
+++ b/lib/spotify-ads.ts
@@ -1,34 +1,30 @@
 // Spotify Ad Analytics (SpAA) pixel + conversion tracking.
 //
 // Used to attribute podcast/audio ad campaigns (e.g. "Last Week in AI") to
-// activity on langfuse.com. Fill in the pixel ID from the Spotify Ad Analytics
+// activity on langfuse.com. The pixel ID comes from the Spotify Ad Analytics
 // dashboard under Manage → Your Pixels.
 //
 // Spotify only supports a fixed set of conversion events (alias, lead, product,
-// addtocart, checkout, purchase). Sign ups and contact-sales requests both map
-// to `lead`, differentiated via the optional `type` / `category` fields.
-// We deliberately do not send a `value`: Spotify recommends only populating it
-// when the lead itself is worth revenue, otherwise it inflates reported value.
+// addtocart, checkout, purchase), so both of our conversions are `lead` events
+// and are distinguished by `category`. The category strings below are taken
+// verbatim from the snippets Ad Analytics generated for this pixel — SpAA groups
+// conversions by that string in reporting, so they must match exactly.
+//
+// `type`, `value` and `currency` are intentionally omitted rather than sent
+// empty: neither conversion is worth a fixed amount of revenue, and Spotify
+// recommends only populating value when the lead itself is, otherwise it
+// inflates reported value.
 // https://help.adanalytics.spotify.com/technical-pixel-docs
 //
-// The pixel only loads when the pixel ID is set, so it is safe to ship before
-// the ID exists.
-export const SPOTIFY_PIXEL_ID: string = "";
+// The pixel only loads when the pixel ID is set, so it is safe to ship without.
+export const SPOTIFY_PIXEL_ID: string = "4c74bba7652e4bb0bf3e1bca5e56f0d1";
 
-export const SPOTIFY_LEADS: {
-  launchApp: SpotifyLead;
-  talkToUs: SpotifyLead;
-} = {
-  launchApp: { type: "signup", category: "cloud_signup" },
-  talkToUs: { type: "contact_sales", category: "talk_to_us" },
-};
+export const SPOTIFY_LEAD_CATEGORIES = {
+  launchApp: "Sign Up",
+  talkToUs: "Demo Request",
+} as const;
 
 export const isSpotifyEnabled = SPOTIFY_PIXEL_ID !== "";
-
-type SpotifyLead = {
-  type: string;
-  category: string;
-};
 
 function isSpotifyReady() {
   return (
@@ -38,10 +34,10 @@ function isSpotifyReady() {
   );
 }
 
-export function reportSpotifyLead(lead: SpotifyLead) {
-  if (!isSpotifyReady()) return;
+export function reportSpotifyLead(category: string) {
+  if (!category || !isSpotifyReady()) return;
 
-  window.spdt("lead", { type: lead.type, category: lead.category });
+  window.spdt("lead", { category });
 }
 
 // Report a page view to Spotify. The base snippet auto-tracks the initial page

--- a/lib/spotify-ads.ts
+++ b/lib/spotify-ads.ts
@@ -1,0 +1,53 @@
+// Spotify Ad Analytics (SpAA) pixel + conversion tracking.
+//
+// Used to attribute podcast/audio ad campaigns (e.g. "Last Week in AI") to
+// activity on langfuse.com. Fill in the pixel ID from the Spotify Ad Analytics
+// dashboard under Manage → Your Pixels.
+//
+// Spotify only supports a fixed set of conversion events (alias, lead, product,
+// addtocart, checkout, purchase). Sign ups and contact-sales requests both map
+// to `lead`, differentiated via the optional `type` / `category` fields.
+// We deliberately do not send a `value`: Spotify recommends only populating it
+// when the lead itself is worth revenue, otherwise it inflates reported value.
+// https://help.adanalytics.spotify.com/technical-pixel-docs
+//
+// The pixel only loads when the pixel ID is set, so it is safe to ship before
+// the ID exists.
+export const SPOTIFY_PIXEL_ID: string = "";
+
+export const SPOTIFY_LEADS: {
+  launchApp: SpotifyLead;
+  talkToUs: SpotifyLead;
+} = {
+  launchApp: { type: "signup", category: "cloud_signup" },
+  talkToUs: { type: "contact_sales", category: "talk_to_us" },
+};
+
+export const isSpotifyEnabled = SPOTIFY_PIXEL_ID !== "";
+
+type SpotifyLead = {
+  type: string;
+  category: string;
+};
+
+function isSpotifyReady() {
+  return (
+    isSpotifyEnabled &&
+    typeof window !== "undefined" &&
+    typeof window.spdt === "function"
+  );
+}
+
+export function reportSpotifyLead(lead: SpotifyLead) {
+  if (!isSpotifyReady()) return;
+
+  window.spdt("lead", { type: lead.type, category: lead.category });
+}
+
+// Report a page view to Spotify. The base snippet auto-tracks the initial page
+// load, so this is only needed for SPA route changes.
+export function spotifyPageView() {
+  if (!isSpotifyReady()) return;
+
+  window.spdt("view");
+}


### PR DESCRIPTION
Adds the Spotify Ad Analytics (SpAA) pixel so we can attribute podcast and audio ad campaigns to activity on langfuse.com. Follows the existing per-platform pixel pattern (Reddit / X / LinkedIn).

## What's included

- `lib/spotify-ads.ts` — pixel ID, event mapping, `reportSpotifyLead()`, `spotifyPageView()`
- `components/analytics/spotify-ads.tsx` — base pixel script
- Mounted in `app/layout.tsx`, so the pixel is on every page (Spotify's guidance is to install it on as many pages as possible)
- `lib/ad-conversions.ts` — both existing conversions now also report to Spotify
- `PostHogProvider.tsx` — the site is a SPA and the base snippet only sees the first page load, so client-side route changes fire an additional `view` (same approach already used for Common Room)
- `global.d.ts` — `window.spdt` type

## Implementation notes

- SpAA only supports `alias` / `lead` / `product` / `addtocart` / `checkout` / `purchase`. Both Langfuse conversions map to `lead`, distinguished by `type` / `category` — [Spotify's guidance](https://help.adanalytics.spotify.com/spotify-pixel-placement-best-practices) puts sign-ups and free trials on `lead`.
- **No `value` is sent.** Spotify recommends only populating value when the lead is itself worth revenue, otherwise reported purchase value is inflated.
- `alias` is omitted — it is for hashed logged-in user IDs, which the marketing site does not have.
- Consent handling is unchanged from the other pixels, so this behaves exactly like the existing Reddit / X tags.

## Pixel ID is intentionally empty

`SPOTIFY_PIXEL_ID` is `""`, so the pixel and every conversion no-op. This is safe to merge before the Spotify Ad Analytics account exists; the ID gets filled in from SpAA → Manage → Your Pixels once the account invite arrives.

## Verification

- `tsc --noEmit` clean for all touched files (remaining errors are pre-existing, from ungenerated Fumadocs types)
- `prettier --check` passes
- Extracted the inline snippet and executed it against a stub DOM: it injects `https://pixel.byspotify.com/ping.min.js` with `id=spdt-capture, async=1` and queues `[["conf",{"key":…}],["view"]]` in the correct order

## Privacy policy

`content/marketing/privacy.mdx` now lists Spotify under "Advertising, Direct Marketing, and Lead Generation", alongside LinkedIn / Reddit / X, and the last-updated date is bumped. This ships in the same PR so the disclosure is live at the same time as the pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the existing third-party ad-pixel pattern (production-only, no-op if the tag is missing). Main impact is extra marketing tracking and a privacy-policy disclosure, not auth or product data.
> 
> **Overview**
> Adds Spotify Ad Analytics (SpAA) so podcast/audio campaigns can be attributed on langfuse.com, using the same pattern as Reddit / LinkedIn / X.
> 
> The base pixel loads in production via `SpotifyPixel`. Launch-app and talk-to-us conversions now also fire Spotify `lead` events (`Sign Up` / `Demo Request`). Client-side route changes send extra `view` events in `PostHogProvider` so SPA navigations are not missed.
> 
> Privacy policy lists Spotify under advertising processors and bumps the last-updated date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2bbf9724b877f70da5ef7de2c5a2dd16e72017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an intentionally disabled Spotify Ad Analytics integration that follows the existing advertising-pixel architecture.
- Adds the Spotify base pixel loader, event definitions, and no-op-safe page-view and lead reporters.
- Fans existing launch-app and contact-sales conversions out to Spotify.
- Tracks SPA route changes while suppressing a duplicate initial page view.
- Mounts the pixel globally once a non-empty pixel ID is configured.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with Spotify tracking remaining intentionally inactive until its pixel ID is configured.

The enabled-state guards prevent script injection and event emission with the current empty ID, while the configured flow follows the repository’s existing global pixel, conversion fan-out, and SPA page-view patterns without an accepted functional or security defect.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant Layout as RootLayout
  participant Pixel as SpotifyPixel
  participant Router as PostHogProvider
  participant Conversion as ad-conversions
  participant Spotify as Spotify Ad Analytics

  Layout->>Pixel: Mount globally in production
  alt Pixel ID configured
    Pixel->>Spotify: Load ping.min.js
    Pixel->>Spotify: conf(pixel ID)
    Pixel->>Spotify: view (initial page)
    Router->>Spotify: view (later SPA navigation)
    Conversion->>Spotify: lead (launch app or talk to us)
  else Pixel ID empty
    Pixel-->>Browser: Render nothing
    Router-->>Browser: Spotify page view no-op
    Conversion-->>Browser: Spotify lead no-op
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Spotify Ad Analytics pixel"](https://github.com/langfuse/langfuse-docs/commit/10d49f1f3d085c9743d46e68307e5243be2fd822) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54304569)</sub>

**Context used:**

- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)
- Knowledge Base — [App Router structure](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/app-routing.md)

<!-- /greptile_comment -->
