### PR TITLE
docs: restructure Releases & Versioning feature page

### DIFF
--- a/content/docs/observability/features/releases-and-versioning.mdx
+++ b/content/docs/observability/features/releases-and-versioning.mdx
@@ -15,10 +15,19 @@ You can track the effect of changes to your LLM app on metrics in Langfuse. This
 - **Explain changes to metrics** over time.
   - _Example:_ "Why did latency in this chain increase?"
 
-## Releases
+## Releases vs versions [#releases-vs-versions]
+
+A `release` tracks the overall version of your application. Commonly it is set to the _semantic version_ or _git commit hash_ of your application.
+
+The `version` parameter can be added to all observation types (e.g., `span`, `generation`, `event`, and [other observation types](/docs/observability/features/observation-types)). Thereby, you can track the effect of a new `version` on the metrics of an object with a specific `name` using [Langfuse analytics](/docs/analytics).
+
+|               | Release                              | Version                                             |
+| ------------- | ------------------------------------ | --------------------------------------------------- |
+| Scope         | Entire application                   | Individual observations with a given `name`         |
+| Typical value | Semantic version or git commit hash  | Component version, for example `1.0`                |
+| When to use   | You deployed a new application build | You changed a specific prompt, chain, or generation |
 
 ```mermaid
-
 flowchart LR
 
     A1[LLM application<br/>release:v2.1.23]
@@ -27,7 +36,33 @@ flowchart LR
     A1 --> A2
 ```
 
-A `release` tracks the overall version of your application. Commonly it is set to the _semantic version_ or _git commit hash_ of your application.
+```mermaid
+flowchart LR
+
+    A1[Generation<br/>name:guess-countries<br/>version:1.0]
+    A2[Generation<br/>name:guess-countries<br/>version:1.1]
+
+    A1 --> A2
+```
+
+## In Langfuse [#in-langfuse]
+
+Both values appear on traces and observations in Langfuse. Filter by them to isolate a deployment or a component change, compare costs, latencies, and quality across them in [analytics](/docs/analytics), or use them to explain why a metric shifted after a change.
+
+_Release in Langfuse interface_
+
+<Frame>
+  ![Picture release in traces
+  table](/images/blog/update-august-2023/release.jpg)
+</Frame>
+
+_Version parameter in Langfuse interface_
+
+<Frame>
+  ![Version on single generation](/images/blog/update-august-2023/version.jpg)
+</Frame>
+
+## Set a release [#set-a-release]
 
 The SDKs look for a `release` in the following order:
 
@@ -78,19 +113,7 @@ If no other `release` is set, the Langfuse SDKs default to a set of known releas
 
 Supported platforms include: Vercel, Heroku, Netlify. See the full list of support environment variables for [JS/TS](https://github.com/langfuse/langfuse-js/blob/v3-stable/langfuse-core/src/release-env.ts) and [Python](https://github.com/langfuse/langfuse-python/blob/main/langfuse/_utils/environment.py).
 
-## Versions
-
-```mermaid
-
-flowchart LR
-
-    A1[Generation<br/>name:guess-countries<br/>version:1.0]
-    A2[Generation<br/>name:guess-countries<br/>version:1.1]
-
-    A1 --> A2
-```
-
-The `version` parameter can be added to all observation types (e.g., `span`, `generation`, `event`, and [other observation types](/docs/observability/features/observation-types)). Thereby, you can track the effect of a new `version` on the metrics of an object with a specific `name` using [Langfuse analytics](/docs/analytics).
+## Set a version [#set-a-version]
 
 <LangTabs items={["Python SDK", "JS/TS SDK", "Langchain (Python)","Langchain (JS)"]}>
 <Tab>
@@ -213,8 +236,8 @@ const handler = new CallbackHandler({
 
 <PropagationRestrictionsCallout attributes={["version"]} />
 
-_Version parameter in Langfuse interface_
+## Related resources [#related-resources]
 
-<Frame>
-  ![Version on single generation](/images/blog/update-august-2023/version.jpg)
-</Frame>
+- To A/B test prompt versions in production, see [A/B Testing](/docs/prompt-management/features/a-b-testing).
+- To benchmark application changes on datasets, see [Datasets](/docs/evaluation/experiments/datasets) and [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui).
+- To compare costs, latencies, and quality by release or version, see [Metrics](/docs/metrics/overview) and [Custom Dashboards](/docs/metrics/features/custom-dashboards).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restructures the [Releases & Versioning](https://langfuse.com/docs/observability/features/releases-and-versioning) docs page so the relationship between releases and observation versions is easier to scan, and so product screenshots appear before SDK configuration.

## Changes

- Keep the existing use-case-led introduction.
- Add a **Releases vs versions** section with the original definitions, a comparison table (scope, typical value, when to use), and the existing mermaid diagrams.
- Add an **In Langfuse** section that explains filtering, comparing, and explaining metric changes. Move the version screenshot up and add the existing release screenshot.
- Follow with separate **Set a release** and **Set a version** implementation sections. SDK snippets and setup instructions are unchanged.
- End with related A/B testing, experiments, metrics, and dashboard links.

Original copy is preserved where it already explained the feature; new text is limited to structure, comparison, and related resources.

## Local preview

[Intro and release vs version comparison table](https://cursor.com/agents/bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freleases_vs_versions_intro.webp)
[In Langfuse screenshots for release and version](https://cursor.com/agents/bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fin_langfuse_screenshots.webp)
[Set a release SDK implementation](https://cursor.com/agents/bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fset_a_release_sdk.webp)
[Related experimentation and analytics resources](https://cursor.com/agents/bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelated_resources.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2300](https://linear.app/clickhouse/issue/LFMKT-2300/restructure-the-releases-and-versioning-feature-page)

<div><a href="https://cursor.com/agents/bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b5ae0d9-1c1c-4796-8138-7e724b2406b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restructures the Releases & Versioning documentation to clarify the distinction between application releases and observation versions.
- Adds a comparison table and consolidates the existing diagrams.
- Moves product screenshots ahead of SDK configuration.
- Separates release and version setup instructions and adds related resources.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking canonical-link cleanup recommended.

The documentation structure and product claims align with existing repository conventions, while the newly added analytics link unnecessarily routes readers through two legacy redirects.

**Files Needing Attention:** content/docs/observability/features/releases-and-versioning.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/observability/features/releases-and-versioning.mdx:50
**Analytics link uses legacy route**

The newly added `/docs/analytics` link sends readers through two legacy redirects before reaching `/docs/metrics/overview`; linking directly to the canonical metrics page avoids that extra navigation and works in outputs where redirect rules are unavailable.

```suggestion
Both values appear on traces and observations in Langfuse. Filter by them to isolate a deployment or a component change, compare costs, latencies, and quality across them in [analytics](/docs/metrics/overview), or use them to explain why a metric shifted after a change.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restructure Releases &amp; Versioning ..."](https://github.com/langfuse/langfuse-docs/commit/ed4529e22511c6df127c62c4ff32d1d236975c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55415896)</sub>

**Context used:**

- Knowledge Base — [Content and MDX Build Pipeline](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-mdx-pipeline.md)
- Knowledge Base — [Product Documentation Content (content/docs, content/guides, content/faq)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/product-docs-content.md)

<!-- /greptile_comment -->