### PR TITLE
docs: note OpenCode plugin contributions welcome

### DIFF
--- a/content/integrations/developer-tools/opencode.mdx
+++ b/content/integrations/developer-tools/opencode.mdx
@@ -157,6 +157,8 @@ When enabled, the plugin sends completed OpenCode session telemetry to Langfuse,
 
 ## Resources
 
+The plugin is open source — contributions are welcome. Open an issue or pull request on the [Langfuse OpenCode Observability Plugin](https://github.com/langfuse/opencode-observability-plugin) repository.
+
 - [Langfuse OpenCode Observability Plugin (GitHub)](https://github.com/langfuse/opencode-observability-plugin)
 - [OpenCode documentation](https://opencode.ai/docs)
 - [OpenCode GitHub repository](https://github.com/anomalyco/opencode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a short note on the OpenCode integration docs page that the Langfuse OpenCode Observability Plugin is open source and contributions (issues / PRs) are welcome.
- Links to https://github.com/langfuse/opencode-observability-plugin

Resolves LFE-15278.

## Test plan

- [x] Confirm the Resources section on `/integrations/developer-tools/opencode` shows the contribution note and correct GitHub link
- [x] Verify single H1 and Prettier formatting

## Walkthrough

[OpenCode docs Resources section with contribution note](https://cursor.com/agents/bc-2c4f4475-8e7d-4a9b-8f5e-210350e791ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopencode_resources_contribute_note.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15278](https://linear.app/clickhouse/issue/LFE-15278/add-note-to-opencode-docs-page-that-users-can-also-contribute-to-this)

<div><a href="https://cursor.com/agents/bc-2c4f4475-8e7d-4a9b-8f5e-210350e791ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4f4475-8e7d-4a9b-8f5e-210350e791ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a contribution note to the OpenCode integration’s Resources section.

- Clarifies that the observability plugin is open source.
- Invites issues and pull requests through the existing canonical GitHub repository link.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added sentence uses valid Markdown and links to the same canonical plugin repository already referenced by the page, with no conflicting repository rules or rendering concerns.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note that OpenCode plugin contribu..."](https://github.com/langfuse/langfuse-docs/commit/14937453b047beb70171e9cee024d39c60ff84ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54370247)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)

<!-- /greptile_comment -->