### PR TITLE
Add /government landing page

### DIFF
--- a/app/government/layout.tsx
+++ b/app/government/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { HomeLayout } from "@/components/layout";
+
+export default function GovernmentLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <HomeLayout
+      showAside={false}
+      footerClassName="md:max-w-none xl:max-w-none px-4 sm:px-6 md:px-8"
+    >
+      {children}
+    </HomeLayout>
+  );
+}

--- a/app/government/page.tsx
+++ b/app/government/page.tsx
@@ -4,7 +4,7 @@ import { buildOgImageUrl } from "@/lib/og-url";
 
 const title = "Langfuse for Government";
 const description =
-  "Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments — and keep traces, prompts, and evaluation data inside your security boundary.";
+  "Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments. Keep traces, prompts, and evaluation data in your security boundary.";
 
 const ogImageUrl = buildOgImageUrl({ title, description });
 

--- a/app/government/page.tsx
+++ b/app/government/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { GovernmentLanding } from "@/components/government/GovernmentLanding";
+import { buildOgImageUrl } from "@/lib/og-url";
+
+const title = "Langfuse for Government";
+const description =
+  "Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments — and keep traces, prompts, and evaluation data inside your security boundary.";
+
+const ogImageUrl = buildOgImageUrl({ title, description });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "https://langfuse.com/government",
+  },
+  openGraph: {
+    title,
+    description,
+    url: "https://langfuse.com/government",
+    images: [{ url: ogImageUrl }],
+  },
+};
+
+export default function GovernmentPage() {
+  return <GovernmentLanding />;
+}

--- a/app/government/page.tsx
+++ b/app/government/page.tsx
@@ -4,7 +4,7 @@ import { buildOgImageUrl } from "@/lib/og-url";
 
 const title = "Langfuse for Government";
 const description =
-  "Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments. Keep traces, prompts, and evaluation data in your security boundary.";
+  "Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and cloud environments. Langfuse Cloud for Government coming soon.";
 
 const ogImageUrl = buildOgImageUrl({ title, description });
 

--- a/app/government/page.tsx
+++ b/app/government/page.tsx
@@ -4,7 +4,7 @@ import { buildOgImageUrl } from "@/lib/og-url";
 
 const title = "Langfuse for Government";
 const description =
