### PR TITLE
integrations: add UserVane integration page

### DIFF
--- a/content/integrations/other/meta.json
+++ b/content/integrations/other/meta.json
@@ -21,6 +21,7 @@
     "slack",
     "tavily",
     "testable-minds",
+    "uservane",
     "weco",
     "zapier"
   ]

--- a/content/integrations/other/uservane.mdx
+++ b/content/integrations/other/uservane.mdx
@@ -1,0 +1,107 @@
+---
+title: Collect End User Satisfaction Scores with UserVane
+sidebarTitle: UserVane
+logo: /images/integrations/uservane_icon.svg
+description: Capture NPS, CSAT, and CES from your real end users in your product and push them back to Langfuse as scores on the session or observation they came from.
+---
+
+# UserVane Integration
+
+[UserVane](https://uservane.com) is an in-product survey tool that collects satisfaction ratings (NPS, CSAT, CES) from your **real end users** and pushes them back to Langfuse as [scores](/docs/evaluation/core-concepts).
+
+Langfuse already documents that [user feedback](/docs/observability/features/user-feedback) is the signal that tells you whether your AI actually helped someone, and that explicit feedback suffers from low response rates and from unhappy users being more likely to respond. UserVane is built around that second problem: every score it reports ships with its margin of error and the sample size it came from, and a sample too thin to report is suppressed rather than printed.
+
+The integration is a round trip. UserVane captures the rating in your product, binds it server side to the session you are already tracing, and an adapter running on **your** server writes it into Langfuse.
+
+<Callout type="info">
+UserVane is not a tracer and does not replace your instrumentation. It sits beside your existing Langfuse tracing and adds one thing to it: what the end user thought.
+</Callout>
+
+## How It Works
+
+1. Your app captures a rating in the conversation using one of the UserVane SDKs. The rating is bound server side to the Langfuse `sessionId` (and, where available, the trace and observation ids) at the moment of capture.
+2. [`@uservane/langfuse-push`](https://www.npmjs.com/package/@uservane/langfuse-push) runs on your server or cron. It polls UserVane for delivered-but-unpushed scores.
+3. For each score it calls the official `langfuse` Node SDK:
+   - an **observation-level** score when both a trace id and an observation id are present,
+   - otherwise a **session-level** score when a session id is present.
+4. Each delivery is acknowledged back to UserVane, so a score is never written twice.
+
+Ratings that arrived without a linked session are never pushed. They stay in UserVane as unlinked rather than being guessed onto a trace.
+
+## Get Started
+
+<Steps>
+
+### Install the adapter
+
+```bash
+npm install @uservane/langfuse-push
+```
+
+This package is server only. It holds your UserVane secret key and your Langfuse write keys, so never import it from a client component or a browser bundle.
+
+### Capture feedback bound to your Langfuse session
+
+Use the UserVane SDK that matches your stack, and pass the same session id you use for Langfuse [sessions](/docs/observability/features/sessions). Framework packages are available for the Vercel AI SDK, the OpenAI Agents SDK, CopilotKit, React, React Native, and plain browser JavaScript.
+
+```bash
+npm install @uservane/vercel-ai   # or @uservane/openai-agents, @uservane/copilotkit, ...
+```
+
+Binding at capture time is what makes the round trip work: the score knows which session it belongs to before it ever reaches Langfuse.
+
+### Run the adapter on your server
+
+```ts
+import { pushPendingScores } from "@uservane/langfuse-push";
+
+const summary = await pushPendingScores({
+  uservane: {
+    secretKey: process.env.USERVANE_SECRET_KEY!, // uv_sk_...
+  },
+  langfuse: {
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY!,
+    secretKey: process.env.LANGFUSE_SECRET_KEY!, // sk-lf-...
+    // baseUrl: "https://cloud.langfuse.com", // or your self-hosted URL
+  },
+});
+
+console.log(summary); // { delivered: number, failed: number }
+```
+
+Run it on whatever schedule suits you. A cron every few minutes is typical.
+
+### View the scores in Langfuse
+
+Scores arrive under the name `uservane.satisfaction` on the session or observation they were bound to. Filter and chart them like any other score.
+
+</Steps>
+
+## Integration Details
+
+#### Score name
+
+Scores are written as `uservane.satisfaction` by default. Pass `scoreName` to change it. The value is the raw rating and the free-text comment, when the user left one, is written as the score comment.
+
+#### Idempotency
+
+Every score is written with a stable id derived from the UserVane score id, so re-running the adapter upserts rather than duplicating. A score is never counted twice in your trace store.
+
+#### Credential handling
+
+The adapter runs in your infrastructure with your credentials. UserVane never receives, stores, or transmits your Langfuse keys, and is never in the write path to your Langfuse project.
+
+#### Failure handling
+
+A score that cannot be delivered is acknowledged as failed rather than silently dropped, and can be re-polled later with `includeFailed: true`. The adapter confirms delivery through the Langfuse SDK's flush callback instead of assuming success.
+
+#### Self-hosted Langfuse
+
+Supported. Pass your own `baseUrl` in the `langfuse` options.
+
+## Learn More
+
+- [UserVane Langfuse integration guide](https://uservane.com/integrations/langfuse)
+- [UserVane documentation](https://docs.uservane.com)
+- [`@uservane/langfuse-push` on npm](https://www.npmjs.com/package/@uservane/langfuse-push)
+- The UserVane SDKs are MIT licensed and open source at [github.com/uservane/uservane-js](https://github.com/uservane/uservane-js)

--- a/content/integrations/other/uservane.mdx
+++ b/content/integrations/other/uservane.mdx
@@ -50,6 +50,8 @@ npm install @uservane/vercel-ai   # or @uservane/openai-agents, @uservane/copilo
 
 Binding at capture time is what makes the round trip work: the score knows which session it belongs to before it ever reaches Langfuse.
 
+A complete runnable version of this step, with the session id threaded from the client through a Next.js route, is in [`examples/vercel-ai-chat`](https://github.com/uservane/uservane-js/tree/main/examples/vercel-ai-chat).
+
 ### Run the adapter on your server
 
 ```ts

--- a/content/integrations/other/uservane.mdx
+++ b/content/integrations/other/uservane.mdx
@@ -95,7 +95,7 @@ The adapter runs in your infrastructure with your credentials. UserVane never re
 
 #### Failure handling
 
-A score that cannot be delivered is acknowledged as failed rather than silently dropped, and can be re-polled later with `includeFailed: true`. The adapter confirms delivery through the Langfuse SDK's flush callback instead of assuming success.
+A score that cannot be delivered is acknowledged as failed rather than silently dropped, and can be re-polled later with `includeFailed: true`. The adapter waits for the SDK to finish processing the queued event before flushing, so an ingestion failure is recorded as failed rather than counted as delivered.
 
 #### Self-hosted Langfuse
 

--- a/public/images/integrations/uservane_icon.svg
+++ b/public/images/integrations/uservane_icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="UserVane"><title>UserVane</title><rect width="48" height="48" rx="10" fill="#E8F1EA"/><polygon points="38,13 30,27 16,38 25,23" fill="none" stroke="#1C7A50" stroke-width="2.4" stroke-linejoin="round"/><circle cx="28" cy="25" r="2.8" fill="#1C7A50"/></svg>


### PR DESCRIPTION
Adds an integration page for **UserVane** under `Other`, alongside Testable Minds.

**Disclosure:** I work on UserVane. Filing this after seeing #2172, where the reply to a similar request was "feel free to contribute an integration page to the documentation, we are happy to review it." Happy to change the framing, the category, or cut it entirely if it is not a fit.

### What the integration is

UserVane collects satisfaction ratings (NPS, CSAT, CES) from real end users inside the product, and pushes them back to Langfuse as scores. It is the same shape as the existing Testable Minds page (a third-party product that writes scores onto Langfuse traces), with the difference that the raters are the application's own end users rather than a recruited participant pool.

The round trip:

1. A UserVane SDK captures the rating in-conversation and binds it server side to the Langfuse `sessionId` (plus trace and observation ids where available).
2. `@uservane/langfuse-push` runs on the customer's own server or cron, polls UserVane for pending scores, and writes them via the official `langfuse` Node SDK: observation-level when both a trace id and observation id are present, otherwise session-level.
3. Deliveries are acknowledged, and each score carries a stable id so re-runs upsert instead of duplicating.

Langfuse never receives the customer's Langfuse keys from UserVane; the adapter runs in the customer's infrastructure with the customer's credentials. Ratings with no linked session are never pushed.

### Scope, stated plainly

UserVane is not a tracer and does not replace any instrumentation. The page says so explicitly. It adds one field to work you are already tracing: what the end user thought.

### Files

- `content/integrations/other/uservane.mdx` (new page)
- `content/integrations/other/meta.json` (one line, alphabetical)
- `public/images/integrations/uservane_icon.svg` (logo)

### Checks

- `prettier --config .prettierrc.json` reports the new `.mdx` and `.json` unchanged (already formatted).
- One `# ` H1 in the page, per `check-h1-headings.js`.
- Internal links used (`/docs/observability/features/user-feedback`, `/docs/observability/features/sessions`, `/docs/evaluation/core-concepts`) were each checked against existing files in `content/docs/`.

The SDKs are MIT and open source at https://github.com/uservane/uservane-js.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of an integration page, nav entry, and icon; no product or security code changes.
> 
> **Overview**
> Adds a **UserVane** page under Other integrations so users can attach in-product NPS/CSAT/CES ratings to Langfuse sessions or observations.
> 
> The page documents the round trip: capture feedback bound to a Langfuse `sessionId`, poll pending scores with `@uservane/langfuse-push` on the customer’s server, and write `uservane.satisfaction` scores via the official Node SDK (observation-level when ids are present, otherwise session-level). It also covers idempotency, credential handling (keys stay on the customer’s infra), retries, and self-hosted `baseUrl`.
> 
> Registers `uservane` in the Other nav and adds the integration icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040fe0bf37923e0ea5295e289d1879189ceef66a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a UserVane integration page describing how end-user satisfaction ratings are attached to Langfuse sessions or observations and pushed from customer infrastructure.

- Registers UserVane in the Other integrations navigation.
- Documents setup, score targeting, idempotency, credential handling, retries, and self-hosted configuration.
- Adds the UserVane integration icon.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after clarifying the non-blocking but inaccurate description of how delivery is confirmed.

The new page is correctly wired into the MDX and integrations pipelines, while its failure-handling section overstates what the documented Langfuse flush behavior can confirm.

**Files Needing Attention:** content/integrations/other/uservane.mdx
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as End User
    participant App as Customer App
    participant UV as UserVane
    participant Adapter as Customer-hosted Adapter
    participant LF as Langfuse
    User->>App: Submit satisfaction rating
    App->>UV: Store rating with session/trace/observation IDs
    Adapter->>UV: Poll pending scores
    Adapter->>LF: Write observation- or session-level score
    Adapter->>UV: Acknowledge delivery status
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/integrations/other/uservane.mdx:96
**Inaccurate flush confirmation claim**

The Langfuse SDK documents that `flush()` logs errors and retries failed batches without throwing, so this sentence overstates the adapter's ability to confirm successful ingestion through a flush callback. Document the adapter's actual confirmation mechanism or avoid claiming that flush confirms delivery.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: list UserVane in Other integration..."](https://github.com/langfuse/langfuse-docs/commit/5557c3be0fed3a47884746e8c42d34e46592d70e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55430094)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->