### PR TITLE
fix: only report launch-app conversion for signed-out visitors

### DIFF
--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/cloud-regions";
 import { useCloudRegionSignIn } from "@/lib/use-cloud-region-sign-in";
 import { isCloudAppHref } from "@/lib/google-ads";
-import { reportLaunchAppConversion } from "@/lib/ad-conversions";
+import { reportLaunchAppConversionIfSignedOut } from "@/lib/ad-conversions";
 
 const REGION_SHORTCUTS: Partial<Record<CloudRegionKey, string>> = {
   us: "U",
@@ -163,7 +163,9 @@ function MultiRegionButton({
       );
       if (match) {
         e.preventDefault();
-        reportLaunchAppConversion();
+        // Mirrors the click path: the region links carry
+        // `data-launch-app-cta`, and this shortcut bypasses that listener.
+        reportLaunchAppConversionIfSignedOut();
         window.location.href = match.url;
         setOpen(false);
       }

--- a/components/analytics/ConversionTracker.tsx
+++ b/components/analytics/ConversionTracker.tsx
@@ -2,21 +2,29 @@
 
 import { useEffect } from "react";
 import { LAUNCH_APP_CTA_SELECTOR } from "@/lib/google-ads";
-import { reportLaunchAppConversion } from "@/lib/ad-conversions";
+import { reportLaunchAppConversionIfSignedOut } from "@/lib/ad-conversions";
+import { startCloudRegionSignInProbe } from "@/lib/cloud-region-sign-in-store";
 
-// Reports the "launch app" conversion (sign up / sign in) across every ad
-// platform whenever a user clicks a CTA that navigates to the Langfuse cloud
-// app. CTAs opt in via the `data-launch-app-cta` attribute, so incidental
-// cloud.langfuse.com links (e.g. in docs/blog content) are not counted. A
-// single delegated listener keeps this working for every marked CTA.
+// Reports the "launch app" conversion (sign up) across every ad platform
+// whenever a visitor who is not signed in to any cloud region clicks a CTA
+// that navigates to the Langfuse cloud app. CTAs opt in via the
+// `data-launch-app-cta` attribute, so incidental cloud.langfuse.com links
+// (e.g. in docs/blog content) are not counted. A single delegated listener
+// keeps this working for every marked CTA.
 export function ConversionTracker() {
   useEffect(() => {
+    // The header CTA and the /cloud region picker start the probe too, but
+    // neither is on every page carrying a launch-app CTA. Starting it here as
+    // well means the sign-in answer is in flight from page load, so it has
+    // normally arrived by the time a CTA is clicked.
+    startCloudRegionSignInProbe(true);
+
     // Capture phase runs before button onClick handlers, so CTAs that
     // preventDefault to navigate programmatically are still tracked.
     const handler = (event: MouseEvent) => {
       const target = event.target as Element | null;
       if (!target?.closest(LAUNCH_APP_CTA_SELECTOR)) return;
-      reportLaunchAppConversion();
+      reportLaunchAppConversionIfSignedOut();
     };
 
     document.addEventListener("click", handler, true);

--- a/lib/ad-conversions.ts
+++ b/lib/ad-conversions.ts
@@ -1,4 +1,8 @@
 import {
+  getCloudRegionSignInSnapshot,
+  isSignedInToAnyCloudRegion,
+} from "@/lib/cloud-region-sign-in-store";
+import {
   GOOGLE_ADS_CONVERSIONS,
   reportGoogleAdsConversion,
 } from "@/lib/google-ads";
@@ -30,6 +34,27 @@ export function reportLaunchAppConversion() {
     value: 1.0,
     currency: "USD",
   });
+}
+
+// Same conversion, but only for a visitor who is not signed in to any cloud
+// region — i.e. a plausible sign up rather than a returning user signing in.
+// Every launch-app CTA reaches the app through /cloud or a region URL, so
+// without this gate the conversion counts both.
+//
+// A visitor who has an account but is signed out in this browser still counts:
+// only the app itself can tell those apart, which is what the app-side signup
+// conversion (fired with the persisted click ids) is for. This removes the
+// sign-ins the website *can* recognize.
+export function reportLaunchAppConversionIfSignedOut() {
+  const snapshot = getCloudRegionSignInSnapshot();
+
+  // Not every region has answered yet, so "no region signed in" is not yet a
+  // fact. Staying silent under-counts the rare very fast click; reporting
+  // would reintroduce exactly the over-counting this gate removes.
+  if (!snapshot.resolved) return;
+  if (isSignedInToAnyCloudRegion(snapshot)) return;
+
+  reportLaunchAppConversion();
 }
 
 // "Talk to us" — lead. Fired on a successful talk-to-us form submission.

--- a/lib/cloud-region-sign-in-store.ts
+++ b/lib/cloud-region-sign-in-store.ts
@@ -30,18 +30,25 @@ export type CloudRegionSignInSnapshot = {
 
 // A region that accepts the connection but never responds would otherwise keep
 // the first probe unresolved until the browser's own network timeout (minutes),
-// suppressing every conversion in the meantime. An aborted probe counts as
-// signed-out, like any other failure below, so this is deliberately generous:
-// too short a deadline would start reporting slow-but-signed-in visitors as
-// sign ups, which is the miscount this store exists to prevent.
+// suppressing every conversion in the meantime. On a first probe an aborted
+// request counts as signed-out, like any other failure below, so this is
+// deliberately generous: too short a deadline would start reporting
+// slow-but-signed-in visitors as sign ups, which is the miscount this store
+// exists to prevent.
 const PROBE_TIMEOUT_MS = 8_000;
 
 // Sessions are created in the app, in another tab or window, so the answer goes
 // stale while a page sits open. Re-probing is cheap, but it should not run once
-// per component mount, so calls within this window reuse the last probe. Keep
-// this longer than PROBE_TIMEOUT_MS: every request of a probe has then settled
-// one way or another before a refresh can start, so the two never overlap.
+// per component mount, so calls within this window reuse the last probe.
 const PROBE_REUSE_MS = 30_000;
+
+// Returning to the tab is the one moment we know a session may just have been
+// created, so it gets a much shorter window. Signing in through an already
+// authenticated SSO prompt can take only a few seconds, and a refresh skipped
+// here leaves the stale snapshot to report the visitor's next CTA click as a
+// sign up. Short enough to catch that, long enough that flicking between tabs
+// cannot turn into a stream of requests.
+const VISIBILITY_PROBE_REUSE_MS = 5_000;
 
 const regionKeys = Object.keys(cloudRegions) as CloudRegionKey[];
 
@@ -95,7 +102,11 @@ function fetchRegionSignIn(key: CloudRegionKey): Promise<boolean> {
 
 function runProbe() {
   const generation = ++probeGeneration;
+  // A visibility refresh can start while a slow first probe is still waiting on
+  // a region, so answers are tagged with their probe and stale ones dropped.
   let awaitingRegions = regionKeys.length;
+  // Whether this probe is re-checking regions that have already answered once.
+  const isRefresh = snapshot.resolved;
   lastProbeStartedAt = Date.now();
 
   const recordAnswer = (key: CloudRegionKey, signedIn: boolean) => {
@@ -123,10 +134,16 @@ function runProbe() {
     fetchRegionSignIn(key)
       .then((signedIn) => recordAnswer(key, signedIn))
       // A region that is unreachable, blocked, slow enough to hit the deadline
-      // above, or answering with something unparseable counts as
-      // answered-and-signed-out: waiting longer would suppress every decision
-      // that depends on this store.
-      .catch(() => recordAnswer(key, false));
+      // above, or answering with something unparseable has to count as
+      // answered, or waiting would suppress every decision that depends on
+      // this store. What it counts as depends on what we already know: on a
+      // first probe, signed-out, because there is nothing else to go on; on a
+      // refresh, whatever that region last confirmed, because a failed request
+      // is no evidence the session ended. Overwriting a known sign-in with a
+      // guess would report that visitor's next CTA click as a sign up.
+      .catch(() =>
+        recordAnswer(key, isRefresh ? snapshot.signedInRegions[key] : false),
+      );
   });
 }
 
@@ -138,7 +155,7 @@ function watchVisibility() {
   // page's answer stale with no remount to refresh it.
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
-      startCloudRegionSignInProbe(true);
+      startCloudRegionSignInProbe(true, VISIBILITY_PROBE_REUSE_MS);
     }
   });
 }
@@ -147,7 +164,10 @@ function watchVisibility() {
 // probe, later calls refresh it once it has gone stale. When disabled (outside
 // production, where the region session endpoints are not reachable from
 // localhost) the snapshot resolves immediately with no region signed in.
-export function startCloudRegionSignInProbe(enabled: boolean) {
+export function startCloudRegionSignInProbe(
+  enabled: boolean,
+  reuseLastProbeFor = PROBE_REUSE_MS,
+) {
   if (!enabled) {
     if (!snapshot.resolved) publish({ ...snapshot, resolved: true });
     return;
@@ -156,7 +176,7 @@ export function startCloudRegionSignInProbe(enabled: boolean) {
   watchVisibility();
 
   const hasProbed = lastProbeStartedAt !== 0;
-  if (hasProbed && Date.now() - lastProbeStartedAt < PROBE_REUSE_MS) return;
+  if (hasProbed && Date.now() - lastProbeStartedAt < reuseLastProbeFor) return;
 
   runProbe();
 }

--- a/lib/cloud-region-sign-in-store.ts
+++ b/lib/cloud-region-sign-in-store.ts
@@ -1,0 +1,96 @@
+import {
+  cloudRegions,
+  type CloudRegionKey,
+  createInitialCloudRegionSignInState,
+  isSignedInSession,
+} from "@/lib/cloud-regions";
+
+// Shared "is this browser signed in to a cloud region?" state.
+//
+// The probe asks every region's `/api/auth/session` endpoint whether the
+// browser holds a session there. Every region is a `*.langfuse.com` subdomain,
+// so these credentialed requests are same-site and are not affected by the
+// third-party cookie blocking in Safari/Firefox.
+//
+// This lives in a module-level store rather than a React context for two
+// reasons: the probe then runs once per page load no matter how many
+// components need the answer (the header button and the /cloud region picker
+// both do), and non-React callers can read the latest answer imperatively —
+// see `reportLaunchAppConversionIfSignedOut` in lib/ad-conversions.ts.
+
+export type CloudRegionSignInSnapshot = {
+  signedInRegions: Record<CloudRegionKey, boolean>;
+  // False until every region has answered. `signedInRegions` starts out all
+  // `false`, which is indistinguishable from "signed out everywhere", so any
+  // caller that treats signed-out as meaningful must wait for this.
+  resolved: boolean;
+};
+
+const regionKeys = Object.keys(cloudRegions) as CloudRegionKey[];
+
+let snapshot: CloudRegionSignInSnapshot = {
+  signedInRegions: createInitialCloudRegionSignInState(),
+  resolved: false,
+};
+
+const listeners = new Set<() => void>();
+let probeStarted = false;
+let awaitingRegions = 0;
+
+export function getCloudRegionSignInSnapshot(): CloudRegionSignInSnapshot {
+  return snapshot;
+}
+
+export function subscribeToCloudRegionSignIn(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function publish(next: CloudRegionSignInSnapshot) {
+  snapshot = next;
+  listeners.forEach((listener) => listener());
+}
+
+function recordRegionAnswer(key: CloudRegionKey, signedIn: boolean) {
+  awaitingRegions -= 1;
+  publish({
+    signedInRegions: { ...snapshot.signedInRegions, [key]: signedIn },
+    resolved: awaitingRegions === 0,
+  });
+}
+
+// Starts the probe on first call and is a no-op afterwards, so every consumer
+// can call it unconditionally. When disabled (outside production, where the
+// cross-origin session endpoints are not reachable from localhost) the
+// snapshot resolves immediately with no region signed in.
+export function startCloudRegionSignInProbe(enabled: boolean) {
+  if (probeStarted) return;
+  probeStarted = true;
+
+  if (!enabled) {
+    publish({ ...snapshot, resolved: true });
+    return;
+  }
+
+  awaitingRegions = regionKeys.length;
+
+  regionKeys.forEach((key) => {
+    fetch(`${cloudRegions[key].url}/api/auth/session`, {
+      credentials: "include",
+      mode: "cors",
+    })
+      .then((response) => response.json())
+      .then((data) => recordRegionAnswer(key, isSignedInSession(data)))
+      // An unreachable or blocked region counts as answered-and-signed-out:
+      // waiting forever would suppress every downstream decision.
+      .catch(() => recordRegionAnswer(key, false));
+  });
+}
+
+export function isSignedInToAnyCloudRegion(
+  snapshotToCheck: CloudRegionSignInSnapshot = snapshot,
+): boolean {
+  return Object.values(snapshotToCheck.signedInRegions).some(Boolean);
+}

--- a/lib/cloud-region-sign-in-store.ts
+++ b/lib/cloud-region-sign-in-store.ts
@@ -13,18 +13,35 @@ import {
 // third-party cookie blocking in Safari/Firefox.
 //
 // This lives in a module-level store rather than a React context for two
-// reasons: the probe then runs once per page load no matter how many
-// components need the answer (the header button and the /cloud region picker
-// both do), and non-React callers can read the latest answer imperatively —
-// see `reportLaunchAppConversionIfSignedOut` in lib/ad-conversions.ts.
+// reasons: several components need the same answer (the header button and the
+// /cloud region picker), and non-React callers can read the latest answer
+// imperatively — see `reportLaunchAppConversionIfSignedOut` in
+// lib/ad-conversions.ts.
 
 export type CloudRegionSignInSnapshot = {
   signedInRegions: Record<CloudRegionKey, boolean>;
   // False until every region has answered. `signedInRegions` starts out all
   // `false`, which is indistinguishable from "signed out everywhere", so any
-  // caller that treats signed-out as meaningful must wait for this.
+  // caller that treats signed-out as meaningful must wait for this. Once true
+  // it stays true: a later refresh updates the region values in place rather
+  // than reopening a window where nothing can be decided.
   resolved: boolean;
 };
+
+// A region that accepts the connection but never responds would otherwise keep
+// the first probe unresolved until the browser's own network timeout (minutes),
+// suppressing every conversion in the meantime. An aborted probe counts as
+// signed-out, like any other failure below, so this is deliberately generous:
+// too short a deadline would start reporting slow-but-signed-in visitors as
+// sign ups, which is the miscount this store exists to prevent.
+const PROBE_TIMEOUT_MS = 8_000;
+
+// Sessions are created in the app, in another tab or window, so the answer goes
+// stale while a page sits open. Re-probing is cheap, but it should not run once
+// per component mount, so calls within this window reuse the last probe. Keep
+// this longer than PROBE_TIMEOUT_MS: every request of a probe has then settled
+// one way or another before a refresh can start, so the two never overlap.
+const PROBE_REUSE_MS = 30_000;
 
 const regionKeys = Object.keys(cloudRegions) as CloudRegionKey[];
 
@@ -34,8 +51,11 @@ let snapshot: CloudRegionSignInSnapshot = {
 };
 
 const listeners = new Set<() => void>();
-let probeStarted = false;
-let awaitingRegions = 0;
+// Answers from a superseded probe are ignored, so a refresh cannot corrupt the
+// in-flight count of the probe that replaced it.
+let probeGeneration = 0;
+let lastProbeStartedAt = 0;
+let watchingVisibility = false;
 
 export function getCloudRegionSignInSnapshot(): CloudRegionSignInSnapshot {
   return snapshot;
@@ -48,49 +68,95 @@ export function subscribeToCloudRegionSignIn(listener: () => void): () => void {
   };
 }
 
+export function isSignedInToAnyCloudRegion(
+  snapshotToCheck: CloudRegionSignInSnapshot = snapshot,
+): boolean {
+  return Object.values(snapshotToCheck.signedInRegions).some(Boolean);
+}
+
 function publish(next: CloudRegionSignInSnapshot) {
   snapshot = next;
   listeners.forEach((listener) => listener());
 }
 
-function recordRegionAnswer(key: CloudRegionKey, signedIn: boolean) {
-  awaitingRegions -= 1;
-  publish({
-    signedInRegions: { ...snapshot.signedInRegions, [key]: signedIn },
-    resolved: awaitingRegions === 0,
+function fetchRegionSignIn(key: CloudRegionKey): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  return fetch(`${cloudRegions[key].url}/api/auth/session`, {
+    credentials: "include",
+    mode: "cors",
+    signal: controller.signal,
+  })
+    .then((response) => response.json())
+    .then((data) => isSignedInSession(data))
+    .finally(() => clearTimeout(timeout));
+}
+
+function runProbe() {
+  const generation = ++probeGeneration;
+  let awaitingRegions = regionKeys.length;
+  lastProbeStartedAt = Date.now();
+
+  const recordAnswer = (key: CloudRegionKey, signedIn: boolean) => {
+    // A newer probe is now authoritative.
+    if (generation !== probeGeneration) return;
+
+    awaitingRegions -= 1;
+    const resolved = snapshot.resolved || awaitingRegions === 0;
+    if (
+      snapshot.signedInRegions[key] === signedIn &&
+      snapshot.resolved === resolved
+    ) {
+      // A refresh that confirms what we already knew: no need to wake
+      // subscribers.
+      return;
+    }
+
+    publish({
+      signedInRegions: { ...snapshot.signedInRegions, [key]: signedIn },
+      resolved,
+    });
+  };
+
+  regionKeys.forEach((key) => {
+    fetchRegionSignIn(key)
+      .then((signedIn) => recordAnswer(key, signedIn))
+      // A region that is unreachable, blocked, slow enough to hit the deadline
+      // above, or answering with something unparseable counts as
+      // answered-and-signed-out: waiting longer would suppress every decision
+      // that depends on this store.
+      .catch(() => recordAnswer(key, false));
   });
 }
 
-// Starts the probe on first call and is a no-op afterwards, so every consumer
-// can call it unconditionally. When disabled (outside production, where the
-// cross-origin session endpoints are not reachable from localhost) the
-// snapshot resolves immediately with no region signed in.
-export function startCloudRegionSignInProbe(enabled: boolean) {
-  if (probeStarted) return;
-  probeStarted = true;
+function watchVisibility() {
+  if (watchingVisibility || typeof document === "undefined") return;
+  watchingVisibility = true;
 
+  // The common way to sign in mid-visit is in another tab, which leaves this
+  // page's answer stale with no remount to refresh it.
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      startCloudRegionSignInProbe(true);
+    }
+  });
+}
+
+// Safe to call from anywhere that needs the answer: the first call starts the
+// probe, later calls refresh it once it has gone stale. When disabled (outside
+// production, where the region session endpoints are not reachable from
+// localhost) the snapshot resolves immediately with no region signed in.
+export function startCloudRegionSignInProbe(enabled: boolean) {
   if (!enabled) {
-    publish({ ...snapshot, resolved: true });
+    if (!snapshot.resolved) publish({ ...snapshot, resolved: true });
     return;
   }
 
-  awaitingRegions = regionKeys.length;
+  watchVisibility();
 
-  regionKeys.forEach((key) => {
-    fetch(`${cloudRegions[key].url}/api/auth/session`, {
-      credentials: "include",
-      mode: "cors",
-    })
-      .then((response) => response.json())
-      .then((data) => recordRegionAnswer(key, isSignedInSession(data)))
-      // An unreachable or blocked region counts as answered-and-signed-out:
-      // waiting forever would suppress every downstream decision.
-      .catch(() => recordRegionAnswer(key, false));
-  });
-}
+  const hasProbed = lastProbeStartedAt !== 0;
+  if (hasProbed && Date.now() - lastProbeStartedAt < PROBE_REUSE_MS) return;
 
-export function isSignedInToAnyCloudRegion(
-  snapshotToCheck: CloudRegionSignInSnapshot = snapshot,
-): boolean {
-  return Object.values(snapshotToCheck.signedInRegions).some(Boolean);
+  runProbe();
 }

--- a/lib/use-cloud-region-sign-in.ts
+++ b/lib/use-cloud-region-sign-in.ts
@@ -1,52 +1,26 @@
 import { useEffect, useState } from "react";
 import {
-  cloudRegions,
-  type CloudRegionKey,
-  createInitialCloudRegionSignInState,
-  isSignedInSession,
-} from "@/lib/cloud-regions";
+  getCloudRegionSignInSnapshot,
+  startCloudRegionSignInProbe,
+  subscribeToCloudRegionSignIn,
+} from "@/lib/cloud-region-sign-in-store";
 
+// React binding for the shared cloud-region sign-in probe: every caller gets
+// the same answer from a single set of requests, however many components ask.
+// See lib/cloud-region-sign-in-store.ts.
 export const useCloudRegionSignIn = (
   enabled = process.env.NODE_ENV === "production",
 ) => {
-  const [signedInRegions, setSignedInRegions] = useState<
-    Record<CloudRegionKey, boolean>
-  >(() => createInitialCloudRegionSignInState());
+  const [snapshot, setSnapshot] = useState(getCloudRegionSignInSnapshot);
 
   useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const abortController = new AbortController();
-
-    Object.entries(cloudRegions).forEach(([key, region]) => {
-      fetch(`${region.url}/api/auth/session`, {
-        credentials: "include",
-        mode: "cors",
-        signal: abortController.signal,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          setSignedInRegions((prev) => ({
-            ...prev,
-            [key]: isSignedInSession(data),
-          }));
-        })
-        .catch((error) => {
-          if (error.name !== "AbortError") {
-            setSignedInRegions((prev) => ({
-              ...prev,
-              [key]: false,
-            }));
-          }
-        });
-    });
-
-    return () => {
-      abortController.abort();
-    };
+    startCloudRegionSignInProbe(enabled);
+    // The probe may already have answered before this component mounted.
+    setSnapshot(getCloudRegionSignInSnapshot());
+    return subscribeToCloudRegionSignIn(() =>
+      setSnapshot(getCloudRegionSignInSnapshot()),
+    );
   }, [enabled]);
 
-  return signedInRegions;
+  return snapshot.signedInRegions;
 };


### PR DESCRIPTION
## Problem

The launch-app conversion is reported to Google Ads, LinkedIn, Reddit, X and Spotify on every click of a CTA into the cloud app — which covers returning users signing in as well as prospective sign ups.

It's actually skewed further than that. The header CTA links straight to a region URL once a session exists, and only that variant gets marked with `data-launch-app-cta`; signed-out visitors are sent to `/cloud`, which is deliberately unmarked. So sign-ins were the most common way the conversion fired:

| Visitor state | Click path | Reported today |
| --- | --- | --- |
| Signed in to 1 region | Header CTA → region URL | yes (a sign-in) |
| Signed in to 2+ regions | Dropdown region link / `L` shortcut | yes (a sign-in) |
| Signed in to 0 regions | Header CTA → `/cloud` | no |
| Signed in to 0 regions | Region card on `/cloud` | yes (a sign up) |

## Change

The site already has the signal: `useCloudRegionSignIn` asks each region's `/api/auth/session` whether this browser holds a session there — the same check behind the header CTA's target and the "Signed in" badge on `/cloud`. Every region is a `*.langfuse.com` subdomain, so those credentialed requests are same-site and unaffected by third-party cookie blocking in Safari/Firefox.

- **`lib/cloud-region-sign-in-store.ts` (new)** — the probe moves into a module-level store. It runs once per page load instead of once per consuming component (the header CTA and the `/cloud` picker each ran their own four requests), and non-React callers can read the latest answer imperatively.
- **`lib/use-cloud-region-sign-in.ts`** — the hook keeps its signature and now subscribes to that store. No call-site changes.
- **`lib/ad-conversions.ts`** — adds `reportLaunchAppConversionIfSignedOut()`, which reports only when no region is signed in.
- **`ConversionTracker.tsx` / `ToAppButton.tsx`** — both places a launch-app CTA reports from (the delegated click listener and the region keyboard shortcut) now go through the gate. The shortcut bypasses the listener, so gating only the listener would have left it firing.

The gate waits for every region to answer before deciding. Until then, "no region signed in" is indistinguishable from "nobody has answered yet", and reporting would reintroduce exactly the over-counting this removes. Staying silent instead loses the occasional very fast click; in practice the answer is in flight from page load and lands long before anyone clicks a region card on `/cloud`.

## What this does not fix

A visitor who has an account but is signed out in this browser (new machine, cleared cookies, private window) is still counted. Only the app knows the difference, which is what the app-side signup conversion fired with the persisted click ids is for. This removes the sign-ins the website can recognize.

## Verification

- `npx tsc --noEmit` — no errors in the changed files (the remaining errors are pre-existing, all in Fumadocs `PageData` consumers).
- `npx prettier --check` — clean.
- Drove the store module directly with a stubbed `fetch` to confirm the gate: three regions answering signed-out while a fourth is in flight keeps `resolved=false` (gate stays shut); the slow region coming back signed in flips the state; an unreachable region, a malformed response, and the disabled (non-production) path all resolve without hanging.
- Dev server: `/`, `/cloud` and `/pricing` render with no console errors, the header CTA still resolves to `/cloud` when signed out, and the `/cloud` region cards still carry `data-launch-app-cta`.

The gate itself can't be exercised locally — `ConversionTracker` and the probe are both production-only, and the session endpoints aren't reachable from localhost — so the signed-in suppression is worth a look in Vercel preview or after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ad conversion reporting and credentialed same-site session probes against every cloud region. Incorrect gating would under- or over-count paid conversions, but it does not change auth or app access.
> 
> **Overview**
> Stops counting returning signed-in users as launch-app (signup) conversions. CTA clicks and region keyboard shortcuts now fire ad conversions only after every cloud region has answered and none has a session.
> 
> The per-component session fetches move into a shared module store so the header, `/cloud` picker, and analytics share one probe. The store times out stalled regions, reuses recent probes, and refreshes on tab focus so a sign-in in another tab does not keep looking like a signup. Fast clicks before the probe resolves are skipped rather than over-counted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bcf0cfe15be0162cfdf853efd7aa51c2847c1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes cloud-region session probing and gates launch-app ad conversions on the resulting signed-out state.
- Adds a module-level sign-in store shared by React and imperative analytics callers.
- Routes delegated CTA clicks and region keyboard shortcuts through the new conversion gate.
- Preserves the existing hook API by subscribing it to the shared snapshot.
- The store currently cannot refresh after sign-in state changes and can remain unresolved indefinitely when one request stalls.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the shared probe can refresh stale sign-in state and cannot remain unresolved indefinitely because one regional request stalls.

The once-only snapshot can report a newly signed-in visitor as a signup, while an unbounded pending fetch suppresses all genuine launch-app conversions for the page lifetime.

**Files Needing Attention:** lib/cloud-region-sign-in-store.ts, lib/ad-conversions.ts, lib/use-cloud-region-sign-in.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Page as Docs page
  participant Store as Region sign-in store
  participant Regions as Session endpoints
  participant CTA as Launch-app CTA
  participant Ads as Ad reporters

  Page->>Store: startCloudRegionSignInProbe(true)
  Store->>Regions: Fetch every /api/auth/session
  alt Every request settles
    Regions-->>Store: Session answers
    Store->>Store: "resolved = true"
    CTA->>Store: Read snapshot
    alt Signed out everywhere
      Store-->>CTA: Eligible
      CTA->>Ads: Report conversion
    else Signed in
      Store-->>CTA: Suppress conversion
    end
  else A request remains pending
    Store->>Store: resolved remains false
    CTA->>Store: Read snapshot
    Store-->>CTA: Suppress indefinitely
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/cloud-region-sign-in-store.ts:69
**Stale sign-in snapshot persists**

When a visitor is initially probed as signed out and later signs in from another tab, `probeStarted` prevents every subsequent mount from refreshing the snapshot. The conversion gate therefore continues reporting launch-app clicks as signups, and the header can continue routing the visitor through `/cloud` instead of their signed-in region.

### Issue 2
lib/cloud-region-sign-in-store.ts:79-83
**Stalled probe blocks resolution**

If any regional session request remains pending without rejecting, it never calls `recordRegionAnswer`, so `snapshot.resolved` remains false for the page lifetime. The conversion gate then silently discards every launch-app conversion on that page, including genuine signed-out signup clicks.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only report launch-app conversion f..."](https://github.com/langfuse/langfuse-docs/commit/575e92a96e71150eabd9451c54720510e6f7d84e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55510797)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Growth Analytics: PostHog, Ad Conversions, and Sign-in Detection](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/growth-analytics.md)

<!-- /greptile_comment -->