### PR TITLE
docs: add Langfuse Assistant to the agents page

### DIFF
--- a/content/marketing/agents.mdx
+++ b/content/marketing/agents.mdx
@@ -14,6 +14,8 @@ There are three ways to connect an agent to Langfuse. They share the same underl
 - **[CLI](#cli)** — full REST API coverage from the command line, for agents that can run bash.
 - **[MCP server](#mcp)** — the Model Context Protocol, for agents that can't run shell commands.
 
+And if you don't want to bring your own agent, the **[Langfuse Assistant](#assistant)** is built into Langfuse Cloud and answers questions about your project data right in the UI.
+
 <Callout type="info">
 This page is also available as markdown. Append `.md` to the URL or send an `Accept: text/markdown` header to get a clean, token-efficient version for your agent: [`langfuse.com/agents.md`](https://langfuse.com/agents.md).
 </Callout>
@@ -104,6 +106,26 @@ To keep an agent read-only, allow-list the lookup tools and leave out the write 
   <Card title="MCP tool reference" href="https://mcp.reference.langfuse.com" />
 </Cards>
 
+## Langfuse Assistant [#assistant]
+
+The [Langfuse Assistant](/docs/langfuse-assistant) is an agent that already lives inside Langfuse Cloud. Ask it about your traces, observations, sessions, and metrics in plain language, and it queries your project through the same [MCP server](#mcp) and answers in context, no setup required.
+
+<Video src="https://static.langfuse.com/docs-videos/in-app-agent.mp4" />
+
+Try questions like:
+
+- _Which traces had the highest latency yesterday?_
+- _Show me failed generations in the last hour._
+- _What's my token spend this week, broken down by model?_
+- _Open the traces table filtered to errors from today._
+
+The Assistant is aware of what you are looking at, so it can pick up the current trace, session, or dashboard without you naming it. It can also propose links to the right Langfuse page and help with actions such as creating a dataset or a score config. Anything that changes data or configuration pauses for your explicit approval, and the Assistant can only do what your own account is already permitted to do in that project.
+
+<Cards>
+  <Card title="Langfuse Assistant docs" href="/docs/langfuse-assistant" />
+  <Card title="Public beta announcement" href="/changelog/2026-06-19-langfuse-assistant-public-beta" />
+</Cards>
+
 ## Built to be fast for agents [#fast]
 
 Agents are impatient. They fan out many queries while working through a task, so slow responses waste both wall-clock time and tokens. Langfuse runs on [ClickHouse](/blog/joining-clickhouse), the columnar database built for fast analytical queries, which keeps reads quick even over hundreds of gigabytes of traces.
@@ -150,5 +172,5 @@ Once an agent can read and write Langfuse data, it can help you measure quality,
 - [Building Langfuse's MCP server](/blog/2025-12-09-building-langfuse-mcp-server)
 - [Using agent skills to improve your prompts](/blog/2026-02-16-prompt-improvement-claude-skills)
 - [Evaluating AI agent skills](/blog/2026-02-26-evaluate-ai-agent-skills)
-- [Agent Skill docs](/docs/api-and-data-platform/features/agent-skill) · [CLI docs](/docs/api-and-data-platform/features/cli) · [MCP server docs](/docs/api-and-data-platform/features/mcp-server)
+- [Agent Skill docs](/docs/api-and-data-platform/features/agent-skill) · [CLI docs](/docs/api-and-data-platform/features/cli) · [MCP server docs](/docs/api-and-data-platform/features/mcp-server) · [Langfuse Assistant docs](/docs/langfuse-assistant)
 - [Skills on GitHub](https://github.com/langfuse/skills) · [langfuse-cli on npm](https://www.npmjs.com/package/langfuse-cli) · [MCP reference](https://mcp.reference.langfuse.com)


### PR DESCRIPTION
Adds the Langfuse Assistant to [langfuse.com/agents](https://langfuse.com/agents) and links to [/docs/langfuse-assistant](https://langfuse.com/docs/langfuse-assistant).

## Changes

- New `## Langfuse Assistant [#assistant]` section after the MCP server section: what it is, the `in-app-agent.mp4` demo video, example questions, UI-context awareness, and the approval/permission model.
- Intro now points at the Assistant as the option for readers who don't want to bring their own agent.
- Cards linking to the Assistant docs and the public beta changelog, plus an entry in the Resources list.

Only `content/marketing/agents.mdx` changed — no `md-override/` file exists for this route, and the `.md` version is generated from the MDX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/docs-only change with no application or API behavior impact.
> 
> **Overview**
> Documents **Langfuse Assistant** on the [Langfuse for agents](https://langfuse.com/agents) marketing page as a fourth option for readers who do not bring their own coding agent.
> 
> The intro now links to **#assistant** and a new section after MCP covers the in-cloud assistant (demo video, example questions, UI context awareness, approval/permission model), with cards to the Assistant docs and public beta changelog. **Resources** also adds a link to the Assistant docs alongside Skill, CLI, and MCP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab8d30b61fc4164498925ad19e97a08486d590b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds the Langfuse Assistant to the agents marketing page and directs readers who do not bring their own agent toward the built-in Cloud experience.
- Adds an Assistant overview, example prompts, demo video, and context-awareness and permission details.
- Adds links to the Assistant documentation and public beta announcement.
- Adds the Assistant documentation to the resources list.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation change appears safe to merge with no actionable defects identified.

The new links resolve to existing content, the Video usage follows established MDX conventions, and the Assistant’s availability, capabilities, approval flow, and permission claims align with its dedicated documentation and public beta announcement.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Langfuse Assistant to the agen..."](https://github.com/langfuse/langfuse-docs/commit/ab8d30b61fc4164498925ad19e97a08486d590b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54686439)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)

<!-- /greptile_comment -->