### PR TITLE
Remove evaluation overview table row

### DIFF
--- a/content/docs/evaluation/overview.mdx
+++ b/content/docs/evaluation/overview.mdx
@@ -35,7 +35,6 @@ Once you have that context, use the table below to find the right feature page:
 | Review and rate traces manually                     | [Annotation Queues](/docs/evaluation/evaluation-methods/annotation-queues), [Scores via UI](/docs/evaluation/evaluation-methods/scores-via-ui) |
 | Collect feedback from your end users                | [User Feedback](/docs/observability/features/user-feedback)                                                                                    |
 | Leave open-ended notes on traces                    | [Text scores](/docs/evaluation/scores/overview#score-types), [Annotation Queues](/docs/evaluation/evaluation-methods/annotation-queues)        |
-| Track recurring failure categories                  | [Score configs](/faq/all/manage-score-configs), [scores](/docs/evaluation/scores/overview#score-types)                                         |
 | Build a reusable set of test cases                  | [Datasets](/docs/evaluation/experiments/datasets)                                                                                              |
 | Compare prompt, model, or code changes side by side | [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui), [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk) |
 | Block deploys on regressions                        | [CI/CD experiments](/docs/evaluation/experiments/experiments-ci-cd)                                                                            |


### PR DESCRIPTION
## Summary

- Remove the recurring failure categories row from the evaluation overview table

## Testing

- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- Verified `/docs/evaluation/overview` returns HTTP 200 locally and the row is absent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no product, API, or runtime impact.
> 
> **Overview**
> Removes one row from the **Getting Started** feature table on the evaluation overview page: the entry that pointed readers who want to **track recurring failure categories** to score configs and score types.
> 
> The rest of the table and page are unchanged; score configs are still referenced from other evaluation docs (annotation queues, scores via UI/SDK, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b578aa9c9bd837e69d9b6037ec952b2eeb434e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the “Track recurring failure categories” entry and its score-configuration links from the evaluation overview table.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change is limited to removing the documented evaluation-overview row and introduces no correctness, rendering, navigation, or security issue.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove evaluation overview table r..."](https://github.com/langfuse/langfuse-docs/commit/b578aa9c9bd837e69d9b6037ec952b2eeb434e23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57318508)</sub>

<!-- /greptile_comment -->