### PR TITLE
docs: add useful links on prompt management get started

### DIFF
--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -133,9 +133,11 @@ This guide helps you get started with Langfuse Prompt Management manually.
 
 ## Next steps
 
-Now that you've used your first prompt, there are a couple of things we recommend you do next to make the most of Langfuse Prompt Management:
+Now that you've used your first prompt, here are a few things we recommend next to make the most of Langfuse Prompt Management:
 
 - [Link prompts to traces](/docs/prompt-management/features/link-to-traces) to analyze performance by prompt version
+- [Improve prompts with experiments](/docs/evaluation/experiments/experiments-via-ui) to test prompt versions on a dataset
 - [Use version control and labels](/docs/prompt-management/features/prompt-version-control#protected-prompt-labels) to manage deployments across environments
+- [Guarantee prompt availability](/docs/prompt-management/features/guaranteed-availability) by pre-fetching prompts or providing a fallback
 
 Looking for something specific? Take a look under _Features_ for guides on specific topics.

--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -125,6 +125,14 @@ This guide helps you get started with Langfuse Prompt Management manually.
 
 <PromptUse />
 
+<Callout type="info">
+
+Prompt Management is not on the critical path of your application. The SDKs [cache prompts client-side](/docs/prompt-management/features/caching), so after the first fetch they are served from memory with no extra latency. If Langfuse goes down, your application continues to use the cached prompt.
+
+If you need 100% availability even when a new instance starts with an empty cache, see [guaranteed availability](/docs/prompt-management/features/guaranteed-availability).
+
+</Callout>
+
 </Steps>
 
 ## Not seeing what you expected?
@@ -138,6 +146,5 @@ Now that you've used your first prompt, here are a few things we recommend next 
 - [Link prompts to traces](/docs/prompt-management/features/link-to-traces) to analyze performance by prompt version
 - [Improve prompts with experiments](/docs/evaluation/experiments/experiments-via-ui) to test prompt versions on a dataset
 - [Use version control and labels](/docs/prompt-management/features/prompt-version-control#protected-prompt-labels) to manage deployments across environments
-- [Guarantee prompt availability](/docs/prompt-management/features/guaranteed-availability) by pre-fetching prompts or providing a fallback
 
 Looking for something specific? Take a look under _Features_ for guides on specific topics.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the [Prompt Management Get Started](https://langfuse.com/docs/prompt-management/get-started) page:

- **Next steps** now includes [experiments via UI](/docs/evaluation/experiments/experiments-via-ui) for iterating on prompts.
- After the first `get_prompt` example, a callout explains that Prompt Management is **not on the critical path**: prompts are cached client-side, so they stay available if Langfuse is down. [Guaranteed availability](/docs/prompt-management/features/guaranteed-availability) is linked only as the empty-cache cold-start hatch — not as a next step.

Resolves LFMKT-2291.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2291](https://linear.app/clickhouse/issue/LFMKT-2291/add-useful-links-to-prompt-mgmt-get-started-page)

<div><a href="https://cursor.com/agents/bc-05e25f2b-8388-4e9f-9c24-6a8f88eaf9d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e25f2b-8388-4e9f-9c24-6a8f88eaf9d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds availability guidance to the Prompt Management getting-started page and recommends UI-based experiments as a next step.

- Explains client-side prompt caching and links cold-start availability guidance.
- Adds prompt experiments to the recommended follow-up workflow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added availability qualification aligns with the documented cache behavior, and the newly added documentation links resolve to pages supporting their descriptions.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: explain prompt caching on get star..."](https://github.com/langfuse/langfuse-docs/commit/2490e9ae20baf1463f705711da899954680192bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55418116)</sub>

<!-- /greptile_comment -->