### PR TITLE
chore(migration): add CLI

### DIFF
--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -40,6 +40,9 @@ All paths are relative to `/api/public`.
 
 `score-create` events sent to `POST /ingestion` by the current SDKs are not deprecated. They remain supported after the v4 cutover.
 
+If you access the public API from shell scripts or coding agents, the [Langfuse CLI](/docs/api-and-data-platform/features/cli) provides commands for all supported endpoints.
+Use at least langfuse-cli version `v1.1.0` to benefit from the new endpoints.
+
 ## Observations [#observations]
 
 **Deprecated:** `GET /observations`, `GET /observations/{observationId}`. Langfuse Cloud serves this endpoint until <V4CutoverDate />; migrate to v4 before this date.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only FAQ copy; no product, API, or security behavior changes.
> 
> **Overview**
> Points readers of the deprecated API migration FAQ to the Langfuse CLI for shell/agent access to supported endpoints, and notes that `langfuse-cli` `v1.1.0+` is required for the new APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e1996cef5f435e6bd298b88e923a6871766005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Langfuse CLI guidance to the deprecated API migration FAQ.

- Directs shell-script and coding-agent users to the CLI documentation.
- Recommends CLI version `v1.1.0` or later for new endpoints.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

No concrete broken link, incorrect reachable migration path, or repository-rule violation was established in the added guidance.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(migration): add CLI"](https://github.com/langfuse/langfuse-docs/commit/07e1996cef5f435e6bd298b88e923a6871766005) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56291642)</sub>

<!-- /greptile_comment -->