-  "Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and cloud environments. Langfuse Cloud for Government coming soon.";
+  "Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and government cloud environments. Langfuse Cloud for Government coming soon.";
 
 const ogImageUrl = buildOgImageUrl({ title, description });
 

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -49,6 +49,7 @@ const pathsWithoutFooterWidgets = [
   "/cookie-policy",
   "/find-us",
   "/japan",
+  "/government",
   "/kr",
   "/oss-friends",
   "/privacy",

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -803,6 +803,8 @@ function GovernmentCloud() {
             <li>FIPS 140-3 hardening</li>
             <li>RBAC, SSO, SCIM, and immutable audit logs</li>
             <li>Data retention and server-side masking</li>
+            <li>Run in AWS GovCloud</li>
+            <li>FEDRAMP Moderate (in-process)</li>
           </ul>
           <div className="flex-1" />
           <Link

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -115,7 +115,7 @@ function Hero() {
             evaluate, and improve AI agents — without sending prompts, traces,
             or evaluation data outside their security boundary. Deploy{" "}
             <b className="font-medium text-text-primary">
-              air-gapped, on premises, or in a private cloud
+              air-gapped, on-premises, or in a private cloud
             </b>
             . The core is open source and inspectable; you operate the stack.
           </p>
@@ -154,6 +154,7 @@ function Hero() {
 }
 
 function HeroArt() {
+  const [lifted, setLifted] = useState<string | null>(null);
   const cards: {
     title: string;
     caption: string;
@@ -201,8 +202,11 @@ function HeroArt() {
   return (
     <>
       <div
-        className="gov-hero-art relative mx-auto hidden h-[420px] w-full max-w-[380px] md:block"
+        className={`gov-hero-art relative mx-auto hidden h-[420px] w-full max-w-[380px] md:block${
+          lifted ? " is-engaged" : ""
+        }`}
         aria-hidden
+        onMouseLeave={() => setLifted(null)}
       >
         <svg
           viewBox="0 0 400 400"
@@ -247,7 +251,10 @@ function HeroArt() {
         {cards.map((c) => (
           <div
             key={c.title}
-            className={`gov-polaroid${c.featured ? " is-featured" : ""}`}
+            className={`gov-polaroid${c.featured ? " is-featured" : ""}${
+              lifted === c.title ? " is-lifted" : ""
+            }`}
+            onMouseEnter={() => setLifted(c.title)}
             style={
               {
                 "--x": `${c.x}px`,
@@ -723,7 +730,7 @@ export function GovernmentLanding() {
   return (
     <div className="gov-page">
       <GovernmentStyles />
-      <div className="mx-auto max-w-[1120px]">
+      <div className="mx-auto max-w-[1000px]">
         <Hero />
         <ProductLoop />
         <Deployment />

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -82,8 +82,8 @@ function Hero() {
           </p>
         </div>
         <p className="gov-body-sm m-0 max-w-[38ch] text-pretty sm:text-right">
-          Observability and evaluations for public-sector AI — inside your
-          security boundary.
+          Observability and evaluations for public-sector AI, in your
+          environment.
         </p>
       </div>
 
@@ -111,18 +111,17 @@ function Hero() {
             Keep it <span className="gov-highlight">under your control.</span>
           </h1>
           <p className="gov-body" style={{ fontSize: 17, maxWidth: "42ch" }}>
-            Government and public-sector teams use Langfuse to observe,
-            evaluate, and improve AI agents — without sending prompts, traces,
-            or evaluation data outside their security boundary. Deploy{" "}
+            Open-source tracing and evaluations for government AI. Run it{" "}
             <b className="font-medium text-text-primary">
               air-gapped, on-premises, or in a private cloud
             </b>
-            . The core is open source and inspectable; you operate the stack.
+            . Prompts, traces, and scores stay in your environment. You run the
+            software.
           </p>
           <ul className="gov-claim-row">
             <li>Your environment</li>
-            <li>Inspectable source</li>
-            <li>Audit-ready traces</li>
+            <li>Open source</li>
+            <li>Your traces</li>
           </ul>
           <Ctas />
         </div>
@@ -369,7 +368,7 @@ function ProductLoop() {
       n: "03",
       eyebrow: "Contain",
       title: "Contain failures early",
-      body: "Monitor quality, security scores, latency, and cost. Set thresholds and route alerts through webhooks, Slack, or GitHub Actions — so teams can act before isolated failures become systemic.",
+      body: "Monitor quality, security scores, latency, and cost. Set thresholds and send alerts to webhooks, Slack, or GitHub Actions so you can respond before a bad run repeats.",
       href: "/docs/observability/features/alerts",
       label: "Alerts docs",
     },
@@ -380,13 +379,13 @@ function ProductLoop() {
       <div className="mb-10 flex flex-col items-start gap-3.5">
         <div className="gov-eyebrow">Observability · Evaluations · Alerts</div>
         <h2 className="gov-h2 max-w-[24ch]">
-          Understand every agent.{" "}
-          <span className="gov-highlight">Improve every outcome.</span>
+          See what happened.{" "}
+          <span className="gov-highlight">Score what works.</span>
         </h2>
         <p className="gov-body">
-          Government AI must do more than work in a demo. Teams need to
-          understand how an agent reached an answer, measure whether it is
-          reliable, and improve it without losing control of sensitive data.
+          You need to see how an agent reached an answer, score whether it is
+          reliable, and change it without moving sensitive data out of your
+          environment.
         </p>
       </div>
 
@@ -447,11 +446,10 @@ function Deployment() {
       title: "Inspect and control the software",
       body: (
         <>
-          The complete Langfuse repository is public. All core product
-          capabilities — tracing, evaluations, prompt management, experiments,
-          and annotation — are MIT-licensed without usage limits. Enterprise
-          extensions live in clearly marked directories and activate only with a
-          license key.
+          The Langfuse repository is public. Tracing, evaluations, prompt
+          management, experiments, and annotation are MIT-licensed, with no
+          usage limits. Enterprise extensions live in marked directories and
+          turn on with a license key.
         </>
       ),
       href: "/handbook/chapters/open-source",
@@ -459,13 +457,13 @@ function Deployment() {
     },
     {
       n: "03",
-      title: "Operate the same architecture proven in the cloud",
+      title: "Same architecture as Langfuse Cloud",
       body: (
         <>
-          Self-hosted Langfuse is not a reduced fork. It uses the same codebase
-          and architecture as Langfuse Cloud. Asynchronous ingestion absorbs
-          traffic spikes, incoming events are persisted before processing, and
-          background migrations reduce disruption during upgrades.
+          Self-hosted Langfuse uses the same codebase and architecture as
+          Langfuse Cloud. Asynchronous ingestion absorbs traffic spikes, events
+          are persisted before processing, and background migrations reduce
+          disruption during upgrades.
         </>
       ),
       href: "/self-hosting#architecture",
@@ -494,13 +492,12 @@ function Deployment() {
       <div className="mb-10 flex flex-col items-start gap-3.5">
         <div className="gov-eyebrow">Self-hosting · Governance</div>
         <h2 className="gov-h2 max-w-[22ch]">
-          Mission-ready deployment,{" "}
-          <span className="gov-highlight">on your terms.</span>
+          Run it where you{" "}
+          <span className="gov-highlight">already operate.</span>
         </h2>
         <p className="gov-body">
-          Langfuse is built to run where government teams already operate —
-          behind a firewall, in a classified network, or in an approved cloud
-          account — without changing the product or the data model.
+          Langfuse runs behind a firewall, on a classified network, or in an
+          approved cloud account. The product and data model stay the same.
         </p>
       </div>
 
@@ -592,12 +589,12 @@ function Security() {
               className="gov-h2 max-w-[16ch]"
               style={{ fontSize: "clamp(28px, 3vw, 40px)" }}
             >
-              Security without giving up developer velocity.
+              Keep data in your environment.
             </h2>
             <p className="gov-body-sm max-w-[40ch]">
-              Self-host Langfuse so application teams can debug and evaluate
-              agents quickly, while security teams keep telemetry, prompts, and
-              evaluation data inside the approved boundary.
+              Application teams can debug and evaluate agents. Security teams
+              keep telemetry, prompts, and evaluation data in the approved
+              boundary.
             </p>
           </div>
           <div
@@ -653,12 +650,11 @@ function GetStarted() {
             style={{ fontSize: "clamp(28px, 3vw, 40px)" }}
           >
             Start locally.{" "}
-            <span className="gov-highlight">Deploy for the mission.</span>
+            <span className="gov-highlight">Deploy in production.</span>
           </h2>
           <p className="gov-body-sm m-0 max-w-[44ch]">
             Run Langfuse locally with Docker Compose in minutes. The repository
-            is public, the core product is MIT-licensed, and the same platform
-            is already used in production at scale. Move to Kubernetes or
+            is public and the core is MIT-licensed. Move to Kubernetes or
             Terraform without changing the product or data model.
           </p>
           <div className="flex flex-wrap gap-1.5">
@@ -712,13 +708,12 @@ function CTABanner() {
       >
         <div className="gov-eyebrow">Langfuse for Government</div>
         <h2 className="gov-h2 max-w-[22ch]">
-          Bring accountable AI into{" "}
+          Run Langfuse in{" "}
           <span className="gov-highlight">your environment.</span>
         </h2>
         <p className="gov-body text-center">
-          See how Langfuse can help your team observe, evaluate, and improve
-          mission-critical AI systems — without moving sensitive data outside
-          your control.
+          Talk through tracing, evaluations, and self-hosting for government AI.
+          Sensitive data stays in infrastructure you control.
         </p>
         <Ctas />
       </div>

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -130,7 +130,7 @@ function Hero() {
       </div>
 
       <div
-        className={`${cornerBoxBase} gov-callout-strip no-tl no-tr no-bl no-br relative -mt-px flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-7`}
+        className={`${cornerBoxBase} gov-callout-strip no-tl no-tr no-bl no-br relative -mt-px -mb-px flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-7`}
       >
         <div className="flex min-w-0 flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-3">
           <span className="gov-ee-pill w-fit">Coming soon</span>
@@ -144,12 +144,21 @@ function Hero() {
             </p>
           </div>
         </div>
-        <Link
-          href="#government-cloud"
-          className="self-start whitespace-nowrap border-b border-text-primary pb-px font-mono text-[12px] text-text-primary sm:self-center"
-        >
-          See both options ↗
-        </Link>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 self-start sm:self-center">
+          <Link
+            href="/talk-to-us"
+            className="gov-btn gov-btn-primary gov-btn-small !shadow-none"
+          >
+            <span>Contact sales</span>
+            <span className="gov-kbd">↗</span>
+          </Link>
+          <Link
+            href="#government-cloud"
+            className="whitespace-nowrap border-b border-text-primary pb-px font-mono text-[12px] text-text-primary"
+          >
+            See both options
+          </Link>
+        </div>
       </div>
 
       <div
@@ -737,8 +746,9 @@ function GovernmentCloud() {
         </h2>
         <p className="gov-body">
           Most government teams run Langfuse Enterprise on their own
-          infrastructure. Langfuse Cloud for Government is a managed option in
-          progress. Talk to sales to learn more.
+          infrastructure, often with ClickHouse Government. Langfuse Cloud for
+          Government is a managed option in progress, with the same Enterprise
+          controls plus public-sector hardening. Talk to sales to learn more.
         </p>
       </div>
 
@@ -749,7 +759,7 @@ function GovernmentCloud() {
             <span className="gov-now-pill">Available today</span>
           </div>
           <div className="font-analog text-[22px] font-medium leading-[1.3] text-text-primary [text-wrap:balance]">
-            Self-hosted Enterprise
+            Self-hosted, on-premises Enterprise
           </div>
           <p className="gov-body-sm m-0">
             Run Langfuse Enterprise on-premises, in a VPC, or air-gapped. Pair
@@ -757,12 +767,12 @@ function GovernmentCloud() {
             <Link className="gov-link" href="https://clickhouse.com/government">
               ClickHouse Government
             </Link>{" "}
-            when you need a government-ready analytics plane.
+            for a government-ready analytics plane you operate yourself.
           </p>
           <ul className="gov-feature-list">
             <li>Your cluster, your network boundary</li>
             <li>FIPS-compliant Docker images upon request</li>
-            <li>RBAC, SSO, SCIM, and audit logs</li>
+            <li>RBAC, SSO, SCIM, and immutable audit logs</li>
             <li>Data retention and server-side masking</li>
           </ul>
           <div className="flex-1" />
@@ -784,13 +794,15 @@ function GovernmentCloud() {
           </div>
           <p className="gov-body-sm m-0">
             A managed Langfuse Cloud for teams that want Langfuse to operate the
-            control plane. Hardening work is underway.
+            control plane. Public-sector hardening is underway on top of
+            Enterprise access and governance controls.
           </p>
           <ul className="gov-feature-list">
             <li>NIST SP 800-53 Rev. 5 hardening</li>
             <li>NIST SSDF (SP 800-218) hardening</li>
-            <li>FIPS 140-3</li>
-            <li>RBAC, SSO, SCIM, audit logs, retention, and data masking</li>
+            <li>FIPS 140-3 hardening</li>
+            <li>RBAC, SSO, SCIM, and immutable audit logs</li>
+            <li>Data retention and server-side masking</li>
           </ul>
           <div className="flex-1" />
           <Link

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -113,7 +113,7 @@ function Hero() {
           <p className="gov-body" style={{ fontSize: 17, maxWidth: "42ch" }}>
             Open-source tracing and evaluations for government AI. Run it{" "}
             <b className="font-medium text-text-primary">
-              air-gapped, on-premises, or in a private cloud
+              air-gapped, on-premises, or in a government cloud
             </b>
             . Prompts, traces, and scores stay in your environment. You run the
             software.
@@ -218,8 +218,8 @@ function HeroArt() {
       icon: "server",
     },
     {
-      title: "Government",
-      caption: "Public sector",
+      title: "Government cloud",
+      caption: "Coming soon",
       rot: -3.5,
       x: 62,
       y: 150,
@@ -299,7 +299,7 @@ function HeroArt() {
             <div className="gov-polaroid-well">
               <EnvIcon kind={c.icon} />
             </div>
-            <div className="mt-2 text-center font-mono text-[11px] font-medium uppercase tracking-[.07em] text-text-primary">
+            <div className="mt-2 text-center font-mono text-[11px] font-medium uppercase leading-tight tracking-[.07em] text-text-primary">
               {c.title}
             </div>
             <div className="text-center font-mono text-[10px] text-text-tertiary">
@@ -325,7 +325,7 @@ function HeroArt() {
             <div className="gov-polaroid-well">
               <EnvIcon kind={c.icon} />
             </div>
-            <div className="mt-1.5 text-center font-mono text-[9px] font-medium uppercase tracking-[.06em] text-text-primary">
+            <div className="mt-1.5 text-center font-mono text-[9px] font-medium uppercase leading-tight tracking-[.06em] text-text-primary">
               {c.title}
             </div>
           </div>

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -252,9 +252,9 @@ function HeroArt() {
               {
                 "--x": `${c.x}px`,
                 "--y": `${c.y}px`,
-                "--z": c.z,
+                "--z": String(c.z),
                 "--rest-rot": `${c.rot}deg`,
-                "--rest-scale": c.scale,
+                "--rest-scale": String(c.scale),
               } as CSSProperties
             }
           >

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -1,0 +1,684 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type ReactNode } from "react";
+import { GovernmentStyles } from "./styles";
+
+const cornerBoxBase =
+  "relative bg-surface-bg border border-line-structure gov-corners";
+
+const DOCKER_QUICKSTART = `git clone https://github.com/langfuse/langfuse.git
+cd langfuse
+docker compose up`;
+
+function CodeBox({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be blocked in some browsers; the command is still visible.
+    }
+  };
+  return (
+    <div className="overflow-hidden rounded-[2px] border border-line-cta bg-text-primary">
+      <div className="flex items-center justify-between border-b border-line-cta bg-text-secondary px-3 py-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-[.08em] text-surface-2">
+          terminal
+        </span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="cursor-pointer border-0 bg-transparent px-1.5 py-0.5 font-mono text-[10px] text-surface-2 hover:text-surface-bg"
+        >
+          {copied ? "copied" : "copy"}
+        </button>
+      </div>
+      <pre className="m-0 overflow-auto p-4 font-mono text-[12.5px] leading-[1.75] text-surface-bg">
+        <span className="text-surface-2">$ </span>
+        git clone https://github.com/langfuse/langfuse.git
+        {"\n"}
+        <span className="text-surface-2">$ </span>
+        cd langfuse
+        {"\n"}
+        <span className="text-surface-2">$ </span>
+        docker compose up
+      </pre>
+    </div>
+  );
+}
+
+function Ctas({ size = "default" }: { size?: "default" | "small" }) {
+  const btn = size === "small" ? "gov-btn gov-btn-small" : "gov-btn";
+  return (
+    <div className="flex flex-wrap gap-2">
+      <span className="gov-btn-wrap">
+        <Link className={`${btn} gov-btn-primary`} href="/talk-to-us">
+          <span>Talk to a public-sector expert</span>
+          <span className="gov-kbd">↗</span>
+        </Link>
+      </span>
+      <span className="gov-btn-wrap">
+        <Link className={`${btn} gov-btn-secondary`} href="/self-hosting">
+          <span>Explore self-hosting</span>
+        </Link>
+      </span>
+    </div>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="gov-section pb-5 pt-10">
+      <div
+        className={`${cornerBoxBase} no-bl no-br flex flex-wrap items-center justify-center gap-x-[18px] gap-y-2 px-5 py-[10px] text-[13px] text-text-secondary`}
+      >
+        <span className="gov-eyebrow">Langfuse for Government</span>
+        <span className="gov-dot" />
+        <span className="whitespace-nowrap">Air-gapped</span>
+        <span className="gov-dot" />
+        <span className="whitespace-nowrap">On-premises</span>
+        <span className="gov-dot" />
+        <span className="whitespace-nowrap">Cloud &amp; VPC</span>
+        <span className="gov-dot" />
+        <span className="whitespace-nowrap">Internet access optional</span>
+      </div>
+
+      <div
+        className={`${cornerBoxBase} no-tl no-tr no-bl no-br relative -mt-px -mb-px grid items-center gap-14 overflow-hidden px-5 py-16 sm:px-8 md:grid-cols-[1.35fr_1fr] md:py-[88px]`}
+      >
+        <div
+          aria-hidden
+          className="gov-blueprint pointer-events-none absolute inset-0 opacity-80"
+          style={{
+            maskImage:
+              "radial-gradient(ellipse 80% 90% at 50% 50%, black, transparent)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 80% 90% at 50% 50%, black, transparent)",
+          }}
+        />
+
+        <div className="relative flex flex-col gap-6">
+          <div className="gov-eyebrow">Open source · Self-hosted</div>
+          <h1 className="gov-h1">
+            Build accountable AI.
+            <br />
+            Keep it <span className="gov-highlight">under your control.</span>
+          </h1>
+          <p className="gov-body" style={{ fontSize: 17, maxWidth: "46ch" }}>
+            Langfuse is the open-source platform for observing, evaluating, and
+            improving AI agents and LLM applications. Deploy across{" "}
+            <b className="font-medium text-text-primary">
+              air-gapped, on-premises, and cloud environments
+            </b>
+            — and keep sensitive prompts, outputs, traces, and evaluation data
+            inside your approved infrastructure.
+          </p>
+          <Ctas />
+        </div>
+
+        <HeroArt />
+      </div>
+
+      <div
+        className={`${cornerBoxBase} gov-proof-grid no-tl no-tr grid grid-cols-2 [border-top:none] md:grid-cols-4`}
+      >
+        {[
+          ["Open-source core", "MIT · no usage limits"],
+          ["Internet optional", "Air-gapped ready"],
+          ["100,000+ engineers", "Building on Langfuse"],
+          ["10+ billion", "Observations / month"],
+        ].map(([top, bot]) => (
+          <div key={top} className="flex flex-col gap-1 px-5 py-[22px]">
+            <span className="text-[13px] font-medium leading-[1.4] text-text-primary">
+              {top}
+            </span>
+            <span className="font-mono text-[12px] text-text-tertiary">
+              {bot}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HeroArt() {
+  const cards: {
+    title: string;
+    caption: string;
+    rot: number;
+    x: number;
+    y: number;
+    z: number;
+    icon: "lock" | "server" | "cloud";
+  }[] = [
+    {
+      title: "Air-gapped",
+      caption: "No outbound network",
+      rot: -8,
+      x: 8,
+      y: 28,
+      z: 1,
+      icon: "lock",
+    },
+    {
+      title: "On-premises",
+      caption: "Your cluster",
+      rot: 7,
+      x: 168,
+      y: 8,
+      z: 3,
+      icon: "server",
+    },
+    {
+      title: "Cloud / VPC",
+      caption: "Your boundary",
+      rot: -5,
+      x: 92,
+      y: 188,
+      z: 2,
+      icon: "cloud",
+    },
+  ];
+
+  return (
+    <div className="relative hidden h-[380px] w-full md:block">
+      <svg
+        viewBox="0 0 400 400"
+        className="pointer-events-none absolute inset-0 opacity-40"
+      >
+        <circle
+          cx="200"
+          cy="200"
+          r="180"
+          fill="none"
+          stroke="var(--line-structure)"
+          strokeDasharray="2 4"
+        />
+        <circle
+          cx="200"
+          cy="200"
+          r="140"
+          fill="none"
+          stroke="var(--line-structure)"
+          strokeDasharray="2 4"
+        />
+        <circle
+          cx="200"
+          cy="200"
+          r="100"
+          fill="none"
+          stroke="var(--line-structure)"
+          strokeDasharray="2 4"
+        />
+        <text
+          x="200"
+          y="204"
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize="9"
+          fill="var(--text-tertiary)"
+          letterSpacing="1.4"
+        >
+          YOUR ENVIRONMENT
+        </text>
+      </svg>
+      {cards.map((c) => (
+        <div
+          key={c.title}
+          className="gov-card-shadow absolute w-[148px] border border-line-structure bg-surface-bg p-2.5"
+          style={{
+            left: c.x,
+            top: c.y,
+            zIndex: c.z,
+            transform: `rotate(${c.rot}deg)`,
+          }}
+        >
+          <div className="flex aspect-square items-center justify-center bg-surface-1">
+            <EnvIcon kind={c.icon} />
+          </div>
+          <div className="mt-2 text-center font-mono text-[10px] uppercase tracking-[.06em] text-text-primary">
+            {c.title}
+          </div>
+          <div className="text-center font-mono text-[10px] text-text-tertiary">
+            {c.caption}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EnvIcon({ kind }: { kind: "lock" | "server" | "cloud" }) {
+  const common = {
+    width: 42,
+    height: 42,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "var(--text-primary)",
+    strokeWidth: 1.4,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+  if (kind === "lock") {
+    return (
+      <svg {...common} aria-hidden>
+        <rect x="5" y="11" width="14" height="10" rx="2" />
+        <path d="M8 11V8a4 4 0 0 1 8 0v3" />
+      </svg>
+    );
+  }
+  if (kind === "server") {
+    return (
+      <svg {...common} aria-hidden>
+        <rect x="3" y="4" width="18" height="6" rx="1.5" />
+        <rect x="3" y="14" width="18" height="6" rx="1.5" />
+        <circle cx="7" cy="7" r="0.8" fill="var(--text-primary)" />
+        <circle cx="7" cy="17" r="0.8" fill="var(--text-primary)" />
+      </svg>
+    );
+  }
+  return (
+    <svg {...common} aria-hidden>
+      <path d="M7 18h11a4 4 0 0 0 .4-8 6 6 0 0 0-11.2-1.6A4.5 4.5 0 0 0 7 18z" />
+    </svg>
+  );
+}
+
+function ProductLoop() {
+  const pillars = [
+    {
+      n: "01",
+      eyebrow: "Observe",
+      title: "See what happened",
+      body: "Trace every model call, tool invocation, retrieval step, and agent decision. Investigate failures with the full context of each request, session, model, prompt, latency, and cost.",
+      href: "/docs/observability/overview",
+      label: "Observability docs",
+    },
+    {
+      n: "02",
+      eyebrow: "Evaluate",
+      title: "Measure what works",
+      body: "Score outputs with LLM-as-a-judge, deterministic checks, human review, and user feedback. Turn production failures into datasets and regression tests before the next release.",
+      href: "/docs/evaluation/overview",
+      label: "Evaluation docs",
+    },
+    {
+      n: "03",
+      eyebrow: "Contain",
+      title: "Contain failures early",
+      body: "Monitor quality, security scores, latency, and cost. Set thresholds and route alerts through webhooks, Slack, or GitHub Actions — so teams can act before isolated failures become systemic.",
+      href: "/docs/observability/features/alerts",
+      label: "Alerts docs",
+    },
+  ];
+
+  return (
+    <section id="observe" className="gov-section scroll-mt-24 pb-10 pt-[100px]">
+      <div className="mb-10 flex flex-col items-start gap-3.5">
+        <div className="gov-eyebrow">Observability · Evaluations · Alerts</div>
+        <h2 className="gov-h2 max-w-[24ch]">
+          Understand every agent.{" "}
+          <span className="gov-highlight">Improve every outcome.</span>
+        </h2>
+        <p className="gov-body">
+          Government AI must do more than work in a demo. Teams need to
+          understand how an agent reached an answer, measure whether it is
+          reliable, and improve it without losing control of sensitive data.
+        </p>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-3">
+        {pillars.map((p) => (
+          <div
+            key={p.n}
+            className="gov-chip-card flex min-h-[280px] flex-col gap-3.5 p-6"
+          >
+            <div className="flex items-center justify-between">
+              <span className="gov-step-num">{p.n}</span>
+              <span className="gov-eyebrow">{p.eyebrow}</span>
+            </div>
+            <div className="font-analog text-[22px] font-medium leading-[1.3] text-text-primary">
+              {p.title}
+            </div>
+            <p className="m-0 text-[13.5px] leading-[1.8] text-text-tertiary">
+              {p.body}
+            </p>
+            <div className="flex-1" />
+            <Link
+              href={p.href}
+              className="self-start border-b border-text-primary pb-px font-mono text-[12px] text-text-primary"
+            >
+              {p.label} ↗
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Deployment() {
+  const cards: {
+    n: string;
+    title: string;
+    body: ReactNode;
+    href: string;
+    label: string;
+    enterprise?: boolean;
+  }[] = [
+    {
+      n: "01",
+      title: "Run inside your security boundary",
+      body: (
+        <>
+          Deploy Langfuse in a VPC, on premises, or in a fully air-gapped
+          Kubernetes environment. Internet access is optional. Bring your own
+          infrastructure, networking, storage, and operational controls.
+        </>
+      ),
+      href: "/self-hosting/security/networking",
+      label: "Networking docs",
+    },
+    {
+      n: "02",
+      title: "Inspect and control the software",
+      body: (
+        <>
+          The complete Langfuse repository is public. All core product
+          capabilities — tracing, evaluations, prompt management, experiments,
+          and annotation — are MIT-licensed without usage limits. Enterprise
+          extensions live in clearly marked directories and activate only with a
+          license key.
+        </>
+      ),
+      href: "/handbook/chapters/open-source",
+      label: "Open-source licensing",
+    },
+    {
+      n: "03",
+      title: "Operate the same architecture proven in the cloud",
+      body: (
+        <>
+          Self-hosted Langfuse is not a reduced fork. It uses the same codebase
+          and architecture as Langfuse Cloud. Asynchronous ingestion absorbs
+          traffic spikes, incoming events are persisted before processing, and
+          background migrations reduce disruption during upgrades.
+        </>
+      ),
+      href: "/self-hosting#architecture",
+      label: "Architecture overview",
+    },
+    {
+      n: "04",
+      title: "Keep AI systems accountable",
+      enterprise: true,
+      body: (
+        <>
+          Application traces create a detailed record of model calls and agent
+          actions. Enterprise audit logs add immutable records of who changed
+          what, when, and with which before-and-after state. SSO, role-based
+          access control, SCIM, retention policies, and server-side data masking
+          support centralized governance.
+        </>
+      ),
+      href: "/docs/administration/audit-logs",
+      label: "Audit logs",
+    },
+  ];
+
+  return (
+    <section id="deploy" className="gov-section scroll-mt-24 pb-10 pt-[100px]">
+      <div className="mb-10 flex flex-col items-start gap-3.5">
+        <div className="gov-eyebrow">Self-hosting · Governance</div>
+        <h2 className="gov-h2 max-w-[22ch]">
+          Mission-ready deployment,{" "}
+          <span className="gov-highlight">on your terms.</span>
+        </h2>
+        <p className="gov-body">
+          Langfuse is built to run where government teams already operate —
+          behind a firewall, in a classified network, or in an approved cloud
+          account — without changing the product or the data model.
+        </p>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-2">
+        {cards.map((c) => (
+          <div key={c.n} className="gov-chip-card flex flex-col gap-3 p-6">
+            <div className="flex items-center justify-between gap-3">
+              <span className="gov-eyebrow">{c.n}</span>
+              {c.enterprise ? (
+                <span className="gov-ee-pill">Enterprise</span>
+              ) : null}
+            </div>
+            <div className="font-analog text-[22px] font-medium leading-[1.3] text-text-primary [text-wrap:balance]">
+              {c.title}
+            </div>
+            <p className="gov-body-sm m-0">{c.body}</p>
+            <div className="flex-1" />
+            <Link
+              href={c.href}
+              className="self-start border-b border-text-primary pb-px font-mono text-[12px] text-text-primary"
+            >
+              {c.label} ↗
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Security() {
+  const items = [
+    {
+      title: "Data stays where you put it",
+      body: "Run the platform and its open-source dependencies in infrastructure you control.",
+    },
+    {
+      title: "Sensitive data can be masked before storage",
+      body: (
+        <>
+          Redact data in the SDK before transmission, or apply{" "}
+          <Link className="gov-link" href="/self-hosting/security/data-masking">
+            centralized ingestion masking
+          </Link>{" "}
+          in self-hosted Enterprise deployments.
+        </>
+      ),
+    },
+    {
+      title: "Open standards reduce lock-in",
+      body: (
+        <>
+          Instrument with{" "}
+          <Link className="gov-link" href="/integrations/native/opentelemetry">
+            OpenTelemetry
+          </Link>
+          , or use Langfuse SDKs and integrations across models, frameworks, and
+          languages.
+        </>
+      ),
+    },
+    {
+      title: "Your team controls upgrades",
+      body: "Use versioned releases and deploy changes on your schedule.",
+    },
+  ];
+
+  return (
+    <section
+      id="security"
+      className="gov-section scroll-mt-24 pb-10 pt-[100px]"
+    >
+      <div className="grid items-stretch gap-4 md:grid-cols-[1fr_1.5fr]">
+        <div
+          className={`${cornerBoxBase} relative flex flex-col gap-5 overflow-hidden p-7`}
+        >
+          <div
+            aria-hidden
+            className="gov-grid-bg pointer-events-none absolute inset-0 opacity-60"
+            style={{
+              maskImage: "linear-gradient(to bottom, black, transparent 75%)",
+              WebkitMaskImage:
+                "linear-gradient(to bottom, black, transparent 75%)",
+            }}
+          />
+          <div className="relative flex flex-col gap-3.5">
+            <div className="gov-eyebrow">Security · Data control</div>
+            <h2
+              className="gov-h2 max-w-[16ch]"
+              style={{ fontSize: "clamp(28px, 3vw, 40px)" }}
+            >
+              Security without giving up developer velocity.
+            </h2>
+            <p className="gov-body-sm max-w-[40ch]">
+              Self-host Langfuse so application teams can debug and evaluate
+              agents quickly, while security teams keep telemetry, prompts, and
+              evaluation data inside the approved boundary.
+            </p>
+          </div>
+          <div
+            id="fips"
+            className="relative mt-auto flex flex-col gap-3 border border-line-structure bg-surface-1 p-4"
+          >
+            <div className="gov-eyebrow">FIPS images</div>
+            <p className="gov-body-sm m-0">
+              For deployments with FIPS requirements, compliant Langfuse Docker
+              images are available upon request.
+            </p>
+            <Link
+              className="gov-btn gov-btn-primary gov-btn-small !shadow-none self-start"
+              href="/talk-to-us"
+            >
+              <span>Book a meeting</span>
+              <span className="gov-kbd">↗</span>
+            </Link>
+          </div>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {items.map((item) => (
+            <div
+              key={item.title}
+              className="gov-chip-card flex flex-col gap-2 p-5"
+            >
+              <div className="font-analog text-[18px] font-medium leading-[1.35] text-text-primary [text-wrap:balance]">
+                {item.title}
+              </div>
+              <p className="gov-body-sm m-0">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GetStarted() {
+  return (
+    <section
+      id="get-started"
+      className="gov-section scroll-mt-24 pb-10 pt-[100px]"
+    >
+      <div
+        className={`${cornerBoxBase} grid items-center gap-10 px-6 py-9 md:grid-cols-[1fr_1.15fr] md:px-8`}
+      >
+        <div className="flex flex-col gap-4">
+          <div className="gov-eyebrow">Get started · MIT licensed</div>
+          <h2
+            className="gov-h2 max-w-[18ch]"
+            style={{ fontSize: "clamp(28px, 3vw, 40px)" }}
+          >
+            Start locally.{" "}
+            <span className="gov-highlight">Deploy for the mission.</span>
+          </h2>
+          <p className="gov-body-sm m-0 max-w-[44ch]">
+            Run Langfuse locally with Docker Compose in minutes. The repository
+            is public, the core product is MIT-licensed, and the same platform
+            is already used in production at scale. Move to Kubernetes or
+            Terraform without changing the product or data model.
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <Link className="gov-code-inline" href="/self-hosting">
+              Deployment guide
+            </Link>
+            <Link
+              className="gov-code-inline"
+              href="https://github.com/langfuse/langfuse"
+            >
+              github.com/langfuse/langfuse
+            </Link>
+            <Link
+              className="gov-code-inline"
+              href="/self-hosting/deployment/kubernetes-helm"
+            >
+              Helm chart
+            </Link>
+            <Link
+              className="gov-code-inline"
+              href="/self-hosting/deployment/aws"
+            >
+              AWS Terraform
+            </Link>
+            <Link
+              className="gov-code-inline"
+              href="/self-hosting/deployment/azure"
+            >
+              Azure Terraform
+            </Link>
+            <Link
+              className="gov-code-inline"
+              href="/self-hosting/deployment/gcp"
+            >
+              GCP Terraform
+            </Link>
+          </div>
+        </div>
+
+        <CodeBox value={DOCKER_QUICKSTART} />
+      </div>
+    </section>
+  );
+}
+
+function CTABanner() {
+  return (
+    <section className="gov-section pb-15 pt-[80px]">
+      <div
+        className={`${cornerBoxBase} gov-stripes-bg flex flex-col items-center gap-[22px] px-8 py-[72px] text-center`}
+      >
+        <div className="gov-eyebrow">Langfuse for Government</div>
+        <h2 className="gov-h2 max-w-[22ch]">
+          Bring accountable AI into{" "}
+          <span className="gov-highlight">your environment.</span>
+        </h2>
+        <p className="gov-body text-center">
+          See how Langfuse can help your team observe, evaluate, and improve
+          mission-critical AI systems — without moving sensitive data outside
+          your control.
+        </p>
+        <Ctas />
+      </div>
+    </section>
+  );
+}
+
+export function GovernmentLanding() {
+  return (
+    <div className="gov-page">
+      <GovernmentStyles />
+      <div className="mx-auto max-w-[1440px]">
+        <Hero />
+        <ProductLoop />
+        <Deployment />
+        <Security />
+        <GetStarted />
+        <CTABanner />
+      </div>
+    </div>
+  );
+}

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -130,6 +130,29 @@ function Hero() {
       </div>
 
       <div
+        className={`${cornerBoxBase} gov-callout-strip no-tl no-tr no-bl no-br relative -mt-px flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-7`}
+      >
+        <div className="flex min-w-0 flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-3">
+          <span className="gov-ee-pill w-fit">Coming soon</span>
+          <div className="min-w-0">
+            <div className="text-[14px] font-medium leading-[1.4] text-text-primary">
+              Langfuse Cloud for Government
+            </div>
+            <p className="gov-body-sm m-0">
+              Managed cloud option. NIST SP 800-53 Rev. 5, SSDF, and FIPS 140-3
+              hardening in progress.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="#government-cloud"
+          className="self-start whitespace-nowrap border-b border-text-primary pb-px font-mono text-[12px] text-text-primary sm:self-center"
+        >
+          See both options ↗
+        </Link>
+      </div>
+
+      <div
         className={`${cornerBoxBase} gov-proof-grid no-tl no-tr grid grid-cols-2 [border-top:none] md:grid-cols-4`}
       >
         {[
@@ -700,6 +723,89 @@ function GetStarted() {
   );
 }
 
+function GovernmentCloud() {
+  return (
+    <section
+      id="government-cloud"
+      className="gov-section scroll-mt-24 pb-10 pt-[100px]"
+    >
+      <div className="mb-10 flex flex-col items-start gap-3.5">
+        <div className="gov-eyebrow">Deployment options</div>
+        <h2 className="gov-h2 max-w-[22ch]">
+          Self-host today.{" "}
+          <span className="gov-highlight">Cloud is coming soon.</span>
+        </h2>
+        <p className="gov-body">
+          Most government teams run Langfuse Enterprise on their own
+          infrastructure. Langfuse Cloud for Government is a managed option in
+          progress. Talk to sales to learn more.
+        </p>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-2">
+        <div className="gov-chip-card flex flex-col gap-3.5 p-6">
+          <div className="flex items-center justify-between gap-3">
+            <span className="gov-eyebrow">Option 01</span>
+            <span className="gov-now-pill">Available today</span>
+          </div>
+          <div className="font-analog text-[22px] font-medium leading-[1.3] text-text-primary [text-wrap:balance]">
+            Self-hosted Enterprise
+          </div>
+          <p className="gov-body-sm m-0">
+            Run Langfuse Enterprise on-premises, in a VPC, or air-gapped. Pair
+            it with{" "}
+            <Link className="gov-link" href="https://clickhouse.com/government">
+              ClickHouse Government
+            </Link>{" "}
+            when you need a government-ready analytics plane.
+          </p>
+          <ul className="gov-feature-list">
+            <li>Your cluster, your network boundary</li>
+            <li>FIPS-compliant Docker images upon request</li>
+            <li>RBAC, SSO, SCIM, and audit logs</li>
+            <li>Data retention and server-side masking</li>
+          </ul>
+          <div className="flex-1" />
+          <Link
+            href="/self-hosting"
+            className="self-start border-b border-text-primary pb-px font-mono text-[12px] text-text-primary"
+          >
+            Explore self-hosting ↗
+          </Link>
+        </div>
+
+        <div className="gov-chip-card gov-option-card is-soon flex flex-col gap-3.5 p-6">
+          <div className="flex items-center justify-between gap-3">
+            <span className="gov-eyebrow">Option 02</span>
+            <span className="gov-ee-pill">Coming soon</span>
+          </div>
+          <div className="font-analog text-[22px] font-medium leading-[1.3] text-text-primary [text-wrap:balance]">
+            Langfuse Cloud for Government
+          </div>
+          <p className="gov-body-sm m-0">
+            A managed Langfuse Cloud for teams that want Langfuse to operate the
+            control plane. Hardening work is underway.
+          </p>
+          <ul className="gov-feature-list">
+            <li>NIST SP 800-53 Rev. 5 hardening</li>
+            <li>NIST SSDF (SP 800-218) hardening</li>
+            <li>FIPS 140-3</li>
+            <li>RBAC, SSO, SCIM, audit logs, retention, and data masking</li>
+          </ul>
+          <div className="flex-1" />
+          <Link
+            href="/talk-to-us"
+            className="gov-btn gov-btn-primary gov-btn-small !shadow-none self-start"
+          >
+            <span>Contact sales</span>
+            <span className="gov-kbd">↗</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function CTABanner() {
   return (
     <section className="gov-section pb-15 pt-[80px]">
@@ -712,8 +818,8 @@ function CTABanner() {
           <span className="gov-highlight">your environment.</span>
         </h2>
         <p className="gov-body text-center">
-          Talk through tracing, evaluations, and self-hosting for government AI.
-          Sensitive data stays in infrastructure you control.
+          Talk through self-hosted Enterprise today, or Langfuse Cloud for
+          Government. Sensitive data stays in infrastructure you control.
         </p>
         <Ctas />
       </div>
@@ -731,6 +837,7 @@ export function GovernmentLanding() {
         <Deployment />
         <Security />
         <GetStarted />
+        <GovernmentCloud />
         <CTABanner />
       </div>
     </div>

--- a/components/government/GovernmentLanding.tsx
+++ b/components/government/GovernmentLanding.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, type ReactNode } from "react";
+import { useState, type CSSProperties, type ReactNode } from "react";
 import { GovernmentStyles } from "./styles";
 
 const cornerBoxBase =
@@ -73,21 +73,22 @@ function Hero() {
   return (
     <section className="gov-section pb-5 pt-10">
       <div
-        className={`${cornerBoxBase} no-bl no-br flex flex-wrap items-center justify-center gap-x-[18px] gap-y-2 px-5 py-[10px] text-[13px] text-text-secondary`}
+        className={`${cornerBoxBase} no-bl no-br flex flex-col gap-3 px-5 py-6 sm:flex-row sm:items-end sm:justify-between sm:gap-8 sm:px-7 sm:py-7`}
       >
-        <span className="gov-eyebrow">Langfuse for Government</span>
-        <span className="gov-dot" />
-        <span className="whitespace-nowrap">Air-gapped</span>
-        <span className="gov-dot" />
-        <span className="whitespace-nowrap">On-premises</span>
-        <span className="gov-dot" />
-        <span className="whitespace-nowrap">Cloud &amp; VPC</span>
-        <span className="gov-dot" />
-        <span className="whitespace-nowrap">Internet access optional</span>
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="gov-eyebrow">Open source · Self-hosted</div>
+          <p className="gov-masthead">
+            Langfuse for <span className="gov-highlight">Government</span>
+          </p>
+        </div>
+        <p className="gov-body-sm m-0 max-w-[38ch] text-pretty sm:text-right">
+          Observability and evaluations for public-sector AI — inside your
+          security boundary.
+        </p>
       </div>
 
       <div
-        className={`${cornerBoxBase} no-tl no-tr no-bl no-br relative -mt-px -mb-px grid items-center gap-14 overflow-hidden px-5 py-16 sm:px-8 md:grid-cols-[1.35fr_1fr] md:py-[88px]`}
+        className={`${cornerBoxBase} no-tl no-tr no-bl no-br relative -mt-px -mb-px grid items-center gap-10 px-5 py-12 sm:px-7 md:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] md:gap-8 md:py-[64px]`}
       >
         <div
           aria-hidden
@@ -100,22 +101,29 @@ function Hero() {
           }}
         />
 
-        <div className="relative flex flex-col gap-6">
-          <div className="gov-eyebrow">Open source · Self-hosted</div>
+        <div className="relative flex flex-col gap-5">
+          <div className="gov-eyebrow">
+            Government · Public sector · Internet optional
+          </div>
           <h1 className="gov-h1">
             Build accountable AI.
             <br />
             Keep it <span className="gov-highlight">under your control.</span>
           </h1>
-          <p className="gov-body" style={{ fontSize: 17, maxWidth: "46ch" }}>
-            Langfuse is the open-source platform for observing, evaluating, and
-            improving AI agents and LLM applications. Deploy across{" "}
+          <p className="gov-body" style={{ fontSize: 17, maxWidth: "42ch" }}>
+            Government and public-sector teams use Langfuse to observe,
+            evaluate, and improve AI agents — without sending prompts, traces,
+            or evaluation data outside their security boundary. Deploy{" "}
             <b className="font-medium text-text-primary">
-              air-gapped, on-premises, and cloud environments
+              air-gapped, on premises, or in a private cloud
             </b>
-            — and keep sensitive prompts, outputs, traces, and evaluation data
-            inside your approved infrastructure.
+            . The core is open source and inspectable; you operate the stack.
           </p>
+          <ul className="gov-claim-row">
+            <li>Your environment</li>
+            <li>Inspectable source</li>
+            <li>Audit-ready traces</li>
+          </ul>
           <Ctas />
         </div>
 
@@ -153,106 +161,143 @@ function HeroArt() {
     x: number;
     y: number;
     z: number;
-    icon: "lock" | "server" | "cloud";
+    scale: number;
+    featured?: boolean;
+    icon: "lock" | "server" | "building";
   }[] = [
     {
       title: "Air-gapped",
       caption: "No outbound network",
-      rot: -8,
-      x: 8,
-      y: 28,
+      rot: -9,
+      x: 4,
+      y: 42,
       z: 1,
+      scale: 1,
       icon: "lock",
     },
     {
       title: "On-premises",
       caption: "Your cluster",
-      rot: 7,
+      rot: 8,
       x: 168,
-      y: 8,
-      z: 3,
+      y: 18,
+      z: 2,
+      scale: 1,
       icon: "server",
     },
     {
-      title: "Cloud / VPC",
-      caption: "Your boundary",
-      rot: -5,
-      x: 92,
-      y: 188,
-      z: 2,
-      icon: "cloud",
+      title: "Government",
+      caption: "Public sector",
+      rot: -3.5,
+      x: 62,
+      y: 150,
+      z: 4,
+      scale: 1.04,
+      featured: true,
+      icon: "building",
     },
   ];
 
   return (
-    <div className="relative hidden h-[380px] w-full md:block">
-      <svg
-        viewBox="0 0 400 400"
-        className="pointer-events-none absolute inset-0 opacity-40"
+    <>
+      <div
+        className="gov-hero-art relative mx-auto hidden h-[420px] w-full max-w-[380px] md:block"
+        aria-hidden
       >
-        <circle
-          cx="200"
-          cy="200"
-          r="180"
-          fill="none"
-          stroke="var(--line-structure)"
-          strokeDasharray="2 4"
-        />
-        <circle
-          cx="200"
-          cy="200"
-          r="140"
-          fill="none"
-          stroke="var(--line-structure)"
-          strokeDasharray="2 4"
-        />
-        <circle
-          cx="200"
-          cy="200"
-          r="100"
-          fill="none"
-          stroke="var(--line-structure)"
-          strokeDasharray="2 4"
-        />
-        <text
-          x="200"
-          y="204"
-          textAnchor="middle"
-          fontFamily="var(--font-mono)"
-          fontSize="9"
-          fill="var(--text-tertiary)"
-          letterSpacing="1.4"
+        <svg
+          viewBox="0 0 400 400"
+          className="pointer-events-none absolute inset-0 opacity-45"
         >
-          YOUR ENVIRONMENT
-        </text>
-      </svg>
-      {cards.map((c) => (
-        <div
-          key={c.title}
-          className="gov-card-shadow absolute w-[148px] border border-line-structure bg-surface-bg p-2.5"
-          style={{
-            left: c.x,
-            top: c.y,
-            zIndex: c.z,
-            transform: `rotate(${c.rot}deg)`,
-          }}
-        >
-          <div className="flex aspect-square items-center justify-center bg-surface-1">
-            <EnvIcon kind={c.icon} />
+          <circle
+            cx="200"
+            cy="200"
+            r="180"
+            fill="none"
+            stroke="var(--line-structure)"
+            strokeDasharray="2 4"
+          />
+          <circle
+            cx="200"
+            cy="200"
+            r="140"
+            fill="none"
+            stroke="var(--line-structure)"
+            strokeDasharray="2 4"
+          />
+          <circle
+            cx="200"
+            cy="200"
+            r="100"
+            fill="none"
+            stroke="var(--line-structure)"
+            strokeDasharray="2 4"
+          />
+          <text
+            x="200"
+            y="206"
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize="11"
+            fill="var(--text-tertiary)"
+            letterSpacing="1.8"
+          >
+            GOVERNMENT
+          </text>
+        </svg>
+        {cards.map((c) => (
+          <div
+            key={c.title}
+            className={`gov-polaroid${c.featured ? " is-featured" : ""}`}
+            style={
+              {
+                "--x": `${c.x}px`,
+                "--y": `${c.y}px`,
+                "--z": c.z,
+                "--rest-rot": `${c.rot}deg`,
+                "--rest-scale": c.scale,
+              } as CSSProperties
+            }
+          >
+            <div className="gov-polaroid-well">
+              <EnvIcon kind={c.icon} />
+            </div>
+            <div className="mt-2 text-center font-mono text-[11px] font-medium uppercase tracking-[.07em] text-text-primary">
+              {c.title}
+            </div>
+            <div className="text-center font-mono text-[10px] text-text-tertiary">
+              {c.caption}
+            </div>
           </div>
-          <div className="mt-2 text-center font-mono text-[10px] uppercase tracking-[.06em] text-text-primary">
-            {c.title}
+        ))}
+      </div>
+      <div
+        className="relative mt-1 flex justify-center gap-2.5 md:hidden"
+        aria-hidden
+      >
+        {cards.map((c) => (
+          <div
+            key={c.title}
+            className={`gov-card-shadow w-[31%] min-w-[96px] max-w-[128px] border border-line-structure bg-surface-bg p-2 ${
+              c.featured ? "relative" : ""
+            }`}
+          >
+            {c.featured ? (
+              <span className="absolute inset-x-0 top-0 h-[3px] bg-surface-cta-primary" />
+            ) : null}
+            <div className="gov-polaroid-well">
+              <EnvIcon kind={c.icon} />
+            </div>
+            <div className="mt-1.5 text-center font-mono text-[9px] font-medium uppercase tracking-[.06em] text-text-primary">
+              {c.title}
+            </div>
           </div>
-          <div className="text-center font-mono text-[10px] text-text-tertiary">
-            {c.caption}
-          </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </>
   );
 }
 
-function EnvIcon({ kind }: { kind: "lock" | "server" | "cloud" }) {
+function EnvIcon({ kind }: { kind: "lock" | "server" | "building" }) {
   const common = {
     width: 42,
     height: 42,
@@ -283,7 +328,14 @@ function EnvIcon({ kind }: { kind: "lock" | "server" | "cloud" }) {
   }
   return (
     <svg {...common} aria-hidden>
-      <path d="M7 18h11a4 4 0 0 0 .4-8 6 6 0 0 0-11.2-1.6A4.5 4.5 0 0 0 7 18z" />
+      <path d="M2 10h20L12 3.5z" />
+      <path d="M4 10v10" />
+      <path d="M20 10v10" />
+      <path d="M3 20h18" />
+      <path d="M8 20v-7" />
+      <path d="M12 20v-7" />
+      <path d="M16 20v-7" />
+      <path d="M8 13h8" />
     </svg>
   );
 }
@@ -671,7 +723,7 @@ export function GovernmentLanding() {
   return (
     <div className="gov-page">
       <GovernmentStyles />
-      <div className="mx-auto max-w-[1440px]">
+      <div className="mx-auto max-w-[1120px]">
         <Hero />
         <ProductLoop />
         <Deployment />

--- a/components/government/styles.tsx
+++ b/components/government/styles.tsx
@@ -312,6 +312,56 @@ export function GovernmentStyles() {
         background: var(--surface-cta-primary);
         border: 1px solid var(--line-cta);
       }
+      .gov-now-pill {
+        display: inline-flex; align-items: center;
+        height: 20px; padding: 0 7px; border-radius: 2px;
+        font-family: var(--font-mono); font-size: 10px;
+        letter-spacing: .08em; text-transform: uppercase;
+        color: var(--text-secondary);
+        background: var(--surface-bg);
+        border: 1px solid var(--line-structure);
+      }
+
+      .gov-callout-strip {
+        background: color-mix(in srgb, var(--surface-cta-primary) 22%, var(--surface-bg));
+      }
+
+      .gov-feature-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .gov-feature-list li {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        font-size: 13.5px;
+        line-height: 1.55;
+        color: var(--text-secondary);
+      }
+      .gov-feature-list li::before {
+        content: "";
+        width: 5px;
+        height: 5px;
+        margin-top: 7px;
+        border-radius: 1px;
+        background: var(--surface-cta-primary);
+        box-shadow: 0 0 0 1px var(--line-cta);
+        flex-shrink: 0;
+      }
+
+      .gov-option-card.is-soon::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--surface-cta-primary);
+      }
 
       .gov-step-num {
         font-family: var(--font-analog), "Inter", system-ui, sans-serif;

--- a/components/government/styles.tsx
+++ b/components/government/styles.tsx
@@ -1,0 +1,228 @@
+export function GovernmentStyles() {
+  return (
+    <style>{`
+      .gov-page {
+        background: var(--surface-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 15px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      .gov-page,
+      .gov-page p {
+        line-height: 1.7;
+      }
+
+      .gov-section {
+        padding-left: 16px;
+        padding-right: 16px;
+      }
+      @media (min-width: 768px) {
+        .gov-section { padding-left: 32px; padding-right: 32px; }
+      }
+
+      .gov-corners::before {
+        content: "";
+        position: absolute;
+        inset: -1px;
+        pointer-events: none;
+        background-color: var(--line-cta);
+        -webkit-mask-image:
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+        mask-image:
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M8 0V1H3C1.89543 1 1 1.89543 1 3V8H0V0H8Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M8 8V7H3C1.89543 7 1 6.10457 1 5V0H0V8H8Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 8V7H5C6.10457 7 7 6.10457 7 5V0H8V8H0Z' fill='black'/%3E%3C/svg%3E"),
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 0V1H5C6.10457 1 7 1.89543 7 3V8H8V0H0Z' fill='black'/%3E%3C/svg%3E");
+        -webkit-mask-position: top left, bottom left, bottom right, top right;
+        mask-position: top left, bottom left, bottom right, top right;
+        -webkit-mask-size: 8px 8px;
+        mask-size: 8px 8px;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+      }
+      .gov-corners.no-tl::before { -webkit-mask-position: 50% 150%, bottom left, bottom right, top right; mask-position: 50% 150%, bottom left, bottom right, top right; }
+      .gov-corners.no-tr::before { -webkit-mask-position: top left, bottom left, bottom right, 50% 150%; mask-position: top left, bottom left, bottom right, 50% 150%; }
+      .gov-corners.no-bl::before { -webkit-mask-position: top left, 50% 150%, bottom right, top right; mask-position: top left, 50% 150%, bottom right, top right; }
+      .gov-corners.no-br::before { -webkit-mask-position: top left, bottom left, 50% 150%, top right; mask-position: top left, bottom left, 50% 150%, top right; }
+      .gov-corners.no-tl.no-tr::before { -webkit-mask-position: 50% 150%, bottom left, bottom right, 50% 150%; mask-position: 50% 150%, bottom left, bottom right, 50% 150%; }
+      .gov-corners.no-bl.no-br::before { -webkit-mask-position: top left, 50% 150%, 50% 150%, top right; mask-position: top left, 50% 150%, 50% 150%, top right; }
+      .gov-corners.no-tl.no-bl::before { -webkit-mask-position: 50% 150%, 50% 150%, bottom right, top right; mask-position: 50% 150%, 50% 150%, bottom right, top right; }
+      .gov-corners.no-tr.no-br::before { -webkit-mask-position: top left, bottom left, 50% 150%, 50% 150%; mask-position: top left, bottom left, 50% 150%, 50% 150%; }
+      .gov-corners.no-tl.no-tr.no-bl::before { -webkit-mask-position: 50% 150%, 50% 150%, bottom right, 50% 150%; mask-position: 50% 150%, 50% 150%, bottom right, 50% 150%; }
+      .gov-corners.no-tl.no-tr.no-br::before { -webkit-mask-position: 50% 150%, bottom left, 50% 150%, 50% 150%; mask-position: 50% 150%, bottom left, 50% 150%, 50% 150%; }
+      .gov-corners.no-tl.no-bl.no-br::before { -webkit-mask-position: 50% 150%, 50% 150%, 50% 150%, top right; mask-position: 50% 150%, 50% 150%, 50% 150%, top right; }
+      .gov-corners.no-tr.no-bl.no-br::before { -webkit-mask-position: top left, 50% 150%, 50% 150%, 50% 150%; mask-position: top left, 50% 150%, 50% 150%, 50% 150%; }
+      .gov-corners.no-tl.no-tr.no-bl.no-br::before { -webkit-mask-position: 50% 150%, 50% 150%, 50% 150%, 50% 150%; mask-position: 50% 150%, 50% 150%, 50% 150%, 50% 150%; }
+
+      .gov-card-shadow {
+        box-shadow:
+          -15px 33px 14px 0 rgba(0,0,0,0.01),
+          -8px 18px 12px 0 rgba(0,0,0,0.02),
+          -4px 8px 9px 0 rgba(0,0,0,0.03),
+          -1px 2px 5px 0 rgba(0,0,0,0.04),
+          0 8px 24px rgba(0,0,0,0.08);
+      }
+
+      .gov-grid-bg {
+        background-image:
+          linear-gradient(to right,  rgba(108,103,96,0.18) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(108,103,96,0.18) 1px, transparent 1px);
+        background-size: 8px 8px;
+      }
+      .gov-stripes-bg {
+        background-image: repeating-linear-gradient(315deg,
+          transparent 0, transparent 2px,
+          rgba(108, 103, 96, 0.12) 2px, rgba(108, 103, 96, 0.12) 3px);
+      }
+      .gov-blueprint {
+        background-image:
+          linear-gradient(to right,  rgba(108,103,96,0.10) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(108,103,96,0.10) 1px, transparent 1px),
+          linear-gradient(to right,  rgba(108,103,96,0.18) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(108,103,96,0.18) 1px, transparent 1px);
+        background-size: 8px 8px, 8px 8px, 64px 64px, 64px 64px;
+      }
+
+      .gov-page .gov-dot {
+        width: 3px; height: 3px; border-radius: 50%;
+        background: var(--text-tertiary); display: inline-block; flex-shrink: 0;
+      }
+
+      .gov-btn-wrap { position: relative; display: inline-flex; align-items: center; padding: 4px; }
+      .gov-btn {
+        display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+        height: 36px; padding: 0 14px; border-radius: 2px;
+        font-size: 13px; font-weight: 500; letter-spacing: -0.06px;
+        border: 1px solid;
+        box-shadow: 0 4px 8px 0 rgba(0,0,0,0.05), 0 4px 4px 0 rgba(0,0,0,0.03);
+        cursor: pointer; transition: background 120ms, border-color 120ms;
+        white-space: nowrap;
+      }
+      .gov-btn-primary { background: var(--text-primary); color: var(--surface-bg); border-color: var(--text-secondary); }
+      .gov-btn-primary:hover { background: var(--text-secondary); }
+      .gov-btn-secondary { background: var(--surface-bg); color: var(--text-secondary); border-color: var(--line-structure); }
+      .gov-btn-secondary:hover { border-color: var(--line-cta); }
+      .gov-btn-small { height: 28px; padding: 0 10px; font-size: 12px; }
+      .gov-kbd {
+        display: inline-flex; align-items: center; justify-content: center;
+        min-width: 20px; height: 20px; padding: 0 4px; border-radius: 1px; font-size: 11px; font-weight: 500;
+        border: 1px solid color-mix(in srgb, var(--text-secondary) 30%, transparent);
+        background: color-mix(in srgb, var(--text-secondary) 40%, transparent);
+        font-family: var(--font-mono);
+      }
+      .gov-btn-secondary .gov-kbd {
+        border-color: color-mix(in srgb, var(--text-secondary) 20%, transparent);
+        background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+        color: var(--text-secondary);
+      }
+
+      .gov-highlight {
+        display: inline-block;
+        background: var(--surface-cta-primary);
+        padding: 0 6px;
+        mix-blend-mode: multiply;
+        color: inherit;
+      }
+      :root[class~="dark"] .gov-highlight { mix-blend-mode: screen; }
+
+      .gov-h1 {
+        font-family: var(--font-analog), "Inter", system-ui, sans-serif;
+        font-weight: 500;
+        font-size: clamp(36px, 5.2vw, 72px);
+        line-height: 1.08;
+        letter-spacing: -0.02em;
+        margin: 0;
+      }
+      .gov-h2 {
+        font-family: var(--font-analog), "Inter", system-ui, sans-serif;
+        font-weight: 500;
+        font-size: clamp(26px, 3vw, 40px);
+        line-height: 1.22;
+        letter-spacing: -0.005em;
+        margin: 0;
+      }
+      .gov-eyebrow {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: .08em;
+        color: var(--text-tertiary);
+        white-space: nowrap;
+      }
+      .gov-body {
+        font-size: 15px;
+        line-height: 1.8;
+        color: var(--text-secondary);
+        max-width: 62ch;
+        text-wrap: pretty;
+        margin: 0;
+      }
+      .gov-body-sm {
+        font-size: 13.5px;
+        line-height: 1.85;
+        color: var(--text-secondary);
+        text-wrap: pretty;
+      }
+
+      .gov-page .font-analog {
+        font-family: var(--font-analog), "Inter", system-ui, sans-serif !important;
+      }
+
+      .gov-chip-card {
+        position: relative; background: var(--surface-1);
+        border: 1px solid var(--line-structure); border-radius: 2px;
+        overflow: hidden; transition: border-color 120ms;
+      }
+      .gov-chip-card:hover { border-color: var(--line-cta); }
+
+      .gov-link { color: var(--text-links); border-bottom: 1px solid currentColor; }
+      .gov-link:hover { opacity: .8; }
+
+      .gov-code-inline {
+        font-family: var(--font-mono);
+        font-size: 12.5px;
+        background: var(--surface-2);
+        border: 1px solid var(--line-structure);
+        border-radius: 3px;
+        padding: 1px 6px;
+        color: var(--text-primary);
+      }
+
+      .gov-ee-pill {
+        display: inline-flex; align-items: center;
+        height: 20px; padding: 0 7px; border-radius: 2px;
+        font-family: var(--font-mono); font-size: 10px;
+        letter-spacing: .08em; text-transform: uppercase;
+        color: var(--text-primary);
+        background: var(--surface-cta-primary);
+        border: 1px solid var(--line-cta);
+      }
+
+      .gov-step-num {
+        font-family: var(--font-analog), "Inter", system-ui, sans-serif;
+        font-size: 40px; font-weight: 500;
+        color: var(--text-primary); line-height: 1;
+        display: inline-flex; align-items: baseline;
+      }
+      .gov-step-num::after {
+        content: ""; display: inline-block; width: 40px; height: 1px;
+        background: var(--line-structure); margin-left: 8px; vertical-align: middle;
+      }
+
+      .gov-proof-grid > div {
+        border-right: 1px solid var(--line-structure);
+        border-top: 1px solid var(--line-structure);
+      }
+      .gov-proof-grid > div:nth-child(2n) { border-right: none; }
+      @media (min-width: 768px) {
+        .gov-proof-grid > div:nth-child(2n) { border-right: 1px solid var(--line-structure); }
+        .gov-proof-grid > div:nth-child(4n) { border-right: none; }
+      }
+    `}</style>
+  );
+}

--- a/components/government/styles.tsx
+++ b/components/government/styles.tsx
@@ -129,9 +129,9 @@ export function GovernmentStyles() {
           transform 480ms cubic-bezier(0.22, 1, 0.36, 1),
           box-shadow 480ms cubic-bezier(0.22, 1, 0.36, 1),
           opacity 280ms ease,
-          border-color 200ms ease,
-          z-index 0ms linear 280ms;
+          border-color 200ms ease;
         cursor: default;
+        pointer-events: auto;
       }
       .gov-polaroid.is-featured {
         width: 196px;
@@ -154,44 +154,27 @@ export function GovernmentStyles() {
         background: color-mix(in srgb, var(--surface-cta-primary) 28%, var(--surface-1));
         transition: background 320ms ease;
       }
-      @media (hover: hover) and (pointer: fine) {
-        .gov-hero-art:hover .gov-polaroid {
-          opacity: 0.58;
-        }
-        .gov-hero-art .gov-polaroid:hover,
-        .gov-hero-art .gov-polaroid:focus-visible {
-          opacity: 1;
-          z-index: 20;
-          border-color: var(--line-cta);
-          transform: rotate(calc(var(--rest-rot) * 0.18)) translateY(-12px) scale(calc(var(--rest-scale, 1) * 1.06));
-          box-shadow:
-            0 28px 44px rgba(0,0,0,0.12),
-            0 10px 18px rgba(0,0,0,0.06),
-            0 0 0 1px color-mix(in srgb, var(--line-cta) 55%, transparent);
-          transition:
-            transform 480ms cubic-bezier(0.22, 1, 0.36, 1),
-            box-shadow 480ms cubic-bezier(0.22, 1, 0.36, 1),
-            opacity 180ms ease,
-            border-color 200ms ease,
-            z-index 0ms;
-        }
-        .gov-hero-art .gov-polaroid:hover .gov-polaroid-well,
-        .gov-hero-art .gov-polaroid:focus-visible .gov-polaroid-well {
-          background: color-mix(in srgb, var(--surface-cta-primary) 62%, var(--surface-1));
-        }
+      .gov-hero-art.is-engaged .gov-polaroid {
+        opacity: 0.46;
+      }
+      .gov-polaroid.is-lifted {
+        opacity: 1 !important;
+        z-index: 20;
+        border-color: var(--line-cta);
+        transform: rotate(calc(var(--rest-rot) * 0.12)) translateY(-16px) scale(calc(var(--rest-scale, 1) * 1.08));
+        box-shadow:
+          0 32px 48px rgba(0,0,0,0.14),
+          0 12px 20px rgba(0,0,0,0.07),
+          0 0 0 1px color-mix(in srgb, var(--line-cta) 60%, transparent);
+      }
+      .gov-polaroid.is-lifted .gov-polaroid-well {
+        background: color-mix(in srgb, var(--surface-cta-primary) 70%, var(--surface-1));
       }
       @media (prefers-reduced-motion: reduce) {
         .gov-polaroid,
-        .gov-hero-art:hover .gov-polaroid,
-        .gov-hero-art .gov-polaroid:hover,
-        .gov-hero-art .gov-polaroid:focus-visible {
+        .gov-polaroid.is-lifted {
           transition: border-color 160ms ease, opacity 160ms ease, background 160ms ease;
           transform: rotate(var(--rest-rot)) scale(var(--rest-scale, 1));
-        }
-        .gov-hero-art .gov-polaroid:hover,
-        .gov-hero-art .gov-polaroid:focus-visible {
-          opacity: 1;
-          border-color: var(--line-cta);
         }
       }
 

--- a/components/government/styles.tsx
+++ b/components/government/styles.tsx
@@ -68,6 +68,133 @@ export function GovernmentStyles() {
           0 8px 24px rgba(0,0,0,0.08);
       }
 
+      .gov-masthead {
+        font-family: var(--font-analog), "Inter", system-ui, sans-serif;
+        font-weight: 500;
+        font-size: clamp(26px, 3.2vw, 40px);
+        line-height: 1.12;
+        letter-spacing: -0.02em;
+        color: var(--text-primary);
+        margin: 0;
+      }
+
+      .gov-claim-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px 14px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .gov-claim-row li {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        letter-spacing: 0.02em;
+        color: var(--text-secondary);
+      }
+      .gov-claim-row li::before {
+        content: "";
+        width: 5px;
+        height: 5px;
+        border-radius: 1px;
+        background: var(--surface-cta-primary);
+        box-shadow: 0 0 0 1px var(--line-cta);
+        flex-shrink: 0;
+      }
+
+      .gov-hero-art {
+        isolation: isolate;
+      }
+      .gov-polaroid {
+        position: absolute;
+        width: 156px;
+        padding: 10px;
+        background: var(--surface-bg);
+        border: 1px solid var(--line-structure);
+        left: var(--x);
+        top: var(--y);
+        z-index: var(--z);
+        transform: rotate(var(--rest-rot)) scale(var(--rest-scale, 1));
+        transform-origin: 50% 60%;
+        box-shadow:
+          -15px 33px 14px 0 rgba(0,0,0,0.01),
+          -8px 18px 12px 0 rgba(0,0,0,0.03),
+          -4px 8px 9px 0 rgba(0,0,0,0.04),
+          0 10px 28px rgba(0,0,0,0.10);
+        transition:
+          transform 480ms cubic-bezier(0.22, 1, 0.36, 1),
+          box-shadow 480ms cubic-bezier(0.22, 1, 0.36, 1),
+          opacity 280ms ease,
+          border-color 200ms ease,
+          z-index 0ms linear 280ms;
+        cursor: default;
+      }
+      .gov-polaroid.is-featured {
+        width: 196px;
+        padding: 12px;
+      }
+      .gov-polaroid.is-featured::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--surface-cta-primary);
+      }
+      .gov-polaroid-well {
+        display: flex;
+        aspect-ratio: 1;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, var(--surface-cta-primary) 28%, var(--surface-1));
+        transition: background 320ms ease;
+      }
+      @media (hover: hover) and (pointer: fine) {
+        .gov-hero-art:hover .gov-polaroid {
+          opacity: 0.58;
+        }
+        .gov-hero-art .gov-polaroid:hover,
+        .gov-hero-art .gov-polaroid:focus-visible {
+          opacity: 1;
+          z-index: 20;
+          border-color: var(--line-cta);
+          transform: rotate(calc(var(--rest-rot) * 0.18)) translateY(-12px) scale(calc(var(--rest-scale, 1) * 1.06));
+          box-shadow:
+            0 28px 44px rgba(0,0,0,0.12),
+            0 10px 18px rgba(0,0,0,0.06),
+            0 0 0 1px color-mix(in srgb, var(--line-cta) 55%, transparent);
+          transition:
+            transform 480ms cubic-bezier(0.22, 1, 0.36, 1),
+            box-shadow 480ms cubic-bezier(0.22, 1, 0.36, 1),
+            opacity 180ms ease,
+            border-color 200ms ease,
+            z-index 0ms;
+        }
+        .gov-hero-art .gov-polaroid:hover .gov-polaroid-well,
+        .gov-hero-art .gov-polaroid:focus-visible .gov-polaroid-well {
+          background: color-mix(in srgb, var(--surface-cta-primary) 62%, var(--surface-1));
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .gov-polaroid,
+        .gov-hero-art:hover .gov-polaroid,
+        .gov-hero-art .gov-polaroid:hover,
+        .gov-hero-art .gov-polaroid:focus-visible {
+          transition: border-color 160ms ease, opacity 160ms ease, background 160ms ease;
+          transform: rotate(var(--rest-rot)) scale(var(--rest-scale, 1));
+        }
+        .gov-hero-art .gov-polaroid:hover,
+        .gov-hero-art .gov-polaroid:focus-visible {
+          opacity: 1;
+          border-color: var(--line-cta);
+        }
+      }
+
       .gov-grid-bg {
         background-image:
           linear-gradient(to right,  rgba(108,103,96,0.18) 1px, transparent 1px),
@@ -133,7 +260,7 @@ export function GovernmentStyles() {
       .gov-h1 {
         font-family: var(--font-analog), "Inter", system-ui, sans-serif;
         font-weight: 500;
-        font-size: clamp(36px, 5.2vw, 72px);
+        font-size: clamp(32px, 4.2vw, 56px);
         line-height: 1.08;
         letter-spacing: -0.02em;
         margin: 0;

--- a/components/government/styles.tsx
+++ b/components/government/styles.tsx
@@ -323,7 +323,16 @@ export function GovernmentStyles() {
       }
 
       .gov-callout-strip {
-        background: color-mix(in srgb, var(--surface-cta-primary) 22%, var(--surface-bg));
+        background: var(--surface-bg);
+      }
+      .gov-callout-strip::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--surface-cta-primary);
       }
 
       .gov-feature-list {

--- a/components/inkeep/floating-ask-ai-bar.tsx
+++ b/components/inkeep/floating-ask-ai-bar.tsx
@@ -34,8 +34,9 @@ const ASK_AI_BAR_HIDDEN_PATHS: ReadonlyArray<RegExp> = [
   /^\/cookie-policy(\/|$)/,
   // App proxy
   /^\/cloud(\/|$)/,
-  // Custom-designed regional / annual landing pages
+  // Custom-designed regional / industry landing pages
   /^\/japan(\/|$)/,
+  /^\/government(\/|$)/,
   /^\/cn(\/|$)/,
   /^\/kr(\/|$)/,
   /^\/wrapped(\/|$)/,

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -46,6 +46,7 @@ const menuItems: {
       },
       { name: "Pricing", href: "/pricing" },
       { name: "Enterprise", href: "/enterprise" },
+      { name: "Government", href: "/government" },
     ],
   },
   {

--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -106,6 +106,7 @@ export function TalkToUsButton() {
 ### Self-hosting
 
 - [Deployment Guide](/self-hosting)
+- [Langfuse for Government](/government)
 - [Open Source Licensing](/open-source)
 - [Comparison](/pricing-self-host) of Open Source and Enterprise version
 - [Langfuse Self-Hosting: EE](/self-hosting) [Terms and Conditions](/terms)

--- a/lib/section-registry.ts
+++ b/lib/section-registry.ts
@@ -173,6 +173,7 @@ export const DEDICATED_MARKETING_SLUGS = new Set<string>([
   "pricing-self-host",
   "japan",
   "events",
+  "government",
 ]);
 
 export const DEDICATED_APP_SECTIONS = new Set<string>([

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -1,6 +1,6 @@
 ---
 title: Langfuse for Government
-description: Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments. Keep traces, prompts, and evaluation data in your security boundary.
+description: Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and cloud environments. Langfuse Cloud for Government coming soon.
 ---
 
 # Build accountable AI. Keep it under your control.
@@ -14,6 +14,8 @@ Open-source tracing and evaluations for government AI. Run it **air-gapped, on-p
 - Your traces
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)
+
+Langfuse Cloud for Government is coming soon. Managed cloud option. NIST SP 800-53 Rev. 5, SSDF, and FIPS 140-3 hardening in progress. [See both options](#government-cloud)
 
 Open-source core (MIT) · Internet access optional · 100,000+ engineers · 10+ billion observations per month
 
@@ -103,9 +105,35 @@ Move to production with the official Kubernetes Helm chart or maintained Terrafo
 - [Azure Terraform](/self-hosting/deployment/azure)
 - [GCP Terraform](/self-hosting/deployment/gcp)
 
+## Self-host today. Cloud is coming soon. [#government-cloud]
+
+Most government teams run Langfuse Enterprise on their own infrastructure. Langfuse Cloud for Government is a managed option in progress. Talk to sales to learn more.
+
+### Self-hosted Enterprise
+
+Available today. Run Langfuse Enterprise on-premises, in a VPC, or air-gapped. Pair it with [ClickHouse Government](https://clickhouse.com/government) when you need a government-ready analytics plane.
+
+- Your cluster, your network boundary
+- FIPS-compliant Docker images upon request
+- RBAC, SSO, SCIM, and audit logs
+- Data retention and server-side masking
+
+[Explore self-hosting](/self-hosting)
+
+### Langfuse Cloud for Government
+
+Coming soon. A managed Langfuse Cloud for teams that want Langfuse to operate the control plane. Hardening work is underway.
+
+- NIST SP 800-53 Rev. 5 hardening
+- NIST SSDF (SP 800-218) hardening
+- FIPS 140-3
+- RBAC, SSO, SCIM, audit logs, retention, and data masking
+
+[Contact sales](/talk-to-us)
+
 ## Run Langfuse in your environment.
 
-Talk through tracing, evaluations, and self-hosting for government AI. Sensitive data stays in infrastructure you control.
+Talk through self-hosted Enterprise today, or Langfuse Cloud for Government. Sensitive data stays in infrastructure you control.
 
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -7,7 +7,7 @@ description: Open-source observability and evaluations for AI agents. Deploy Lan
 
 Langfuse for Government — observability and evaluations for public-sector AI, inside your security boundary.
 
-Government and public-sector teams use Langfuse to observe, evaluate, and improve AI agents — without sending prompts, traces, or evaluation data outside their security boundary. Deploy **air-gapped, on premises, or in a private cloud**. The core is open source and inspectable; you operate the stack.
+Government and public-sector teams use Langfuse to observe, evaluate, and improve AI agents — without sending prompts, traces, or evaluation data outside their security boundary. Deploy **air-gapped, on-premises, or in a private cloud**. The core is open source and inspectable; you operate the stack.
 
 - Your environment
 - Inspectable source

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -5,8 +5,13 @@ description: Open-source observability and evaluations for AI agents. Deploy Lan
 
 # Build accountable AI. Keep it under your control.
 
-Langfuse is the open-source platform for observing, evaluating, and improving AI agents and LLM applications. Deploy across **air-gapped, on-premises, and cloud environments**—and keep sensitive prompts, outputs, traces, and evaluation data inside your approved infrastructure.
+Langfuse for Government — observability and evaluations for public-sector AI, inside your security boundary.
 
+Government and public-sector teams use Langfuse to observe, evaluate, and improve AI agents — without sending prompts, traces, or evaluation data outside their security boundary. Deploy **air-gapped, on premises, or in a private cloud**. The core is open source and inspectable; you operate the stack.
+
+- Your environment
+- Inspectable source
+- Audit-ready traces
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)
 

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -15,7 +15,7 @@ Open-source tracing and evaluations for government AI. Run it **air-gapped, on-p
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)
 
-Langfuse Cloud for Government is coming soon. Managed cloud option. NIST SP 800-53 Rev. 5, SSDF, and FIPS 140-3 hardening in progress. [See both options](#government-cloud)
+Langfuse Cloud for Government is coming soon. Managed cloud option. NIST SP 800-53 Rev. 5, SSDF, and FIPS 140-3 hardening in progress. [Contact sales](/talk-to-us) to learn more. [See both options](#government-cloud)
 
 Open-source core (MIT) · Internet access optional · 100,000+ engineers · 10+ billion observations per month
 
@@ -107,29 +107,30 @@ Move to production with the official Kubernetes Helm chart or maintained Terrafo
 
 ## Self-host today. Cloud is coming soon. [#government-cloud]
 
-Most government teams run Langfuse Enterprise on their own infrastructure. Langfuse Cloud for Government is a managed option in progress. Talk to sales to learn more.
+Most government teams run Langfuse Enterprise on their own infrastructure, often with ClickHouse Government. Langfuse Cloud for Government is a managed option in progress, with the same Enterprise controls plus public-sector hardening. Talk to sales to learn more.
 
-### Self-hosted Enterprise
+### Self-hosted, on-premises Enterprise
 
-Available today. Run Langfuse Enterprise on-premises, in a VPC, or air-gapped. Pair it with [ClickHouse Government](https://clickhouse.com/government) when you need a government-ready analytics plane.
+Available today. Run Langfuse Enterprise on-premises, in a VPC, or air-gapped. Pair it with [ClickHouse Government](https://clickhouse.com/government) for a government-ready analytics plane you operate yourself.
 
 - Your cluster, your network boundary
 - FIPS-compliant Docker images upon request
-- RBAC, SSO, SCIM, and audit logs
+- RBAC, SSO, SCIM, and immutable audit logs
 - Data retention and server-side masking
 
 [Explore self-hosting](/self-hosting)
 
 ### Langfuse Cloud for Government
 
-Coming soon. A managed Langfuse Cloud for teams that want Langfuse to operate the control plane. Hardening work is underway.
+Coming soon. A managed Langfuse Cloud for teams that want Langfuse to operate the control plane. Public-sector hardening is underway on top of Enterprise access and governance controls.
 
 - NIST SP 800-53 Rev. 5 hardening
 - NIST SSDF (SP 800-218) hardening
-- FIPS 140-3
-- RBAC, SSO, SCIM, audit logs, retention, and data masking
+- FIPS 140-3 hardening
+- RBAC, SSO, SCIM, and immutable audit logs
+- Data retention and server-side masking
 
-[Contact sales](/talk-to-us)
+[Contact sales](/talk-to-us) to learn more.
 
 ## Run Langfuse in your environment.
 

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -1,13 +1,13 @@
 ---
 title: Langfuse for Government
-description: Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and cloud environments. Langfuse Cloud for Government coming soon.
+description: Open-source observability and evaluations for AI agents. Self-host in air-gapped, on-premises, and government cloud environments. Langfuse Cloud for Government coming soon.
 ---
 
 # Build accountable AI. Keep it under your control.
 
 Langfuse for Government. Observability and evaluations for public-sector AI, in your environment.
 
-Open-source tracing and evaluations for government AI. Run it **air-gapped, on-premises, or in a private cloud**. Prompts, traces, and scores stay in your environment. You run the software.
+Open-source tracing and evaluations for government AI. Run it **air-gapped, on-premises, or in a government cloud**. Prompts, traces, and scores stay in your environment. You run the software.
 
 - Your environment
 - Open source

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -1,0 +1,108 @@
+---
+title: Langfuse for Government
+description: Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments — and keep traces, prompts, and evaluation data inside your security boundary.
+---
+
+# Build accountable AI. Keep it under your control.
+
+Langfuse is the open-source platform for observing, evaluating, and improving AI agents and LLM applications. Deploy across **air-gapped, on-premises, and cloud environments**—and keep sensitive prompts, outputs, traces, and evaluation data inside your approved infrastructure.
+
+- [Talk to a public-sector expert](/talk-to-us)
+- [Explore self-hosting](/self-hosting)
+
+Open-source core (MIT) · Internet access optional · 100,000+ engineers · 10+ billion observations per month
+
+## Understand every agent. Improve every outcome. [#observe]
+
+Government AI must do more than work in a demo. Teams need to understand how an agent reached an answer, measure whether it is reliable, and improve it without losing control of sensitive data.
+
+Langfuse brings the full improvement loop into one platform:
+
+### See what happened
+
+Trace every model call, tool invocation, retrieval step, and agent decision. Investigate failures with the full context of each request, session, model, prompt, latency, and cost.
+
+[Observability docs](/docs/observability/overview)
+
+### Measure what works
+
+Score outputs with LLM-as-a-judge, deterministic checks, human review, and user feedback. Turn production failures into datasets and regression tests before the next release.
+
+[Evaluation docs](/docs/evaluation/overview)
+
+### Contain failures early
+
+Monitor quality, security scores, latency, and cost. Set thresholds and route alerts through webhooks, Slack, or GitHub Actions — so teams can act before isolated failures become systemic.
+
+[Alerts docs](/docs/observability/features/alerts)
+
+## Mission-ready deployment, on your terms [#deploy]
+
+Langfuse is built to run where government teams already operate — behind a firewall, in a classified network, or in an approved cloud account — without changing the product or the data model.
+
+### Run inside your security boundary
+
+Deploy Langfuse in a VPC, on premises, or in a fully air-gapped Kubernetes environment. Internet access is optional. Bring your own infrastructure, networking, storage, and operational controls.
+
+[Networking docs](/self-hosting/security/networking)
+
+### Inspect and control the software
+
+The complete Langfuse repository is public. All core product capabilities — tracing, evaluations, prompt management, experiments, and annotation — are MIT-licensed without usage limits. Enterprise extensions live in clearly marked directories and activate only with a license key.
+
+[Open-source licensing](/handbook/chapters/open-source)
+
+### Operate the same architecture proven in the cloud
+
+Self-hosted Langfuse is not a reduced fork. It uses the same codebase and architecture as Langfuse Cloud. Asynchronous ingestion absorbs traffic spikes, incoming events are persisted before processing, and background migrations reduce disruption during upgrades.
+
+[Architecture overview](/self-hosting#architecture)
+
+### Keep AI systems accountable
+
+Application traces create a detailed record of model calls and agent actions. Enterprise audit logs add immutable records of who changed what, when, and with which before-and-after state. SSO, role-based access control, SCIM, retention policies, and server-side data masking support centralized governance.
+
+This governance set is available with Langfuse Enterprise.
+
+[Audit logs](/docs/administration/audit-logs)
+
+## Security without giving up developer velocity [#security]
+
+Self-host Langfuse so application teams can debug and evaluate agents quickly, while security teams keep telemetry, prompts, and evaluation data inside the approved boundary.
+
+- **Data stays where you put it.** Run the platform and its open-source dependencies in infrastructure you control.
+- **Sensitive data can be masked before storage.** Redact data in the SDK before transmission, or apply [centralized ingestion masking](/self-hosting/security/data-masking) in self-hosted Enterprise deployments.
+- **Open standards reduce lock-in.** Instrument with [OpenTelemetry](/integrations/native/opentelemetry) or use Langfuse SDKs and integrations across models, frameworks, and languages.
+- **Your team controls upgrades.** Use versioned releases and deploy changes on your schedule.
+
+### FIPS-compliant Docker images available upon request [#fips]
+
+For deployments with FIPS requirements, compliant Langfuse Docker images are available upon request.
+
+[Book a meeting](/talk-to-us)
+
+## Start locally. Deploy for the mission. [#get-started]
+
+Run Langfuse locally with Docker Compose in minutes:
+
+```bash
+git clone https://github.com/langfuse/langfuse.git
+cd langfuse
+docker compose up
+```
+
+Move to production with the official Kubernetes Helm chart or maintained Terraform modules for AWS, Azure, and Google Cloud — without changing the product or data model.
+
+- [Read the deployment guide](/self-hosting)
+- [View the source on GitHub](https://github.com/langfuse/langfuse)
+- [Kubernetes Helm chart](/self-hosting/deployment/kubernetes-helm)
+- [AWS Terraform](/self-hosting/deployment/aws)
+- [Azure Terraform](/self-hosting/deployment/azure)
+- [GCP Terraform](/self-hosting/deployment/gcp)
+
+## Bring accountable AI into your environment.
+
+See how Langfuse can help your team observe, evaluate, and improve mission-critical AI systems — without moving sensitive data outside your control.
+
+- [Talk to a public-sector expert](/talk-to-us)
+- [Explore self-hosting](/self-hosting)

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -1,27 +1,25 @@
 ---
 title: Langfuse for Government
-description: Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments — and keep traces, prompts, and evaluation data inside your security boundary.
+description: Open-source observability and evaluations for AI agents. Deploy Langfuse in air-gapped, on-premises, and cloud environments. Keep traces, prompts, and evaluation data in your security boundary.
 ---
 
 # Build accountable AI. Keep it under your control.
 
-Langfuse for Government — observability and evaluations for public-sector AI, inside your security boundary.
+Langfuse for Government. Observability and evaluations for public-sector AI, in your environment.
 
-Government and public-sector teams use Langfuse to observe, evaluate, and improve AI agents — without sending prompts, traces, or evaluation data outside their security boundary. Deploy **air-gapped, on-premises, or in a private cloud**. The core is open source and inspectable; you operate the stack.
+Open-source tracing and evaluations for government AI. Run it **air-gapped, on-premises, or in a private cloud**. Prompts, traces, and scores stay in your environment. You run the software.
 
 - Your environment
-- Inspectable source
-- Audit-ready traces
+- Open source
+- Your traces
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)
 
 Open-source core (MIT) · Internet access optional · 100,000+ engineers · 10+ billion observations per month
 
-## Understand every agent. Improve every outcome. [#observe]
+## See what happened. Score what works. [#observe]
 
-Government AI must do more than work in a demo. Teams need to understand how an agent reached an answer, measure whether it is reliable, and improve it without losing control of sensitive data.
-
-Langfuse brings the full improvement loop into one platform:
+You need to see how an agent reached an answer, score whether it is reliable, and change it without moving sensitive data out of your environment.
 
 ### See what happened
 
@@ -37,13 +35,13 @@ Score outputs with LLM-as-a-judge, deterministic checks, human review, and user 
 
 ### Contain failures early
 
-Monitor quality, security scores, latency, and cost. Set thresholds and route alerts through webhooks, Slack, or GitHub Actions — so teams can act before isolated failures become systemic.
+Monitor quality, security scores, latency, and cost. Set thresholds and send alerts to webhooks, Slack, or GitHub Actions so you can respond before a bad run repeats.
 
 [Alerts docs](/docs/observability/features/alerts)
 
-## Mission-ready deployment, on your terms [#deploy]
+## Run it where you already operate [#deploy]
 
-Langfuse is built to run where government teams already operate — behind a firewall, in a classified network, or in an approved cloud account — without changing the product or the data model.
+Langfuse runs behind a firewall, on a classified network, or in an approved cloud account. The product and data model stay the same.
 
 ### Run inside your security boundary
 
@@ -53,13 +51,13 @@ Deploy Langfuse in a VPC, on premises, or in a fully air-gapped Kubernetes envir
 
 ### Inspect and control the software
 
-The complete Langfuse repository is public. All core product capabilities — tracing, evaluations, prompt management, experiments, and annotation — are MIT-licensed without usage limits. Enterprise extensions live in clearly marked directories and activate only with a license key.
+The Langfuse repository is public. Tracing, evaluations, prompt management, experiments, and annotation are MIT-licensed, with no usage limits. Enterprise extensions live in marked directories and turn on with a license key.
 
 [Open-source licensing](/handbook/chapters/open-source)
 
-### Operate the same architecture proven in the cloud
+### Same architecture as Langfuse Cloud
 
-Self-hosted Langfuse is not a reduced fork. It uses the same codebase and architecture as Langfuse Cloud. Asynchronous ingestion absorbs traffic spikes, incoming events are persisted before processing, and background migrations reduce disruption during upgrades.
+Self-hosted Langfuse uses the same codebase and architecture as Langfuse Cloud. Asynchronous ingestion absorbs traffic spikes, events are persisted before processing, and background migrations reduce disruption during upgrades.
 
 [Architecture overview](/self-hosting#architecture)
 
@@ -71,9 +69,9 @@ This governance set is available with Langfuse Enterprise.
 
 [Audit logs](/docs/administration/audit-logs)
 
-## Security without giving up developer velocity [#security]
+## Keep data in your environment [#security]
 
-Self-host Langfuse so application teams can debug and evaluate agents quickly, while security teams keep telemetry, prompts, and evaluation data inside the approved boundary.
+Self-host Langfuse so application teams can debug and evaluate agents. Security teams keep telemetry, prompts, and evaluation data in the approved boundary.
 
 - **Data stays where you put it.** Run the platform and its open-source dependencies in infrastructure you control.
 - **Sensitive data can be masked before storage.** Redact data in the SDK before transmission, or apply [centralized ingestion masking](/self-hosting/security/data-masking) in self-hosted Enterprise deployments.
@@ -86,7 +84,7 @@ For deployments with FIPS requirements, compliant Langfuse Docker images are ava
 
 [Book a meeting](/talk-to-us)
 
-## Start locally. Deploy for the mission. [#get-started]
+## Start locally. Deploy in production. [#get-started]
 
 Run Langfuse locally with Docker Compose in minutes:
 
@@ -96,7 +94,7 @@ cd langfuse
 docker compose up
 ```
 
-Move to production with the official Kubernetes Helm chart or maintained Terraform modules for AWS, Azure, and Google Cloud — without changing the product or data model.
+Move to production with the official Kubernetes Helm chart or maintained Terraform modules for AWS, Azure, and Google Cloud. The product and data model stay the same.
 
 - [Read the deployment guide](/self-hosting)
 - [View the source on GitHub](https://github.com/langfuse/langfuse)
@@ -105,9 +103,9 @@ Move to production with the official Kubernetes Helm chart or maintained Terrafo
 - [Azure Terraform](/self-hosting/deployment/azure)
 - [GCP Terraform](/self-hosting/deployment/gcp)
 
-## Bring accountable AI into your environment.
+## Run Langfuse in your environment.
 
-See how Langfuse can help your team observe, evaluate, and improve mission-critical AI systems — without moving sensitive data outside your control.
+Talk through tracing, evaluations, and self-hosting for government AI. Sensitive data stays in infrastructure you control.
 
 - [Talk to a public-sector expert](/talk-to-us)
 - [Explore self-hosting](/self-hosting)

--- a/md-override/government.md
+++ b/md-override/government.md
@@ -129,6 +129,8 @@ Coming soon. A managed Langfuse Cloud for teams that want Langfuse to operate th
 - FIPS 140-3 hardening
 - RBAC, SSO, SCIM, and immutable audit logs
 - Data retention and server-side masking
+- Run in AWS GovCloud
+- FEDRAMP Moderate (in-process)
 
 [Contact sales](/talk-to-us) to learn more.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a dedicated **Langfuse for Government** landing page at `/government`, styled after `/japan` and `/launch-week-5`.

The page is self-hosting-first and leads with control and accountability:

- Hero: a **Langfuse for Government** masthead, the catchphrase “Build accountable AI. Keep it under your control.”, and short claims (your environment, open source, your traces)
- Hero copy now says **air-gapped, on-premises, or in a government cloud** (not private cloud), with a featured Government cloud polaroid
- Hero callout for **Langfuse Cloud for Government** (coming soon), with NIST SP 800-53 Rev. 5, SSDF, and FIPS 140-3 described as hardening in progress, plus a **Contact sales** CTA and a link to compare both options
- Two deployment options lower on the page: self-hosted, on-premises Enterprise (available today, including ClickHouse Government) and Cloud for Government (coming soon), with a Contact sales CTA
- Option 02 bullets now also include **Run in AWS GovCloud** and **FEDRAMP Moderate (in-process)**
- Narrower editorial layout (`max-w-[1000px]`) with a featured Government polaroid that lifts and straightens on hover
- Observe, evaluate, and contain loop for AI agents
- Security summary, scoped FIPS image request, and a Docker Compose quickstart

NIST and FIPS items for Cloud for Government are framed as work in progress, not completed authorizations. A Markdown mirror lives in `md-override/government.md`.

## Test plan

- [x] Load `/government` on desktop and confirm hero, proof strip, sections, and final CTA render
- [x] Check mobile layout (proof strip 2×2, compact hero cards, stacked sections)
- [x] Click primary CTA → `/talk-to-us` and secondary CTA → `/self-hosting`
- [x] Copy the Docker Compose snippet
- [x] Confirm footer “Government” link and Enterprise page resource link
- [x] Fetch `/government.md` and confirm the Markdown mirror matches the page
- [x] Confirm the narrower hero, government masthead, and polaroid hover on desktop
- [x] Confirm government page copy has no em dashes and reads in plain language
- [x] Confirm hero “Coming soon” callout, Contact sales → `/talk-to-us`, and `#government-cloud` section (self-host vs Cloud for Government)
- [x] Confirm hero says “government cloud” and Option 02 still lists NIST / SSDF / FIPS hardening with Contact sales
- [x] Confirm Option 02 bullets include AWS GovCloud and FEDRAMP Moderate (in-process)

![Option 02 with AWS GovCloud and FedRAMP bullets](https://cursor.com/artifacts/c/art-7ba309f1-195b-4435-8fa8-fde742f868b0)
<a href="https://cursor.com/agents/bc-db506eb2-c368-42b9-b321-35fc648ba60a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgovernment_option_02_govcloud_fedramp_bullets.mp4"><img src="https://cursor.com/artifacts/c/art-445be650-4a50-4d05-afa3-d7c0fbd519b7" alt="government_option_02_govcloud_fedramp_bullets.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b7f79b5-e673-4ef5-9415-da07c8550363?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b7f79b5-e673-4ef5-9415-da07c8550363&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated government landing page centered on self-hosted deployment, observability, evaluation, governance, and public-sector conversion paths.

- Registers `/government` as a dedicated marketing route with custom metadata, layout, responsive presentation, and CTA behavior.
- Adds a Markdown mirror and links the page from the footer and Enterprise resources.
- Adjusts shared feedback and Ask AI chrome for the custom landing-page experience.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation fix recommended for the incomplete Docker Compose quickstart.

The route, page shell, Markdown override, and internal destinations are coherently connected; the displayed startup commands skip the secret-update step required by the canonical deployment guide.

**Files Needing Attention:** components/government/GovernmentLanding.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/government/GovernmentLanding.tsx:8-11
**Quickstart skips secret configuration**

The copied quickstart proceeds directly from cloning to `docker compose up`, while the canonical Docker Compose guide requires updating the secrets first. Presenting these commands as the complete setup procedure leaves users with unchanged placeholder secrets or an unsupported deployment setup.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add /government landing page for public-..."](https://github.com/langfuse/langfuse-docs/commit/9e31f7a59f6393cc5a34345619522d80c0f0ddea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56670468)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Route resolution and layouts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/route-resolution-and-layouts.md)
- Knowledge Base — [Content publishing automation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-publishing-automation.md)
- Knowledge Base — [Commercial and community experiences](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/commercial-and-community-experiences.md)
- Knowledge Base — [Interactive site services](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/interactive-site-services.md)
</details>


<!-- /greptile_comment -->