### PR TITLE
docs: serve Langfuse images from docker.langfuse.com

### DIFF
--- a/content/integrations/no-code/langflow.mdx
+++ b/content/integrations/no-code/langflow.mdx
@@ -149,7 +149,7 @@ services:
 
   # https://github.com/langfuse/langfuse/blob/main/docker-compose.yml
   langfuse-worker:
-    image: langfuse/langfuse-worker:4
+    image: docker.langfuse.com/langfuse/langfuse-worker:4
     restart: always
     depends_on: &langfuse-depends-on
       postgres:
@@ -208,7 +208,7 @@ services:
       REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
 
   langfuse-web:
-    image: langfuse/langfuse:4
+    image: docker.langfuse.com/langfuse/langfuse:4
     restart: always
     depends_on: *langfuse-depends-on
     ports:

--- a/content/self-hosting/deployment/infrastructure/containers.mdx
+++ b/content/self-hosting/deployment/infrastructure/containers.mdx
@@ -18,6 +18,8 @@ Langfuse uses Docker to containerize the application. The application is split i
 - **Langfuse Web**: The web server that serves the Langfuse Console and API.
 - **Langfuse Worker**: The worker that handles background tasks such as sending emails or processing events.
 
+The prebuilt images are served from `docker.langfuse.com`, an alias that redirects to Docker Hub. If your environment restricts image pulls to `*.docker.io`, pull the same images directly from Docker Hub instead (`docker.io/langfuse/langfuse:4` and `docker.io/langfuse/langfuse-worker:4`).
+
 ## Recommended sizing
 
 For production environments, we recommend to use at least 2 CPUs and 4 GB of RAM for all containers.
@@ -78,7 +80,7 @@ docker run --name langfuse-web \
   -e LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=bPxRfiCYEXAMPLEKEY \
   -p 3000:3000 \
   -a STDOUT \
-langfuse/langfuse:4
+docker.langfuse.com/langfuse/langfuse:4
 ```
 
 ## Run Langfuse Worker
@@ -103,5 +105,5 @@ docker run --name langfuse-worker \
   -e LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=bPxRfiCYEXAMPLEKEY \
   -p 3030:3030 \
   -a STDOUT \
-langfuse/langfuse-worker:4
+docker.langfuse.com/langfuse/langfuse-worker:4
 ```

--- a/content/self-hosting/deployment/infrastructure/containers.mdx
+++ b/content/self-hosting/deployment/infrastructure/containers.mdx
@@ -18,8 +18,6 @@ Langfuse uses Docker to containerize the application. The application is split i
 - **Langfuse Web**: The web server that serves the Langfuse Console and API.
 - **Langfuse Worker**: The worker that handles background tasks such as sending emails or processing events.
 
-The prebuilt images are served from `docker.langfuse.com`, an alias that redirects to Docker Hub. If your environment restricts image pulls to `*.docker.io`, pull the same images directly from Docker Hub instead (`docker.io/langfuse/langfuse:4` and `docker.io/langfuse/langfuse-worker:4`).
-
 ## Recommended sizing
 
 For production environments, we recommend to use at least 2 CPUs and 4 GB of RAM for all containers.


### PR DESCRIPTION
## What does this PR do?

Updates the two docs pages that embed direct Langfuse image references to pull through `docker.langfuse.com`, the registry alias in front of Docker Hub, matching the defaults already changed in [`langfuse/langfuse#16265`](https://github.com/langfuse/langfuse/pull/16265) (docker-compose.yml) and [`langfuse/langfuse-k8s#388`](https://github.com/langfuse/langfuse-k8s/pull/388) (Helm chart v2):

- **Application containers page** (`/self-hosting/deployment/infrastructure/containers`): the `docker run` commands for Langfuse Web and Worker now reference `docker.langfuse.com/langfuse/langfuse:4` and `docker.langfuse.com/langfuse/langfuse-worker:4`. Also adds a one-line note about the alias with the `docker.io` fallback for registry-restricted environments, mirroring the escape hatch documented in the compose file header.
- **Langflow integration guide** (`/integrations/no-code/langflow`): the embedded docker-compose snippet (adapted from the langfuse repo's `docker-compose.yml`) now uses the same image references.

Deliberately unchanged:

- `docker build -t langfuse/langfuse` commands (local build tags, not pulls).
- The docker-compose and Kubernetes deployment guides — they link/clone `langfuse/langfuse` and embed the langfuse-k8s README live, so they pick up the upstream changes automatically.
- Legacy v2 self-hosting docs and historical changelog/blog posts.

`pnpm run format` has been run; no `md-override/` files correspond to these routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example image URLs and compose env vars; no application or deployment code paths are modified.
> 
> **Overview**
> Self-hosting and integration docs now point **Langfuse Web** and **Worker** pulls at `docker.langfuse.com/langfuse/...:4` instead of bare `langfuse/...` on Docker Hub, aligning embedded examples with upstream compose/Helm defaults.
> 
> On the **Application Containers** page, both `docker run` examples use the new registry host. The **Langflow** guide’s compose snippet updates the same two `image:` lines and adds **Langfuse API env vars** (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`) on the Langflow service so the stack can talk to the bundled Langfuse server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b6fdc2a7a41d6d0cb5137b5007d5aeb28c7b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes Langfuse Web and Worker image references in two documentation pages to use `docker.langfuse.com`.

- Updates the standalone application-container `docker run` commands and documents direct Docker Hub fallbacks.
- Updates the embedded Langflow Compose example to use the same registry alias.
- The Langflow example does not carry over the fallback needed in registry-restricted environments.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Langflow deployment guidance should document or preserve the Docker Hub fallback before merging so registry-restricted users are not left with an unusable Compose example.

The new Langflow image references unconditionally use a hostname that the companion documentation explicitly says some environments cannot pull from, while the Langflow page provides no alternative.

**Files Needing Attention:** content/integrations/no-code/langflow.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/integrations/no-code/langflow.mdx:152
**Registry fallback is missing**

If an environment permits `*.docker.io` but restricts `docker.langfuse.com`, this Compose example unconditionally pulls both changed images through the restricted alias, causing the documented Langflow and Langfuse stack to fail to start without the Docker Hub fallback documented on the containers page.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: serve Langfuse images from docker...."](https://github.com/langfuse/langfuse-docs/commit/6b35ed4dcd9f2c2374d4e5693770fba2b36cb316) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54700604)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->