### PR TITLE
Remove ClickHouse Private from self-hosted pricing

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -241,7 +241,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
       price: "Custom Pricing",
       mainFeatures: [
         "All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs",
-        "Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private",
+        "Bundled with ClickHouse Cloud or ClickHouse BYOC",
         "Langfuse pricing is additive to your ClickHouse commercial plan",
         "Dedicated support engineer for deployment and hosting guidance",
         "Solutions architect support during evaluation and rollout",
@@ -881,11 +881,11 @@ const sections: Section[] = [
       {
         name: "ClickHouse deployment model",
         description:
-          "Open Source assumes you operate ClickHouse yourself. Enterprise is bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private.",
+          "Open Source assumes you operate ClickHouse yourself. Enterprise is bundled with ClickHouse Cloud or ClickHouse BYOC.",
         tiers: {
           selfHosted: {
             "Open Source": "Self-managed ClickHouse OSS",
-            Enterprise: "Bundled: ClickHouse Cloud / BYOC / Private",
+            Enterprise: "Bundled: ClickHouse Cloud / BYOC",
           },
         },
       },

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -25,10 +25,10 @@ Self-host all core Langfuse features for free without any limitations.
 
 ### Self-Hosted Enterprise (Custom Pricing)
 
-Dedicated Langfuse deployment with enterprise capabilities and support. Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private.
+Dedicated Langfuse deployment with enterprise capabilities and support. Bundled with ClickHouse Cloud or ClickHouse BYOC.
 
 - All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs
-- Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private
+- Bundled with ClickHouse Cloud or ClickHouse BYOC
 - Langfuse pricing is additive to your ClickHouse commercial plan
 - Dedicated support engineer for deployment and hosting guidance
 - Solutions architect support during evaluation and rollout
@@ -41,92 +41,92 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 
 ## Feature Comparison (Self-Hosted)
 
-| Feature                                                                                             | Open Source                 | Enterprise                                 |
-| --------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
-| **LLM Application & Agent Tracing**                                                                 |                             |                                            |
-| [Traces and graphs (agents)](/docs/observability/overview)                                          | Yes                         | Yes                                        |
-| [Session tracking (chats/threads)](/docs/observability/features/sessions)                           | Yes                         | Yes                                        |
-| [User tracking](/docs/observability/features/users)                                                 | Yes                         | Yes                                        |
-| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                         | Yes                                        |
-| [Native framework integrations](/integrations)                                                      | Yes                         | Yes                                        |
-| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                         | Yes                                        |
-| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                         | Yes                                        |
-| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                         | Yes                                        |
-| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                         | Yes                                        |
-| Included usage                                                                                      | Unlimited                   | Unlimited                                  |
-| [Multi-modal](/docs/observability/features/multi-modality)                                          | Yes                         | Yes                                        |
-| **Langfuse AI**                                                                                     |                             |                                            |
-| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                       | --                          | --                                         |
-| **Prompt Management**                                                                               |                             |                                            |
-| [Prompt versioning](/docs/prompt-management/get-started)                                            | Yes                         | Yes                                        |
-| Prompt fetching                                                                                     | Unlimited                   | Unlimited                                  |
-| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                | Yes                         | Yes                                        |
-| [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                         | Yes                                        |
-| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                         | Yes                                        |
-| [Playground](/docs/prompt-management/features/playground)                                           | Yes                         | Yes                                        |
-| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                         | Yes                                        |
-| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                         | Yes                                        |
-| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                          | Yes                                        |
-| **Evaluation (online and offline)**                                                                 |                             |                                            |
-| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                         | Yes                                        |
-| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                         | Yes                                        |
-| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                         | Yes                                        |
-| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                         | Yes                                        |
-| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                         | Yes                                        |
-| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                         | Yes                                        |
-| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                         | Yes                                        |
-| [Human annotation](/docs/scores/annotation)                                                         | Yes                         | Yes                                        |
-| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | Yes                         | Yes                                        |
-| **Metrics**                                                                                         |                             |                                            |
-| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                         | Yes                                        |
-| [Alerts](/docs/observability/features/alerts)                                                       | Langfuse v4+                | Langfuse v4+                               |
-| **Collaboration**                                                                                   |                             |                                            |
-| Projects                                                                                            | Unlimited                   | Unlimited                                  |
-| Users                                                                                               | Unlimited                   | Unlimited                                  |
-| **API**                                                                                             |                             |                                            |
-| [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                         | Yes                                        |
-| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                           | Langfuse v4+                | Langfuse v4+                               |
-| **Exports**                                                                                         |                             |                                            |
-| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                         | Yes                                        |
-| [PostHog integration](/integrations/analytics/posthog)                                              | Yes                         | Yes                                        |
-| [Mixpanel integration](/integrations/analytics/mixpanel)                                            | Yes                         | Yes                                        |
-| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage) | Yes                         | Yes                                        |
-| **Deployment**                                                                                      |                             |                                            |
-| ClickHouse deployment model                                                                         | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC / Private |
-| [Deployment templates](/self-hosting)                                                               | Yes                         | Yes                                        |
-| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                   | Yes                         | Yes                                        |
-| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                       | Yes                         | Yes                                        |
-| [AWS (Terraform)](/self-hosting/deployment/aws)                                                     | Yes                         | Yes                                        |
-| [Azure (Terraform)](/self-hosting/deployment/azure)                                                 | Yes                         | Yes                                        |
-| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                     | Yes                         | Yes                                        |
-| **Support**                                                                                         |                             |                                            |
-| [Ask AI](/docs/ask-ai)                                                                              | Yes                         | Yes                                        |
-| [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                                        |
-| [In-app support](/support#in-app)                                                                   | --                          | Yes                                        |
-| [Private Slack channel](/support#slack)                                                             | --                          | Yes                                        |
-| [Dedicated support engineer](/support#onboarding)                                                   | --                          | Yes                                        |
-| [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                                        |
-| Solutions architect support                                                                         | --                          | Yes                                        |
-| Product team feedback channel                                                                       | --                          | Yes                                        |
-| [Support SLA](/enterprise#faq)                                                                      | --                          | Yes                                        |
-| **Security**                                                                                        |                             |                                            |
-| Sign in with Google, AzureAD, GitHub                                                                | Yes                         | Yes                                        |
-| [Organization-level RBAC](/docs/administration/rbac)                                                | Yes                         | Yes                                        |
-| Enterprise SSO (e.g. Okta, EntraID)                                                                 | Yes                         | Yes                                        |
-| SSO enforcement                                                                                     | Yes                         | Yes                                        |
-| [Client-side data masking](/docs/observability/features/masking)                                    | Yes                         | Yes                                        |
-| [Server-side data masking](/self-hosting/security/data-masking)                                     | --                          | Yes                                        |
-| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                 | --                          | Yes                                        |
-| [Data retention management](/docs/administration/data-retention)                                    | --                          | Yes                                        |
-| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                     | --                          | Yes                                        |
-| [Organization creators](/self-hosting/administration/organization-creators)                         | --                          | Yes                                        |
-| [UI customization](/self-hosting/administration/ui-customization)                                   | --                          | Yes                                        |
-| [Audit logs](/docs/administration/audit-logs)                                                       | --                          | Yes                                        |
-| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                       | --                          | Yes                                        |
-| [Instance management API](/self-hosting/administration/instance-management-api)                     | --                          | Yes                                        |
-| **Compliance**                                                                                      |                             |                                            |
-| SOC2 Type II & ISO27001 reports                                                                     | --                          | Yes                                        |
-| InfoSec/legal reviews                                                                               | --                          | Yes                                        |
+| Feature                                                                                             | Open Source                 | Enterprise                       |
+| --------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------- |
+| **LLM Application & Agent Tracing**                                                                 |                             |                                  |
+| [Traces and graphs (agents)](/docs/observability/overview)                                          | Yes                         | Yes                              |
+| [Session tracking (chats/threads)](/docs/observability/features/sessions)                           | Yes                         | Yes                              |
+| [User tracking](/docs/observability/features/users)                                                 | Yes                         | Yes                              |
+| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                         | Yes                              |
+| [Native framework integrations](/integrations)                                                      | Yes                         | Yes                              |
+| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                         | Yes                              |
+| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                         | Yes                              |
+| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                         | Yes                              |
+| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                         | Yes                              |
+| Included usage                                                                                      | Unlimited                   | Unlimited                        |
+| [Multi-modal](/docs/observability/features/multi-modality)                                          | Yes                         | Yes                              |
+| **Langfuse AI**                                                                                     |                             |                                  |
+| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                       | --                          | --                               |
+| **Prompt Management**                                                                               |                             |                                  |
+| [Prompt versioning](/docs/prompt-management/get-started)                                            | Yes                         | Yes                              |
+| Prompt fetching                                                                                     | Unlimited                   | Unlimited                        |
+| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                | Yes                         | Yes                              |
+| [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                         | Yes                              |
+| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                         | Yes                              |
+| [Playground](/docs/prompt-management/features/playground)                                           | Yes                         | Yes                              |
+| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                         | Yes                              |
+| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                         | Yes                              |
+| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                          | Yes                              |
+| **Evaluation (online and offline)**                                                                 |                             |                                  |
+| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                         | Yes                              |
+| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                         | Yes                              |
+| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                         | Yes                              |
+| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                         | Yes                              |
+| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                         | Yes                              |
+| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                         | Yes                              |
+| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                         | Yes                              |
+| [Human annotation](/docs/scores/annotation)                                                         | Yes                         | Yes                              |
+| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | Yes                         | Yes                              |
+| **Metrics**                                                                                         |                             |                                  |
+| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                         | Yes                              |
+| [Alerts](/docs/observability/features/alerts)                                                       | Langfuse v4+                | Langfuse v4+                     |
+| **Collaboration**                                                                                   |                             |                                  |
+| Projects                                                                                            | Unlimited                   | Unlimited                        |
+| Users                                                                                               | Unlimited                   | Unlimited                        |
+| **API**                                                                                             |                             |                                  |
+| [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                         | Yes                              |
+| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                           | Langfuse v4+                | Langfuse v4+                     |
+| **Exports**                                                                                         |                             |                                  |
+| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                         | Yes                              |
+| [PostHog integration](/integrations/analytics/posthog)                                              | Yes                         | Yes                              |
+| [Mixpanel integration](/integrations/analytics/mixpanel)                                            | Yes                         | Yes                              |
+| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage) | Yes                         | Yes                              |
+| **Deployment**                                                                                      |                             |                                  |
+| ClickHouse deployment model                                                                         | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC |
+| [Deployment templates](/self-hosting)                                                               | Yes                         | Yes                              |
+| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                   | Yes                         | Yes                              |
+| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                       | Yes                         | Yes                              |
+| [AWS (Terraform)](/self-hosting/deployment/aws)                                                     | Yes                         | Yes                              |
+| [Azure (Terraform)](/self-hosting/deployment/azure)                                                 | Yes                         | Yes                              |
+| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                     | Yes                         | Yes                              |
+| **Support**                                                                                         |                             |                                  |
+| [Ask AI](/docs/ask-ai)                                                                              | Yes                         | Yes                              |
+| [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                              |
+| [In-app support](/support#in-app)                                                                   | --                          | Yes                              |
+| [Private Slack channel](/support#slack)                                                             | --                          | Yes                              |
+| [Dedicated support engineer](/support#onboarding)                                                   | --                          | Yes                              |
+| [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                              |
+| Solutions architect support                                                                         | --                          | Yes                              |
+| Product team feedback channel                                                                       | --                          | Yes                              |
+| [Support SLA](/enterprise#faq)                                                                      | --                          | Yes                              |
+| **Security**                                                                                        |                             |                                  |
+| Sign in with Google, AzureAD, GitHub                                                                | Yes                         | Yes                              |
+| [Organization-level RBAC](/docs/administration/rbac)                                                | Yes                         | Yes                              |
+| Enterprise SSO (e.g. Okta, EntraID)                                                                 | Yes                         | Yes                              |
+| SSO enforcement                                                                                     | Yes                         | Yes                              |
+| [Client-side data masking](/docs/observability/features/masking)                                    | Yes                         | Yes                              |
+| [Server-side data masking](/self-hosting/security/data-masking)                                     | --                          | Yes                              |
+| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                 | --                          | Yes                              |
+| [Data retention management](/docs/administration/data-retention)                                    | --                          | Yes                              |
+| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                     | --                          | Yes                              |
+| [Organization creators](/self-hosting/administration/organization-creators)                         | --                          | Yes                              |
+| [UI customization](/self-hosting/administration/ui-customization)                                   | --                          | Yes                              |
+| [Audit logs](/docs/administration/audit-logs)                                                       | --                          | Yes                              |
+| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                       | --                          | Yes                              |
+| [Instance management API](/self-hosting/administration/instance-management-api)                     | --                          | Yes                              |
+| **Compliance**                                                                                      |                             |                                  |
+| SOC2 Type II & ISO27001 reports                                                                     | --                          | Yes                              |
+| InfoSec/legal reviews                                                                               | --                          | Yes                              |
 
 ## Discounts
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes mistaken **ClickHouse Private** references from the self-hosted pricing page.

Enterprise self-host is bundled with ClickHouse Cloud or ClickHouse BYOC only. Open Source remains self-managed ClickHouse OSS.

## Changes
- Enterprise plan feature: `Bundled with ClickHouse Cloud or ClickHouse BYOC`
- Deployment comparison row: `Bundled: ClickHouse Cloud / BYOC`
- Synced `md-override/pricing-self-host.md` with the rendered pricing table

## Testing
Verified on the local `/pricing-self-host` page: no remaining "ClickHouse Private" or "ClickHouse Government" copy. Find-in-page for "ClickHouse Government" returned 0 matches.

[Enterprise card bundled with ClickHouse Cloud or BYOC](https://cursor.com/agents/bc-2be59b5a-8a43-40da-b0e1-82c3887f1740/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fself_hosted_pricing_enterprise_card.webp)
[Deployment row shows Cloud / BYOC and ClickHouse OSS](https://cursor.com/agents/bc-2be59b5a-8a43-40da-b0e1-82c3887f1740/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fself_hosted_pricing_deployment_row.webp)
[Find-in-page shows zero ClickHouse Government matches](https://cursor.com/agents/bc-2be59b5a-8a43-40da-b0e1-82c3887f1740/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fself_hosted_pricing_no_government_search.webp)

Fixes LFE-15457


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15457](https://linear.app/clickhouse/issue/LFE-15457/remove-clickhouse-government-references-from-self-hosted-pricing)

<div><a href="https://cursor.com/agents/bc-2be59b5a-8a43-40da-b0e1-82c3887f1740?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2be59b5a-8a43-40da-b0e1-82c3887f1740&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes mistaken ClickHouse Private references from self-hosted Enterprise pricing while keeping the rendered page and markdown override synchronized.

- Updates the Enterprise plan description to list ClickHouse Cloud and ClickHouse BYOC only.
- Updates the deployment comparison row to match.
- Realigns the markdown table after shortening the Enterprise copy.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the rendered and markdown pricing representations consistently updated.

The changes are limited to pricing copy, retain synchronization between the live component and markdown override, and leave no concrete functional or content defect.
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove ClickHouse Private from self-host..."](https://github.com/langfuse/langfuse-docs/commit/ad41b0fb45c509c3489b471d4951416b0047ee6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55914506)</sub>

**Context used:**

- Knowledge Base — [Self-Hosting, Security, and Cloud/Pricing Content](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/deployment-content.md)

<!-- /greptile_comment -->