### PR TITLE
docs: restructure the MCP Server feature page

### DIFF
--- a/content/docs/api-and-data-platform/features/mcp-server.mdx
+++ b/content/docs/api-and-data-platform/features/mcp-server.mdx
@@ -22,7 +22,13 @@ This is the authenticated MCP server for the Langfuse data platform. There is al
 
 </Callout>
 
-## Configuration
+## MCP Reference
+
+The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source for current Langfuse MCP servers, setup snippets, tools, input schemas, and generated request examples.
+
+**Both read and write tools are available by default.** If you only want to use read-only tools, configure your MCP client with an allowlist to restrict access to write operations. For a full list of tools, see the [MCP Reference](https://mcp.reference.langfuse.com).
+
+## Set up [#set-up]
 
 The Langfuse MCP server uses a stateless architecture where each API key is scoped to a specific project. Use the following configuration to connect to the MCP server:
 
@@ -73,33 +79,6 @@ The Langfuse MCP server uses a stateless architecture where each API key is scop
 </Tab>
 
 </Tabs>
-
-## MCP Reference
-
-<Callout type="info">
-
-The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source for current Langfuse MCP servers, setup snippets, tools, input schemas, and generated request examples.
-
-</Callout>
-
-<Callout type="warning">
-  **Both read and write tools are available by default.** If you only want to
-  use read-only tools, configure your MCP client with an allowlist to restrict
-  access to write operations. For a full list of tools, see the [MCP Reference](https://mcp.reference.langfuse.com).
-</Callout>
-
-## Filter logical root observations [#logical-root-observations]
-
-The observation tools distinguish logical roots from physical parentage:
-
-- `listObservations` accepts the optional boolean `isRootObservation` filter. Set it to `true` to match observations without a physical parent or observations explicitly marked as application roots by the SDK.
-- Physical-parent filtering remains separate. An application-root observation can match `isRootObservation: true` even when it has a physical parent.
-- `isRootObservation` is included in the default observation fields returned by `listObservations`.
-- `getObservationFilterValues` supports `isRootObservation` as a filter-value column, so you can discover and combine logical-root values with other observation filters.
-
-For the complete tool schemas and request examples, see the [MCP Reference](https://mcp.reference.langfuse.com).
-
-## Set up [#set-up]
 
 <Steps>
 
@@ -417,12 +396,6 @@ http_headers = { "Authorization" = "Basic {your-base64-token}" }
 
 <Tab>
 
-- Endpoint: `/api/public/mcp`
-  - EU: `https://cloud.langfuse.com/api/public/mcp`
-  - US: `https://us.cloud.langfuse.com/api/public/mcp`
-  - Japan: `https://jp.cloud.langfuse.com/api/public/mcp`
-  - HIPAA: `https://hipaa.cloud.langfuse.com/api/public/mcp`
-  - Self-Hosted: `https://your-domain.com/api/public/mcp`
 - Transport: `streamableHttp`
 - Authentication: Basic Auth via authorization header
   - `Authorization: Basic {your-base64-token}`
@@ -431,6 +404,17 @@ http_headers = { "Authorization" = "Basic {your-base64-token}" }
 </Tabs>
 
 </Steps>
+
+## Filter logical root observations [#logical-root-observations]
+
+The observation tools distinguish logical roots from physical parentage:
+
+- `listObservations` accepts the optional boolean `isRootObservation` filter. Set it to `true` to match observations without a physical parent or observations explicitly marked as application roots by the SDK.
+- Physical-parent filtering remains separate. An application-root observation can match `isRootObservation: true` even when it has a physical parent.
+- `isRootObservation` is included in the default observation fields returned by `listObservations`.
+- `getObservationFilterValues` supports `isRootObservation` as a filter-value column, so you can discover and combine logical-root values with other observation filters.
+
+For the complete tool schemas and request examples, see the [MCP Reference](https://mcp.reference.langfuse.com).
 
 ## Feedback
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restructures the [MCP Server](https://langfuse.com/docs/api-and-data-platform/features/mcp-server) docs page so the guided flow matches how people actually set things up.

## What changed

- Kept the concise introduction and the guidance to prefer the Agent Skill when CLI tools are available.
- Converted the MCP Reference section from stacked callouts to regular paragraphs.
- Folded the former Configuration section into Set up so endpoint, transport, and authentication details are documented once (removed the duplicate endpoint list from Other MCP Clients).
- Moved logical-root filtering to immediately after setup.
- Left Feedback and Related Documentation at the end.

Original wording is unchanged except where duplicate endpoint lines were removed.

## New page order

1. Intro + Agent Skill / docs MCP guidance
2. MCP Reference (paragraphs)
3. Set up (endpoints + auth + client setup)
4. Filter logical root observations
5. Feedback
6. Related Documentation

## Testing

- `pnpm run format`
- `node scripts/check-h1-headings.js`
- Rendered `http://127.0.0.1:3333/docs/api-and-data-platform/features/mcp-server` (HTTP 200)
- Manual walkthrough of the restructured page

[Intro, Agent Skill guidance, and MCP Reference as paragraphs](https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_intro_and_reference.webp)
[Set up section with region endpoint tabs](https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_setup_endpoint_tabs.webp)
[Other MCP Clients tab without repeated endpoint list](https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_other_clients_no_duplicate_endpoints.webp)
[Logical-root filtering, Feedback, and Related Documentation](https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_filtering_feedback_related.webp)
[mcp_server_page_restructured_walkthrough.mp4](https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_page_restructured_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2304](https://linear.app/clickhouse/issue/LFMKT-2304/restructure-the-mcp-server-feature-page)

<div><a href="https://cursor.com/agents/bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3284c0f2-ed41-449f-b1a3-c048fcdcf137&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes the MCP Server documentation into a setup-oriented flow, converts reference callouts into paragraphs, removes duplicate endpoint details, and moves logical-root filtering after setup.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking deep-link compatibility issue for the removed Configuration heading.

The content restructure preserves the page and setup instructions, but external links using the former `#configuration` fragment will no longer navigate to those instructions.

**Files Needing Attention:** content/docs/api-and-data-platform/features/mcp-server.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/api-and-data-platform/features/mcp-server.mdx:31
**Preserve the configuration deep link**

The former `Configuration` heading generated a `#configuration` fragment, but the replacement setup section only exposes `#set-up`. Existing external bookmarks and shared links to `mcp-server#configuration` now land at the top of the page instead of the endpoint and authentication instructions, so preserve the old anchor or redirect it to the new section.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restructure MCP Server feature pag..."](https://github.com/langfuse/langfuse-docs/commit/c900bef1a3da09c12d372bbed01294aff25e9593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55414090)</sub>

<!-- /greptile_comment -->