### PR TITLE
docs: restructure the Environments feature page

### DIFF
--- a/content/docs/observability/features/environments.mdx
+++ b/content/docs/observability/features/environments.mdx
@@ -22,6 +22,8 @@ See our [API Reference](/docs/api) for details on how to filter by environment o
 
 Environments are created the first time data is ingested with a given `environment` value and are persistent. They cannot currently be deleted or renamed via the UI.
 
+For guidance on how to structure, separate, and work with multiple environments across projects and stages, see the FAQ: [Managing different environments](/faq/all/managing-different-environments).
+
 ## Configure environments [#configure-environments]
 
 You can configure the environment by setting the `LANGFUSE_TRACING_ENVIRONMENT` environment variable (recommended) or by using the `environment` parameter in the client initialization.
@@ -238,8 +240,6 @@ export function register() {
 1. **Consistent Environment Names**: Use consistent environment names across your application to make filtering and analysis easier.
 2. **Environment-Specific Analysis**: Use environments to analyze and compare metrics across different deployment stages.
 3. **Testing**: Use separate environments for testing to avoid polluting production data.
-
-For guidance on how to structure, separate, and work with multiple environments across projects and stages, see the FAQ: [Managing different environments](/faq/all/managing-different-environments).
 
 ## GitHub Discussions
 

--- a/content/docs/observability/features/environments.mdx
+++ b/content/docs/observability/features/environments.mdx
@@ -12,13 +12,34 @@ Environments allow you to organize your traces, observations, and scores from di
 - Filter and analyze data by environment
 - Reuse datasets and prompts across environments
 
+## Filtering
+
+In the Langfuse UI, you can filter events by environment using the environment filter in the navigation bar. This filter applies across all views in Langfuse.
+
+See our [API Reference](/docs/api) for details on how to filter by environment on our API.
+
+## Managing Environments
+
+Environments are created the first time data is ingested with a given `environment` value and are persistent. They cannot currently be deleted or renamed via the UI.
+
+## Configure environments [#configure-environments]
+
 You can configure the environment by setting the `LANGFUSE_TRACING_ENVIRONMENT` environment variable (recommended) or by using the `environment` parameter in the client initialization.
 If both are specified, the initialization parameter takes precedence.
 If nothing is specified, the default environment is `default`.
 
 In the Python SDK, you can also set the environment for a specific trace scope with `propagate_attributes(environment="...")`. This is useful when the environment belongs to the incoming request rather than to the service process itself, for example when one shared LLM proxy handles requests from development, staging, QA, and production. Use `as_baggage=True` to propagate that environment across service boundaries.
 
-## Data Model
+### Naming constraints
+
+The environment must be a string that follows this regex pattern: `^(?!langfuse)[a-z0-9-_]+$` with at most 40 characters.
+
+This means:
+
+- Cannot start with "langfuse"
+- Can only contain lowercase letters, numbers, hyphens, and underscores
+
+### Data Model
 
 The `environment` attribute is available on all events in Langfuse:
 
@@ -28,15 +49,6 @@ The `environment` attribute is available on all events in Langfuse:
 - Sessions
 
 See [Data Model](/docs/observability/data-model) for more details.
-
-The environment must be a string that follows this regex pattern: `^(?!langfuse)[a-z0-9-_]+$` with at most 40 characters.
-
-This means:
-
-- Cannot start with "langfuse"
-- Can only contain lowercase letters, numbers, hyphens, and underscores
-
-## Usage
 
 <LangTabs items={["Python SDK", "JS/TS SDK", "OpenTelemetry", "OpenAI (Python)", "OpenAI (JS/TS)", "Langchain (Python)", "Langchain (JS/TS)", "Vercel AI SDK (JS/TS)"]}>
 <Tab title="Python SDK">
@@ -221,23 +233,13 @@ export function register() {
 
 </LangTabs>
 
-## Filtering
-
-In the Langfuse UI, you can filter events by environment using the environment filter in the navigation bar. This filter applies across all views in Langfuse.
-
-See our [API Reference](/docs/api) for details on how to filter by environment on our API.
-
-## Managing Environments
-
-Environments are created the first time data is ingested with a given `environment` value and are persistent. They cannot currently be deleted or renamed via the UI.
-
-For guidance on how to structure, separate, and work with multiple environments across projects and stages, see the FAQ: [Managing different environments](/faq/all/managing-different-environments).
-
 ## Best Practices
 
 1. **Consistent Environment Names**: Use consistent environment names across your application to make filtering and analysis easier.
 2. **Environment-Specific Analysis**: Use environments to analyze and compare metrics across different deployment stages.
 3. **Testing**: Use separate environments for testing to avoid polluting production data.
+
+For guidance on how to structure, separate, and work with multiple environments across projects and stages, see the FAQ: [Managing different environments](/faq/all/managing-different-environments).
 
 ## GitHub Discussions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restructures the [Environments](https://langfuse.com/docs/observability/features/environments) docs page so readers see how environments are used in Langfuse before implementation details.

## Changes

- Keep the existing introduction and use cases.
- Show the product experience next: filtering by environment and how environments are created and managed.
- Follow with a **Configure environments** section that groups precedence rules, naming constraints, the data model, and all SDK/integration examples.
- End with best practices and GitHub discussions.

The FAQ on [how to structure and separate environments](/faq/all/managing-different-environments) is in **Managing Environments**, next to the creation and persistence guidance.

No original body copy was rewritten; sections were reordered and given clearer headings. There is no dedicated environments UI screenshot in the repo, so none was added.

## Verification

The local docs page at `/docs/observability/features/environments` returns HTTP 200. The structure FAQ link is back under Managing Environments.

[Managing Environments section with FAQ link](https://cursor.com/agents/bc-a0416bac-fc06-4c1d-b4cc-fcbef4122359/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironments_managing_section_faq.webp)

Resolves LFMKT-2299.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2299](https://linear.app/clickhouse/issue/LFMKT-2299/restructure-the-environments-feature-page)

<div><a href="https://cursor.com/agents/bc-a0416bac-fc06-4c1d-b4cc-fcbef4122359?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0416bac-fc06-4c1d-b4cc-fcbef4122359&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes the Environments documentation so product filtering and management appear before configuration details.

- Moves filtering and environment-management guidance near the beginning.
- Groups naming constraints, the data model, and SDK examples beneath a new Configure environments section.
- Leaves best practices and discussion links at the end.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking caveat that the former Usage deep link should be preserved.

The reordered content remains renderable and retains its original guidance, but external bookmarks to the removed `#usage` heading will no longer navigate to the examples.

**Files Needing Attention:** content/docs/observability/features/environments.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/observability/features/environments.mdx:27
**Preserve the Usage deep link**

The removed `Usage` heading also removes its generated `#usage` target, so existing external links and bookmarks no longer navigate to the SDK examples. Retain a compatibility anchor while using the new section heading.

```suggestion
<span id="usage" />

## Configure environments [#configure-environments]
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: keep environments FAQ link in Mana..."](https://github.com/langfuse/langfuse-docs/commit/a64178aab578759e88a9b25d7626fb7d0788185d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55417961)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->