### PR TITLE
feat: update helm chart disclaimers in upgrade guide

### DIFF
--- a/content/faq/all/upgrade-to-langfuse-v4.mdx
+++ b/content/faq/all/upgrade-to-langfuse-v4.mdx
@@ -55,6 +55,8 @@ We will email project owners and admins a summary of the actions required for th
 
 Self-hosted v4 is generally available. Follow the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4) to migrate your deployment; the `legacy` and `dual` write modes let you schedule each migration step independently.
 
+If you deploy with the [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) and run its bundled ClickHouse, [upgrade the chart from v1 to v2](/self-hosting/deployment/kubernetes-helm#chart-v1-to-v2) first. The v1 chart cannot bring its bundled ClickHouse to a v4-compatible version.
+
 There is no forced cutover date. Langfuse v3 receives security patches through January 2027. The [self-hosted compatibility matrix](/self-hosting/upgrade/versioning#sdk-server) lists supported SDKs and APIs.
 
 ## Questions [#questions]

--- a/content/self-hosting/configuration/scaling.mdx
+++ b/content/self-hosting/configuration/scaling.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "Sizing & Scaling"
 
 This guide covers how you can operate your Langfuse deployment at scale and includes best practices and tweaks to get the best performance.
 
-## Minimum Infrastructure Requirements
+## Minimum Infrastructure Requirements [#minimum-infrastructure-requirements]
 
 | Service                                                                         | Minimum Requirements                                         |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -191,7 +191,7 @@ Langfuse does not read from these tables, so you can safely reduce them. Two opt
 </clickhouse>
 ```
 
-On the Bitnami ClickHouse Helm chart, you can ship the same block via `clickhouse.extraOverrides`. Keep `query_log`, `part_log`, and `error_log` enabled — they are useful for debugging and remain small.
+On the [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) (`v2.x`), you can ship the same block via `clickhouse.cluster.settings`. Keep `query_log`, `part_log`, and `error_log` enabled — they are useful for debugging and remain small.
 
 **Option 2 — Aggressive TTLs.** If you want to keep the tables around for debugging, attach short TTLs and disable the query profiler instead:
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -201,7 +201,7 @@ LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE
 
 [MinIO](https://min.io/) and its commercial distribution [AIStor](https://www.min.io/product/aistor) are object storage servers that are compatible with the S3 API.
 They are a popular choice for on-premise deployments and local development.
-Langfuse uses MinIO for local development and as a default in our [Docker Compose](/self-hosting/deployment/docker-compose) and [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) deployment options.
+Langfuse uses MinIO for local development and as a default in our [Docker Compose](/self-hosting/deployment/docker-compose) deployment option. The [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) chart bundled MinIO up to chart version `v1.x` and bundles SeaweedFS from chart `v2.0.0` onwards.
 
 #### Example Configuration
 

--- a/content/self-hosting/deployment/infrastructure/cache.mdx
+++ b/content/self-hosting/deployment/infrastructure/cache.mdx
@@ -110,7 +110,7 @@ Raising `REDIS_SOCKET_TIMEOUT_MS` only lengthens the watchdog; it does not addre
 
 This section covers different deployment options and provides example environment variables.
 
-### Managed Redis/Valkey by Cloud Providers
+### Managed Redis/Valkey by Cloud Providers [#managed-redis-valkey]
 
 [Amazon ElastiCache](https://aws.amazon.com/de/elasticache/redis/), [Azure Cache for Redis](https://azure.microsoft.com/de-de/products/cache/), and [GCP Memorystore](https://cloud.google.com/memorystore/?hl=en) are fully managed Redis services.
 Langfuse handles failovers between read-replicas and supports Redis cluster mode for horizontal scaling.
@@ -139,30 +139,36 @@ You must set the parameter `maxmemory-policy` to `noeviction` to ensure that the
 
 ### Redis on Kubernetes (Helm)
 
-Bitnami offers Helm Charts for [Redis](https://github.com/bitnami/charts/tree/main/bitnami/redis) and [Valkey](https://github.com/bitnami/charts/tree/main/bitnami/valkey).
-We use the Valkey chart as a dependency for [Langfuse K8s](https://github.com/langfuse/langfuse-k8s).
-See [Langfuse on Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) for more details on how to deploy Langfuse on Kubernetes.
+The [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) can deploy a cache for you via `redis.deploy: true`.
+From chart version `v2.0.0` onwards it bundles the [valkey-io/valkey](https://github.com/valkey-io/valkey) chart and wires Langfuse to it automatically, including credentials.
+
+This bundled instance is a single Valkey pod and is intended for smaller deployments.
+For high availability, set `redis.deploy: false` and point Langfuse at an external Redis or Valkey cluster, for example a [managed service](#managed-redis-valkey).
 
 #### Example Configuration
 
-For a minimum production setup, we recommend to use the following values.yaml overwrites when deploying the Valkey Helm chart:
-
 ```yaml
-valkey:
+redis:
   deploy: true
-  architecture: standalone
-  primary:
-    extraFlags:
-      - "--maxmemory-policy noeviction" # Necessary to handle queue jobs correctly
   auth:
+    # Leave the password empty to have the chart generate one, or point
+    # auth.existingSecret at a secret you manage.
     password: changeme
 ```
 
-Set the following environment variables to connect to your Redis instance:
+For an external instance, set `redis.deploy: false` and provide the connection details:
 
 ```yaml
-REDIS_CONNECTION_STRING=redis://default:changeme@<chart-name>-valkey-master:6379/0
+redis:
+  deploy: false
+  host: your-redis-endpoint
+  port: 6379
+  auth:
+    existingSecret: my-redis-secret
+    existingSecretPasswordKey: password
 ```
+
+Whichever option you choose, make sure `maxmemory-policy` is set to `noeviction` on the instance so that queue jobs are not evicted.
 
 ### Docker
 

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -24,14 +24,14 @@ Langfuse v3 supports ClickHouse versions >= 24.3. Langfuse v4 requires ClickHous
 ClickHouse can be consumed as a managed service or self-managed on your own infrastructure.
 We distinguish between officially supported and community-supported deployment options:
 
-| Option                                                                          | Support Level |
-| ------------------------------------------------------------------------------- | ------------- |
-| [ClickHouse Cloud](#cloudbyoc)                                                  | Official      |
-| [ClickHouse BYOC (Bring Your Own Cloud)](#cloudbyoc)                            | Official      |
-| [ClickHouse Kubernetes Operator](#clickhouse-kubernetes-operator)               | Official      |
-| [ClickHouse on Kubernetes (Bitnami Helm chart)](#clickhouse-on-kubernetes-helm) | Community     |
-| [Single-container Docker (development only)](#docker)                           | Community     |
-| Other managed ClickHouse offerings                                              | Community     |
+| Option                                                                 | Support Level |
+| ---------------------------------------------------------------------- | ------------- |
+| [ClickHouse Cloud](#cloudbyoc)                                         | Official      |
+| [ClickHouse BYOC (Bring Your Own Cloud)](#cloudbyoc)                   | Official      |
+| [ClickHouse Kubernetes Operator](#clickhouse-kubernetes-operator)      | Official      |
+| [Bundled with the Langfuse Helm chart](#clickhouse-on-kubernetes-helm) | Community     |
+| [Single-container Docker (development only)](#docker)                  | Community     |
+| Other managed ClickHouse offerings                                     | Community     |
 
 import SelfHostSupportLevels from "@/components-mdx/self-host-support-levels.mdx";
 
@@ -177,36 +177,52 @@ It is the officially supported option for running self-managed ClickHouse on Kub
 
 Follow the [operator documentation](https://clickhouse.com/docs/clickhouse-operator/overview) to provision a cluster, then connect Langfuse to it using the environment variables described above.
 The same [user permissions](#user-permissions) and [timezone](#timezones) requirements apply.
+The [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) uses the operator to deploy the bundled ClickHouse from chart version `v2.0.0` onwards.
 
-### ClickHouse on Kubernetes (Helm) [#clickhouse-on-kubernetes-helm]
+### Bundled ClickHouse in the Langfuse Helm chart [#clickhouse-on-kubernetes-helm]
 
-The [Bitnami ClickHouse Helm Chart](https://github.com/bitnami/charts/tree/main/bitnami/clickhouse) provides a production ready deployment of ClickHouse using a given Kubernetes cluster.
-We use it as a dependency for [Langfuse K8s](https://github.com/langfuse/langfuse-k8s).
-See [Langfuse on Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) for more details on how to deploy Langfuse on Kubernetes.
-This deployment option is community-supported; for an officially supported self-managed setup on Kubernetes, consider the [ClickHouse Kubernetes Operator](#clickhouse-kubernetes-operator).
+The [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) can deploy ClickHouse for you via `clickhouse.deploy: true`.
+From chart version `v2.0.0` onwards it does so through the [ClickHouse Kubernetes Operator](#clickhouse-kubernetes-operator), rendering a `ClickHouseCluster` and a `KeeperCluster` resource.
+The operator and cert-manager must be installed in the cluster before you install the chart; see the [deployment guide](/self-hosting/deployment/kubernetes-helm#prerequisites).
+
+This deployment option is community-supported. For an officially supported setup, use [ClickHouse Cloud or BYOC](#cloudbyoc), or manage the cluster with the [operator](#clickhouse-kubernetes-operator) yourself and connect Langfuse to it with `clickhouse.deploy: false`.
+
+<Callout type="warning">
+
+Chart `v1.x` deployed the bundled ClickHouse from a third-party sub-chart that cannot reach the ClickHouse version Langfuse v4 requires. If you still run chart `v1.x` with `clickhouse.deploy: true`, [upgrade the chart to v2](/self-hosting/deployment/kubernetes-helm#chart-v1-to-v2) before you upgrade Langfuse to v4.
+
+</Callout>
 
 #### Example Configuration
 
-For a minimum production setup, we recommend using the following values.yaml overrides when deploying the ClickHouse Helm chart:
+For a minimum production setup, we recommend the following values.yaml overrides:
 
 ```yaml
 clickhouse:
   deploy: true
-  shards: 1 # Fixed: Langfuse does not support multi-shard clusters
-  replicaCount: 3
-  resourcesPreset: large # or more
-  persistence:
-    size: 100Gi # Start with a large volume to prevent early resizing. Alternatively, consider a blob storage-backed disk.
   auth:
     username: default
-    password: changeme
+    password: changeme # or point auth.existingSecret at a secret you manage
+  cluster:
+    replicas: 3
+    storage:
+      size: 100Gi # Start with a large volume to prevent early resizing. Alternatively, consider a blob storage-backed disk.
+    resources:
+      requests:
+        cpu: "2"
+        memory: 8Gi
+      limits:
+        memory: 16Gi
+  keeper:
+    replicas: 3
 ```
 
-- **shards**: Shards are used for horizontally scaling ClickHouse. A single ClickHouse shard can handle multiple Terabytes of data. Today, Langfuse does not support a multi-shard cluster, i.e. this value _must_ be set to 1. Please get in touch with us if you hit scaling limits of a single shard cluster or consider ClickHouse Cloud/BYOC.
-- **replicaCount**: The number of replicas for each shard. ClickHouse counts the all instances towards the number of replicas, i.e. a replica count of 1 means no redundancy at all. We recommend a minimum of 3 replicas for production setups. The number of replicas cannot be increased at runtime without manual intervention or downtime.
-- **resourcesPreset**: ClickHouse is CPU and memory intensive for analytical and highly concurrent requests. We recommend at least the `large` resourcesPreset and more for larger deployments.
-- **auth**: The username and password for the ClickHouse database. Overwrite those values according to your preferences, or mount them from a secret.
-- **disk**: The ClickHouse Helm chart uses the default storage class to create volumes for each replica. Ensure that the storage class has `allowVolumeExpansion = true` as observability workloads tend to be very disk heavy. For cloud providers like AWS, GCP, and Azure this should be the default.
+- **Shards**: Shards are used for horizontally scaling ClickHouse. A single ClickHouse shard can handle multiple Terabytes of data. Today, Langfuse does not support a multi-shard cluster, and the chart always deploys a single shard. Please get in touch with us if you hit scaling limits of a single shard cluster, or consider [ClickHouse Cloud/BYOC](#cloudbyoc).
+- **cluster.replicas**: ClickHouse counts all instances towards the number of replicas, i.e. a replica count of 1 means no redundancy at all. We recommend a minimum of 3 replicas for production setups. The number of replicas cannot be increased at runtime without manual intervention or downtime.
+- **cluster.resources**: ClickHouse is CPU and memory intensive for analytical and highly concurrent requests. The chart defaults are sized for local experimentation; start from the [minimum infrastructure requirements](/self-hosting/configuration/scaling#minimum-infrastructure-requirements) and scale up for larger deployments.
+- **keeper.replicas**: ClickHouse Keeper coordinates replication and requires an odd replica count. Use 3 for production high availability.
+- **auth**: The username and password Langfuse uses to connect. Overwrite these values according to your preferences, or mount them from a secret via `auth.existingSecret`.
+- **Disk**: The chart uses the default storage class unless you set `cluster.storage.className`. Ensure that the storage class has `allowVolumeExpansion = true`, as observability workloads tend to be very disk heavy. For cloud providers like AWS, GCP, and Azure this should be the default.
 
 Langfuse assumes that certain parameters are set in the ClickHouse configurations.
 To perform our database migrations, the following values must be provided:
@@ -229,13 +245,13 @@ To perform our database migrations, the following values must be provided:
 -->
 ```
 
-`macros` and `default_replica_*` configuration should be covered by the Helm chart without any further configuration.
+`macros` and `default_replica_*` configuration is handled by the chart and the operator without any further configuration.
 
-Set the following environment variables to connect to your ClickHouse instance assuming that Langfuse runs within the same Cluster and Namespace:
+When `clickhouse.deploy` is `true`, the chart wires Langfuse to the bundled cluster automatically. For a ClickHouse you run yourself in the same cluster and namespace, set `clickhouse.deploy: false` and the following environment variables:
 
 ```yaml
-CLICKHOUSE_URL=http://<chart-name>-clickhouse:8123
-CLICKHOUSE_MIGRATION_URL=clickhouse://<chart-name>-clickhouse:9000
+CLICKHOUSE_URL=http://<clickhouse-service>:8123
+CLICKHOUSE_MIGRATION_URL=clickhouse://<clickhouse-service>:9000
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=changeme
 ```
@@ -247,8 +263,8 @@ CLICKHOUSE_PASSWORD=changeme
   **1. Check current disk usage:**
 
   ```bash
-  # Check PVC status
-  kubectl get pvc -l app.kubernetes.io/name=clickhouse
+  # List the ClickHouse PVCs; their names depend on how ClickHouse was deployed
+  kubectl get pvc
 
   # Check disk usage inside ClickHouse pods
   kubectl exec -it <clickhouse-pod-name> -- df -h /var/lib/clickhouse
@@ -258,12 +274,10 @@ CLICKHOUSE_PASSWORD=changeme
 
   ```bash
   # Edit the PVC directly
-  kubectl edit pvc data-<chart-name>-clickhouse-0
+  kubectl edit pvc <clickhouse-pvc-name>
 
-  # Or patch all ClickHouse PVCs at once
-  kubectl patch pvc data-<chart-name>-clickhouse-0 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
-  kubectl patch pvc data-<chart-name>-clickhouse-1 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
-  kubectl patch pvc data-<chart-name>-clickhouse-2 -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
+  # Or patch it in place; repeat for the PVC of every replica
+  kubectl patch pvc <clickhouse-pvc-name> -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
   ```
 
   **3. Monitor expansion progress:**
@@ -280,7 +294,7 @@ CLICKHOUSE_PASSWORD=changeme
 
   ```bash
   # Restart all pods individually to make use of the larger volumes
-  kubectl rollout restart statefulset <chart-name>-clickhouse
+  kubectl rollout restart statefulset <clickhouse-statefulset-name>
   ```
 
   **Prevention tips:**
@@ -354,57 +368,40 @@ For local disk storage or additional encryption layers, ClickHouse supports conf
 
 #### Kubernetes Configuration
 
-For Kubernetes deployments using the Bitnami ClickHouse Helm chart, you can configure disk encryption by creating a custom configuration file:
+On Kubernetes, mount the following ClickHouse server configuration into `/etc/clickhouse-server/config.d/`:
 
-```yaml
-# values.yaml
-clickhouse:
-  extraConfigmaps:
-    - name: encryption-config
-      mountPath: /etc/clickhouse-server/config.d/encrypted_storage.xml
-      data:
-        encryption.xml: |
-          <clickhouse>
-            <storage_configuration>
-              <disks>
-                <encrypted_disk>
-                  <type>encrypted</type>
-                  <disk>default</disk>
-                  <path>encrypted/</path>
-                  <algorithm>AES_128_CTR</algorithm>
-                  <key_hex id="0" from_env="CLICKHOUSE_ENCRYPTION_KEY"></key_hex>
-                </encrypted_disk>
-              </disks>
-              <policies>
-                <encrypted_policy>
-                  <volumes>
-                    <main>
-                      <disk>encrypted_disk</disk>
-                    </main>
-                  </volumes>
-                </encrypted_policy>
-              </policies>
-            </storage_configuration>
-            <merge_tree>
-              <storage_policy>encrypted_policy</storage_policy>
-            </merge_tree>
-          </clickhouse>
+```xml
+<!-- encrypted_storage.xml -->
+<clickhouse>
+  <storage_configuration>
+    <disks>
+      <encrypted_disk>
+        <type>encrypted</type>
+        <disk>default</disk>
+        <path>encrypted/</path>
+        <algorithm>AES_128_CTR</algorithm>
+        <key_hex id="0" from_env="CLICKHOUSE_ENCRYPTION_KEY"></key_hex>
+      </encrypted_disk>
+    </disks>
+    <policies>
+      <encrypted_policy>
+        <volumes>
+          <main>
+            <disk>encrypted_disk</disk>
+          </main>
+        </volumes>
+      </encrypted_policy>
+    </policies>
+  </storage_configuration>
+  <merge_tree>
+    <storage_policy>encrypted_policy</storage_policy>
+  </merge_tree>
+</clickhouse>
 ```
 
-Set the encryption key as an environment variable:
+With the [ClickHouse Kubernetes Operator](#clickhouse-kubernetes-operator), add the file to the configuration of your cluster resource. With the [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm), pass the same settings via `clickhouse.cluster.settings`.
 
-```yaml
-# values.yaml
-clickhouse:
-  extraEnvVars:
-    - name: CLICKHOUSE_ENCRYPTION_KEY
-      valueFrom:
-        secretKeyRef:
-          name: clickhouse-encryption-key
-          key: key
-```
-
-Create the encryption key secret:
+Provide the key to the ClickHouse pods through a `CLICKHOUSE_ENCRYPTION_KEY` environment variable that reads from a secret:
 
 ```bash
 kubectl create secret generic clickhouse-encryption-key \

--- a/content/self-hosting/deployment/kubernetes-helm.mdx
+++ b/content/self-hosting/deployment/kubernetes-helm.mdx
@@ -32,6 +32,13 @@ Alternatively, you can use one of the following cloud-specific deployment guides
 
 </Callout>
 
+## Prerequisites [#prerequisites]
+
+- **Kubernetes `v1.28` or newer**, as required by the [ClickHouse Kubernetes Operator](/self-hosting/deployment/infrastructure/clickhouse#clickhouse-kubernetes-operator).
+- **cert-manager and the ClickHouse operator, installed once per cluster.** From chart version `v2.0.0` onwards, `clickhouse.deploy: true` (the default) renders `ClickHouseCluster` and `KeeperCluster` resources, and the operator creates cert-manager resources for its webhooks. Both CRD sets must exist before `helm install`; the chart preflights the ClickHouse CRDs and fails fast if they are missing. The [Readme](#readme) below lists the exact install commands.
+
+Deployments that point every data store at an external service (`*.deploy: false`) do not need the operator.
+
 ## Fetch the Helm chart and customize values
 
 Fetch the `langfuse-k8s` Helm chart.
@@ -77,7 +84,7 @@ Use `kubectl get services -n langfuse` and search for `langfuse-web` to see the 
 Create a port-forward via `kubectl port-forward svc/langfuse-web -n langfuse <local-port>:<nodeport>` and access the UI via `http://localhost:<local-port>` in your browser.
 Go ahead and register, create a new organization, project, and explore Langfuse.
 
-## Readme
+## Readme [#readme]
 
 Source: [langfuse/langfuse-k8s](https://github.com/langfuse/langfuse-k8s)
 
@@ -107,11 +114,25 @@ kubectl delete namespace langfuse
 
 ## How to Upgrade
 
-Run the following commands to upgrade the Helm chart to the latest version:
+Run the following commands to upgrade the Helm chart within a chart major version:
 
 ```bash
 helm repo update
 helm upgrade langfuse langfuse/langfuse -n langfuse
 ```
 
-For more details on upgrading, please refer to the [upgrade guide](/self-hosting/upgrade).
+For more details on upgrading Langfuse itself, please refer to the [upgrade guide](/self-hosting/upgrade).
+
+### Upgrade the chart from v1 to v2 [#chart-v1-to-v2]
+
+<Callout type="warning">
+
+Chart `v2.0.0` is a major version of the Helm chart: it replaces every bundled Bitnami sub-chart with an OSS-licensed alternative. ClickHouse now runs through the [ClickHouse Kubernetes Operator](/self-hosting/deployment/infrastructure/clickhouse#clickhouse-kubernetes-operator), PostgreSQL through `groundhog2k/postgres`, Valkey through `valkey-io/valkey`, and bundled object storage through SeaweedFS. Because StatefulSet identities and PVC layouts change, a plain `helm upgrade` from a v1 release that deploys any of these stores is blocked by the chart.
+
+Follow the [v1 to v2 chart upgrade guide](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2). It covers both paths: releases that point to external stores (`*.deploy: false`) upgrade in place, while releases with bundled stores install a sibling v2 release, copy the data over, and then shift traffic. Your deployment must run at least Langfuse v3.224.1 before you start.
+
+</Callout>
+
+If you run the bundled ClickHouse (`clickhouse.deploy: true`), **complete the chart v1 to v2 upgrade before you upgrade Langfuse to v4**. The v1 chart cannot bring its bundled ClickHouse to the version that [Langfuse v4 requires](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#step-1); the v2 chart can. Deployments that connect to an external ClickHouse are not affected and can upgrade Langfuse to v4 independently of the chart.
+
+Chart `v2.0.0` ships Langfuse v4 as its default `appVersion`. To keep the chart migration and the Langfuse v4 upgrade as two separate steps, pin `langfuse.image.tag` to your current Langfuse v3 image while you move to the v2 chart, then follow the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4). To stay on the v1 chart for now, pass a `1.x` chart version explicitly via `helm upgrade --version`.

--- a/content/self-hosting/upgrade/index.mdx
+++ b/content/self-hosting/upgrade/index.mdx
@@ -40,6 +40,12 @@ If you upgrade between major versions, please follow our migration guides:
 - [v2.x.x to v3.x.x](/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3)
 - [v1.x.x to v2.x.x](/self-hosting/upgrade/upgrade-guides/upgrade-v1-to-v2)
 
+<Callout type="info">
+
+The [Langfuse Helm chart](/self-hosting/deployment/kubernetes-helm) is versioned independently of the Langfuse server and has its own major versions. If you run the chart with bundled data stores, [upgrade the chart from v1 to v2](/self-hosting/deployment/kubernetes-helm#chart-v1-to-v2) before you upgrade Langfuse to v4: the v1 chart cannot bring its bundled ClickHouse to a v4-compatible version.
+
+</Callout>
+
 ## Release Notes
 
 import SelfHostUpdateSignup from "@/components-mdx/self-host-update-signup.mdx";

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -177,6 +177,7 @@ Upgrade ClickHouse **before** the server upgrade. Langfuse v3 releases are fully
 **Helm chart with built-in ClickHouse**: deployments that run the ClickHouse instance bundled with the [Langfuse Helm chart](https://github.com/langfuse/langfuse-k8s) (`clickhouse.deploy: true`) need to take an extra step before upgrading to Langfuse v4, as the v1 version of the chart does not provide an upgrade path to a v4-compatible ClickHouse version.
 Follow our [v1 to v2 chart upgrade guide](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2) to move to the new major version of the Langfuse helm chart
 before you proceed with your Langfuse v4 upgrade.
+See [chart v1 to v2](/self-hosting/deployment/kubernetes-helm#chart-v1-to-v2) for the prerequisites and how to sequence the two upgrades.
 Deployments that connect to an external ClickHouse are not affected.
 
 </Callout>

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -174,7 +174,10 @@ Upgrade ClickHouse **before** the server upgrade. Langfuse v3 releases are fully
 
 <Callout type="warning">
 
-**Helm chart with built-in ClickHouse:** deployments that run the ClickHouse instance bundled with the [Langfuse Helm chart](https://github.com/langfuse/langfuse-k8s) (`clickhouse.deploy: true`) cannot upgrade to Langfuse v4 yet, as the chart does not provide an upgrade path to a v4-compatible ClickHouse version. [Subscribe to the self-hosting mailing list](/self-hosting#subscribe) to get notified as soon as an upgrade path is available. Deployments that connect to an external ClickHouse are not affected.
+**Helm chart with built-in ClickHouse**: deployments that run the ClickHouse instance bundled with the [Langfuse Helm chart](https://github.com/langfuse/langfuse-k8s) (`clickhouse.deploy: true`) need to take an extra step before upgrading to Langfuse v4, as the v1 version of the chart does not provide an upgrade path to a v4-compatible ClickHouse version.
+Follow our [v1 to v2 chart upgrade guide](https://github.com/langfuse/langfuse-k8s/tree/main/examples/upgrade-v1-to-v2) to move to the new major version of the Langfuse helm chart
+before you proceed with your Langfuse v4 upgrade.
+Deployments that connect to an external ClickHouse are not affected.
 
 </Callout>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact; incorrect sequencing guidance could confuse operators but does not affect deployed systems directly.
> 
> **Overview**
> Self-hosting documentation is updated so **bundled ClickHouse on Helm chart v1 is no longer described as blocking Langfuse v4**. Operators are told to **[upgrade the Langfuse Helm chart from v1 to v2](/self-hosting/deployment/kubernetes-helm#chart-v1-to-v2) first**, because v1 cannot reach a v4-compatible ClickHouse version; **external ClickHouse** deployments are unchanged.
> 
> The **Kubernetes Helm guide** gains **prerequisites** (Kubernetes ≥1.28, cert-manager, ClickHouse operator when `clickhouse.deploy: true`) and a **chart v1→v2** section (Bitnami sub-charts replaced, in-place vs data-copy paths, sequencing with pinning `langfuse.image.tag` on v3). The **v3→v4 upgrade guide**, **upgrade index**, and **v4 readiness FAQ** cross-link this prerequisite.
> 
> **Infrastructure pages** are reframed for **chart v2**: bundled ClickHouse via the **ClickHouse Kubernetes Operator** and new `clickhouse.cluster` / `keeper` values; **Redis** via `redis.deploy` and the Valkey chart; **blob storage** notes **MinIO on chart v1** and **SeaweedFS from v2**; scaling docs reference `clickhouse.cluster.settings` instead of Bitnami `extraOverrides`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016062c222b19e95bc1db3551b516d7b523af33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the v3-to-v4 self-hosting upgrade guide to explain that deployments using the Helm chart’s bundled ClickHouse must migrate from chart v1 to v2 before upgrading Langfuse.

- Replaces the prior statement that these deployments cannot yet upgrade.
- Links to the dedicated Helm chart migration guide.
- Clarifies that external ClickHouse deployments are unaffected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge, with no concrete defect identified.

The updated warning provides an explicit prerequisite and delegates detailed migration instructions to a dedicated guide while preserving the external-ClickHouse exception.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: update helm chart disclaimers in u..."](https://github.com/langfuse/langfuse-docs/commit/a7dd96276b7469d1866da8fbcc234b4ac4183ae3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54705223)</sub>

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)
- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)

<!-- /greptile_comment -->