### PR TITLE
docs: list the new AI feature telemetry fields

### DIFF
--- a/content/self-hosting/security/telemetry.mdx
+++ b/content/self-hosting/security/telemetry.mdx
@@ -43,6 +43,12 @@ Langfuse does not send raw ClickHouse rows or per-project breakdowns.
 | `datasetItems`                    | Total dataset items created in the reporting window                                                                                | Postgres                   |
 | `datasetRuns`                     | Total dataset runs created in the reporting window                                                                                 | Postgres                   |
 | `datasetRunItems`                 | Total dataset run items created in the reporting window                                                                            | Local ClickHouse aggregate |
+| `totalOrganizations`              | Current number of organizations                                                                                                    | Postgres                   |
+| `aiFeaturesEnabledOrganizations`  | Number of organizations with **AI Features** enabled in their settings                                                             | Postgres                   |
+| `assistantInstanceEnabled`        | Whether `LANGFUSE_IN_APP_AGENT_ENABLED` is `true`                                                                                  | Environment variable       |
+| `langfuseAiModelConfigured`       | Whether a usable Langfuse AI model is configured. No model ID is sent                                                              | Environment variables      |
+| `langfuseAiProvider`              | The resolved provider (`bedrock`, `anthropic`, or `openai`), or empty when no usable model is configured                           | Environment variables      |
+| `assistantRuns`                   | Total Langfuse Assistant runs started in the reporting window                                                                      | Postgres                   |
 | `startTimeframe` / `endTimeframe` | The reporting window used for the counts above                                                                                     | Application metadata       |
 
 ## Can I disable telemetry?


### PR DESCRIPTION
## Summary

Pairs with langfuse#16587, which adds six properties to the self-hosted telemetry event.

The field table on `/self-hosting/security/telemetry` enumerates every property a self-hosted instance sends, under a promise that no raw traces, prompts, observations, scores or dataset contents leave the instance. If the code ships new properties and the table does not list them, the page is false. So this has to merge with the code, not after it.

New rows: `totalOrganizations`, `aiFeaturesEnabledOrganizations`, `assistantInstanceEnabled`, `langfuseAiModelConfigured`, `langfuseAiProvider`, `assistantRuns`.

All six are booleans, counts, or one enum value, so the no-raw-content promise still holds.

The `langfuseAiModelConfigured` row says explicitly that no model ID is sent, because the variable names suggest otherwise and a reader auditing this page should not have to infer it.

## Test plan

- [x] `prettier --check` clean
- [ ] Render `/self-hosting/security/telemetry` on the preview and confirm the table renders with the new rows in the right order

## Sequencing

Draft until langfuse#16587 is ready. Merging this first would document fields we do not send yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)