### PR TITLE
Cache GitHub star count

### DIFF
--- a/.github/workflows/update-github-stars.yml
+++ b/.github/workflows/update-github-stars.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           token: ${{ secrets.UPDATE_DOCS_MAIN_BRANCH_PAT }}
           persist-credentials: false
+          ref: main
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -35,4 +36,4 @@ jobs:
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
           git add src/github-stars.ts
-          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update cached GitHub star count" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "${GITHUB_REF#refs/heads/}")
+          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update cached GitHub star count" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" main)

--- a/.github/workflows/update-github-stars.yml
+++ b/.github/workflows/update-github-stars.yml
@@ -2,7 +2,7 @@ name: Update GitHub star count
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 12 * * MON"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/update-github-stars.yml
+++ b/.github/workflows/update-github-stars.yml
@@ -1,0 +1,38 @@
+name: Update GitHub star count
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update-github-stars:
+    runs-on: ubuntu-latest
+    environment: "main"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.UPDATE_DOCS_MAIN_BRANCH_PAT }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Update cached GitHub star count
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/update-github-stars.js
+
+      - name: Commit and push if changed
+        env:
+          UPDATE_DOCS_MAIN_BRANCH_PAT: ${{ secrets.UPDATE_DOCS_MAIN_BRANCH_PAT }}
+        run: |
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+          git add src/github-stars.ts
+          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update cached GitHub star count" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "${GITHUB_REF#refs/heads/}")

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --experimental-cli --write .",
     "format:check": "prettier --experimental-cli --check .",
     "postinstall": "bash scripts/postinstall.sh",
-    "prebuild": "node scripts/sync-wordmark-png-for-og.mjs && node scripts/generate_brand_assets_zip.js && node scripts/generate-default-og-png.mjs && node scripts/update-github-stars.js && node scripts/authors/generate-contributors.js && pnpm workshop:sync && node scripts/copy_md_sources.js && node scripts/generate-sitemap-excludes.js && node scripts/sync-design-tokens.js",
+    "prebuild": "node scripts/sync-wordmark-png-for-og.mjs && node scripts/generate_brand_assets_zip.js && node scripts/generate-default-og-png.mjs && node scripts/authors/generate-contributors.js && pnpm workshop:sync && node scripts/copy_md_sources.js && node scripts/generate-sitemap-excludes.js && node scripts/sync-design-tokens.js",
     "build": "next build",
     "postbuild": "pnpm run postbuild:sitemap && pnpm run postbuild:cleanup && pnpm run postbuild:llms-txt",
     "build:static": "cross-env STATIC_EXPORT=true pnpm run prebuild && cross-env STATIC_EXPORT=true next build && pnpm run postbuild:static",

--- a/src/github-stars.ts
+++ b/src/github-stars.ts
@@ -1,1 +1,1 @@
-export const GITHUB_STARS = 23619;
+export const GITHUB_STARS = 33614;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- remove the GitHub repository API request from the documentation prebuild pipeline
- use the committed `src/github-stars.ts` value as the build-time cache
- refresh the cached count daily through an authenticated GitHub Actions workflow, with manual dispatch support
- ensure scheduled and manual refreshes always check out and update `main`
- update the cached count from 23,619 to 33,614 stars

## Testing

- `node scripts/update-github-stars.js`
- targeted assertion that `prebuild` no longer invokes `update-github-stars.js`
- mocked execution of the scheduled cache updater
- targeted assertion that refresh runs check out and push `main`
- `pnpm run format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15484](https://linear.app/clickhouse/issue/LFE-15484/cache-github-star-count-in-langfuse-docs)

<div><a href="https://cursor.com/agents/bc-2a11a55e-9bb9-48e6-92a0-679e6bccf200?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a11a55e-9bb9-48e6-92a0-679e6bccf200&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes GitHub star retrieval from documentation prebuilds and adds daily/manual automation that updates the committed cache.
- Adds a scheduled GitHub Actions workflow with manual dispatch support.
- Commits and pushes changed star counts using the documentation update PAT.
- Removes the star-update script from the prebuild pipeline.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The manual refresh path should be fixed to target main before merging because a successful run can otherwise leave the production cache unchanged.

The scheduled main-branch path works as intended, but workflow_dispatch exposes selectable refs while the push destination follows that ref rather than the workflow’s stated main-branch cache target.

**Files Needing Attention:** .github/workflows/update-github-stars.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/update-github-stars.yml:38
**Manual dispatch updates wrong branch**

When a maintainer manually dispatches this workflow on a non-main branch, `GITHUB_REF` names that selected branch and the push commits the refreshed count there, causing the successful run to leave the main-branch production cache stale.

```suggestion
          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update cached GitHub star count" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" main)
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Cache GitHub star count outside document..."](https://github.com/langfuse/langfuse-docs/commit/fb6d945f99bd29c90c728087e4ddb5d26e2e007d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56187065)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content publishing automation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-publishing-automation.md)

<!-- /greptile_comment -->