### PR TITLE
docs: restructure the LLM-as-a-Judge feature page

### DIFF
--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -303,27 +303,6 @@ To see your evaluator in action, you need to either [send traces](/docs/observab
   pipeline](/docs/evaluation/evaluation-methods/scores-via-sdk).
 </Callout>
 
-## Debug LLM-as-a-Judge Executions
-
-Every LLM-as-a-Judge evaluator execution creates a full trace, giving you complete visibility into the evaluation process. This allows you to debug prompt issues, inspect model responses, monitor token usage, and trace evaluation history.
-
-You can show the LLM-as-a-Judge execution traces by filtering for the environment `langfuse-llm-as-a-judge` in the tracing table:
-
-<Frame fullWidth>
-  ![Tracing table filtered to langfuse-llm-as-a-judge
-  environment](/images/docs/evaluation/llm-as-a-judge-debug-traces.png)
-</Frame>
-
-<Details>
-<Summary>LLM-as-a-Judge Execution Status</Summary>
-
-- **Completed**: Evaluation finished successfully.
-- **Error**: Evaluation failed (click execution trace ID for details).
-- **Delayed**: Evaluation hit rate limits by the LLM provider and is being retried with exponential backoff.
-- **Pending**: Evaluation is queued and waiting to run.
-
-</Details>
-
 ## Programmatic Setup via API [#api]
 
 Beyond the UI, you can set up and manage LLM-as-a-Judge evaluation programmatically through the public API. This is useful for version-controlling your evaluation setup, replicating it across projects, or automating rollouts from a deployment pipeline.
@@ -358,10 +337,6 @@ Observation evaluation rules support a boolean `isRootObservation` filter with t
 
 If you have existing evaluators running on traces and want to upgrade to running on observations for better performance and reliability, check out our comprehensive [Evaluator Migration Guide](/faq/all/llm-as-a-judge-migration).
 
-### Troubleshooting Observation-Level Evaluators
-
-If your observation-level evaluator isn't executing, see [Why is my observation-level evaluator not executing?](/faq/all/observation-eval-not-executing) for common causes and solutions.
-
 ### Backfill Historical Observation Scores
 
 You can run observation-level LLM-as-a-Judge on historical data from the observations table. This is useful if you have already ingested production data and want to score matching observations retroactively with a new or updated evaluator.
@@ -381,6 +356,31 @@ To backfill scores:
 </Frame>
 
 This backfill flow runs from the traces table, but the resulting scores are attached to the matching observations inside each trace.
+
+## Debug LLM-as-a-Judge Executions
+
+Every LLM-as-a-Judge evaluator execution creates a full trace, giving you complete visibility into the evaluation process. This allows you to debug prompt issues, inspect model responses, monitor token usage, and trace evaluation history.
+
+You can show the LLM-as-a-Judge execution traces by filtering for the environment `langfuse-llm-as-a-judge` in the tracing table:
+
+<Frame fullWidth>
+  ![Tracing table filtered to langfuse-llm-as-a-judge
+  environment](/images/docs/evaluation/llm-as-a-judge-debug-traces.png)
+</Frame>
+
+<Details>
+<Summary>LLM-as-a-Judge Execution Status</Summary>
+
+- **Completed**: Evaluation finished successfully.
+- **Error**: Evaluation failed (click execution trace ID for details).
+- **Delayed**: Evaluation hit rate limits by the LLM provider and is being retried with exponential backoff.
+- **Pending**: Evaluation is queued and waiting to run.
+
+</Details>
+
+### Troubleshooting Observation-Level Evaluators
+
+If your observation-level evaluator isn't executing, see [Why is my observation-level evaluator not executing?](/faq/all/observation-eval-not-executing) for common causes and solutions.
 
 ## FAQ
 
@@ -418,6 +418,13 @@ Cost depends on the judge model and the size of the inputs being evaluated. A ty
 Yes. LLM-as-a-Judge is particularly effective for RAG pipelines. You can evaluate faithfulness (is the answer grounded in the retrieved context?), relevance (does the answer address the question?), and completeness (does the answer cover all relevant information?). Langfuse also integrates with [RAGAS](/resources/engineering/evaluation-of-rag-with-ragas) for specialized RAG evaluation metrics.
 
 </Details>
+
+## Related Resources
+
+- [Langfuse Academy: Evaluation](/academy/evaluate) covers how LLM-as-a-judge fits with manual review and code evaluators.
+- [Writing good evaluators](/academy/evaluate/writing-evaluators) explains how to design judge prompts you can trust.
+- [Choosing what to evaluate](/academy/evaluate/choosing-what-to-evaluate) helps you decide which quality checks are worth automating.
+- [Calibrate your LLM-as-a-judge](/guides/llm-as-a-judge-calibration-skill) to check whether your judge agrees with how you would label cases.
 
 ## GitHub Discussions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reorders the [LLM-as-a-Judge](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge) docs page so implementation paths come before debugging and FAQ.

## Changes

- Keep the introduction, overview video, how-it-works content, and evaluation-target guidance in place.
- Keep UI setup as the first implementation path.
- Move programmatic/API setup and advanced operations (migration, backfilling) immediately after UI setup.
- Group debugging, observation-level troubleshooting, and FAQ after all implementation paths.
- Add a Related Resources section with Langfuse Academy evaluation material and the judge-calibration guide.

Existing conceptual copy is unchanged; this is a reordering and grouping pass.

## Verification

The local docs page renders with the new heading order. Existing anchors (`#set-up-step-by-step`, `#api`, `#understanding-each-evaluation-target`) are preserved. Academy and calibration links return 200.

[Page TOC after restructure](https://cursor.com/agents/bc-9f351b51-b261-47b1-966a-3b2c5cce858c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fllm_as_a_judge_toc_after_restructure.webp)
[API setup and advanced topics](https://cursor.com/agents/bc-9f351b51-b261-47b1-966a-3b2c5cce858c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fllm_as_a_judge_api_and_advanced_topics.webp)
[Debug, FAQ, and Related Resources](https://cursor.com/agents/bc-9f351b51-b261-47b1-966a-3b2c5cce858c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fllm_as_a_judge_debug_faq_related_resources.webp)
[llm_as_a_judge_restructured_page_walkthrough.mp4](https://cursor.com/agents/bc-9f351b51-b261-47b1-966a-3b2c5cce858c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fllm_as_a_judge_restructured_page_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2307](https://linear.app/clickhouse/issue/LFMKT-2307/restructure-the-llm-as-a-judge-feature-page)

<div><a href="https://cursor.com/agents/bc-9f351b51-b261-47b1-966a-3b2c5cce858c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f351b51-b261-47b1-966a-3b2c5cce858c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes the LLM-as-a-Judge documentation so programmatic setup and advanced operations precede debugging and FAQ content.

- Moves execution debugging and observation-level troubleshooting after all implementation paths.
- Adds Related Resources links to relevant Academy lessons and the judge-calibration guide.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the reorganized heading structure remains valid and all newly added resource links resolve to the intended documentation.

No changed-code-triggered failures or independently actionable non-blocking issues remain after checking heading anchors, hierarchy, inbound references, and added link destinations.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restructure LLM-as-a-Judge feature..."](https://github.com/langfuse/langfuse-docs/commit/666b36d53c9c9148210f1b5cf9d19d6f2e836537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55416858)</sub>

<!-- /greptile_comment -->