### PR TITLE
docs: drop the beta label from Ask AI in the filter search bar

### DIFF
--- a/content/docs/observability/features/filter-search-bar.mdx
+++ b/content/docs/observability/features/filter-search-bar.mdx
@@ -111,10 +111,10 @@ Most fields accept a short alias so you can type less. The canonical field name 
 If you don't know a project's field names yet, click **Ask AI**, describe the filter you want in plain language, and the bar builds the query for you as editable pills.
 
 <Callout type="info">
-  Ask AI is in beta and available on **Langfuse Cloud only**. It is **off by
-  default**; an organization owner or admin enables it in **Organization
-  Settings → General → AI Features**. It runs on models hosted on AWS Bedrock
-  with zero data retention. See [data privacy and security](/security/ai-features).
+  Ask AI is **off by default**; an organization owner or admin enables it in
+  **Organization Settings → General → AI Features**. On Langfuse Cloud it runs
+  on models hosted on AWS Bedrock with zero data retention. See
+  [data privacy and security](/security/ai-features).
 </Callout>
 
 Ask AI is **project-aware**: the request carries a compact, client-side snapshot of the columns, values, and metadata keys already loaded in the table, so natural language maps to your project's real schema rather than a generic guess. "enterprise customers in the membership-support queue", for example, resolves to the actual `metadata.*` keys your traces use.


### PR DESCRIPTION
**TL;DR** — Ask AI is out of beta, so the docs callout that still called it beta is gone. While there, the callout's "Langfuse Cloud only" claim turned out to be wrong for this feature and is gone too. One paragraph changed.

## Why

Ask AI shipped as beta and the product has since dropped its Beta badge. The callout on the filter search bar page was the last place in the docs still calling it beta, which was raised internally.

## What

One `<Callout>` on `content/docs/observability/features/filter-search-bar.mdx`:

- **Beta removed.**
- **"Langfuse Cloud only" removed** — this is a correction, not a scope creep. The search bar's Ask AI runs through `searchBar.generateFilter`, which has **no** cloud-region gate. It requires the organization's **AI Features** toggle and a configured model, and nothing else. The Cloud-only path is the older table-level "Filter with AI" (`naturalLanguageFilter.createCompletion`), a different endpoint that throws on self-hosted. The search bar's own README already says as much: *"Self-hosted uses Ask AI on this bar only."*
- **Bedrock / zero-data-retention scoped to Cloud**, which is where Bedrock is.

## Result

The callout now reads:

> Ask AI is **off by default**; an organization owner or admin enables it in **Organization Settings → General → AI Features**. On Langfuse Cloud it runs on models hosted on AWS Bedrock with zero data retention. See [data privacy and security](/security/ai-features).

## What a reviewer should doubt

**The linked page still says Beta, on purpose.** `/security/ai-features` is titled "AI Powered Features Within Langfuse (Beta)" and says the features "are currently in beta and are only available on Langfuse Cloud". So this callout now links one click away to a page that contradicts it on both counts.

That was left deliberately, because it is a broader product call than this change: that page covers AI features generally, not just Ask AI, and the general gate (`resolveLangfuseAiFeatureAvailability`) *does* return `self-hosted` → unavailable. So the page remains correct about everything except the search bar's Ask AI. Taking the whole AI Features surface out of beta, and restating its availability, wants its own decision and its own pull request. **Say the word if you would rather that happen here instead.**

<details>
<summary>Verification, and what was deliberately left alone</summary>

**How the Cloud-only correction was checked** — read at `langfuse/langfuse` `origin/main`:

- `web/src/features/search-bar/server/router.ts` → `generateFilter` gates on `project:read`, `organization.aiFeaturesEnabled`, and `getInAppAgentModelConfig()`. There is no `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` check.
- `web/src/features/natural-language-filters/server/router.ts` → `createCompletion` opens with an explicit cloud-region check and the comment *"Leftover table-wand path: still Cloud-only … v4 Ask AI (`searchBar.generateFilter`) is the self-hosted path."*
- `web/src/__tests__/server/ai-filter-access.servertest.ts` has a case named *"generates Ask AI on self-hosted and keeps Filter with AI Cloud-only"* — the two endpoints are asserted to behave differently on the same unset cloud region.
- `web/src/features/search-bar/README.md`: *"Self-hosted uses Ask AI on this bar only."*

**Left alone on purpose:**

- The June 2026 changelog entry keeps its beta wording — it is a historical launch note and should read as one.
- `/security/ai-features`, per the section above.
- No product-side change is included here; the Beta badge is already absent from the Ask AI button.

**Checks:** `prettier --check` passes on the changed file. No build was run — the edit is prose inside an existing `<Callout>` and changes no structure.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose in a single MDX callout; no code or runtime behavior changes.
> 
> **Overview**
> Updates the **Ask AI** info callout on the filter search bar docs so it matches current product positioning.
> 
> The callout no longer describes Ask AI as **beta** or **Langfuse Cloud only**. It still explains that the feature is **off by default** and must be turned on under **Organization Settings → General → AI Features**, and it now states that **AWS Bedrock** and **zero data retention** apply **on Langfuse Cloud** only. The link to [data privacy and security](/security/ai-features) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0d82edf5edf730725d8496eacb3079e5ca61eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the beta and Cloud-only labels from the filter search bar’s Ask AI callout and scopes its Bedrock privacy statement to Langfuse Cloud.
- Documents Ask AI as available beyond Langfuse Cloud.
- Retains the organization AI Features toggle instructions.
- Clarifies that Bedrock with zero data retention describes the Cloud path.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should be corrected before merging because self-hosted readers can complete the documented toggle step and still be unable to use Ask AI without a configured model.

The availability correction broadens the callout to self-hosted deployments while leaving its setup instructions incomplete despite the PR’s own confirmation that model configuration is required.

**Files Needing Attention:** content/docs/observability/features/filter-search-bar.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/docs/observability/features/filter-search-bar.mdx:114-116
**Configured model prerequisite omitted**

When a self-hosted organization enables AI Features without configuring an eligible model, these broadened setup instructions present the toggle as sufficient, causing Ask AI to remain unavailable or nonfunctional after the documented setup is completed.

```suggestion
  Ask AI is **off by default**; an organization owner or admin enables it in
  **Organization Settings → General → AI Features** and configures a model. On
  Langfuse Cloud it runs on models hosted on AWS Bedrock with zero data
  retention. See
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: drop the beta label from Ask AI in..."](https://github.com/langfuse/langfuse-docs/commit/cf0d82edf5edf730725d8496eacb3079e5ca61eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57284981)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->