### PR TITLE
Trim MCP initialize volume, identify docs search callers

### DIFF
--- a/app/api/search-docs/route.ts
+++ b/app/api/search-docs/route.ts
@@ -35,15 +35,22 @@ export async function GET(request: NextRequest) {
   }
 
   // Fire PostHog event immediately so it has time to flush
+  const userAgent = request.headers.get("user-agent") ?? undefined;
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
   waitUntil(
     (async () => {
       try {
         posthog?.capture({
-          distinctId: "docs-search-api",
+          // Identify the caller by user agent, like the docs MCP events do, so
+          // searches can be split by agent vs human and classified with
+          // PostHog's $virt_* traffic properties (derived from the raw UA).
+          distinctId: userAgent || "docs-search-api",
           event: "docs_search:query",
           properties: {
             query,
             $process_person_profile: false,
+            $raw_user_agent: userAgent,
+            $ip: ip,
           },
         });
         await posthog?.flush();

--- a/lib/mcp-handler.ts
+++ b/lib/mcp-handler.ts
@@ -34,10 +34,20 @@ export const mcpRequestContextFromRequest = (
   ip: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim(),
 });
 
+// Clients re-run the initialize handshake on every session and reconnect, so it
+// fires roughly 37x more often than a tool actually runs. Sampling keeps the
+// client mix and its trend intact at a fraction of the event volume; multiply
+// counts by 1 / sample_rate (the rate is recorded on each event) to estimate
+// absolute handshakes.
+const MCP_INITIALIZE_SAMPLE_RATE = 0.05;
+
 // The MCP initialize handshake carries clientInfo ({ name, version }) — the
-// most reliable identifier of which agent/IDE is talking to the docs server.
+// most reliable identifier of which agent/IDE is talking to the docs server,
+// since two thirds of tool-call requests arrive without a useful user agent.
 export const trackMcpInitializeFromRequest = (request: Request) => {
   if (!posthog || request.method !== "POST") return;
+  // Sample before parsing the body so skipped requests cost nothing.
+  if (Math.random() >= MCP_INITIALIZE_SAMPLE_RATE) return;
   const clone = request.clone();
   const { userAgent, ip } = mcpRequestContextFromRequest(request);
   waitUntil(
@@ -59,6 +69,7 @@ export const trackMcpInitializeFromRequest = (request: Request) => {
             $ip: ip,
             client_name: clientInfo?.name,
             client_version: clientInfo?.version,
+            sample_rate: MCP_INITIALIZE_SAMPLE_RATE,
           },
         });
         await posthog.flush();


### PR DESCRIPTION
Two small follow-ups to the agent-traffic tracking in #3384, both in the same server-side analytics layer.

## 1. Sample `docs_mcp:initialize` at 5%

MCP clients re-run the initialize handshake on every session and reconnect, so it fires far more often than any actual work: **33,763 initialize vs 901 `execute_tool` per day — a 37:1 ratio**, and the majority of the new server-side event volume added by #3384.

Sampling at 5% keeps the client mix and its trend intact while cutting that volume. Each event records `sample_rate`, so absolute handshake counts are recoverable by multiplying by `1 / sample_rate`.

Kept rather than dropped: `clientInfo` is the only reliable client identifier, since roughly two thirds of tool-call requests arrive without a useful user agent.

## 2. Identify callers of `/api/search-docs`

`docs_search:query` already recorded the query text — ~1,300/day on weekdays, and almost entirely unique (1,294 distinct out of 1,356 on Aug 19), which makes it a genuinely useful feed of what people are stuck on. But it carried **no caller information at all**: a fixed `distinctId: "docs-search-api"` and no user agent, confirmed by 0 of 4,900 events in the last 7 days having `$raw_user_agent`.

That meant no agent-vs-human split, no client attribution, and no `$virt_*` traffic classification (it's derived from the raw user agent, so it couldn't resolve). This endpoint was the last one still on the pre-#3384 pattern.

Now captures `$raw_user_agent`, `$ip`, and a user-agent-derived distinct id, matching `lib/mcp-handler.ts`. Together with the existing `query` property, every question asked of the docs — via MCP or the search API — becomes attributable to a client.

## Verified

Ran the dev server against a local mock PostHog endpoint (gzip-aware, since posthog-node batches compressed):

- `/api/search-docs?query=...` with a ChatGPT-User UA, a Chrome UA, and `claude-code/2.1.235 (cli)` → three `docs_search:query` events, each carrying the correct `$raw_user_agent`, `$ip`, and distinct id, with `$process_person_profile: false` preserved.
- `/api/search-docs` with no `query` → 400 and **no** event (the guard short-circuits before capture).
- 80 concurrent `initialize` POSTs to `/api/mcp` → **3 events** (≈4 expected at 5%), each with `client_name: "claude-code"` and `sample_rate: 0.05`.

Note the 500s on `/api/search-docs` locally are expected — no `INKEEP_BACKEND_API_KEY` in the test environment. The analytics call fires before the Inkeep request, which is what this PR touches.

## Notes for reviewers

- No behavior change to responses; both events stay fire-and-forget via `waitUntil` and remain anonymous (`$process_person_profile: false`).
- Dashboards counting `docs_mcp:initialize` need a `1 / sample_rate` multiplier from here on. Historical events before this deploy have no `sample_rate` property and are unsampled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 606ae6c731b6699e3592f7a10279f10ef9172055. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves server-side documentation analytics while reducing high-volume MCP initialization telemetry.

- Samples `docs_mcp:initialize` events at 5% and records the sampling rate for aggregate reconstruction.
- Adds user-agent and IP metadata to `docs_search:query` events and derives caller identity from the user agent.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The analytics changes preserve existing request behavior and event guards while implementing the intended caller attribution and initialization-event sampling.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): identify callers of the..."](https://github.com/langfuse/langfuse-docs/commit/606ae6c731b6699e3592f7a10279f10ef9172055) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55106537)</sub>

<!-- /greptile_comment -->