### PR TITLE
fix: stop double-counting Spotify pageviews on SPA navigations

### DIFF
--- a/components/analytics/PostHogProvider.tsx
+++ b/components/analytics/PostHogProvider.tsx
@@ -6,7 +6,6 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { hsPageView } from "@/components/analytics/hubspot";
 import { crPageView } from "@/components/analytics/common-room";
-import { spotifyPageView } from "@/lib/spotify-ads";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
 
@@ -39,13 +38,12 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     if (pathname) {
       posthog.capture("$pageview");
       hsPageView(pathname);
-      // The Common Room and Spotify snippets auto-track the first page load, so
-      // only report subsequent client-side navigations to avoid double counting.
+      // Common Room's snippet auto-tracks the first page load, so only report
+      // subsequent client-side navigations to avoid double counting.
       if (isInitialPageView.current) {
         isInitialPageView.current = false;
       } else {
         crPageView();
-        spotifyPageView();
       }
     }
   }, [pathname]);

--- a/components/analytics/spotify-ads.tsx
+++ b/components/analytics/spotify-ads.tsx
@@ -1,10 +1,11 @@
 import Script from "next/script";
 import { SPOTIFY_PIXEL_ID, isSpotifyEnabled } from "@/lib/spotify-ads";
 
-// Spotify Ad Analytics (SpAA) base pixel. Tracks the initial page view; because
-// the docs site is a single-page app, subsequent client-side navigations are
-// reported manually via `spotifyPageView` (see PostHogProvider). Conversions are
-// reported via `reportSpotifyLead` (see lib/ad-conversions.ts).
+// Spotify Ad Analytics (SpAA) base pixel. ping.min.js patches the History API
+// and reports client-side route changes on its own, so this must be the only
+// source of `view` events — reporting SPA navigations manually as well doubles
+// every pageview after the first. Conversions are reported via
+// `reportSpotifyLead` (see lib/ad-conversions.ts).
 export function SpotifyPixel() {
   if (!isSpotifyEnabled) return null;
 

--- a/lib/spotify-ads.ts
+++ b/lib/spotify-ads.ts
@@ -39,11 +39,3 @@ export function reportSpotifyLead(category: string) {
 
   window.spdt("lead", { category });
 }
-
-// Report a page view to Spotify. The base snippet auto-tracks the initial page
-// load, so this is only needed for SPA route changes.
-export function spotifyPageView() {
-  if (!isSpotifyReady()) return;
-
-  window.spdt("view");
-}


### PR DESCRIPTION
Follow-up to #3555. The manual `spotifyPageView()` call added there is redundant and doubles every pageview after the first.

## Cause

`ping.min.js` patches the History API and reports client-side route changes on its own. I had assumed it behaved like the Common Room snippet, which genuinely only sees the first page load and needs manual SPA reporting. Spotify's does not.

## Evidence (measured on production langfuse.com)

Counting POSTs to `pixels.spotify.com/v1/ingest` across one client-side navigation:

| Scenario | Ingest calls per SPA navigation |
| --- | --- |
| With the manual `view` call (current `main`) | **2** |
| With the manual `view` call suppressed | **1** |

Instrumenting `window.spdt` showed exactly **one** `'view'` call originating from our own bundle per navigation, so the second ingest is the library's own history tracking, not a duplicate call from our code.

## Fix

Removes `spotifyPageView()` and its call site in `PostHogProvider`. The base pixel in the root layout is now the only source of `view` events. The `crPageView()` call for Common Room is untouched — that one is still required.

## Impact

Pageview counts in Spotify Ad Analytics have been roughly 2× for client-side navigations since #3555 deployed. Conversions are unaffected: `lead` events fire once per user action and were never routed through the pageview path.

## Verification

- `tsc --noEmit` clean on touched files
- `prettier --check` clean
- No remaining references to `spotifyPageView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change: drops a duplicate pixel pageview call. No auth, data, or conversion-path changes.
> 
> **Overview**
> Stops Spotify Ad Analytics from counting every client-side navigation twice.
> 
> Removes the manual `spotifyPageView()` helper and its call from `PostHogProvider`. The base pixel already patches History and emits `view` events on its own, so extra SPA reporting was redundant. Common Room still uses the skip-first-load path; conversion `lead` events are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9733d5b59d9bb2b767e6ea6f25bdaeab7f32314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes redundant manual Spotify pageview reporting because Spotify’s pixel already tracks History API navigations, preventing SPA pageviews from being counted twice.
- Removes the `spotifyPageView` call from `PostHogProvider`.
- Deletes the now-unused helper from `lib/spotify-ads.ts`.
- Documents the Spotify pixel’s automatic SPA navigation tracking.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the redundant Spotify pageview path removed consistently across its export and sole consumer.

No actionable failure remains; Spotify’s base pixel continues to provide pageview tracking, conversion reporting is unchanged, and no code still references the removed helper.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop double-counting Spotify pagevi..."](https://github.com/langfuse/langfuse-docs/commit/d9733d5b59d9bb2b767e6ea6f25bdaeab7f32314) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55497454)</sub>

<!-- /greptile_comment -->