### PR TITLE
docs: explain missing v4 experiment runs

### DIFF
--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -45,29 +45,40 @@ This affects the following combination:
 
 ## What to change for new experiments
 
-1. Upgrade to the latest [JS/TS SDK](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
-2. Run new experiments with the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) instead of calling `item.link()`.
+Run new experiments with the [Experiment runner
+SDK](/docs/evaluation/experiments/experiments-via-sdk) instead of calling
+`item.link()`.
 
 ## How to recover historic experiments
 
 Historic traces remain available, but they are missing the experiment attributes
 required by the v4 UI.
 
-Run the experiment using the current [Experiment runner
-SDK](/docs/evaluation/experiments/experiments-via-sdk), using the same dataset
-and task logic as the historic run:
+To preserve the historic experiment, re-ingest each complete trace through
+[direct OpenTelemetry ingestion with experiment
+attributes](/integrations/native/opentelemetry/experiments). Preserve every
+observation's original ID, parent ID, start time, and end time, and add the
+required `langfuse.experiment.*` attributes.
 
-```ts
-const dataset = await langfuse.dataset.get("my-evaluation-dataset");
-
-await dataset.runExperiment({
-  name: "Recovery run",
-  task: async (item) => runYourApplication(item.input),
-});
+```text
+for each historic trace:
+  re-ingest every observation with:
+    traceId: original trace ID
+    spanId: original observation ID
+    parentSpanId: original parent observation ID
+    startTime and endTime: original timestamps
+    attributes: original attributes + required experiment attributes
 ```
 
-The runner creates a new experiment run and new traces when it runs. It does
-not provide a way to preserve the original timestamps of historic traces.
+When the trace ID, observation IDs, and start times remain unchanged, Langfuse
+writes newer event versions and ClickHouse eventually replaces the previous
+versions during background merges. This replacement is not immediate.
+
+If eventual replacement is not sufficient, use a new trace ID when
+re-ingesting. The observations can keep their existing IDs because observation
+IDs are scoped to a trace. This creates a separate corrected trace without
+waiting for replacement; the historic trace remains available under its
+original ID.
 
 Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
-upgrading or recovering your experiments.
+recovering historic experiments.

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -28,18 +28,14 @@ on the ingested observations, including:
 - `langfuse.experiment.item.id`
 - `langfuse.experiment.item.root_observation_id`
 
-The legacy `item.link()` path creates a dataset run item, but affected JS/TS
-SDK versions do not reliably propagate the corresponding experiment attributes
-to the trace. Langfuse can therefore see the dataset run item and the trace,
-but cannot associate the trace with an experiment in the v4 data model.
+The legacy `item.link()` path did not reliably propagate the corresponding
+experiment attributes to the trace. Historic traces remain available, but are
+missing the experiment attributes required by the v4 data model and are
+therefore not served in the v4 UI.
 
 The JS/TS and Python SDKs did not behave consistently during this transition.
 The legacy method was deprecated in the Python SDK, but we missed deprecating it
 in the new JS/TS major. This was a bug in our SDK upgrade path.
-
-The v4 backfill does not add missing experiment attributes to events that were
-written directly through this legacy path. Waiting for the backfill to finish
-will therefore not make these runs appear.
 
 This affects the following combination:
 
@@ -50,20 +46,28 @@ This affects the following combination:
 ## What to change for new experiments
 
 1. Upgrade to the latest [JS/TS SDK](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
-2. Replace manual `item.link()` calls with the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk).
-3. Run the experiment so the SDK creates the experiment run and propagates
-   the required attributes to the new traces.
+2. Run new experiments with the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk) instead of calling `item.link()`.
 
 ## How to recover historic experiments
 
-The existing dataset run items and traces remain available, but the v4 backfill
-does not add missing experiment attributes to events that were written directly
-through the legacy path. Waiting for the backfill to finish will therefore not
-make these runs appear.
+Historic traces remain available, but they are missing the experiment attributes
+required by the v4 UI.
 
-The recommended recovery path is to run the experiment again with the current
-Experiment runner SDK. This creates a new experiment run and propagates the
-required attributes to the new traces.
+Run the experiment using the current [Experiment runner
+SDK](/docs/evaluation/experiments/experiments-via-sdk), using the same dataset
+and task logic as the historic run:
+
+```ts
+const dataset = await langfuse.dataset.get("my-evaluation-dataset");
+
+await dataset.runExperiment({
+  name: "Recovery run",
+  task: async (item) => runYourApplication(item.input),
+});
+```
+
+The runner creates a new experiment run and new traces when it runs. It does
+not provide a way to preserve the original timestamps of historic traces.
 
 Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
 upgrading or recovering your experiments.

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -54,16 +54,24 @@ SDK](/docs/evaluation/experiments/experiments-via-sdk) instead of calling
 
 ## How to recover historic experiments
 
-Historic traces remain available, but they are missing the experiment attributes
-required by the v4 UI.
+Historic traces remain available, but they are missing the experiment
+attributes required by the v4 UI.
 
-To preserve the historic experiment, re-ingest each complete trace through
-[direct OpenTelemetry ingestion with experiment
-attributes](/integrations/native/opentelemetry/experiments). Preserve every
-observation's original ID, parent ID, start time, and end time, and add the
-complete experiment context. Preserve the optional description, experiment
-metadata, item version, expected output, and item metadata when they were
-present in the historic experiment.
+Recover each complete trace through [direct OpenTelemetry ingestion with
+experiment attributes](/integrations/native/opentelemetry/experiments). Add the
+complete experiment context to every observation. Preserve the optional
+description, experiment metadata, item version, expected output, and item
+metadata when they were present in the historic experiment.
+
+Choose one of the following recovery options based on whether preserving
+existing score links or avoiding background replacement is more important.
+
+### Option 1: Preserve existing score links
+
+Re-ingest every observation with its original trace ID, observation ID, parent
+observation ID, and exact original start time. Preserve the original end time
+as well. Existing trace-level and observation-level scores remain linked
+because their target IDs do not change.
 
 ```text
 experimentAttributes = {
@@ -77,7 +85,7 @@ experimentAttributes = {
 for each historic experiment item trace:
   itemAttributes = {
     "langfuse.experiment.item.id": original item ID,
-    "langfuse.experiment.item.root_observation_id": root observation ID,
+    "langfuse.experiment.item.root_observation_id": original root observation ID,
     "langfuse.experiment.item.version": original item version // if present
   }
 
@@ -85,7 +93,7 @@ for each historic experiment item trace:
     traceId: original trace ID
     spanId: original observation ID
     parentSpanId: original parent observation ID
-    startTime and endTime: original timestamps
+    startTime and endTime: exact original timestamps
     attributes: original attributes + experimentAttributes + itemAttributes
 
   additionally on the root observation:
@@ -97,15 +105,47 @@ Use the same `langfuse.experiment.id` and `langfuse.experiment.name` values for
 the entire recovered experiment. Changing either value between item traces
 splits them into different experiments in the v4 UI.
 
-When the trace ID, observation IDs, and start times remain unchanged, Langfuse
-writes newer event versions and ClickHouse eventually replaces the previous
-versions during background merges. This replacement is not immediate.
+<Callout type="warning">
+  The start time must match exactly. Do not add an offset. ClickHouse only
+  considers the new event a replacement when the trace ID, observation ID, and
+  exact observation start time all match. A changed start time creates a
+  separate permanent observation under the same trace and can inflate costs,
+  usage, and observation counts.
 
-If eventual replacement is not sufficient, use a new trace ID when
-re-ingesting. The observations can keep their existing IDs because observation
-IDs are scoped to a trace. This creates a separate corrected trace without
-waiting for replacement; the historic trace remains available under its
-original ID.
+Replacement happens during ClickHouse background merges. Until a merge
+completes, duplicate event versions may affect results. There is no time
+guarantee for these merges.
+
+</Callout>
+
+### Option 2: Avoid waiting for background replacement
+
+Use a new trace ID when re-ingesting each complete trace. Observation IDs and
+parent observation IDs can remain unchanged because they are scoped to the
+trace. Continue to use the exact original start and end times to preserve the
+historic experiment timing.
+
+Scores are stored separately and do not move to the new trace automatically.
+Do not create copies with new score IDs. Instead, reassociate each score by
+resending its complete payload as a `score-create` event through the [Ingestion
+API](https://api.reference.langfuse.com/#tag/ingestion/POST/api/public/ingestion):
+
+- Keep the original score ID, name, value, and other score fields.
+- Set the new trace ID and, for observation-level or experiment-item scores,
+  the corresponding observation ID. For experiment-item scores, use the item
+  root observation.
+- Set the event timestamp later than the original score timestamp, but on the
+  same UTC calendar date.
+
+This is a complete score upsert, not a partial patch. A matching score ID, name,
+and date replaces the previous score after ClickHouse processes the update. The
+regular `POST /api/public/scores` endpoint cannot be used for this recovery
+because it assigns the current timestamp, which may create another score for a
+historic date. Experiment-level scores remain linked when you keep the original
+experiment ID.
+
+This option creates separate corrected traces immediately. The historic traces
+remain available under their original IDs.
 
 Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
 recovering historic experiments.

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -1,0 +1,70 @@
+---
+title: Why are my experiment runs not visible after upgrading to Langfuse v4?
+description: Understand why experiments created with the legacy JavaScript item.link() method may not appear in Langfuse v4 and how to recover.
+tags: [experiments, sdk, v4]
+---
+
+# Why are my experiment runs not visible after upgrading to Langfuse v4?
+
+If you use the JS/TS SDK `>=5.0.0` and still call `item.link()` manually, your
+dataset run items and traces may exist in Langfuse without appearing as an
+experiment run in the v4 UI.
+
+<Callout type="warning">
+  Do not use `item.link()` for new experiments. Upgrade the JS/TS SDK and
+  re-run the experiment with the [Experiment runner
+  SDK](/docs/evaluation/experiments/experiments-via-sdk).
+</Callout>
+
+## Why this happens
+
+Langfuse v4 connects experiment runs to traces through experiment attributes
+on the ingested observations, including:
+
+- `langfuse.experiment.id`
+- `langfuse.experiment.dataset.id`
+- `langfuse.experiment.item.id`
+- `langfuse.experiment.item.root_observation_id`
+
+The legacy `item.link()` path creates a dataset run item, but affected JS/TS
+SDK versions do not reliably propagate the corresponding experiment attributes
+to the trace. Langfuse can therefore see the dataset run item and the trace,
+but cannot associate the trace with an experiment in the v4 data model.
+
+The v4 backfill does not add missing experiment attributes to events that were
+written directly through this legacy path. Waiting for the backfill to finish
+will therefore not make these runs appear.
+
+This affects the following combination:
+
+- JS/TS SDK `>=5.0.0`
+- Manual calls to `item.link()`
+- Traces that do not contain `langfuse.experiment.*` attributes
+
+## Recommended solution
+
+1. Upgrade to the latest [JS/TS SDK](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
+2. Replace manual `item.link()` calls with the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk).
+3. Re-run the experiment so the SDK creates the experiment run and propagates
+   the required attributes to the new traces.
+
+The existing dataset run items and traces remain available, but they cannot be
+reliably connected automatically if the intended observation was not recorded
+by the legacy link call.
+
+<Callout type="info">
+  When re-ingesting an existing trace and span ID, preserve the original
+  observation timestamp. The event timestamp is part of the event identity: a
+  different timestamp creates a separate event instead of replacing the
+  original. Re-running the experiment with new traces is the recommended
+  recovery path.
+</Callout>
+
+## How to check whether this affects you
+
+Search your experiment code for `item.link()`. If it is used with the JS/TS
+SDK `>=5.0.0`, check whether the linked traces contain the
+`langfuse.experiment.*` attributes listed above. If they do not, re-run the
+experiment with the current Experiment runner SDK.
+
+For general upgrade guidance, see the [Langfuse v4 overview](/docs/v4).

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -126,26 +126,25 @@ trace. Continue to use the exact original start and end times to preserve the
 historic experiment timing.
 
 Scores are stored separately and do not move to the new trace automatically.
-Do not create copies with new score IDs. Instead, reassociate each score by
-resending its complete payload as a `score-create` event through the [Ingestion
-API](https://api.reference.langfuse.com/#tag/ingestion/POST/api/public/ingestion):
+Send each trace-level, observation-level, or experiment-item score again through
+[`POST /api/public/scores`](https://api.reference.langfuse.com/#tag/legacyscorev1/POST/api/public/scores),
+using its original score ID and all supported score fields. Set the new trace ID
+and, for observation-level or experiment-item scores, the corresponding
+observation ID. For experiment-item scores, use the item root observation.
+Experiment-level scores remain linked when you keep the original experiment ID.
 
-- Keep the original score ID, name, value, and other score fields.
-- Set the new trace ID and, for observation-level or experiment-item scores,
-  the corresponding observation ID. For experiment-item scores, use the item
-  root observation.
-- Set the event timestamp later than the original score timestamp, but on the
-  same UTC calendar date.
+The Scores API assigns the current timestamp when it receives the score. Native
+experiment views and charts associate the score with the recovered experiment
+through its new trace and observation IDs. Scores originally created by an
+evaluator are recorded with source `API`, because the public endpoint does not
+accept `EVAL` as a source. Time-based dashboards and exports attribute the score
+to the correction date rather than its historic date. Public Experiments API
+responses that request scores may omit corrected scores because they constrain
+score timestamps to the historic experiment item window.
 
-This is a complete score upsert, not a partial patch. A matching score ID, name,
-and date replaces the previous score after ClickHouse processes the update. The
-regular `POST /api/public/scores` endpoint cannot be used for this recovery
-because it assigns the current timestamp, which may create another score for a
-historic date. Experiment-level scores remain linked when you keep the original
-experiment ID.
-
-This option creates separate corrected traces immediately. The historic traces
-remain available under their original IDs.
+This option creates separate corrected traces without waiting for the historic
+trace versions to be replaced. The historic traces remain available under their
+original IDs.
 
 Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
 recovering historic experiments.

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -8,11 +8,13 @@ tags: [experiments, sdk, v4]
 
 If you use the JS/TS SDK `>=5.0.0` and still call `item.link()` manually, your
 dataset run items and traces may exist in Langfuse without appearing as an
-experiment run in the v4 UI.
+experiment run in the v4 UI. This is the result of a divergence between our
+SDKs during the v4 upgrade: the legacy link method should have been deprecated
+in the new JS/TS major, but this was missed on our side.
 
 <Callout type="warning">
   Do not use `item.link()` for new experiments. Upgrade the JS/TS SDK and
-  re-run the experiment with the [Experiment runner
+  run the experiment with the [Experiment runner
   SDK](/docs/evaluation/experiments/experiments-via-sdk).
 </Callout>
 
@@ -31,6 +33,10 @@ SDK versions do not reliably propagate the corresponding experiment attributes
 to the trace. Langfuse can therefore see the dataset run item and the trace,
 but cannot associate the trace with an experiment in the v4 data model.
 
+The JS/TS and Python SDKs did not behave consistently during this transition.
+The legacy method was deprecated in the Python SDK, but we missed deprecating it
+in the new JS/TS major. This was a bug in our SDK upgrade path.
+
 The v4 backfill does not add missing experiment attributes to events that were
 written directly through this legacy path. Waiting for the backfill to finish
 will therefore not make these runs appear.
@@ -41,30 +47,23 @@ This affects the following combination:
 - Manual calls to `item.link()`
 - Traces that do not contain `langfuse.experiment.*` attributes
 
-## Recommended solution
+## What to change for new experiments
 
 1. Upgrade to the latest [JS/TS SDK](/docs/observability/sdk/upgrade-path/js-v4-to-v5).
 2. Replace manual `item.link()` calls with the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk).
-3. Re-run the experiment so the SDK creates the experiment run and propagates
+3. Run the experiment so the SDK creates the experiment run and propagates
    the required attributes to the new traces.
 
-The existing dataset run items and traces remain available, but they cannot be
-reliably connected automatically if the intended observation was not recorded
-by the legacy link call.
+## How to recover historic experiments
 
-<Callout type="info">
-  When re-ingesting an existing trace and span ID, preserve the original
-  observation timestamp. The event timestamp is part of the event identity: a
-  different timestamp creates a separate event instead of replacing the
-  original. Re-running the experiment with new traces is the recommended
-  recovery path.
-</Callout>
+The existing dataset run items and traces remain available, but the v4 backfill
+does not add missing experiment attributes to events that were written directly
+through the legacy path. Waiting for the backfill to finish will therefore not
+make these runs appear.
 
-## How to check whether this affects you
+The recommended recovery path is to run the experiment again with the current
+Experiment runner SDK. This creates a new experiment run and propagates the
+required attributes to the new traces.
 
-Search your experiment code for `item.link()`. If it is used with the JS/TS
-SDK `>=5.0.0`, check whether the linked traces contain the
-`langfuse.experiment.*` attributes listed above. If they do not, re-run the
-experiment with the current Experiment runner SDK.
-
-For general upgrade guidance, see the [Langfuse v4 overview](/docs/v4).
+Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
+upgrading or recovering your experiments.

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -21,21 +21,24 @@ in the new JS/TS major, but this was missed on our side.
 ## Why this happens
 
 Langfuse v4 connects experiment runs to traces through experiment attributes
-on the ingested observations, including:
+on the ingested observations. Every observation in an experiment item trace
+must include:
 
 - `langfuse.experiment.id`
+- `langfuse.experiment.name`
 - `langfuse.experiment.dataset.id`
 - `langfuse.experiment.item.id`
 - `langfuse.experiment.item.root_observation_id`
+
+The experiment ID, name, and dataset ID must be identical across every
+observation in every item trace of the experiment. The item ID and root
+observation ID must be identical across every observation within one item
+trace.
 
 The legacy `item.link()` path did not reliably propagate the corresponding
 experiment attributes to the trace. Historic traces remain available, but are
 missing the experiment attributes required by the v4 data model and are
 therefore not served in the v4 UI.
-
-The JS/TS and Python SDKs did not behave consistently during this transition.
-The legacy method was deprecated in the Python SDK, but we missed deprecating it
-in the new JS/TS major. This was a bug in our SDK upgrade path.
 
 This affects the following combination:
 
@@ -58,17 +61,41 @@ To preserve the historic experiment, re-ingest each complete trace through
 [direct OpenTelemetry ingestion with experiment
 attributes](/integrations/native/opentelemetry/experiments). Preserve every
 observation's original ID, parent ID, start time, and end time, and add the
-required `langfuse.experiment.*` attributes.
+complete experiment context. Preserve the optional description, experiment
+metadata, item version, expected output, and item metadata when they were
+present in the historic experiment.
 
 ```text
-for each historic trace:
+experimentAttributes = {
+  "langfuse.experiment.id": original experiment ID,
+  "langfuse.experiment.name": original experiment name,
+  "langfuse.experiment.dataset.id": original dataset ID,
+  "langfuse.experiment.description": original description,       // if present
+  "langfuse.experiment.metadata.*": original experiment metadata // if present
+}
+
+for each historic experiment item trace:
+  itemAttributes = {
+    "langfuse.experiment.item.id": original item ID,
+    "langfuse.experiment.item.root_observation_id": root observation ID,
+    "langfuse.experiment.item.version": original item version // if present
+  }
+
   re-ingest every observation with:
     traceId: original trace ID
     spanId: original observation ID
     parentSpanId: original parent observation ID
     startTime and endTime: original timestamps
-    attributes: original attributes + required experiment attributes
+    attributes: original attributes + experimentAttributes + itemAttributes
+
+  additionally on the root observation:
+    "langfuse.experiment.item.expected_output": original expected output // if present
+    "langfuse.experiment.item.metadata.*": original item metadata        // if present
 ```
+
+Use the same `langfuse.experiment.id` and `langfuse.experiment.name` values for
+the entire recovered experiment. Changing either value between item traces
+splits them into different experiments in the v4 UI.
 
 When the trace ID, observation IDs, and start times remain unchanged, Langfuse
 writes newer event versions and ClickHouse eventually replaces the previous

--- a/content/faq/all/experiment-runs-not-visible-v4.mdx
+++ b/content/faq/all/experiment-runs-not-visible-v4.mdx
@@ -63,10 +63,19 @@ complete experiment context to every observation. Preserve the optional
 description, experiment metadata, item version, expected output, and item
 metadata when they were present in the historic experiment.
 
-Choose one of the following recovery options based on whether preserving
-existing score links or avoiding background replacement is more important.
+Choose one of the following options based on whether you need historic
+experiment data to appear in the v4 UI.
 
-### Option 1: Preserve existing score links
+### Option 1: Keep historic experiments out of v4
+
+If you only need experiment data within your retention window, you can continue
+using Langfuse v4 without recovering historic experiments. The historic traces
+remain available, but they will not appear as experiment runs in the v4 UI.
+
+This can be a reasonable option when historic experiment data is no longer
+needed or will expire through your normal data retention policy.
+
+### Option 2: Preserve existing score links
 
 Re-ingest every observation with its original trace ID, observation ID, parent
 observation ID, and exact original start time. Preserve the original end time
@@ -117,34 +126,6 @@ completes, duplicate event versions may affect results. There is no time
 guarantee for these merges.
 
 </Callout>
-
-### Option 2: Avoid waiting for background replacement
-
-Use a new trace ID when re-ingesting each complete trace. Observation IDs and
-parent observation IDs can remain unchanged because they are scoped to the
-trace. Continue to use the exact original start and end times to preserve the
-historic experiment timing.
-
-Scores are stored separately and do not move to the new trace automatically.
-Send each trace-level, observation-level, or experiment-item score again through
-[`POST /api/public/scores`](https://api.reference.langfuse.com/#tag/legacyscorev1/POST/api/public/scores),
-using its original score ID and all supported score fields. Set the new trace ID
-and, for observation-level or experiment-item scores, the corresponding
-observation ID. For experiment-item scores, use the item root observation.
-Experiment-level scores remain linked when you keep the original experiment ID.
-
-The Scores API assigns the current timestamp when it receives the score. Native
-experiment views and charts associate the score with the recovered experiment
-through its new trace and observation IDs. Scores originally created by an
-evaluator are recorded with source `API`, because the public endpoint does not
-accept `EVAL` as a source. Time-based dashboards and exports attribute the score
-to the correction date rather than its historic date. Public Experiments API
-responses that request scores may omit corrected scores because they constrain
-score timestamps to the historic experiment item window.
-
-This option creates separate corrected traces without waiting for the historic
-trace versions to be replaced. The historic traces remain available under their
-original IDs.
 
 Please [contact Langfuse support](mailto:support@langfuse.com) if you need help
 recovering historic experiments.


### PR DESCRIPTION
## Summary
- add an FAQ for JS/TS SDK users whose experiment runs are missing after the v4 upgrade
- explain the legacy `item.link()` path and recommend the Experiment runner SDK
- document the timestamp caveat when re-ingesting existing trace and span IDs

## Verification
- `pnpm --dir ../langfuse-docs exec prettier --write /Users/marliesmayerhofer/Documents/Code/langfuse-docs-v4-experiment-faq/content/faq/all/experiment-runs-not-visible-v4.mdx`
- `git diff --check`
- Tests and dev server not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-path impact; recovery guidance is operational and should be read alongside merge/deduplication caveats in the doc.
> 
> **Overview**
> Adds FAQ **`experiment-runs-not-visible-v4.mdx`** for JS/TS SDK users who still call **`item.link()`** and no longer see experiment runs in Langfuse v4.
> 
> The page explains that v4 ties experiments to traces via **`langfuse.experiment.*`** attributes that the legacy link path often omitted, lists the required attributes, and directs new work to the [Experiment runner SDK](/docs/evaluation/experiments/experiments-via-sdk).
> 
> For historic data it outlines **Option 1** (leave runs out of the v4 UI) and **Option 2** (re-ingest via OpenTelemetry with experiment attributes while reusing original trace/observation IDs and **exact** start times so scores stay linked). A warning documents ClickHouse merge-based replacement behavior and the risk of duplicate observations if timestamps differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801c88e5847868bcb9f76b258d1175235ce86119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an FAQ explaining why legacy JavaScript/TypeScript `item.link()` experiment runs may be absent from the v4 UI and how to migrate or recover them.

- Documents the experiment attributes required on re-ingested observations.
- Recommends the Experiment runner SDK for new experiments.
- Provides a historic-trace recovery recipe and discusses identifier reuse.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the same-ID recovery instructions stop promising reliable replacement and warn users about duplicate observations.

The documented recovery path directs users to re-ingest immutable v4 observations with existing identifiers even though current repository guidance says this can duplicate records, inflate metrics, and yield inconsistent queries.

**Files Needing Attention:** content/faq/all/experiment-runs-not-visible-v4.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/faq/all/experiment-runs-not-visible-v4.mdx:100-103
**Same-ID re-ingestion creates duplicates**

When a user re-ingests a historic trace with its original trace and observation IDs, v4 does not reliably deduplicate those records, so promising eventual replacement directs users into duplicate observations, inflated metrics, and inconsistent query results.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: detail historic experiment attribu..."](https://github.com/langfuse/langfuse-docs/commit/43845a5a68f3ca89ef6d23e978e1b7486a14f359) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54713504)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->