### PR TITLE
Add FAQ for migrating ClickHouse OSS to Cloud or BYOC

### DIFF
--- a/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
+++ b/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
@@ -1,0 +1,30 @@
+---
+title: How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?
+sidebarTitle: Migrate ClickHouse OSS to Cloud or BYOC
+description: Keep historical traces, observations, and scores when moving a self-hosted Langfuse ClickHouse deployment from OSS to ClickHouse Cloud or BYOC.
+tags: [self-hosting]
+---
+
+# How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?
+
+Traces, observations, and scores live in ClickHouse. Moving from self-managed ClickHouse (OSS) to [ClickHouse Cloud or BYOC](/self-hosting/deployment/infrastructure/clickhouse#cloudbyoc) is a ClickHouse deployment-model change, not a Langfuse version upgrade. Keep the Langfuse application version the same throughout, and leave Postgres, Redis, and blob storage in place so media and event payloads continue to resolve.
+
+Do not use Langfuse [blob storage exports](/docs/api-and-data-platform/features/export-to-blob-storage) as the restore path. Those exports are for analytics, not for recreating a ClickHouse database.
+
+## Recommended path [#recommended-path]
+
+1. **Keep Langfuse on the same version.** Provision the target Cloud or BYOC service and confirm it meets the [ClickHouse version requirements](/self-hosting/deployment/infrastructure/clickhouse) for your Langfuse release.
+2. **Pause ingestion.** Scale down the Langfuse web and worker containers, or otherwise stop accepting traces, so no new rows are written during the copy.
+3. **Copy the Langfuse ClickHouse database** (schema and data) with a ClickHouse-supported method:
+   - [`remoteSecure`](https://clickhouse.com/docs/get-started/migrate/oss-to-cloud/clickhouse-to-cloud) — pull or push tables directly. Typical for smaller or single-node sources.
+   - [`BACKUP` / `RESTORE`](https://clickhouse.com/docs/get-started/migrate/oss-to-cloud/oss-to-cloud-backup-restore) via object storage. Typical for clustered sources; Cloud restores convert `ReplicatedMergeTree` tables to `SharedMergeTree`.
+4. **Point Langfuse at the new service.** Update `CLICKHOUSE_URL`, `CLICKHOUSE_MIGRATION_URL`, credentials, and SSL using the [Cloud/BYOC connection settings](/self-hosting/deployment/infrastructure/clickhouse#cloudbyoc). Grant the [required user permissions](/self-hosting/deployment/infrastructure/clickhouse#user-permissions) on the new service, and keep ClickHouse on [UTC](/self-hosting/deployment/infrastructure/clickhouse#timezones).
+5. **Resume ingestion** and confirm historic traces, observations, and scores in the UI.
+
+## Upgrading Langfuse at the same time [#upgrading-langfuse]
+
+Treat the ClickHouse move and a Langfuse major-version upgrade as separate steps. Langfuse v3 is compatible with current ClickHouse versions, so you can move to Cloud or BYOC first, then follow the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4). That guide's historic-data backfill is for the v4 events tables, not for copying an existing ClickHouse cluster.
+
+## Zero-downtime cutovers [#zero-downtime]
+
+A live dual-write cutover is theoretically possible but is not the recommended path and has not been validated for Langfuse. Plan for a pause of ingestion. Contact [support](/support) if you need to discuss a custom approach.

--- a/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
+++ b/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?
 sidebarTitle: Migrate ClickHouse OSS to Cloud or BYOC
-description: Keep historical traces, observations, and scores when moving a self-hosted Langfuse ClickHouse deployment from OSS to ClickHouse Cloud or BYOC.
+description: Keep historical traces, observations, and scores when moving a self-hosted Langfuse deployment from ClickHouse OSS to ClickHouse Cloud or BYOC.
 tags: [self-hosting]
 ---
 
@@ -23,7 +23,7 @@ Do not use Langfuse [blob storage exports](/docs/api-and-data-platform/features/
 
 ## Upgrading Langfuse at the same time [#upgrading-langfuse]
 
-Treat the ClickHouse move and a Langfuse major-version upgrade as separate steps. Langfuse v3 is compatible with current ClickHouse versions, so you can move to Cloud or BYOC first, then follow the [v3 to v4 upgrade guide](/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4). That guide's historic-data backfill is for the v4 events tables, not for copying an existing ClickHouse cluster.
+Treat the ClickHouse move and a Langfuse major-version upgrade as separate steps.
 
 ## Zero-downtime cutovers [#zero-downtime]
 

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -404,21 +404,18 @@ CLICKHOUSE_PASSWORD=clickhouse
 CLICKHOUSE_CLUSTER_ENABLED=false
 ```
 
-## Migrating to a New Instance
+## Migrating to a New Instance [#migrating-to-a-new-instance]
 
-You may want to move Langfuse to a different ClickHouse instance, e.g. when switching providers or moving from a single-node to a clustered setup.
-We recommend the following approach:
+You may want to move Langfuse to a different ClickHouse instance, for example when switching from self-managed ClickHouse OSS to [Cloud or BYOC](#cloudbyoc), changing providers, or moving from a single-node to a clustered setup.
 
-1. Point Langfuse to the new ClickHouse instance so that incoming data is captured there.
-2. Create a backup of the existing instance to blob storage and restore it into the new instance.
+The recommended path is: keep the Langfuse application version unchanged, pause ingestion, copy the ClickHouse database with a ClickHouse-supported method, then point Langfuse at the new service. See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud) for the Langfuse-side checklist.
 
-A zero-downtime switch where data is written to both instances concurrently is technically possible, but we have not tested it and it is not recommended by ClickHouse.
-Please reach out to Langfuse Support if you want to explore this option.
+Use the ClickHouse documentation for the data copy itself:
 
-Refer to the ClickHouse migration guides for backup and restore instructions:
+- [ClickHouse to ClickHouse via remoteSecure](https://clickhouse.com/docs/get-started/migrate/oss-to-cloud/clickhouse-to-cloud)
+- [ClickHouse to ClickHouse via backup and restore](https://clickhouse.com/docs/get-started/migrate/oss-to-cloud/oss-to-cloud-backup-restore)
 
-- [ClickHouse to ClickHouse via remoteSecure](https://clickhouse.com/docs/cloud/migration/clickhouse-to-cloud)
-- [ClickHouse to ClickHouse via backup and restore](https://clickhouse.com/docs/cloud/migration/oss-to-cloud-backup-restore)
+A zero-downtime switch where data is written to both instances concurrently is technically possible, but we have not tested it and it is not recommended. Contact [support](/support) if you want to explore this option.
 
 ## Encryption
 
@@ -642,6 +639,10 @@ volumes:
 This will store ClickHouse data within the Azurite bucket.
 
 ## FAQ
+
+### How do I migrate from self-managed ClickHouse to Cloud or BYOC? [#migrate-oss-to-cloud]
+
+See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud). Keep the Langfuse version the same, pause ingestion, copy ClickHouse with a ClickHouse-supported method, then point Langfuse at the new service.
 
 ### Is ClickHouse required for self-hosting Langfuse?
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a concise self-hosting FAQ for customers moving Langfuse from self-managed ClickHouse (OSS) to ClickHouse Cloud or BYOC while keeping historical traces, observations, and scores.

The FAQ is a Langfuse-side checklist and links out to ClickHouse’s `remoteSecure` and `BACKUP`/`RESTORE` guides for the data copy. It also points at the existing v3 → v4 upgrade guide when customers want to change Langfuse version as a separate step.

The ClickHouse deep dive page now references the FAQ from the migrating-instance section and from its FAQ list, and the previous “point Langfuse first, then restore” steps are aligned with the recommended pause-ingest path.

## Test plan

- Open `/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud` and confirm the page renders with a single H1, the five-step path, and working internal/external links.
- Open `/faq/tag/self-hosting` and `/self-hosting/troubleshooting-and-faq` and confirm the new FAQ is listed.
- Open `/self-hosting/deployment/infrastructure/clickhouse` and confirm both the migrating-instance section and the FAQ section link to the new page.
- Follow the in-page links to Cloud/BYOC config, user permissions, timezones, blob storage export, v3 → v4, and support.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-1011](https://linear.app/clickhouse/issue/DOC-1011/create-faq-for-migrating-langfuse-oss-to-byoccloud)

<div><a href="https://cursor.com/agents/bc-f32a343e-3322-4f45-9557-123fb1a01aa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f32a343e-3322-4f45-9557-123fb1a01aa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a self-hosting FAQ for moving Langfuse data from ClickHouse OSS to Cloud or BYOC and updates the ClickHouse infrastructure page to reference the pause-copy-reconfigure-resume workflow.

- Documents supported ClickHouse copy methods and required Langfuse connection updates.
- Separates the ClickHouse migration from a Langfuse v3-to-v4 upgrade.
- Replaces the previous point-first migration sequence with a paused-ingestion cutover.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge with no concrete broken route, contradictory migration instruction, or unsupported operational failure identified.

The new FAQ preserves the recommended same-version cutover boundary, delegates method-specific and upgrade-specific details to the relevant guides, and updates the existing ClickHouse page consistently.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add FAQ for migrating ClickHouse O..."](https://github.com/langfuse/langfuse-docs/commit/487c84a1b04be61e7d21cdbc146a6df752370afb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57017076)</sub>

<!-- /greptile_comment -->