### PR TITLE
Add AI features section to the docs overview

### DIFF
--- a/components/FeatureOverview.tsx
+++ b/components/FeatureOverview.tsx
@@ -2,6 +2,7 @@ import {
   TextQuote,
   GitPullRequestArrow,
   ThumbsUp,
+  Sparkles,
   Database,
 } from "lucide-react";
 import { CornerBox } from "./ui/corner-box";
@@ -37,15 +38,26 @@ const features = [
   },
 ];
 
-const platformFeature = {
-  icon: Database,
-  title: "Platform",
-  items: [
-    "API-first architecture",
-    "Data exports to blob storage",
-    "Enterprise security and administration",
-  ],
-};
+const wideFeatures = [
+  {
+    icon: Sparkles,
+    title: "AI features",
+    items: [
+      "Agent skill for coding agents",
+      "MCP server for assistants",
+      "In-app Langfuse Assistant",
+    ],
+  },
+  {
+    icon: Database,
+    title: "Platform",
+    items: [
+      "API-first architecture",
+      "Data exports to blob storage",
+      "Enterprise security and administration",
+    ],
+  },
+];
 
 export const FeatureOverview = () => {
   return (
@@ -76,27 +88,29 @@ export const FeatureOverview = () => {
         </div>
       ))}
 
-      <div className="md:col-span-3 -mt-px -ml-px -mr-px">
-        <CornerBox className="flex relative z-0 flex-col p-0 min-h-0 h-full p-4">
-          <div className="flex items-center gap-3 mb-4">
-            <platformFeature.icon className="h-3.5 w-3.5 text-muted-foreground" />
-            <Text as="h3" size="m" className="mt-1 text-text-primary">
-              {platformFeature.title}
-            </Text>
-          </div>
-          <ul className="list-none flex flex-col gap-1.5">
-            {platformFeature.items.map((item, itemIndex) => (
-              <li key={itemIndex} className="flex items-start gap-2">
-                <span
-                  className="w-0.75 h-0.75 shrink-0 bg-text-tertiary"
-                  aria-hidden
-                />
-                <Text size="s">{item}</Text>
-              </li>
-            ))}
-          </ul>
-        </CornerBox>
-      </div>
+      {wideFeatures.map((feature) => (
+        <div key={feature.title} className="md:col-span-3 -mt-px -ml-px -mr-px">
+          <CornerBox className="flex relative z-0 flex-col p-0 min-h-0 h-full p-4">
+            <div className="flex items-center gap-3 mb-4">
+              <feature.icon className="h-3.5 w-3.5 text-muted-foreground" />
+              <Text as="h3" size="m" className="mt-1 text-text-primary">
+                {feature.title}
+              </Text>
+            </div>
+            <ul className="list-none flex flex-col gap-1.5">
+              {feature.items.map((item, itemIndex) => (
+                <li key={itemIndex} className="flex items-start gap-2">
+                  <span
+                    className="w-0.75 h-0.75 shrink-0 bg-text-tertiary"
+                    aria-hidden
+                  />
+                  <Text size="s">{item}</Text>
+                </li>
+              ))}
+            </ul>
+          </CornerBox>
+        </div>
+      ))}
     </div>
   );
 };

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -12,7 +12,9 @@ import {
   TextQuote,
   GitPullRequestArrow,
   ThumbsUp,
-  FlaskConical,
+  Sparkles,
+  Blocks,
+  Bot,
 } from "lucide-react";
 
 <FeatureOverview />
@@ -78,6 +80,43 @@ import EvaluationOverview from "@/components-mdx/evaluation-overview-gifs.mdx";
 <div className="h-6" />
 <EvaluationOverview />
 
