### PR TITLE
docs: detail evaluator design in academy examples

### DIFF
--- a/content/academy/examples/customer-support-chatbot.mdx
+++ b/content/academy/examples/customer-support-chatbot.mdx
@@ -125,7 +125,27 @@ We now iterate on the prompt, [running each version against these datasets](/aca
           evaluator: the expected output gives it the sources and
           recommendation from the human reply to compare against. It has to be an LLM-as-a-judge
           rather than a code check because two replies can recommend the same
-          thing in completely different words.
+          thing in completely different words. It needs the expected output to
+          run, so it can grade experiment runs on these datasets but never
+          live traffic.
+        </>
+      ),
+    },
+    {
+      name: "links_valid",
+      type: "Code",
+      check: "Every help article linked in the draft exists in the help center",
+      returns: "binary, per dataset item",
+      details: (
+        <>
+          Added after manual review turned up drafts linking help articles
+          that don't exist. Whether an article exists is a lookup in the
+          help-article index, so a{" "}
+          <a href="/academy/evaluate/writing-evaluators#make-it-verifiable">
+            code evaluator settles it exactly
+          </a>
+          , in milliseconds and for free. It also needs no expected output, so
+          the same check can keep running on live replies in the later phases.
         </>
       ),
     },
@@ -232,7 +252,12 @@ Both signals are captured as [scores](/docs/evaluation/scores/overview) on every
           that something wrong was removed or fixed, <code>added</code> that
           the draft was kept but missing information was added. It has to be a
           judge because telling a rewording apart from a content change
-          requires reading both texts.
+          requires reading both texts. Like any judge, it starts out untested:
+          hand-label a sample of drafts and their sent replies, and{" "}
+          <a href="/academy/evaluate/writing-evaluators#validate-the-judge">
+            check that the judge classifies them the way you would
+          </a>
+          .
         </>
       ),
     },
@@ -254,7 +279,7 @@ Both signals are captured as [scores](/docs/evaluation/scores/overview) on every
 
 Traces with a bad score can then be looked at, improved, and added to the datasets if they weren't covered before. One way to do this is using the [error analysis](/academy/monitoring/error-analysis) process.
 
-One iteration through the loop then looks like this: [monitoring](/academy/monitoring#metrics-and-signals) shows a spike of `corrected` drafts in the `troubleshooting` category. The traces reveal the agent keeps citing an outdated export dialog, because the help-article index is stale. The index gets refreshed, the `troubleshooting` dataset is rerun to confirm the fix, and the share of `corrected` drafts drops.
+One iteration through the loop then looks like this: [monitoring](/academy/monitoring#metrics-and-signals) shows a spike of `corrected` drafts in the `troubleshooting` category. The traces reveal the agent keeps citing an outdated export dialog, because the help-article index is stale. The index gets refreshed, the `troubleshooting` dataset is rerun to confirm the fix, and the share of `corrected` drafts drops. No new evaluator comes out of this: a stale index is a [one-time fix](/academy/evaluate/choosing-what-to-evaluate#fix-first), not a failure mode to keep tracking.
 
 The share of edited drafts should go down over time. Once drafts go out mostly unchanged across all ticket categories, the agent is ready to face customers.
 
@@ -318,17 +343,22 @@ Customers rarely rate their support chat, so the main focus is on gathering impl
         <>
           Runs when the conversation closes and classifies it as{" "}
           <code>resolved</code>, <code>abandoned</code>, or{" "}
-          <code>handed_off</code>. Categorical because the three endings each
-          mean something different for the bot's performance. Scored on the
-          session rather than the trace, since the outcome belongs to the
-          conversation as a whole.
+          <code>handed_off</code>. The three endings each mean something
+          different for the bot's performance and are mutually exclusive, so
+          this is{" "}
+          <a href="/academy/evaluate/writing-evaluators#binary-verdicts">
+            one categorical evaluator rather than several overlapping binary
+            ones
+          </a>
+          . Scored on the session rather than the trace, since the outcome
+          belongs to the conversation as a whole.
         </>
       ),
     },
   ]}
 />
 
