### PR TITLE
docs: Restructure the Public API feature page

### DIFF
--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -7,9 +7,33 @@ description: All Langfuse data and features are available via the API. Follow th
 import { V4CutoverDate } from "@/components/V4CutoverDate";
 import { V4_CUTOVER_DATE_SHORT } from "@/lib/v4-migration-dates";
 
-# Public API
+# Public API [#public-api]
 
 Langfuse is open and meant to be extended via custom workflows and integrations. All Langfuse data and features are available via the API.
+
+<Callout type="info">
+
+There are 3 different groups of APIs:
+
+- This page -> Project-level APIs: CRUD traces/evals/prompts/configuration within a project
+- [Organization-level APIs](/docs/administration/scim-and-org-api): provision projects, users (SCIM), and permissions
+- [Instance Management API](/self-hosting/administration/instance-management-api): administer organizations on self-hosted installations
+
+</Callout>
+
+## Quickstart [#quickstart]
+
+<Steps>
+
+### Obtain credentials [#authentication]
+
+Authenticate with the API using [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication).
+The API keys are available in the Langfuse project settings.
+
+- Username: Langfuse Public Key
+- Password: Langfuse Secret Key
+
+### Select the regional base URL [#base-urls]
 
 <Tabs items={["Path", "Cloud US", "Cloud EU", "Cloud Japan", "HIPAA US"]}>
 
@@ -50,34 +74,43 @@ https://hipaa.cloud.langfuse.com/api/public
 </Tab>
 </Tabs>
 
-References:
-
-- API Reference: https://api.reference.langfuse.com
-- OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
-
-<Callout type="info">
-
-There are 3 different groups of APIs:
-
-- This page -> Project-level APIs: CRUD traces/evals/prompts/configuration within a project
-- [Organization-level APIs](/docs/administration/scim-and-org-api): provision projects, users (SCIM), and permissions
-- [Instance Management API](/self-hosting/administration/instance-management-api): administer organizations on self-hosted installations
-
-</Callout>
-
-## Authentication
-
-Authenticate with the API using [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication).
-The API keys are available in the Langfuse project settings.
-
-- Username: Langfuse Public Key
-- Password: Langfuse Secret Key
+### Make an authenticated request
 
 Example:
 
 ```bash
 curl -u public-key:secret-key https://cloud.langfuse.com/api/public/projects
 ```
+
+### Understand the result
+
+A successful response returns the project associated with your API key:
+
+```json
+{
+  "data": [
+    {
+      "id": "clxxxx",
+      "name": "My Project",
+      "organization": {
+        "id": "clyyyy",
+        "name": "My Org"
+      }
+    }
+  ]
+}
+```
+
+Use the same credentials and regional base URL for the rest of the Public API.
+
+</Steps>
+
+## API reference [#api-reference]
+
+References:
+
+- API Reference: https://api.reference.langfuse.com
+- OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
 
 ## Access via SDKs [#access-via-sdks]
 
@@ -266,6 +299,19 @@ You can also export data via:
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
 <FaqPreview tags={["platform"]} />
+
+## Related API resources [#related-api-resources]
+
+- [Query via SDKs](/docs/api-and-data-platform/features/query-via-sdk) — typed Python and JS/TS wrappers for the same endpoints
+- [Observations API v2](/docs/api-and-data-platform/features/observations-api#v2) — retrieve row-level spans, generations, and events
+- [Scores API v3](/docs/api-and-data-platform/features/scores-api#v3) — retrieve evaluation and annotation scores
+- [Metrics API v2](/docs/metrics/features/metrics-api#v2) — retrieve aggregated analytics
+- [Experiments API](/docs/api-and-data-platform/features/experiments-api) — retrieve experiment runs and items
+- [CLI](/docs/api-and-data-platform/features/cli) — call the Public API from the terminal
+- [MCP Server](/docs/api-and-data-platform/features/mcp-server) — connect AI assistants to Langfuse data
+- [Organization-level APIs](/docs/administration/scim-and-org-api) — provision projects, users (SCIM), and permissions
+- [Instance Management API](/self-hosting/administration/instance-management-api) — administer organizations on self-hosted installations
+- [Migration of deprecated APIs](/faq/all/deprecated-api-migration) — replacements for sunset read and ingestion endpoints
 
 ## GitHub Discussions
 

--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -21,6 +21,13 @@ There are 3 different groups of APIs:
 
 </Callout>
 
+## API reference [#api-reference]
+
+References:
+
+- API Reference: https://api.reference.langfuse.com
+- OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
+
 ## Quickstart [#quickstart]
 
 <Steps>
@@ -100,13 +107,6 @@ A successful response returns the project associated with your API key:
 Use the same credentials and regional base URL for the rest of the Public API.
 
 </Steps>
-
-## API reference [#api-reference]
-
-References:
-
-- API Reference: https://api.reference.langfuse.com
-- OpenAPI spec: https://cloud.langfuse.com/generated/api/openapi.yml
 
 ## Access via SDKs [#access-via-sdks]
 

--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -27,11 +27,7 @@ There are 3 different groups of APIs:
 
 ### Obtain credentials [#authentication]
 
-Authenticate with the API using [Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication).
-The API keys are available in the Langfuse project settings.
-
-- Username: Langfuse Public Key
-- Password: Langfuse Secret Key
+The public and secret keys are available in the Langfuse project settings.
 
 ### Select the regional base URL [#base-urls]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Public API page previously jumped from a one-sentence intro into base URLs, references, authentication, and large SDK examples. This change gives the page a first-use path without rewriting existing copy.

## Changes

- Keep the concise intro and move the project / organization / instance API distinction to the top
- Place the API reference links immediately under that callout
- Add a compact quickstart: obtain credentials, select the regional base URL, make one authenticated request, and understand the result
- Group the remaining implementation paths as SDK wrappers, trace ingestion, and data retrieval
- Keep export options as alternatives
- End with FAQ, related API resources, and GitHub Discussions
- Use public and secret keys in the credentials step, not username/password labels

Existing anchors such as `#access-via-sdks` and `#public-api` are preserved.

## Walkthrough

[API reference under the intro callout](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_reference_under_intro.webp)

[Credentials step uses public and secret keys](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_credentials_use_keys.webp)

[Quickstart request and result](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_quickstart_request_and_result.webp)

[Ingest, retrieve, and export alternatives](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_ingest_retrieve_alternatives.webp)

[FAQ and related API resources](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_faq_and_related_resources.webp)

[public_api_page_restructure_walkthrough.mp4](https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_page_restructure_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2305](https://linear.app/clickhouse/issue/LFMKT-2305/restructure-the-public-api-feature-page)

<div><a href="https://cursor.com/agents/bc-76e96f4d-cf57-4698-904f-8f198058f918?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76e96f4d-cf57-4698-904f-8f198058f918&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restructures the Public API documentation into a clearer first-use flow while preserving established anchors and existing implementation guidance.

- Moves API scope distinctions and reference links near the introduction.
- Adds a credentials, regional URL, request, and response quickstart.
- Adds a consolidated list of related API resources.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge with no concrete broken links, anchors, rendering behavior, or API guidance identified.

The restructured MDX uses established heading and Steps patterns, preserves important anchors, and points all newly added internal links and fragments to existing targets.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: move Public API reference under th..."](https://github.com/langfuse/langfuse-docs/commit/3ef042878fdae3038f9ab4d6d3745d45f0d7da39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55418772)</sub>

<!-- /greptile_comment -->