### PR TITLE
docs(self-hosting): align key prefix in LANGFUSE_INIT_* examples with other instances

### DIFF
--- a/content/self-hosting/administration/headless-initialization.mdx
+++ b/content/self-hosting/administration/headless-initialization.mdx
@@ -39,8 +39,8 @@ Organization
 | `LANGFUSE_INIT_PROJECT_ID`         | Unique identifier for the project                                                              | Yes                         | `my-project`       |
 | `LANGFUSE_INIT_PROJECT_NAME`       | Name of the project                                                                            | No                          | `My Project`       |
 | `LANGFUSE_INIT_PROJECT_RETENTION`  | [Data Retention](/docs/data-retention) in days for project. Leave blank to retain data forever | No                          | `30`               |
-| `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` | Public API key for the project                                                                 | Yes                         | `lf_pk_1234567890` |
-| `LANGFUSE_INIT_PROJECT_SECRET_KEY` | Secret API key for the project                                                                 | Yes                         | `lf_sk_1234567890` |
+| `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` | Public API key for the project                                                                 | Yes                         | `pk-lf-1234567890` |
+| `LANGFUSE_INIT_PROJECT_SECRET_KEY` | Secret API key for the project                                                                 | Yes                         | `sk-lf-1234567890` |
 | `LANGFUSE_INIT_USER_EMAIL`         | Email address of the initial user                                                              | Yes                         | `user@example.com` |
 | `LANGFUSE_INIT_USER_NAME`          | Name of the initial user                                                                       | No                          | `John Doe`         |
 | `LANGFUSE_INIT_USER_PASSWORD`      | Password for the initial user                                                                  | Yes                         | `password123`      |


### PR DESCRIPTION
The public key and private keys' example initialization values documented at `content/self-hosting/administration/headless-initialization.mdx` have prefix of `lf_pk_` and `lf_sk_` respectively, contradicting the prefix used everywhere else, which are `pk-lf-` and `sk-lf-`.

This does not have any real functional impact, but I figured it can use a quick fix.

Note that `content/self-hosting/v2/deployment-guide.mdx` has the exact same error. For it being a legacy doc, I didn't include it in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example string changes with no runtime or security impact.
> 
> **Overview**
> Updates the **headless initialization** env var table so example values for `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `LANGFUSE_INIT_PROJECT_SECRET_KEY` use **`pk-lf-`** and **`sk-lf-`** instead of the outdated **`lf_pk_`** / **`lf_sk_`** prefixes.
> 
> This is documentation-only and matches how API keys are shown elsewhere in the docs; behavior of headless init is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d426f1b4d1123092b8d99042c469e8222ffe7bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the headless initialization documentation so example project API keys use the standard `pk-lf-` and `sk-lf-` prefixes.
- Aligns public and secret key examples with current Langfuse documentation.
- Leaves the legacy v2 deployment guide unchanged, as described in the PR.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only prefix correction appears safe to merge.

The changed examples align with the key format used throughout current documentation, and no concrete functional, rendering, or repository-rule issue remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["Align key prefix in LANGFUSE\_INIT\_\* exam..."](https://github.com/langfuse/langfuse-docs/commit/0478c02f76ae20b33db3a7c5206a4f040a4a3ba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54754683)</sub>

<!-- /greptile_comment -->