### PR TITLE
docs(self-hosting): add the system table grants Langfuse v4 needs

### DIFF
--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -90,9 +90,31 @@ GRANT ALTER UPDATE, ALTER DELETE ON default.* TO 'user';
 GRANT ALTER DROP INDEX ON default.* TO 'user';
 GRANT CREATE ON default.* TO 'user';
 GRANT DROP TABLE ON default.* TO 'user';
+
+-- Langfuse v4 additionally reads ClickHouse system tables, see below
+GRANT SELECT ON system.tables TO 'user';
+GRANT SELECT ON system.parts TO 'user';
+GRANT SELECT ON system.processes TO 'user';
+GRANT SELECT ON system.query_log TO 'user';
+GRANT SELECT ON system.replicas TO 'user';
 ```
 
 Replace `'user'` with your actual ClickHouse username and adjust the database name if you're using a different database than `default`.
+
+### Why the `system.*` grants are required [#system-table-grants]
+
+ClickHouse enables `access_control_improvements.select_from_system_db_requires_grant` by default, so a least-privilege user cannot read the `system` database without an explicit grant. Langfuse v4 requires ClickHouse >= 25.12, where this default applies.
+
+Langfuse v4 reads these tables to discover work:
+
+| Table | Used by |
+| --- | --- |
+| `system.parts` | the dual-write propagation job, to find completed `observations_batch_staging` partitions, and every step of the historic backfill |
+| `system.tables` | the historic backfill, to resolve table engines |
+| `system.processes`, `system.query_log` | the historic backfill, which starts long-running queries with an explicit `query_id`, drops the HTTP connection, and polls for completion |
+| `system.replicas` | the historic backfill on `Replicated*` engines only (skipped on SharedMergeTree) |
+
+Without these grants the dual write fails on every run while ingestion keeps returning `207`, so the new `events` tables stay behind without any error surfacing.
 
 ## Direct ClickHouse Access for Custom Tools [#direct-clickhouse-access]
 


### PR DESCRIPTION
## What

Adds the `system.*` grants that Langfuse v4 needs to the ClickHouse user permissions list, plus a short section explaining what reads them.

## Why

The documented grant list is scoped entirely to `default.*`. Langfuse v4 also reads the `system` database, and ClickHouse denies that to a least-privilege user by default:

```cpp
// ClickHouse src/Access/AccessControl.cpp
setSelectFromSystemDatabaseRequiresGrant(
  config_.getBool("access_control_improvements.select_from_system_db_requires_grant", true));
```

The default is `true` on 25.12, which is the minimum version the [v3 to v4 guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4#step-1) requires, so following both pages as written produces a deployment that cannot run the dual write.

Where v4 reads them:

- `worker/src/features/eventPropagation/handleEventPropagationJob.ts` — selects `partition` from `system.parts` to find `observations_batch_staging` partitions ready to propagate. This is the dual write's work-discovery query.
- `worker/src/backgroundMigrations/utils/backfillBase.ts` — `system.tables`, `system.parts`, `system.processes`, `system.query_log`
- `worker/src/backgroundMigrations/rewriteObservationsToPidTidSorting.ts` — `system.parts`
- `worker/src/backgroundMigrations/backfillEventsFullFromObservations.ts` — `system.parts`, `system.replicas`

## How it shows up

The failure is silent. Ingestion continues to answer `207`, no user-visible error appears, and the events tables just do not fill. We ran a v3 to v4 migration on a least-privilege user and the propagation job failed on every run for 26 minutes before we noticed, purely from a row-count comparison.

`system.replicas` is only touched on `Replicated*` engines, so ClickHouse Cloud / SharedMergeTree deployments do not strictly need it. It is included so the list works for self-managed clusters too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 880e687b6e04d58c91745c21760e50118f131c59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the explicit ClickHouse system-table permissions required by Langfuse v4 and explains how dual-write propagation and historical backfills use each table.
- Grants `SELECT` on five required `system` tables to the Langfuse user.
- Documents the least-privilege failure mode and table-specific consumers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The SQL permissions are presented consistently with the existing least-privilege setup, and the added heading and table use established, supported MDX conventions.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(self-hosting): add the system table..."](https://github.com/langfuse/langfuse-docs/commit/880e687b6e04d58c91745c21760e50118f131c59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55095771)</sub>

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->