+## AI features [#ai-features]
+
+Give coding agents and the in-app Assistant access to Langfuse. Query traces, manage prompts, and run evaluations from your editor, an MCP client, or the Langfuse Cloud UI.
+
+- [Agent Skill](/docs/api-and-data-platform/features/agent-skill): a playbook for Claude Code, Cursor, Codex, and other compatible agents. Install it so your agent follows Langfuse best practices for tracing, prompt management, and evaluations
+- [MCP Server](/docs/api-and-data-platform/features/mcp-server): connect assistants that cannot run shell commands to your project data. There is also a public [Docs MCP server](/docs/docs-mcp) for documentation search
+- [Langfuse Assistant](/docs/langfuse-assistant): the in-app agent in Langfuse Cloud. Ask about traces, observations, sessions, and metrics in plain language; actions that change data pause for your approval
+
+See [Langfuse for agents](/agents) for a comparison of the skill, CLI, and MCP server.
+
+<Cards num={3}>
+  <Card
+    icon={<Sparkles size="24" />}
+    title="Agent Skill"
+    href="/docs/api-and-data-platform/features/agent-skill"
+    arrow
+  />
+  <Card
+    icon={<Blocks size="24" />}
+    title="MCP Server"
+    href="/docs/api-and-data-platform/features/mcp-server"
+    arrow
+  />
+  <Card
+    icon={<Bot size="24" />}
+    title="Langfuse Assistant"
+    href="/docs/langfuse-assistant"
+    arrow
+  />
+</Cards>
+
+<Callout type="info" emoji="🚀">
+
+Want to try it? [**Install the Agent Skill**](/docs/api-and-data-platform/features/agent-skill) in your editor, or [**create a free account**](/cloud) and ask the [Langfuse Assistant](/docs/langfuse-assistant) about the [example project](/docs/demo).
+
+</Callout>
+
 ## Where to start?
 
 Setting up the full process of online tracing, prompt management, production evaluations to identify issues, and offline evaluations on datasets requires some time. This guide is meant to help you figure out what is most important for your use case.
@@ -122,6 +161,12 @@ Get up and running with Langfuse in minutes. Choose the path that best fits your
     icon={<ThumbsUp size="24" />}
     title="Setup Evaluations"
     href="/docs/evaluation/overview"
+    arrow
+  />
+  <Card
+    icon={<Sparkles size="24" />}
+    title="Connect an AI Agent"
+    href="/docs/api-and-data-platform/features/agent-skill"
     arrow
   />
 </Cards>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an AI features section to `/docs` covering the agent skill, MCP servers, and the in-app Langfuse Assistant.

## Changes

- New **AI features** section on the docs overview after Evaluation, with links to the Agent Skill, platform MCP server, Docs MCP server, and Langfuse Assistant
- Cards and a Quickstarts entry so readers can jump to the relevant setup pages
- Feature overview grid now includes an AI features row (also shown on the enterprise page, which reuses the same component)

## Testing

- `pnpm run format`
- H1 check on the edited markdown file
- Manual review of `/docs` on the local dev server: overview row, section, quickstart card, and destination pages all render and link correctly

[Docs overview with AI features row](https://cursor.com/agents/bc-614d6654-587a-4b58-8d2a-2401890ca9af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_overview_ai_features_row.webp)
[AI features section on /docs](https://cursor.com/agents/bc-614d6654-587a-4b58-8d2a-2401890ca9af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_ai_features_section.webp)
[docs_ai_features_section_demo.mp4](https://cursor.com/agents/bc-614d6654-587a-4b58-8d2a-2401890ca9af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_ai_features_section_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15456](https://linear.app/clickhouse/issue/LFE-15456/add-ai-features-section-to-docs-page)

<div><a href="https://cursor.com/agents/bc-614d6654-587a-4b58-8d2a-2401890ca9af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-614d6654-587a-4b58-8d2a-2401890ca9af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an AI features section to the documentation overview.
- Introduces links and cards for the Agent Skill, MCP servers, and Langfuse Assistant.
- Adds an AI features row to the shared feature overview.
- Adds an AI-agent entry to the Quickstarts section.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking issues identified.

The new documentation links resolve to existing routes, and the shared overview change matches the explicitly described behavior across its consumers.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add AI features section to docs ov..."](https://github.com/langfuse/langfuse-docs/commit/736dc3edac8d3b1add7c0d1e4b4e8113dcca8104) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55862692)</sub>

<!-- /greptile_comment -->