### PR TITLE
fix: disable font ligatures in fenced code blocks

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -950,6 +950,21 @@ ul[data-gh-discussions-list] {
   padding: 0 0.25rem;
 }
 
+/* Geist Mono ligates `--` into a single long dash whose ink covers the
+   preceding space, so `langfuse api prompts create --type text` renders as
+   `create--type`. The space is still in the layout and copies correctly, but
+   nothing is painted in it. Fenced code blocks live inside a `not-prose`
+   figure, so the inline-code rule above never reaches them. */
+pre,
+pre code,
+.shiki,
+.shiki code {
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
+}
+
 .prose
   table
   :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *)) {


### PR DESCRIPTION
## Problem

Geist Mono ligates `--` into a single long dash, and that glyph's ink extends left over the preceding space's cell. The space is still in the layout and still copies correctly, but nothing is painted in it, so this:

```bash
langfuse api prompts create --type text --name greeting
```

renders as `langfuse api prompts create--type text--name greeting`.

This is site-wide and affects every fenced code block containing a double-dash flag: `docker run --rm`, `pip install --upgrade`, `npm i --global`, and every CLI example in the docs.

## Cause

Inline code already opts out of ligatures in `src/overrides.css` (`font-variant-ligatures: none` plus `"liga" 0, "calt" 0`), so inline `` `--all` `` renders correctly. Fenced code blocks sit inside a `not-prose` figure, so the `.prose :where(code):not(:where([class~="not-prose"], ...))` selector never reaches them, and they keep `font-variant-ligatures: normal`.

## Fix

Extends that existing intent to fenced blocks.

## Verification

Measured character advances on a deployed page, same element, same 13px font size:

| | ligatures | dash 1 | dash 2 | next char |
|---|---|---|---|---|
| inline `code` chip | `none` | 7.80px | 7.80px | 7.81px |
| fenced block (before) | `normal` | 3.91px | 3.91px | 7.81px |
| fenced block (after) | `none` | full cell | full cell | full cell |

The 3.91px readings against a 7.80px monospace cell are the ligature glyph being split across character ranges. With ligatures disabled, the space and both dashes each occupy a uniform cell and the gap renders, with `--` shown as two distinct hyphens.

Reviewers: worth a look at the Vercel preview on any page with CLI examples, e.g. `/docs/api-and-data-platform/features/cli` and the self-hosting Docker pages, to confirm the change reads well across code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography tweak for docs code blocks; no logic, auth, or data-handling changes.
> 
> **Overview**
> Stops Geist Mono from ligating `--` in fenced/Shiki code blocks, which previously painted a long dash over the preceding space so CLI flags like `create --type` looked like `create--type`.
> 
> Inline `code` already disabled ligatures; fenced blocks sit in `not-prose` figures so that rule never applied. The same `liga`/`calt` off settings now cover `pre`, `.shiki`, and nested `code`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4085d25ac150e95c2e4403a89e82448528a85dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables standard and contextual ligatures in fenced and Shiki-rendered code blocks so double-dash CLI flags retain visually distinct spacing.
- Adds global font-feature overrides for `pre`, nested code, and Shiki elements.
- Aligns fenced code rendering with the existing inline-code behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new CSS consistently disables the problematic ligature features across current code and preformatted-text renderers, and no affected element was found to depend on those features.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: disable font ligatures in fenced co..."](https://github.com/langfuse/langfuse-docs/commit/a4085d25ac150e95c2e4403a89e82448528a85dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55596373)</sub>

<!-- /greptile_comment -->