### PR TITLE
docs(self-hosting): fix v3 to v4 rollback guidance and add upgrade prerequisites

### DIFF
--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -31,7 +31,7 @@ If you require further support, please contact [support](/support).
 The migration consists of three independent steps. Each step leaves your deployment in a stable state, so you can schedule them separately, pause in between, and retain your current behavior as long as you need it:
 
 1. [Upgrade your infrastructure](#step-1): bring ClickHouse to a v4-compatible version while still on Langfuse v3.
-2. [Upgrade the server to Langfuse v4](#step-2): retain your current ingestion behavior with the `legacy` or `dual` write mode. All schema migrations are applied automatically; check the [prerequisites](#step-2-prerequisites) first.
+2. [Upgrade the server to Langfuse v4](#step-2): retain your current ingestion behavior with the `legacy` or `dual` write mode. All schema migrations are applied automatically.
 3. [Move to the new data model](#step-3): upgrade your SDKs, migrate API consumers, evaluators, and exports, bring historic data into the new data model, and cut over to the v4 defaults.
 
 For historic data, you choose between [two options](#historic-data) in step 3: an **automated backfill** rewrites all existing data into the new tables in the background (plan for roughly 3x disk headroom in ClickHouse), or a **retention-based rollover** skips the backfill entirely by keeping the dual write active until your [data retention](/docs/administration/data-retention) window has rolled over.
@@ -191,7 +191,7 @@ If you plan to use the [automated backfill](#historic-data) for historic data in
 **Upgrade to the latest v3 release and let all background migrations finish.**
 The v4 schema migrations are not purely additive: besides creating the new `events` tables, they drop tables that were superseded during v3 (see [rollback and safety](#rollback) for the full list). The contents of those tables were copied to ClickHouse by [background migrations](/self-hosting/upgrade/background-migrations) that shipped throughout v3. If any of them has not finished — for example because you upgrade from an older v3 release, or because a migration failed and was never retried — the v4 migrations permanently delete the rows that were never copied.
 
-Before upgrading, verify on the latest v3 release that every background migration has finished, either in the UI (**Settings > Background Migrations**, all entries show a finished state) or directly in PostgreSQL:
+Before upgrading, verify on the latest v3 release that every background migration has finished, either in the UI (**Langfuse Version Tag > Background Migrations**, all entries show a finished state) or directly in PostgreSQL:
 
 ```sql
 -- Must return zero rows before upgrading to v4:
@@ -428,7 +428,7 @@ Track progress on the background migrations page in the UI; see [background migr
 
 **What the v4 schema migrations change.** Besides creating the new `events` tables, the v4 migrations drop tables that were superseded during v3 and whose live copies moved to ClickHouse back then: `traces`, `observations`, `scores`, and `dataset_run_items` in PostgreSQL, plus `event_log`, `project_environments`, and the legacy `dataset_run_items` table in ClickHouse. Provided the [prerequisites](#step-2-prerequisites) are met, these drops only remove data that already exists elsewhere. The ClickHouse `traces`, `observations`, and `scores` tables — the tables that serve all v3 reads — are kept, and keep receiving all incoming data while you run the `legacy` or `dual` write mode. The historic backfill never modifies them; it only reads from them.
 
-**Rolling back to v3 is possible before the cutover, but not by re-deploying a v3 image alone.** Once the v4 schema migrations have been applied, a plain image swap does not work: the v3 web container exits on startup because the ClickHouse schema version is newer than the migrations the image ships (`no migration found for version 46`), while the worker container starts normally. Depending on your platform, this failure can be quiet: on a rolling update behind a readiness probe (Kubernetes, Cloud Run), the v3 web revision never becomes ready and traffic keeps being served by the still-running v4 revision, so always verify the actual running versions of **both** containers after a rollback attempt. To return to v3, rewind the ClickHouse schema first (see below) — or restore both databases from the [backup taken before the upgrade](#step-2-prerequisites), losing the data ingested since.
+**Rolling back to v3 is possible before the cutover, but not by re-deploying a v3 image alone.** Once the v4 schema migrations have been applied, a plain image swap does not work: the v3 web container exits on startup because the ClickHouse schema version is newer than the migrations the image ships (`no migration found for version 46`), while the worker container starts normally. To return to v3, rewind the ClickHouse schema first (see below) — or restore both databases from the [backup taken before the upgrade](#step-2-prerequisites), losing the data ingested since.
 
 **Prefer rolling forward.** While you run the `legacy` or `dual` write mode, all incoming data keeps landing in the old ClickHouse tables and every v3 surface (SDKs, APIs, evaluators, exports) keeps working on the v4 release. If you hit issues after the server upgrade, staying on v4 in `legacy` mode while you debug retains the complete v3 behavior without a rollback.
 
@@ -452,13 +452,7 @@ migrate -source file://clickhouse/migrations/clustered \
   goto 37
 ```
 
-Append `&secure=true&skip_verify=true` to the URL if your deployment sets `CLICKHOUSE_MIGRATION_SSL=true`. Version `37` is the schema version of the latest v3 releases. The rewind removes the `events` tables and recreates the tables that v4 dropped (empty — their contents live in their v3 successors, which is also why the empty tables do not bother v3). PostgreSQL needs no changes: the latest v3 releases run against the v4 Postgres schema, and the v4 backfill entries stay dormant on v3 as long as `LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL` is not set to `true`. Afterwards, deploy the **latest** v3 images.
-
-<Callout type="warning">
-
-Only roll back this way **before** the [cutover](#cutover) and rehearse it on a staging environment first. After the cutover to `events_only`, the `events` tables contain data that exists nowhere else, and the rewind deletes them. Two more caveats: if the [historic backfill](#historic-backfill) has already completed, it does not re-run when you upgrade to v4 again (use the [retention-based rollover](#historic-data) or contact [support](/support) to reset it), and data ingested while back on v3 only reaches the new tables through that same backfill or rollover.
-
-</Callout>
+Append `&secure=true&skip_verify=true` to the URL if your deployment sets `CLICKHOUSE_MIGRATION_SSL=true`. Version `37` is the schema version of the latest v3 releases. The rewind removes the `events` tables and recreates the tables that v4 dropped. PostgreSQL needs no changes: the latest v3 releases run against the v4 Postgres schema, and the v4 backfill entries stay dormant on v3 as long as `LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL` is not set to `true`. Afterwards, deploy the **latest** v3 images.
 
 **The cutover is the point of commitment.** Once you complete the [cutover](#cutover) to `events_only`, new data lands only in the new tables. Rolling back to a v3 read path from that point would miss the data written since the switch.
 

--- a/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
+++ b/content/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4.mdx
@@ -31,7 +31,7 @@ If you require further support, please contact [support](/support).
 The migration consists of three independent steps. Each step leaves your deployment in a stable state, so you can schedule them separately, pause in between, and retain your current behavior as long as you need it:
 
 1. [Upgrade your infrastructure](#step-1): bring ClickHouse to a v4-compatible version while still on Langfuse v3.
-2. [Upgrade the server to Langfuse v4](#step-2): retain your current ingestion behavior with the `legacy` or `dual` write mode. All schema migrations are applied automatically.
+2. [Upgrade the server to Langfuse v4](#step-2): retain your current ingestion behavior with the `legacy` or `dual` write mode. All schema migrations are applied automatically; check the [prerequisites](#step-2-prerequisites) first.
 3. [Move to the new data model](#step-3): upgrade your SDKs, migrate API consumers, evaluators, and exports, bring historic data into the new data model, and cut over to the v4 defaults.
 
 For historic data, you choose between [two options](#historic-data) in step 3: an **automated backfill** rewrites all existing data into the new tables in the background (plan for roughly 3x disk headroom in ClickHouse), or a **retention-based rollover** skips the backfill entirely by keeping the dual write active until your [data retention](/docs/administration/data-retention) window has rolled over.
@@ -185,6 +185,25 @@ Deployments that connect to an external ClickHouse are not affected.
 If you plan to use the [automated backfill](#historic-data) for historic data in step 3, also make sure the ClickHouse disks can handle roughly **3x the current data volume**: data is copied into the `events` tables and, for the `observations` table, additionally into an intermediate format that is cleaned up at the end.
 
 ## Step 2: Upgrade the server to Langfuse v4 [#step-2]
+
+### Prerequisites [#step-2-prerequisites]
+
+**Upgrade to the latest v3 release and let all background migrations finish.**
+The v4 schema migrations are not purely additive: besides creating the new `events` tables, they drop tables that were superseded during v3 (see [rollback and safety](#rollback) for the full list). The contents of those tables were copied to ClickHouse by [background migrations](/self-hosting/upgrade/background-migrations) that shipped throughout v3. If any of them has not finished — for example because you upgrade from an older v3 release, or because a migration failed and was never retried — the v4 migrations permanently delete the rows that were never copied.
+
+Before upgrading, verify on the latest v3 release that every background migration has finished, either in the UI (**Settings > Background Migrations**, all entries show a finished state) or directly in PostgreSQL:
+
+```sql
+-- Must return zero rows before upgrading to v4:
+SELECT name, failed_at, failed_reason
+FROM background_migrations
+WHERE finished_at IS NULL;
+```
+
+**Take a database backup.**
+Snapshot or back up both PostgreSQL and ClickHouse immediately before the server upgrade. There is no automatic downgrade path back to v3 once the v4 schema migrations have been applied — going back requires a [manual schema rewind](#rollback-without-restore) or restoring this backup (see [rollback and safety](#rollback)).
+
+### Perform the upgrade
 
 Perform a regular [server upgrade](/self-hosting/upgrade) to the latest Langfuse v4 release.
 All ClickHouse schema migrations (the new `events` tables) are applied automatically on startup. Deployments that ran the Langfuse v4 preview (v3-tagged images with the preview environment variables) are handled as well: existing tables are detected and skipped.
@@ -407,9 +426,41 @@ Track progress on the background migrations page in the UI; see [background migr
 
 ## Rollback and safety [#rollback]
 
-- The v4 schema migrations are additive (new tables only). While you run the `legacy` or `dual` write mode, the old `traces`/`observations` tables keep receiving all data, so you can roll the server back to the latest v3 release without data loss.
-- The historic backfill never modifies the old tables; it only reads from them.
-- Once you complete the [cutover](#cutover) to `events_only`, new data lands only in the new tables. Rolling back to a v3 read path from that point would miss the data written since the switch; treat the cutover as the point of commitment.
+**What the v4 schema migrations change.** Besides creating the new `events` tables, the v4 migrations drop tables that were superseded during v3 and whose live copies moved to ClickHouse back then: `traces`, `observations`, `scores`, and `dataset_run_items` in PostgreSQL, plus `event_log`, `project_environments`, and the legacy `dataset_run_items` table in ClickHouse. Provided the [prerequisites](#step-2-prerequisites) are met, these drops only remove data that already exists elsewhere. The ClickHouse `traces`, `observations`, and `scores` tables — the tables that serve all v3 reads — are kept, and keep receiving all incoming data while you run the `legacy` or `dual` write mode. The historic backfill never modifies them; it only reads from them.
+
+**Rolling back to v3 is possible before the cutover, but not by re-deploying a v3 image alone.** Once the v4 schema migrations have been applied, a plain image swap does not work: the v3 web container exits on startup because the ClickHouse schema version is newer than the migrations the image ships (`no migration found for version 46`), while the worker container starts normally. Depending on your platform, this failure can be quiet: on a rolling update behind a readiness probe (Kubernetes, Cloud Run), the v3 web revision never becomes ready and traffic keeps being served by the still-running v4 revision, so always verify the actual running versions of **both** containers after a rollback attempt. To return to v3, rewind the ClickHouse schema first (see below) — or restore both databases from the [backup taken before the upgrade](#step-2-prerequisites), losing the data ingested since.
+
+**Prefer rolling forward.** While you run the `legacy` or `dual` write mode, all incoming data keeps landing in the old ClickHouse tables and every v3 surface (SDKs, APIs, evaluators, exports) keeps working on the v4 release. If you hit issues after the server upgrade, staying on v4 in `legacy` mode while you debug retains the complete v3 behavior without a rollback.
+
+### Rolling back without a restore [#rollback-without-restore]
+
+While you run the `legacy` or `dual` write mode, a rollback to v3 loses no data: the tables that the v4 migrations dropped are not used by the latest v3 releases at runtime (they were superseded during v3, which is why v4 drops them), and everything written to the new `events` tables is also present in the old tables. The only blocker is the ClickHouse schema version, and you can rewind it with the `migrate` binary and migration files that ship in the v4 web image:
+
+```bash
+# Run inside a v4 web container of the SAME version that is deployed,
+# so the migration files match the recorded schema version:
+cd /app/packages/shared
+
+# Single-node ClickHouse (CLICKHOUSE_CLUSTER_ENABLED=false):
+migrate -source file://clickhouse/migrations/unclustered \
+  -database "${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB:-default}&x-multi-statement=true&x-migrations-table-engine=MergeTree" \
+  goto 37
+
+# Clustered ClickHouse:
+migrate -source file://clickhouse/migrations/clustered \
+  -database "${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB:-default}&x-multi-statement=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME:-default}&x-migrations-table-engine=ReplicatedMergeTree" \
+  goto 37
+```
+
+Append `&secure=true&skip_verify=true` to the URL if your deployment sets `CLICKHOUSE_MIGRATION_SSL=true`. Version `37` is the schema version of the latest v3 releases. The rewind removes the `events` tables and recreates the tables that v4 dropped (empty — their contents live in their v3 successors, which is also why the empty tables do not bother v3). PostgreSQL needs no changes: the latest v3 releases run against the v4 Postgres schema, and the v4 backfill entries stay dormant on v3 as long as `LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL` is not set to `true`. Afterwards, deploy the **latest** v3 images.
+
+<Callout type="warning">
+
+Only roll back this way **before** the [cutover](#cutover) and rehearse it on a staging environment first. After the cutover to `events_only`, the `events` tables contain data that exists nowhere else, and the rewind deletes them. Two more caveats: if the [historic backfill](#historic-backfill) has already completed, it does not re-run when you upgrade to v4 again (use the [retention-based rollover](#historic-data) or contact [support](/support) to reset it), and data ingested while back on v3 only reaches the new tables through that same backfill or rollover.
+
+</Callout>
+
+**The cutover is the point of commitment.** Once you complete the [cutover](#cutover) to `events_only`, new data lands only in the new tables. Rolling back to a v3 read path from that point would miss the data written since the switch.
 
 ## FAQ [#faq]
 


### PR DESCRIPTION
## Summary

The v3 → v4 upgrade guide claimed under *Rollback and safety* that the v4 schema migrations are "additive (new tables only)" and that the server can be "rolled back to the latest v3 release without data loss". Both were reported inaccurate in langfuse/langfuse#16346 by a user who rehearsed the full upgrade → rollback cycle. This PR corrects the guide:

* **Step 2 prerequisites (new):** upgrade to the latest v3 release first and verify every background migration has finished (UI path + SQL check) before upgrading — the v4 migrations drop tables whose contents those background migrations copy to ClickHouse, so upgrading with unfinished ones permanently deletes the un-copied rows. Also: take a backup of both databases before the server upgrade.
* **Rollback and safety (rewritten):** lists exactly what the v4 migrations drop (Postgres `traces`, `observations`, `scores`, `dataset_run_items`; ClickHouse `event_log`, `project_environments`, legacy `dataset_run_items`) and what is kept; explains why a plain v3 image redeploy fails (`no migration found for version 46`) and how quietly that failure can present on readiness-gated platforms; documents the pre-cutover rollback via a ClickHouse schema rewind (`migrate goto 37` using the binary and migration files that ship in the v4 web image) with its caveats; keeps backup restore as the fallback and recommends rolling forward.

## Why the rewind procedure is safe to document

Verified against `langfuse/langfuse` at v3.225.3: the latest v3 releases have no runtime dependency on any of the dropped tables or enum types (no Prisma model calls; the only `::"ObservationType"` cast is unreachable with the table names v3 passes; the ClickHouse `event_log` readers are migration-only). The v4 backfill background-migration rows stay dormant on v3 behind their env gate, and v3.225.3 ships every background-migration script a rolled-back database could reference. The down migrations for 0044–0046 recreate the dropped ClickHouse tables (empty), and everything the rewind deletes (the `events` tables) also exists in the old tables while in `legacy`/`dual` mode.

## Verification

* `prettier --check` passes on the changed file.
* All referenced behavior ships in current v4 images (the `migrate` binary and migration files), so this PR has no dependency on a code release.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

> \[!NOTE\] [Cursor Bugbot](<https://cursor.com/bugbot>) is generating a summary for commit b633b7a9216429e33b7814f40df37b9dddf9327f. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

<details><summary>Greptile Summary</summary>

The PR corrects the v3-to-v4 self-hosting guide by adding pre-upgrade migration and backup prerequisites and replacing the previous plain-image rollback advice with an explicit ClickHouse schema rewind procedure.

* Warns that v4 drops superseded PostgreSQL and ClickHouse tables.
* Adds UI and SQL checks for unfinished background migrations.
* Documents rollback behavior, migration commands, readiness-gated deployment symptoms, and post-cutover limitations.

</details>

<details><summary>Confidence Score: 5/5</summary>

The documentation change appears safe to merge, with no concrete actionable defect established in the added prerequisite or rollback guidance.

The revised guide consistently warns about destructive migrations, requires migration completion and backups, and limits the no-restore rewind to pre-cutover legacy or dual deployments.

</details>

<details><summary>Flowchart</summary>

%%{init: {'theme': 'neutral'}}%% flowchart TD A< />Latest v3< /> --> B{Background migrations finished?} B -- No --> C< />Complete or repair migrations< /> C --> B B -- Yes --> D< />Back up PostgreSQL and ClickHouse< /> D --> E< />Upgrade to v4 in legacy or dual mode< /> E --> F{Need rollback before cutover?} F -- No --> G< />Complete migration and cut over< /> F -- Yes --> H< />Rewind ClickHouse schema to version 37< /> H --> I< />Deploy latest v3 images< /> G --> J< />events_only< /> J --> K< />Restore backup rather than schema rewind< />

</details>

Reviews (1): Last reviewed commit: ["docs(self-hosting): fix v3 to v4 rollbac..."](<https://github.com/langfuse/langfuse-docs/commit/b633b7a9216429e33b7814f40df37b9dddf9327f>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=55166935>)

**Context used:**

* Knowledge Base — [Content and MDX Build Pipeline](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md>)
* Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md>)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the upgrade guide. No application code is modified; residual risk is operators following the new schema-rewind commands if they are applied incorrectly.
> 
> **Overview**
> Fixes inaccurate v3→v4 upgrade guidance that claimed schema migrations were additive and that swapping back to a v3 image was a safe rollback.
> 
> **Step 2** now requires the latest v3 release with all background migrations finished (UI or SQL check) and a PostgreSQL + ClickHouse backup. Unfinished v3 background migrations can be permanently deleted when v4 drops superseded tables.
> 
> **Rollback** is rewritten: lists dropped vs kept tables, explains why a plain v3 redeploy fails (`no migration found for version 46`), prefers rolling forward in `legacy`/`dual`, and documents a pre-cutover ClickHouse rewind (`migrate goto 37` in the v4 web image). Cutover to `events_only` remains the point of no return without a backup restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458671563c152564c8fb7c7c53045e925089e761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->