-With no human in the loop anymore, we monitor every reply for reputation-damaging behavior. These evaluators don't block anything: they flag sent replies so the team can follow up with the customer quickly.
+With no human in the loop anymore, we monitor every reply for reputation-damaging behavior. These two evaluators come from [hard constraints](/academy/evaluate/choosing-what-to-evaluate#goals-and-hard-constraints) rather than observed failures: they exist from day one, even though neither has ever fired. They don't block anything: they flag sent replies so the team can follow up with the customer quickly.
 
 <EvaluatorBlock
   evaluators={[

--- a/content/academy/examples/music-streaming-dj.mdx
+++ b/content/academy/examples/music-streaming-dj.mdx
@@ -210,7 +210,16 @@ In order to learn from users, we will log some [interesting behavior](/academy/m
           the failure counts. <code>correction</code> means the DJ's last
           action missed. <code>repeated_instruction</code> means the DJ failed
           to follow an instruction it already got: a compliance failure rather
-          than a taste miss, and it asks for a different fix.
+          than a taste miss, and it{" "}
+          <a href="/academy/evaluate/choosing-what-to-evaluate#tie-every-metric-to-a-decision">
+            asks for a different fix
+          </a>
+          . It is also the only signal here with LLM costs to run, and voice
+          requests are a small slice of the traffic, so the{" "}
+          <a href="/academy/evaluate/choosing-what-to-evaluate#mind-the-budget">
+            evaluator budget
+          </a>{" "}
+          stays small.
         </>
       ),
     },
@@ -308,6 +317,6 @@ With this in place, the full loop is running:
 
 ## Conclusion
 
-This is an example of a feature that's is low risk and there is no historical data to learn from. The best thing you can do in such cases is getting traces in as soon as possible and start monitoring them to learn from. Everything else, datasets, experiments, A/B tests, can be built on top of that over time.
+This is an example of a feature that is low risk and has no historical data to learn from. The best thing you can do in such cases is get traces in as soon as possible and start monitoring them. Everything else, datasets, experiments, A/B tests, can be built on top of that over time.
 
 Check out the [other examples](/academy/examples) or the [academy](/academy) to learn more.


### PR DESCRIPTION
Elaborates the evaluator sections of the two academy example pages so they concretely demonstrate the concepts taught in the evaluation academy pages ([Choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate), [Writing good evaluators](/academy/evaluate/writing-evaluators)).

## Customer support chatbot
- Add a `links_valid` **code evaluator** in phase 1 so the example shows all three evaluation methods (code, LLM-as-a-judge, human), and demonstrates deterministic-first.
- Note that `resolution_match` is reference-based, so it grades experiments but never live traffic.
- Add a judge-validation step to `edit_type`, linking to the calibration guidance.
- Frame the phase 2 stale-index fix as a one-time fix, not a failure mode to keep tracking.
- Source the phase 3 risk monitors (`data_leak`, `out_of_scope_help`) from hard constraints rather than observed failures.
- Link `session_outcome` to the categorical-over-overlapping-binaries guidance.

## Music streaming DJ
- Tie `message_type` to a decision and to the evaluator budget (only signal with LLM-level cost).
- Fix grammar in the conclusion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to academy MDX examples with no runtime or security impact.
> 
> **Overview**
> **Customer support chatbot** phase 1 now includes a **`links_valid` code evaluator** so the walkthrough shows code, LLM-as-a-judge, and human review together, with copy on deterministic checks and reuse on live traffic. **`resolution_match`** explicitly states it is reference-based and cannot run on live traffic.
> 
> Phase 2 adds **judge calibration** guidance for **`edit_type`** and frames the stale-index incident as a **one-time fix** rather than a new metric. Phase 3 links **`session_outcome`** to categorical-vs-overlapping-binaries guidance and describes **`data_leak`** / **`out_of_scope_help`** as **hard-constraint** monitors from day one.
> 
> **Music streaming DJ** ties **`message_type`** to decision-making and evaluator budget; the conclusion gets light grammar edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011724e5fd6034b262df1eca32f7af51ef232bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands two Academy examples to connect evaluator choices to the evaluation-design curriculum.
- Adds a deterministic link-validity evaluator and clarifies offline versus live applicability in the customer-support example.
- Adds judge validation, one-time-fix, hard-constraint, and categorical-evaluator guidance.
- Connects the music DJ’s message classifier to remediation decisions and evaluator cost, while correcting conclusion grammar.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge, with all newly introduced section links resolving and no actionable inconsistency established.

The new evaluator explanations align with the surrounding phase structure, target valid Academy anchors, and preserve valid MDX syntax and documentation behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: detail evaluator design in academy..."](https://github.com/langfuse/langfuse-docs/commit/011724e5fd6034b262df1eca32f7af51ef232bb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54879058)</sub>

<!-- /greptile_comment -->