### PR TITLE
docs: Railway deployment callout on the LiteLLM Proxy integration page

### DIFF
--- a/content/integrations/gateways/litellm.mdx
+++ b/content/integrations/gateways/litellm.mdx
@@ -111,6 +111,12 @@ You can add additional Langfuse attributes to the requests in order to group req
 </Tab>
 </Tabs>
 
+<Callout type="info">
+
+**Self-host both on Railway:** the community-maintained [AI Gateway + Observability template](https://railway.com/deploy/ai-gateway-observability-litellm-langfus) deploys LiteLLM and Langfuse v3 together with the success/failure callbacks pre-configured over a private network ([source](https://github.com/Kjudeh/ai-gateway-stack)).
+
+</Callout>
+
 ## Trace calls client-side with the OpenAI SDK wrapper [#openai-sdk-wrapper]
 
 Instead of (or in addition to) logging from the proxy, you can trace calls in your application code with the Langfuse OpenAI SDK wrapper ([Python](/integrations/model-providers/openai-py), [JS/TS](/integrations/model-providers/openai-js)). Since the proxy exposes an OpenAI-compatible API, the wrapper captures every call routed through it as a generation in Langfuse, and you can group multiple calls into a single trace.


### PR DESCRIPTION
Adds a short callout to the LiteLLM Proxy integration page pointing to a Railway template that deploys LiteLLM + Langfuse v3 together with the Langfuse success/failure callbacks pre-configured.

Disclosure: we (Bubbles Studio) build and maintain the template. It follows the Langfuse v3 self-hosting topology exactly (web + worker + Postgres + Redis + ClickHouse + S3-compatible storage), upstream images are digest-pinned with weekly reviewed bump PRs, and it is test-deployed from scratch before every update. Scoped this to the LiteLLM integration page (not your existing Railway deployment page, which already links the standalone Langfuse template).

Happy to adjust wording/placement however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, auth, or data-handling impact. Third-party community template is clearly labeled.
> 
> **Overview**
> Adds an info callout on the LiteLLM Proxy integration page pointing to a community-maintained Railway template that deploys LiteLLM and Langfuse v3 together with success/failure callbacks pre-configured.
> 
> The callout sits after the proxy setup tabs and links both the Railway deploy template and the GitHub source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6261ed66e4d5cf1844f4d74ab76ed72fef15d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an informational callout to the LiteLLM Proxy integration guide for a community-maintained Railway deployment template.

- Links to a combined LiteLLM and Langfuse v3 Railway template.
- States that success/failure callbacks and private networking are pre-configured.
- Links to the template’s source repository.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge, with no concrete blocking or non-blocking defect established.

The added MDX uses a supported Callout type and follows existing document conventions, while the available evidence does not establish that its links or deployment claims are incorrect.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Railway self-host template cal..."](https://github.com/langfuse/langfuse-docs/commit/8e6261ed66e4d5cf1844f4d74ab76ed72fef15d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56071416)</sub>

<!-- /greptile_comment -->