### PR TITLE
docs: restructure User Tracking page to show product views before setup

### DIFF
--- a/content/docs/observability/features/users.mdx
+++ b/content/docs/observability/features/users.mdx
@@ -10,6 +10,26 @@ import { PropagationRestrictionsCallout } from "@/components/PropagationRestrict
 
 The Users view provides an overview of all users. It also offers an in-depth look into individual users. It's easy to map data in Langfuse to individual users. Just propagate the `userId` attribute across observations. This can be a username, email, or any other unique identifier. The `userId` is optional, but using it helps you get more from Langfuse aggregating metrics such as LLM usage cost by `userId`. See the integration docs to learn more.
 
+## Product use [#product-use]
+
+### View all users [#view-all-users]
+
+The user list provides an overview of all users that have been tracked by Langfuse. It makes it simple to segment by overall token usage, number of traces, and user feedback.
+
+<Frame>
+![User List](/images/docs/users-list.png)
+</Frame>
+
+### Individual user view [#individual-user-view]
+
+The individual user view provides an in-depth look into a single user. Explore aggregated metrics or view all traces and feedback for a user.
+
+<Frame>
+![User Detail View](/images/docs/user-detail-view.png)
+</Frame>
+
+## Set up user tracking [#set-up-user-tracking]
+
 <LangTabs items={["Python SDK", "JS/TS SDK", "OpenAI (Python)", "Langchain (Python)", "Langchain (JS/TS)"]}>
 <Tab>
 When using the `@observe()` decorator:
@@ -177,21 +197,7 @@ await startActiveObservation("langchain-call", async () => {
 
 <PropagationRestrictionsCallout attributes={["userId"]} />
 
-## View all users
-
-The user list provides an overview of all users that have been tracked by Langfuse. It makes it simple to segment by overall token usage, number of traces, and user feedback.
-
-<Frame>
-![User List](/images/docs/users-list.png)
-</Frame>
-
-## Individual user view
-
-The individual user view provides an in-depth look into a single user. Explore aggregated metrics or view all traces and feedback for a user.
-
-<Frame>
-![User Detail View](/images/docs/user-detail-view.png)
-</Frame>
+## Deep-linking [#deep-linking]
 
 You can deep link to this view via the following URL format: `https://<hostname>/project/{projectId}/users/{userId}`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructures the [User Tracking](https://langfuse.com/docs/observability/features/users) docs page so readers see the product value before the implementation details.

The page previously jumped from a short introduction into a large SDK block. The user-list and individual-user screenshots only appeared after setup.

New page order:

1. Keep the existing introduction on user-level analysis
2. **Product use** — View all users and Individual user view, with their existing screenshots
3. **Set up user tracking** — user ID propagation variants (Python, JS/TS, OpenAI, LangChain)
4. Propagation restrictions, deep-linking, and Related Resources (custom dashboards, Metrics API)

Original copy is unchanged except for the new section headings needed to make this order clear.

## Test plan

- [x] Confirm the page renders at `/docs/observability/features/users`
- [x] Confirm TOC order: Product use → View all users → Individual user view → Set up user tracking → Deep-linking → Related Resources
- [x] Confirm both screenshots still appear under the product-use sections
- [x] Confirm SDK tabs still switch and show the same code samples
- [x] Confirm internal links (custom dashboards, Metrics API) still resolve

[Top of page: intro then Product use and View all users](https://cursor.com/agents/bc-257241c3-8ae6-4dee-818c-03671bf41d99/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuser_tracking_top_product_use.webp)
[Individual user view screenshot before setup](https://cursor.com/agents/bc-257241c3-8ae6-4dee-818c-03671bf41d99/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuser_tracking_individual_user_view.webp)
[user_tracking_page_restructure_walkthrough.mp4](https://cursor.com/agents/bc-257241c3-8ae6-4dee-818c-03671bf41d99/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuser_tracking_page_restructure_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2303](https://linear.app/clickhouse/issue/LFMKT-2303/restructure-the-user-tracking-feature-page)

<div><a href="https://cursor.com/agents/bc-257241c3-8ae6-4dee-818c-03671bf41d99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-257241c3-8ae6-4dee-818c-03671bf41d99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restructures the User Tracking documentation so readers see product capabilities before implementation guidance.

- Moves the user-list and individual-user-view sections and screenshots ahead of SDK setup.
- Adds explicit Product use, Set up user tracking, and Deep-linking sections with stable anchors.
- Preserves the existing setup examples, propagation restrictions, and related resources.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only restructuring appears safe to merge.

The changed headings use the repository’s established anchor convention, the intended TOC hierarchy remains valid, and the existing screenshots and setup content are preserved.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restructure User Tracking page to ..."](https://github.com/langfuse/langfuse-docs/commit/87b2e34a0dc9b104089c2d2e383c2c06988cded7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55414697)</sub>

<!-- /greptile_comment -->