### PR TITLE
docs: add OpenAI Fast mode cost tracking

### DIFF
--- a/content/changelog/2026-08-18-openai-fast-mode-cost-tracking.mdx
+++ b/content/changelog/2026-08-18-openai-fast-mode-cost-tracking.mdx
@@ -1,0 +1,37 @@
+---
+date: 2026-08-18
+title: Cost tracking support for OpenAI Fast mode
+description: Track OpenAI Fast mode costs automatically, including GPT-5.6 long-context rates.
+author: Hassieb
+canonical: /docs/observability/features/token-and-cost-tracking#pricing-tiers
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book, Gauge } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now track OpenAI Fast mode spend accurately in Langfuse without ingesting costs manually. For supported OpenAI models, Langfuse automatically selects Fast mode pricing when a generation's model parameters contain `service_tier: "fast"` or `service_tier: "priority"`.
+
+- See the Fast mode surcharge in each generation's cost breakdown.
+- Keep aggregate cost dashboards accurate when you mix Standard and Fast mode traffic.
+- Apply the correct short- or long-context rate for GPT-5.6 calls.
+
+[OpenAI Fast mode](https://developers.openai.com/api/docs/guides/fast-mode) offers faster inference at a per-token premium. OpenAI accepts both `fast` and the previous `priority` value for `service_tier`; for GPT-5.6 and earlier models, the response reports `priority` for either request value. Langfuse therefore matches both values. For GPT-5.6 models, it combines that service-tier match with input usage to select from the full Standard/Fast and short/long-context pricing matrix.
+
+Pricing tiers are now more flexible for custom model definitions, too. In addition to matching numeric thresholds across usage details, a tier can match one or more exact values from any top-level model-parameter or metadata key. For example, you can price by the `service_tier` model parameter or top-level metadata keys such as `region` and `model_provider`. Configure these conditions under **Project Settings > Models**.
+
+<Cards num={2}>
+  <Card
+    title="Pricing tier documentation"
+    href="/docs/observability/features/token-and-cost-tracking#pricing-tiers"
+    icon={<Book />}
+    arrow
+  />
+  <Card
+    title="OpenAI Fast mode"
+    href="https://developers.openai.com/api/docs/guides/fast-mode"
+    icon={<Gauge />}
+    arrow
+  />
+</Cards>

--- a/content/docs/observability/features/token-and-cost-tracking.mdx
+++ b/content/docs/observability/features/token-and-cost-tracking.mdx
@@ -108,9 +108,9 @@ This process keeps the default definitions current without relying on a third-pa
 
 ### Pricing Tiers [#pricing-tiers]
 
-Some model providers charge different rates depending on the number of input tokens used. For example, Anthropic's Claude Sonnet 4.5 and Google's Gemini 2.5 Pro apply higher pricing when more than 200K input tokens are used.
+Some model providers charge different rates depending on context length or request attributes. For example, Anthropic's Claude Sonnet 4.5 and Google's Gemini 2.5 Pro apply higher pricing when more than 200K input tokens are used, while [OpenAI Fast mode](https://developers.openai.com/api/docs/guides/fast-mode) charges a premium based on the request's `service_tier`.
 
-Langfuse supports **pricing tiers** for models, enabling accurate cost calculation for these context-dependent pricing structures.
+Langfuse supports **pricing tiers** for models, enabling accurate cost calculation across usage thresholds, model parameters, and metadata.
 
 #### How tier matching works
 
@@ -123,14 +123,17 @@ Each model can have multiple pricing tiers, each with:
 
 When calculating cost, Langfuse evaluates tiers in priority order (excluding the default tier). The first tier whose conditions are satisfied is used. If no conditional tier matches, the default tier is applied.
 
-**Condition format:**
+Each condition selects one of these sources:
 
-- `usageDetailPattern`: A regex pattern to match usage detail keys (e.g., `input` matches `input_tokens`, `input_cached_tokens`, etc.)
-- `operator`: Comparison operator (`gt`, `gte`, `lt`, `lte`, `eq`, `neq`)
-- `value`: The threshold value to compare against
-- `caseSensitive`: Whether the pattern matching is case-sensitive (default: false)
+- **Usage details:** Match usage-detail keys with a regex, sum their values, and compare the result with `gt`, `gte`, `lt`, `lte`, `eq`, or `neq`. You can also control whether the key pattern is case-sensitive.
+- **Model parameters:** Match a top-level model-parameter key against one or more exact values.
+- **Metadata:** Match a top-level metadata key against one or more exact values.
+
+For model parameters and metadata, select the source in the pricing-tier editor, enter the **Top-level key**, and add comma-separated exact values. String, number, and boolean values are compared as strings. Nested paths and non-primitive values are not supported. When a tier has multiple conditions, all of them must match.
 
 For example, the "Large Context" tier for Claude Sonnet 4.5 has a condition: `input > 200000`, meaning it applies when the sum of all usage details matching the pattern "input" exceeds 200,000 tokens.
+
+OpenAI Fast mode tiers match the top-level model parameter `service_tier` against `fast` or `priority`. For GPT-5.6 models, this condition is combined with the input-token threshold to distinguish Standard/Fast and short/long-context prices.
 
 ### Custom model definitions [#custom-model-definitions]
 


### PR DESCRIPTION
## Summary

- announce native OpenAI Fast mode cost tracking for `fast` and `priority` service tiers
- explain GPT-5.6 short- and long-context pricing selection
- document exact top-level model-parameter and metadata matching for custom pricing tiers

## Validation

- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- generated Markdown source inspection
- verified the new internal route and anchor locally
- verified the OpenAI Fast mode URL returns HTTP 200

`pnpm run link-check` was also run, but the repository-wide check requires a local docs server and reported existing localhost failures across the site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents **automatic OpenAI Fast mode cost tracking** and expands how **pricing tiers** are described for observability.
> 
> A new changelog entry explains that Langfuse infers Fast mode pricing when `service_tier` is `fast` or `priority`, including GPT-5.6 short/long-context selection and mixed Standard/Fast traffic on dashboards. The **Token & Cost Tracking** guide’s **Pricing Tiers** section is updated to cover request attributes (not only input-token thresholds), and to document three condition sources: **usage details**, **top-level model parameters**, and **top-level metadata** (exact values, all conditions must match). It adds concrete guidance for OpenAI Fast mode via `service_tier` and GPT-5.6 tier combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a6d8c98cc0baa353db7acc18ac921efacf4dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a changelog announcement and expands cost-tracking documentation for OpenAI Fast mode and custom pricing-tier matching.
- Documents `fast` and `priority` service-tier matching.
- Explains GPT-5.6 short- and long-context pricing selection.
- Describes top-level model-parameter and metadata conditions for custom pricing tiers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new changelog entry conforms to the repository’s content pipeline and established rendering patterns, and the documentation edits introduce no internally contradicted or demonstrably broken behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add OpenAI Fast mode cost tracking"](https://github.com/langfuse/langfuse-docs/commit/a9a6d8c98cc0baa353db7acc18ac921efacf4dc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54343360)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Editorial content: blog, changelog, and handbook](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/editorial-content.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)
</details>

<!-- /greptile_comment -->