### PR TITLE
Recommend latest Langfuse OSS before ClickHouse SKU moves

### DIFF
--- a/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
+++ b/content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx
@@ -7,13 +7,13 @@ tags: [self-hosting]
 
 # How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?
 
-Traces, observations, and scores live in ClickHouse. Moving from self-managed ClickHouse (OSS) to [ClickHouse Cloud or BYOC](/self-hosting/deployment/infrastructure/clickhouse#cloudbyoc) is a ClickHouse deployment-model change, not a Langfuse version upgrade. Keep the Langfuse application version the same throughout, and leave Postgres, Redis, and blob storage in place so media and event payloads continue to resolve.
+Traces, observations, and scores live in ClickHouse. Moving from self-managed ClickHouse (OSS) to [ClickHouse Cloud or BYOC](/self-hosting/deployment/infrastructure/clickhouse#cloudbyoc) is a ClickHouse deployment-model change, not a Langfuse version upgrade. Run the [latest Langfuse OSS release](/self-hosting/upgrade) first so everything works as expected, then keep that version unchanged throughout. Leave Postgres, Redis, and blob storage in place so media and event payloads continue to resolve.
 
 Do not use Langfuse [blob storage exports](/docs/api-and-data-platform/features/export-to-blob-storage) as the restore path. Those exports are for analytics, not for recreating a ClickHouse database.
 
 ## Recommended path [#recommended-path]
 
-1. **Keep Langfuse on the same version.** Provision the target Cloud or BYOC service and confirm it meets the [ClickHouse version requirements](/self-hosting/deployment/infrastructure/clickhouse) for your Langfuse release.
+1. **Run the latest Langfuse OSS release.** Upgrade first if you are not already current, then keep that version unchanged during the ClickHouse move. Provision the target Cloud or BYOC service and confirm it meets the [ClickHouse version requirements](/self-hosting/deployment/infrastructure/clickhouse) for your Langfuse release.
 2. **Pause ingestion.** Scale down the Langfuse web and worker containers, or otherwise stop accepting traces, so no new rows are written during the copy.
 3. **Copy the Langfuse ClickHouse database** (schema and data) with a ClickHouse-supported method:
    - [`remoteSecure`](https://clickhouse.com/docs/get-started/migrate/oss-to-cloud/clickhouse-to-cloud) — pull or push tables directly. Typical for smaller or single-node sources.

--- a/content/self-hosting/deployment/infrastructure/clickhouse.mdx
+++ b/content/self-hosting/deployment/infrastructure/clickhouse.mdx
@@ -408,7 +408,7 @@ CLICKHOUSE_CLUSTER_ENABLED=false
 
 You may want to move Langfuse to a different ClickHouse instance, for example when switching from self-managed ClickHouse OSS to [Cloud or BYOC](#cloudbyoc), changing providers, or moving from a single-node to a clustered setup.
 
-The recommended path is: keep the Langfuse application version unchanged, pause ingestion, copy the ClickHouse database with a ClickHouse-supported method, then point Langfuse at the new service. See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud) for the Langfuse-side checklist.
+The recommended path is: run the latest Langfuse OSS release first and keep that version unchanged, pause ingestion, copy the ClickHouse database with a ClickHouse-supported method, then point Langfuse at the new service. See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud) for the Langfuse-side checklist.
 
 Use the ClickHouse documentation for the data copy itself:
 
@@ -642,7 +642,7 @@ This will store ClickHouse data within the Azurite bucket.
 
 ### How do I migrate from self-managed ClickHouse to Cloud or BYOC? [#migrate-oss-to-cloud]
 
-See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud). Keep the Langfuse version the same, pause ingestion, copy ClickHouse with a ClickHouse-supported method, then point Langfuse at the new service.
+See [How do I migrate Langfuse from ClickHouse OSS to Cloud or BYOC?](/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud). Run the latest Langfuse OSS release first, keep that version unchanged, pause ingestion, copy ClickHouse with a ClickHouse-supported method, then point Langfuse at the new service.
 
 ### Is ClickHouse required for self-hosting Langfuse?
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recommends running the latest Langfuse OSS release before moving ClickHouse from OSS to Cloud or BYOC, then keeping that version unchanged during the cutover.

This is a small follow-up to the already-merged migration FAQ. It is a durable note only — no version-specific upgrade path.

## Test plan

- Open `/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud` and confirm the intro and step 1 recommend the latest OSS release, with a link to `/self-hosting/upgrade`.
- Confirm the upgrade section still only says to treat a Langfuse major-version upgrade as a separate step.
- Open `/self-hosting/deployment/infrastructure/clickhouse#migrating-to-a-new-instance` and the page FAQ and confirm both mention running the latest OSS release first.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15622](https://linear.app/clickhouse/issue/LFE-15622/create-faq-for-migrating-langfuse-oss-to-byoccloud)

<div><a href="https://cursor.com/agents/bc-f32a343e-3322-4f45-9557-123fb1a01aa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f32a343e-3322-4f45-9557-123fb1a01aa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates ClickHouse migration documentation to recommend upgrading Langfuse before moving from self-managed ClickHouse to Cloud or BYOC, then holding the application version constant during the cutover.
- Adds the recommendation to the dedicated migration FAQ and its first checklist step.
- Repeats the recommendation in the ClickHouse infrastructure migration overview and FAQ.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The migration guidance should not merge until “latest” is scoped to the operator’s current major version or the sequencing is otherwise reconciled with the major-upgrade guide.

Operators on a supported older major are told to upgrade Langfuse before moving ClickHouse, even though the major-upgrade documentation requires ClickHouse to be upgraded first and permits the older Langfuse major to remain in service.

**Files Needing Attention:** content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx; content/self-hosting/deployment/infrastructure/clickhouse.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/faq/all/self-hosting-migrate-clickhouse-oss-to-cloud.mdx:16
**Major upgrade ordering conflict**

When an operator on a supported older major such as Langfuse v3 follows “upgrade first if you are not already current,” this guidance directs them to upgrade Langfuse before moving ClickHouse. That reverses the documented v3-to-v4 ClickHouse-before-server sequence and combines two migrations that this FAQ says to perform separately.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: recommend latest Langfuse OSS befo..."](https://github.com/langfuse/langfuse-docs/commit/add05b27d954c4c5688007a701016bd21ecbe740) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57043963)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->