### PR TITLE
Clarify evaluator terminology in changelog

### DIFF
--- a/content/changelog/2026-08-22-reusable-evaluators-and-rules.mdx
+++ b/content/changelog/2026-08-22-reusable-evaluators-and-rules.mdx
@@ -11,8 +11,7 @@ import { Book } from "lucide-react";
 
 <ChangelogHeader />
 
-We rebuilt the evaluator setup experience to make evaluations easier to create, test, and manage. Test judges against real observations, map variables with ease and reuse your Evaluation
-targets across evaluators.
+We rebuilt the evaluator setup experience to make it easier to create, test, and manage [LLM-as-a-Judge](/docs/evaluation/evaluation-methods/llm-as-a-judge) and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators). Test evaluators against real observations, map variables with ease, and reuse your evaluation targets across evaluators.
 
 <Video
   src="https://static.langfuse.com/docs-videos/2026-08-22-new-eval-experience.mp4"
@@ -21,9 +20,10 @@ targets across evaluators.
 />
 
 - Meet [rules](/docs/evaluation/core-concepts#evaluators-and-rules): Evaluators define how data is scored. Rules define which incoming observations are evaluated. Reuse a rule's filters and sampling across evaluators, or run the same evaluator with different rules.
-- Test your judge: Define and test evaluators side by side using data from real observations. Inspect the result, then refine the model, prompt, score definition, or mappings before saving.
-- Goodbye JSONPath: Map data to judge variables by clicking through real observations. JSONPath remains available for advanced mappings.
+- Test your evaluator: Define and test evaluators side by side using data from real observations. Inspect the result, then refine the model, prompt, score definition, or mappings before saving.
+- Goodbye JSONPath: Map data to LLM-as-a-Judge variables by clicking through real observations. JSONPath remains available for advanced mappings.
 - Stay in control of costs: Before running online evaluations, review the matching volume from the past seven days. For LLM-as-a-Judge evaluators, you can also review the estimated cost and adjust sampling.
+- Build production-ready evaluators faster with our updated selection of evaluator templates.
 
 Existing observation-level evaluators have been upgraded to the new experience. For trace-level evaluators, follow the [migration steps](/faq/all/llm-as-a-judge-migration).
 


### PR DESCRIPTION
Clarifies evaluator terminology in the changelog and links readers to the LLM-as-a-Judge and code evaluator setup guides.

Also adds the updated evaluator template gallery message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog wording and links; no product or security impact.
> 
> **Overview**
> Updates the Aug 22 evaluation changelog so copy talks about **evaluators** generally, not just “judges,” and links to the LLM-as-a-Judge and code evaluator docs.
> 
> Also tightens mapping language to LLM-as-a-Judge variables and adds a bullet about the updated evaluator template gallery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d541beef1287d88f639aa24cfb6d23a1e9c02a44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies evaluator terminology in the changelog and links readers to the relevant setup guides.

- Replaces “judge” terminology with “evaluator” where appropriate.
- Distinguishes LLM-as-a-Judge variables from general evaluator concepts.
- Highlights the updated evaluator template selection.
- Adds direct links to the LLM-as-a-Judge and code evaluator documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the terminology changes are internally consistent and the new documentation links resolve to existing pages.

The changed MDX preserves valid syntax, points to canonical evaluator guides, and introduces no blocking behavioral or content-pipeline failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify evaluator changelog termin..."](https://github.com/langfuse/langfuse-docs/commit/d541beef1287d88f639aa24cfb6d23a1e9c02a44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55871634)</sub>

<!-- /greptile_comment -->