### PR TITLE
docs: document AUTH_CUSTOM_FETCH_USERINFO for custom OIDC SSO

### DIFF
--- a/content/self-hosting/security/authentication-and-sso.mdx
+++ b/content/self-hosting/security/authentication-and-sso.mdx
@@ -262,13 +262,27 @@ Provider: `WORDPRESS`
 
 [NextAuth Custom OAuth Provider Docs](https://next-auth.js.org/configuration/providers/oauth#using-a-custom-provider) ([source](https://github.com/langfuse/langfuse/blob/main/web/src/server/auth.ts))
 
-| Configuration      | Value                                                                                                                                                                                                                                                                                                                                                    |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Required Variables | `AUTH_CUSTOM_CLIENT_ID`<br/>`AUTH_CUSTOM_CLIENT_SECRET`<br/>`AUTH_CUSTOM_ISSUER`<br/>`AUTH_CUSTOM_NAME` (any, used only in UI)                                                                                                                                                                                                                           |
-| Optional Variables | `AUTH_CUSTOM_SCOPE` (defaults to `"openid email profile"`)<br/>`AUTH_CUSTOM_ID_TOKEN` (Defaults to `true`, set to `false` if you want to make a request to the `userinfo` endpoint instead of extracting user information from the `id_token` claims)<br/><br/>See [additional configuration](#additional-configuration) section below for more options. |
-| OAuth Redirect URL | `/api/auth/callback/custom`                                                                                                                                                                                                                                                                                                                              |
+| Configuration      | Value                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Required Variables | `AUTH_CUSTOM_CLIENT_ID`<br/>`AUTH_CUSTOM_CLIENT_SECRET`<br/>`AUTH_CUSTOM_ISSUER`<br/>`AUTH_CUSTOM_NAME` (any, used only in UI)                                                                                                                                                                                                                                                                                                       |
+| Optional Variables | `AUTH_CUSTOM_SCOPE` (defaults to `"openid email profile"`)<br/>`AUTH_CUSTOM_FETCH_USERINFO` (defaults to `false`, see [reading the profile from the `userinfo` endpoint](#custom-oauth-userinfo))<br/>`AUTH_CUSTOM_ID_TOKEN` (defaults to `true`, see [reading the profile from the `userinfo` endpoint](#custom-oauth-userinfo))<br/><br/>See [additional configuration](#additional-configuration) section below for more options. |
+| OAuth Redirect URL | `/api/auth/callback/custom`                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 Provider: `CUSTOM`
+
+#### Reading the profile from the `userinfo` endpoint [#custom-oauth-userinfo]
+
+By default, Langfuse builds the user profile from the `id_token` claims. Some providers (for example Oracle IAM) do not include `email` or `name` in the ID token and only serve them from the `userinfo` endpoint. Set `AUTH_CUSTOM_FETCH_USERINFO=true` to read the profile from `userinfo` instead:
+
+```bash
+AUTH_CUSTOM_FETCH_USERINFO=true
+```
+
+Claims from both sources are merged with `userinfo` taking precedence, so claims that only the ID token carries (such as `sub`) are preserved. The OIDC callback and ID token signature validation are unchanged.
+
+Keep `AUTH_CUSTOM_ID_TOKEN` at its default of `true` in this case. Setting it to `false` is not an alternative: it switches the token exchange to the plain OAuth2 callback, which fails whenever the token response contains an `id_token` — as it does for any request that includes the `openid` scope. Sign-in then fails with a generic `OAuthCallback` error.
+
+`AUTH_CUSTOM_FETCH_USERINFO` is available on version `>=v4.21.0` of Langfuse.
 
 ## HTTP Proxy for SSO
 
@@ -320,6 +334,7 @@ These are additional configuration variables. Replace `<PROVIDER>` with the prov
 - Error: _"Please sign in with the same provider that you used to create this account"._ This error occurs when you try to sign in with a different provider than the one you used to create your account. To fix this, you need to sign in with the same provider that you used to create your account or allow for account linking/takeover by setting `AUTH_<PROVIDER>_ALLOW_ACCOUNT_LINKING=true` (env depends on the provider, see above).
 - For password reset, see the [Password Reset](#password-reset) section.
 - Langfuse authentication relies on email addresses. When using SSO, ensure that the user's email address is included in their IDP profile.
+- Error: _"OAuthCallback"_ when signing in with a custom OIDC provider. If your provider does not include `email` or `name` in the `id_token`, set `AUTH_CUSTOM_FETCH_USERINFO=true` to source the profile from the `userinfo` endpoint. See [reading the profile from the `userinfo` endpoint](#custom-oauth-userinfo).
 - If authentication with your provider fails, please try different applicable combinations of the `CLIENT_AUTH_METHOD` and `CHECKS` as outlined above.
 
 ## Related Resources


### PR DESCRIPTION
Documents `AUTH_CUSTOM_FETCH_USERINFO`, added in langfuse/langfuse#16607 (shipped in v4.21.0) to fix langfuse/langfuse#16519.

## Changes

`content/self-hosting/security/authentication-and-sso.mdx`:

- Add `AUTH_CUSTOM_FETCH_USERINFO` to the Custom OAuth Provider optional variables.
- New subsection "Reading the profile from the `userinfo` endpoint" covering when to set it, the claim merge behavior (`userinfo` wins, ID-token-only claims like `sub` survive), and the `>=v4.21.0` version requirement.
- Correct the `AUTH_CUSTOM_ID_TOKEN` description. It previously said setting it to `false` makes Langfuse request the `userinfo` endpoint instead of reading `id_token` claims. That is not what it does: it switches the token exchange to the plain OAuth2 callback, which `openid-client` rejects whenever the token response carries an `id_token` — i.e. always, for an `openid` scope. Following that advice produced the generic `OAuthCallback` failure reported in the issue.
- Add a troubleshooting bullet mapping the `OAuthCallback` error to this configuration.

## Follow-up (not in this PR)

The `AUTH_KEYCLOAK_ID_TOKEN` row carries the same inaccurate "set to `false` to use the `userinfo` endpoint" claim, but there is no `AUTH_KEYCLOAK_FETCH_USERINFO` counterpart yet, so there is no correct configuration to point Keycloak users at. Worth a code change to extend the flag to the other OIDC providers, then a docs follow-up.

## Verification

- `node scripts/check-h1-headings.js` passes.
- `prettier --check` passes on the edited file.
- Page renders at HTTP 200 on the dev server; the `#custom-oauth-userinfo` anchor is emitted and all in-page links to it resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to self-hosting SSO guidance; no application code or runtime behavior changes in this repository.
> 
> **Overview**
> **Documents** the `AUTH_CUSTOM_FETCH_USERINFO` option for the Custom OAuth provider and **fixes** misleading guidance around `AUTH_CUSTOM_ID_TOKEN`.
> 
> The Custom OAuth optional-variables table now lists `AUTH_CUSTOM_FETCH_USERINFO` (default `false`) and points to a new subsection on **reading the profile from the `userinfo` endpoint**. That section explains when to enable it (e.g. providers that omit `email`/`name` from the ID token), claim merge behavior (`userinfo` wins; ID-token-only claims like `sub` remain), that OIDC validation is unchanged, the `>=v4.21.0` requirement, and that **`AUTH_CUSTOM_ID_TOKEN=false` is not** a substitute—it forces plain OAuth2 and can cause `OAuthCallback` failures with `openid` scope.
> 
> Troubleshooting adds a bullet mapping generic **`OAuthCallback`** errors on custom OIDC to `AUTH_CUSTOM_FETCH_USERINFO=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2859b293e61636ef1558f18eea07df6508ee096f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents the custom OIDC userinfo-fetch option introduced in Langfuse v4.21.0 and corrects misleading guidance about `AUTH_CUSTOM_ID_TOKEN`.

- Adds `AUTH_CUSTOM_FETCH_USERINFO` to the custom provider configuration.
- Explains claim merging, validation behavior, and version availability.
- Adds targeted troubleshooting guidance for custom OIDC profile-claim failures.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new configuration guidance is internally consistent with the described v4.21.0 feature, preserves the default OIDC validation path, and provides a concrete remedy for providers that expose profile claims only through userinfo.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document AUTH\_CUSTOM\_FETCH\_USERINF..."](https://github.com/langfuse/langfuse-docs/commit/2859b293e61636ef1558f18eea07df6508ee096f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57063648)</sub>

<!-- /greptile_comment -->