### PR TITLE
fix: gate ad pixels behind CookieYes advertisement consent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,7 @@ import { RedditPixel } from "@/components/analytics/reddit-ads";
 import { SpotifyPixel } from "@/components/analytics/spotify-ads";
 import { TwitterPixel } from "@/components/analytics/twitter-ads";
 import { ConversionTracker } from "@/components/analytics/ConversionTracker";
+import { AdConsentGate } from "@/components/analytics/AdConsentGate";
 import { ClickIdPersistence } from "@/components/analytics/ClickIdPersistence";
 import { CommonRoom } from "@/components/analytics/common-room";
 import { AhrefsAnalytics } from "@/components/analytics/ahrefs";
@@ -99,11 +100,17 @@ export default function RootLayout({
         {process.env.NODE_ENV === "production" && (
           <>
             <GoogleTagManager gtmId="GTM-NGLK4TZX" />
-            <GoogleAds />
-            <LinkedInInsightTag />
-            <RedditPixel />
-            <SpotifyPixel />
-            <TwitterPixel />
+            {/* Ad pixels require prior consent (CookieYes "advertisement"
+                category). The gate keeps them from loading or setting cookies
+                until it is granted; every conversion helper already no-ops
+                when its tag is absent, so nothing else needs gating. */}
+            <AdConsentGate>
+              <GoogleAds />
+              <LinkedInInsightTag />
+              <RedditPixel />
+              <SpotifyPixel />
+              <TwitterPixel />
+            </AdConsentGate>
             <ConversionTracker />
             <ClickIdPersistence />
             <Hubspot />

--- a/components/analytics/AdConsentGate.tsx
+++ b/components/analytics/AdConsentGate.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { readAdvertisementConsent } from "@/lib/cookie-consent";
+
+// Renders its children (the ad pixels) only once the CookieYes "advertisement"
+// category is granted, so no ad tag loads or sets cookies before consent.
+// CookieYes's own script-blocking does not catch these tags (they are injected
+// dynamically via next/script), which is why the gate exists in code.
+//
+// Consent is detected the same way as in ClickIdPersistence:
+//  - an initial check on mount (returning visitors with stored consent),
+//  - `cookieyes_banner_load`, which makes the consent state readable at all
+//    and is the only signal in notice-only regions where the category is
+//    granted without any banner interaction,
+//  - `cookieyes_consent_update`, when the visitor answers the banner or edits
+//    their choices in the preference center.
+//
+// Once granted, the gate stays open for the lifetime of the page: loaded
+// scripts cannot be un-executed, so revoking consent takes effect on the next
+// page load, when the gate starts closed again.
+export function AdConsentGate({ children }: { children: React.ReactNode }) {
+  const [granted, setGranted] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      if (readAdvertisementConsent() === "granted") setGranted(true);
+    };
+
+    check();
+    document.addEventListener("cookieyes_banner_load", check);
+    document.addEventListener("cookieyes_consent_update", check);
+    return () => {
+      document.removeEventListener("cookieyes_banner_load", check);
+      document.removeEventListener("cookieyes_consent_update", check);
+    };
+  }, []);
+
+  return granted ? <>{children}</> : null;
+}

--- a/components/analytics/ClickIdPersistence.tsx
+++ b/components/analytics/ClickIdPersistence.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { readAdvertisementConsent } from "@/lib/cookie-consent";
 
 // Ad-platform click-id URL params appended to landing pages by ad clicks.
 const CLICK_ID_PARAMS = [
@@ -15,58 +16,13 @@ const CLICK_ID_PARAMS = [
 const CLICK_ID_FORMAT = /^[A-Za-z0-9_.-]{1,512}$/;
 const NINETY_DAYS_IN_SECONDS = 90 * 24 * 60 * 60;
 
-type CkyConsent = {
-  categories?: {
-    advertisement?: boolean;
-  };
-};
-
-declare global {
-  interface Window {
-    getCkyConsent?: () => CkyConsent;
-  }
-}
-
 // Click ids are ad-click attribution data, so they fall under the CookieYes
-// "advertisement" category — the same category that gates the Google Ads /
-// LinkedIn / Reddit pixels. Unlike those, this is first-party inline code
-// that CookieYes can't script-block, so consent is checked explicitly here.
-//
-// Three states, not a boolean: `getCkyConsent()` only returns real data once
-// the CookieYes banner has finished loading, so an early read can look like a
-// denial when the visitor has in fact consented. Treating that as "denied"
-// would expire previously stored click ids (see `syncClickIdCookies`), and a
-// return visit has no click-id params in the URL to rewrite them from.
-// "unknown" therefore means "leave everything as it is".
-type ConsentState = "granted" | "denied" | "unknown";
-
-function readAdvertisementConsent(): ConsentState {
-  // The live API wins whenever it can answer: it reflects in-session changes
-  // — most importantly a revoke in the preference center — that the persisted
-  // cookie may not have been rewritten with yet. Withdrawal must never be
-  // masked by a stale grant, so a conclusive `false` here is a denial even if
-  // the cookie still says yes.
-  try {
-    const advertisement = window.getCkyConsent?.()?.categories?.advertisement;
-    if (typeof advertisement === "boolean")
-      return advertisement ? "granted" : "denied";
-  } catch {
-    // an unavailable API is inconclusive, not a denial — fall through
-  }
-
-  // CookieYes has not loaded (or is blocked), so fall back to its persisted
-  // cookie: the durable record of an earlier decision, which survives reloads
-  // and is written in notice-only regions too, where the category is granted
-  // by default. It enumerates every category, so its presence is conclusive.
-  const consentCookie = document.cookie
-    .split("; ")
-    .find((cookie) => cookie.startsWith("cookieyes-consent="));
-  if (consentCookie)
-    return consentCookie.includes("advertisement:yes") ? "granted" : "denied";
-
-  // Neither source could answer: leave any stored click ids untouched.
-  return "unknown";
-}
+// "advertisement" category — the same category the AdConsentGate uses for the
+// ad pixels. Unlike those, this is first-party inline code, and a wrong
+// "denied" reading would expire previously stored click ids (see
+// `syncClickIdCookies`) that a return visit can't rewrite from the URL — so
+// the shared three-state `readAdvertisementConsent` is used and "unknown"
+// means "leave everything as it is".
 
 function syncClickIdCookies(clickIds: Partial<Record<string, string>>) {
   const { hostname, protocol } = window.location;

--- a/global.d.ts
+++ b/global.d.ts
@@ -2,6 +2,11 @@ interface Window {
   _hsq?: any[];
   dataLayer?: any[];
   gtag?: (...args: any[]) => void;
+  getCkyConsent?: () => {
+    activeLaw: string;
+    categories: Record<string, boolean>;
+    isUserActionCompleted: boolean;
+  };
   lintrk?: (...args: any[]) => void;
   _linkedin_data_partner_ids?: any[];
   rdt?: (...args: any[]) => void;

--- a/lib/cookie-consent.ts
+++ b/lib/cookie-consent.ts
@@ -1,0 +1,41 @@
+// CookieYes "advertisement"-category consent, read client-side. Shared by the
+// AdConsentGate (which keeps ad pixels from loading pre-consent) and
+// ClickIdPersistence (which stores/expires first-party click-id cookies).
+//
+// Three states, not a boolean: `getCkyConsent()` only returns real data once
+// the CookieYes banner has finished loading, so an early read can look like a
+// denial when the visitor has in fact consented. Callers that must not act on
+// a wrong "denied" (like ClickIdPersistence, which would expire previously
+// stored click ids) treat "unknown" as "leave everything as it is"; callers
+// that gate script loading simply keep the gate closed until "granted".
+export type ConsentState = "granted" | "denied" | "unknown";
+
+export function readAdvertisementConsent(): ConsentState {
+  if (typeof window === "undefined") return "unknown";
+
+  // The live API wins whenever it can answer: it reflects in-session changes
+  // — most importantly a revoke in the preference center — that the persisted
+  // cookie may not have been rewritten with yet. Withdrawal must never be
+  // masked by a stale grant, so a conclusive `false` here is a denial even if
+  // the cookie still says yes.
+  try {
+    const advertisement = window.getCkyConsent?.()?.categories?.advertisement;
+    if (typeof advertisement === "boolean")
+      return advertisement ? "granted" : "denied";
+  } catch {
+    // an unavailable API is inconclusive, not a denial — fall through
+  }
+
+  // CookieYes has not loaded (or is blocked), so fall back to its persisted
+  // cookie: the durable record of an earlier decision, which survives reloads
+  // and is written in notice-only regions too, where the category is granted
+  // by default. It enumerates every category, so its presence is conclusive.
+  const consentCookie = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith("cookieyes-consent="));
+  if (consentCookie)
+    return consentCookie.includes("advertisement:yes") ? "granted" : "denied";
+
+  // Neither source could answer.
+  return "unknown";
+}


### PR DESCRIPTION
## Problem

On production, for a fresh EU visitor (CookieYes reports `activeLaw: "gdpr"`, `advertisement: false`, no banner interaction), all five ad pixels — Google Ads, LinkedIn, Reddit, Spotify, X — load anyway and set tracking cookies (`__spdt`, `_rdt_uuid`, `_twpid` observed before any consent). Under GDPR/ePrivacy these need prior opt-in consent. CookieYes's own script-blocking does not catch the tags because they are injected dynamically via `next/script` — a comment in `ClickIdPersistence` assumed that blocking covered them, but measured behavior shows it does not.

## Fix

A new `AdConsentGate` client component wraps the five pixel components in the root layout and renders them only once the CookieYes `advertisement` category is granted.

Consent detection mirrors the pattern already established in `ClickIdPersistence`:
- initial check on mount — returning visitors with stored consent get pixels immediately,
- `cookieyes_banner_load` — the only signal in notice-only regions, where CookieYes grants the category with no user interaction,
- `cookieyes_consent_update` — the visitor answers the banner or edits the preference center.

Once open, the gate stays open for the page's lifetime (loaded scripts can't be un-executed); revoking consent takes effect on the next page load.

## Refactor included

The three-state consent reader (`granted` / `denied` / `unknown`) is extracted from `ClickIdPersistence` into a shared `lib/cookie-consent.ts` — logic and comments preserved verbatim, behavior unchanged — and the `getCkyConsent` window declaration is centralized in `global.d.ts` (the local `declare global` in `ClickIdPersistence` would have collided with a second declaration).

## What deliberately isn't gated

- **`ConversionTracker` / `lib/ad-conversions.ts`** — every platform helper already no-ops when its tag is absent, so a non-consenting visitor's CTA click reports to zero platforms with no further changes.
- **GTM, PostHog, HubSpot, Common Room, Ahrefs** — different consent categories (analytics/functional) and a policy question for whoever owns privacy; out of scope here so this PR stays a pure advertisement-category fix.

## Expected impact

EU ad attribution (pageviews and conversions on all five platforms) will drop to consenting visitors only — that is the corrected baseline, not a regression. Non-GDPR regions are unaffected in practice: the gate follows CookieYes's own state, which grants the category automatically under opt-out/notice-only laws.

## Verification

- 10-scenario test of the consent reader (GDPR accept/reject, returning visitor before the banner script loads, in-session revoke masking a stale cookie grant, notice-only auto-grant, empty cookie jar, API throwing) — all pass
- `tsc --noEmit` clean on all touched files
- `prettier --check` clean
- Live check on the Vercel preview to follow in a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GDPR/ePrivacy consent and ad-tracking load order. A wrong consent read would either leak pixels before opt-in or drop attribution for consenting visitors.
> 
> **Overview**
> Stops production ad pixels (Google Ads, LinkedIn, Reddit, Spotify, X) from loading until CookieYes **advertisement** consent is granted. CookieYes script-blocking does not catch these `next/script` tags, so they previously set tracking cookies for GDPR visitors with no opt-in.
> 
> Adds `AdConsentGate`, which mounts the pixels only after `readAdvertisementConsent()` is `"granted"` (on mount, `cookieyes_banner_load`, and `cookieyes_consent_update`). The gate stays open for the page lifetime; revoke applies on the next load. Conversion helpers are left ungated because they already no-op when tags are missing.
> 
> Extracts the three-state consent reader from `ClickIdPersistence` into shared `lib/cookie-consent.ts` and centralizes `getCkyConsent` on `Window`. Click-id cookie behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b55dd6a1fb8e36309acd0a4896cb9acf10827ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents advertisement pixels from rendering until CookieYes reports advertisement consent and centralizes the shared three-state consent reader.
- Wraps Google Ads, LinkedIn, Reddit, Spotify, and X pixels in a client-side consent gate.
- Checks consent on mount and after CookieYes banner-load or consent-update events.
- Reuses the same consent state logic for click-ID persistence and centralizes the CookieYes window type.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The consent gate remains closed until a live or persisted advertisement grant is observed, then renders the existing pixel loaders; absent tags continue to make conversion reporting safely no-op.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Production page loads] --> B[AdConsentGate mounts closed]
  B --> C[Read CookieYes live API or persisted cookie]
  B --> D[Listen for banner load and consent update]
  D --> C
  C -->|Granted| E[Render ad pixel components]
  C -->|Denied or unknown| F[Keep pixels unloaded]
  E --> G[Vendor globals become available]
  G --> H[Conversion helpers can report events]
  F --> I[Conversion helpers safely no-op]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gate ad pixels behind CookieYes adv..."](https://github.com/langfuse/langfuse-docs/commit/2b55dd6a1fb8e36309acd0a4896cb9acf10827ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55507662)</sub>

**Context used:**

- Knowledge Base — [App Router structure](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/app-routing.md)
- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)

<!-- /greptile_comment -->