### PR TITLE
docs(sdk): list community-maintained Go SDK

### DIFF
--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -407,6 +407,10 @@ The Langfuse SDKs provide wrappers around OTel spans ([`LangfuseSpan`](https://p
 
 Langfuse maintains SDKs for Python and JavaScript/TypeScript. For other languages, you can use our [OpenTelemetry endpoint](/integrations/native/opentelemetry) to instrument your application and use the [public API](/docs/api-and-data-platform/features/public-api) to use Langfuse prompt management, evaluation, and querying.
 
+### Community-maintained SDKs
+
+- **Go:** [langfuse-go](https://github.com/git-hulk/langfuse-go) provides tracing and typed clients for the Langfuse public API.
+
 ### Instrumentation
 
 To instrument your application, you can send OpenTelemetry spans to the [Langfuse OTel endpoint](/integrations/native/opentelemetry). For this, you can use the following OpenTelemetry SDKs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change that links an unofficial community SDK; no product or security logic is modified.
> 
> **Overview**
> Adds a **Community-maintained SDKs** subsection under Other languages on the SDK overview, linking to [langfuse-go](https://github.com/git-hulk/langfuse-go) for tracing and typed public API clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34071c26eb3b3080107d4711b5d719bc9d467159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a community-maintained SDK section to the observability SDK overview and lists `langfuse-go` as a Go option for tracing and typed public API access.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added Markdown is valid, clearly distinguishes the Go SDK as community-maintained, and makes capability claims consistent with the linked project.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sdk): list community-maintained Go ..."](https://github.com/langfuse/langfuse-docs/commit/34071c26eb3b3080107d4711b5d719bc9d467159) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55852869)</sub>

<!-- /greptile_comment -->