### PR TITLE
docs: add evaluator AI autocomplete

### DIFF
--- a/content/security/ai-features.mdx
+++ b/content/security/ai-features.mdx
@@ -20,7 +20,7 @@ Non-exhaustive list of available AI features in Langfuse:
 
 - [Langfuse Assistant](/docs/langfuse-assistant) for asking questions about traces, observations, and metrics in plain language
 - Natural language-based filter builder for tables
-- AI-powered autocomplete for evaluator names and descriptions in the evaluation UI
+- AI-powered generation of evaluator names and descriptions
 
 ## Data Privacy
 

--- a/content/security/ai-features.mdx
+++ b/content/security/ai-features.mdx
@@ -20,6 +20,7 @@ Non-exhaustive list of available AI features in Langfuse:
 
 - [Langfuse Assistant](/docs/langfuse-assistant) for asking questions about traces, observations, and metrics in plain language
 - Natural language-based filter builder for tables
+- AI-powered autocomplete for evaluator names and descriptions in the evaluation UI
 
 ## Data Privacy
 


### PR DESCRIPTION
## Summary

- Add AI-powered autocomplete for evaluator names and descriptions to the available AI features list

## Checks

- `pnpm run format`
- `pnpm run format:check`
- `node scripts/check-h1-headings.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation change with no code, configuration, or security behavior changes.
> 
> **Overview**
> Updates the **Available AI Features** section on the security AI features page to include **AI-powered generation of evaluator names and descriptions**, alongside the existing assistant and filter-builder entries.
> 
> The new bullet is a documentation-only addition to the non-exhaustive feature list; it inherits the page’s existing Cloud-only, beta, org opt-in, and Bedrock data-privacy framing without changing those sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65f13e86bc3656bc9fe3e91b085a5d3b8ece0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds evaluator name and description autocomplete to the documented list of AI-powered Langfuse features.

- Identifies the feature as part of the evaluation UI.
- Inherits the page-wide Cloud-only, beta, opt-in, and data-privacy disclosures.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new list entry is consistent with the page’s existing structure and inherits its global availability and data-privacy qualifications; no actionable defect was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add evaluator AI autocomplete"](https://github.com/langfuse/langfuse-docs/commit/a5df7b00daa7ebc439b5a0e84ac7af3c5b6e0bee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57022470)</sub>

<!-- /greptile_comment -->