### PR TITLE
Add changelog for restoring evaluator versions

### DIFF
--- a/content/changelog/2026-08-27-restore-evaluator-versions.mdx
+++ b/content/changelog/2026-08-27-restore-evaluator-versions.mdx
@@ -1,0 +1,24 @@
+---
+title: Restore evaluator versions
+date: 2026-08-27
+description: Restore a previous evaluator version as a draft, review it, and save it as a new version.
+author: Tobias Wochinger
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Book } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now restore any previous evaluator version from the version history.
+
+Use it to roll back an unsuccessful change, recover an earlier score definition, or use a proven version as the starting point for your next iteration. Restoring does not change the version history or save automatically. Review and test the draft first, then save it as a new version when you are ready.
+
+<Cards num={1}>
+  <Card
+    title="Evaluation concepts"
+    href="/docs/evaluation/core-concepts"
+    icon={<Book />}
+    arrow
+  />
+</Cards>


### PR DESCRIPTION
## Summary

Adds a short changelog for restoring previous evaluator versions as drafts.

Related product change: https://github.com/langfuse/langfuse/pull/16674

## Checks

- `pnpm dlx prettier@3.8.3 --write content/changelog/2026-08-27-restore-evaluator-versions.mdx`
- `node scripts/check-h1-headings.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or product code changes in this repo.
> 
> **Overview**
> Adds a **2026-08-27** changelog post announcing that users can **restore prior evaluator versions** from version history as a **draft** (rollback, recover score definitions, or iterate from an older version), with a note that restore does not rewrite history or auto-save until they publish a new version.
> 
> The entry follows the usual changelog MDX pattern (`ChangelogHeader`, short body copy) and links readers to **Evaluation concepts** docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bff7f0359a3ec64d27fde2ee038487199486293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a changelog entry announcing that users can restore a previous evaluator version as a draft, review and test it, and save it as a new version.

- Describes rollback and reuse scenarios for evaluator versions.
- Links readers to the evaluation concepts documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new changelog follows existing content conventions, satisfies the changelog metadata and rendering contracts, and links to an existing published documentation route.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add changelog for restoring evaluator ve..."](https://github.com/langfuse/langfuse-docs/commit/3bff7f0359a3ec64d27fde2ee038487199486293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57487967)</sub>

<!-- /greptile_comment -->