### PR TITLE
Add stable evaluator API changelog

### DIFF
--- a/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
+++ b/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
@@ -7,6 +7,7 @@ canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { V4CutoverDate } from "@/components/V4CutoverDate";
 import { Book, Code } from "lucide-react";
 
 <ChangelogHeader />
@@ -15,7 +16,7 @@ import { Book, Code } from "lucide-react";
   A new [stable API for evaluators and evaluation
   rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
   `/api/public/v2`. The unstable API described below remains available until
-  November 16, 2026.
+  <V4CutoverDate />.
 </Callout>
 
 You can now set up and manage LLM-as-a-Judge evaluation programmatically through the public API, in addition to the Langfuse UI. This lets you define how data is scored and what data gets evaluated entirely in code, so your evaluation setup can live in version control and roll out the same way across projects.

--- a/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
+++ b/content/changelog/2026-04-15-llm-as-a-judge-api.mdx
@@ -11,6 +11,13 @@ import { Book, Code } from "lucide-react";
 
 <ChangelogHeader />
 
+<Callout type="info">
+  A new [stable API for evaluators and evaluation
+  rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
+  `/api/public/v2`. The unstable API described below remains available until
+  November 16, 2026.
+</Callout>
+
 You can now set up and manage LLM-as-a-Judge evaluation programmatically through the public API, in addition to the Langfuse UI. This lets you define how data is scored and what data gets evaluated entirely in code, so your evaluation setup can live in version control and roll out the same way across projects.
 
 Common things this unlocks:

--- a/content/changelog/2026-06-10-evaluators-via-mcp.mdx
+++ b/content/changelog/2026-06-10-evaluators-via-mcp.mdx
@@ -6,6 +6,7 @@ author: Tobias Wochinger
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { V4CutoverDate } from "@/components/V4CutoverDate";
 import { Book, Code, FileCode } from "lucide-react";
 
 <ChangelogHeader />
@@ -14,7 +15,7 @@ import { Book, Code, FileCode } from "lucide-react";
   A new [stable API for evaluators and evaluation
   rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
   `/api/public/v2`. The unstable API described below remains available until
-  November 16, 2026.
+  <V4CutoverDate />.
 </Callout>
 
 You can now set up and manage evaluation directly from AI agents: the Langfuse MCP server exposes evaluators and evaluation rules as tools, and the unstable public API now supports [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) in addition to LLM-as-a-Judge.

--- a/content/changelog/2026-06-10-evaluators-via-mcp.mdx
+++ b/content/changelog/2026-06-10-evaluators-via-mcp.mdx
@@ -10,6 +10,13 @@ import { Book, Code, FileCode } from "lucide-react";
 
 <ChangelogHeader />
 
+<Callout type="info">
+  A new [stable API for evaluators and evaluation
+  rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
+  `/api/public/v2`. The unstable API described below remains available until
+  November 16, 2026.
+</Callout>
+
 You can now set up and manage evaluation directly from AI agents: the Langfuse MCP server exposes evaluators and evaluation rules as tools, and the unstable public API now supports [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators) in addition to LLM-as-a-Judge.
 
 This lets agents own more of the evaluation loop. For example, an agent can inspect failing traces, write a code evaluator that catches the failure pattern, and wire up an evaluation rule that runs it on live observations — all without leaving the chat.

--- a/content/changelog/2026-06-15-delete-evaluator-templates.mdx
+++ b/content/changelog/2026-06-15-delete-evaluator-templates.mdx
@@ -11,6 +11,13 @@ import { Book, Code } from "lucide-react";
 
 <ChangelogHeader />
 
+<Callout type="info">
+  A new [stable API for evaluators and evaluation
+  rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
+  `/api/public/v2`. The unstable API described below remains available until
+  November 16, 2026.
+</Callout>
+
 You can now delete evaluator templates you no longer need — from the Langfuse UI, the unstable public API (`DELETE /unstable/evaluators/{id}`), and MCP. Deleting an evaluator template removes all of its versions in one step.
 
 To prevent accidental breakage, deletion is blocked while running evaluators or evaluation rules still reference the template — the UI surfaces those dependencies upfront in the delete dialog so you know what to detach first. Langfuse-managed evaluator templates cannot be deleted.

--- a/content/changelog/2026-06-15-delete-evaluator-templates.mdx
+++ b/content/changelog/2026-06-15-delete-evaluator-templates.mdx
@@ -7,6 +7,7 @@ canonical: /docs/evaluation/evaluation-methods/llm-as-a-judge
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { V4CutoverDate } from "@/components/V4CutoverDate";
 import { Book, Code } from "lucide-react";
 
 <ChangelogHeader />
@@ -15,7 +16,7 @@ import { Book, Code } from "lucide-react";
   A new [stable API for evaluators and evaluation
   rules](/changelog/2026-08-27-stable-evaluator-api) is now available under
   `/api/public/v2`. The unstable API described below remains available until
-  November 16, 2026.
+  <V4CutoverDate />.
 </Callout>
 
 You can now delete evaluator templates you no longer need — from the Langfuse UI, the unstable public API (`DELETE /unstable/evaluators/{id}`), and MCP. Deleting an evaluator template removes all of its versions in one step.

--- a/content/changelog/2026-08-27-stable-evaluator-api.mdx
+++ b/content/changelog/2026-08-27-stable-evaluator-api.mdx
@@ -6,6 +6,7 @@ author: Tobias Wochinger
 ---
 
 import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { V4CutoverDate } from "@/components/V4CutoverDate";
 import { Code } from "lucide-react";
 
 <ChangelogHeader />
@@ -37,7 +38,7 @@ DELETE /api/public/v2/evaluation-rules/{evaluationRuleId}
 
 Evaluator and rule names no longer act as identifiers. Each resource has a stable ID, and rules always use the latest version of their assigned evaluators. List endpoints use cursor pagination, and API errors include structured codes that automation can handle without parsing error messages.
 
-If you use the previous unstable evaluator endpoints, migrate to `/api/public/v2` by November 16, 2026.
+If you use the previous unstable evaluator endpoints, migrate to `/api/public/v2` by <V4CutoverDate />.
 
 <Cards num={2}>
   <Card

--- a/content/changelog/2026-08-27-stable-evaluator-api.mdx
+++ b/content/changelog/2026-08-27-stable-evaluator-api.mdx
@@ -1,0 +1,55 @@
+---
+date: 2026-08-27
+title: Manage evaluators with the stable API
+description: Create, version, and manage evaluators and evaluation rules through stable, ID-based public APIs.
+author: Tobias Wochinger
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+import { Code } from "lucide-react";
+
+<ChangelogHeader />
+
+You can now manage LLM-as-a-Judge and code evaluators through stable, ID-based public APIs. Evaluators define how data is scored, while evaluation rules define which incoming observations are evaluated.
+
+A few things you can automate:
+
+- **Keep evaluation setup in version control.** Create evaluators from CI, update their definitions as new versions, and inspect their version history.
+- **Reuse setups across projects.** Replicate evaluators, filters, sampling, variable mappings, and rule assignments between staging and production.
+- **Migrate legacy rules.** Read existing trace and dataset rules through the stable API, then deactivate or delete them after moving to observation-level evaluation.
+
+The new endpoints are available under `/api/public/v2`:
+
+```text
+POST   /api/public/v2/evaluators
+GET    /api/public/v2/evaluators
+GET    /api/public/v2/evaluators/{evaluatorId}
+PATCH  /api/public/v2/evaluators/{evaluatorId}
+DELETE /api/public/v2/evaluators/{evaluatorId}
+GET    /api/public/v2/evaluators/{evaluatorId}/versions
+
+POST   /api/public/v2/evaluation-rules
+GET    /api/public/v2/evaluation-rules
+GET    /api/public/v2/evaluation-rules/{evaluationRuleId}
+PATCH  /api/public/v2/evaluation-rules/{evaluationRuleId}
+DELETE /api/public/v2/evaluation-rules/{evaluationRuleId}
+```
+
+Evaluator and rule names no longer act as identifiers. Each resource has a stable ID, and rules always use the latest version of their assigned evaluators. List endpoints use cursor pagination, and API errors include structured codes that automation can handle without parsing error messages.
+
+If you use the previous unstable evaluator endpoints, migrate to `/api/public/v2` by November 16, 2026.
+
+<Cards num={2}>
+  <Card
+    title="Evaluators API reference"
+    href="https://api.reference.langfuse.com/#tag/evaluators"
+    icon={<Code />}
+    arrow
+  />
+  <Card
+    title="Evaluation Rules API reference"
+    href="https://api.reference.langfuse.com/#tag/evaluationrules"
+    icon={<Code />}
+    arrow
+  />
+</Cards>

--- a/content/docs/evaluation/evaluation-methods/code-evaluators.mdx
+++ b/content/docs/evaluation/evaluation-methods/code-evaluators.mdx
@@ -537,7 +537,7 @@ No. Code evaluators currently support standard libraries only. If your evaluatio
 <Details>
 <Summary>Can I create code evaluators via API or SDK?</Summary>
 
-Yes. In addition to the Langfuse UI, the unstable public evaluator endpoints accept `type: "code"` to create code evaluators and reference them from evaluation rules. See the [Evaluators API reference](https://api.reference.langfuse.com/#tag/unstableevaluators) — note that these endpoints are unstable and may change.
+Yes. In addition to the Langfuse UI, the stable public evaluator endpoints accept `type: "code"` to create code evaluators and reference them from evaluation rules. See the [Evaluators API reference](https://api.reference.langfuse.com/#tag/evaluators).
 
 If you want to run deterministic evaluation logic in your own application or CI pipeline, use [Scores via API/SDK](/docs/evaluation/evaluation-methods/scores-via-sdk) to ingest the resulting scores into Langfuse.
 

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -241,10 +241,10 @@ Beyond the UI, you can set up and manage LLM-as-a-Judge evaluation programmatica
 
 The setup is split into two resources:
 
-- **Evaluators** define _how_ to score data: the judge prompt, its `{{variables}}`, default variable mappings, the structured output definition (numeric, boolean, or categorical), and the optional model configuration. Evaluators are versioned—creating one under an existing name produces the next version, and active rules automatically move to it.
+- **Evaluators** define _how_ to score data: the judge prompt, its `{{variables}}`, default variable mappings, the structured output definition (numeric, boolean, or categorical), and the optional model configuration. Each evaluator has a stable ID. Updating its definition creates a new version, and active rules automatically use the latest version.
 - **Evaluation rules** define _which_ live observations are evaluated: filters, sampling rate, and one or more evaluator assignments. An assignment can use the evaluator's default mapping or override it for that rule. The `tool_calls` mapping source is available for observation data.
 
-A typical flow is to create an evaluator, read back its variables and output definition, then create a rule and attach one or more evaluators to it.
+A typical flow is to create an evaluator, read back its stable ID, variables, and output definition, then create a rule and attach one or more evaluators to it.
 
 The endpoints are designed to be explored and consumed by coding agents. The recommended way to set up evaluators programmatically is to point an agent at the API reference and have it create the evaluators and wire up the evaluation rules for you.
 
@@ -259,9 +259,7 @@ Observation evaluation rules support a boolean `isRootObservation` filter with t
 }
 ```
 
-<Callout type="info">
-  These endpoints are currently **unstable** and may change while the underlying evaluation data model is being redesigned. See the [Evaluators](https://api.reference.langfuse.com/#tag/unstableevaluators) and [Evaluation Rules](https://api.reference.langfuse.com/#tag/unstableevaluationrules) API reference for the full request and response schemas.
-</Callout>
+See the stable [Evaluators](https://api.reference.langfuse.com/#tag/evaluators) and [Evaluation Rules](https://api.reference.langfuse.com/#tag/evaluationrules) API reference for the full request and response schemas.
 
 ## Advanced Topics
 

--- a/content/faq/all/llm-as-a-judge-migration.mdx
+++ b/content/faq/all/llm-as-a-judge-migration.mdx
@@ -30,10 +30,11 @@ Observation-level evaluators run in real time and scale with larger traces and h
 </Callout>
 
 <Callout type="info">
-  Only the unstable Evaluation Rules APIs continue to return legacy `trace` and
-  `dataset` evaluator targets. Stable APIs expose observation-level evaluator
-  targets only; use the unstable APIs when reading these configurations for
-  migration.
+  The stable [Evaluation Rules
+  API](https://api.reference.langfuse.com/#tag/evaluationrules) returns legacy
+  `trace` and `dataset` rules so you can inspect and migrate them. These legacy
+  rules can be deactivated or deleted through the API, but their other settings
+  cannot be changed.
 </Callout>
 
 <Callout type="info">

--- a/content/resources/engineering/ai-agent-evaluation.mdx
+++ b/content/resources/engineering/ai-agent-evaluation.mdx
@@ -101,7 +101,7 @@ Concretely:
 2. Map `{{input}}` and `{{output}}` from the root observation's fields, and preview the populated prompt against matched data from the last 24 hours before activating.
 3. Set a sampling rate to control judge cost in production, and choose a score type: boolean for "task completed, yes or no", numeric for degrees of completion, categorical for outcome labels.
 
-For common dimensions you can skip prompt writing: Langfuse ships a catalog of managed evaluators, built with partners such as Ragas, covering dimensions like hallucination, context relevance, toxicity, and helpfulness. For experiments with ground truth, map the dataset item's expected output as the judge's reference. Evaluators and their rules can also be created via the public API, which is useful for version-controlling your evaluation setup, though those endpoints are still marked unstable as of July 2026.
+For common dimensions you can skip prompt writing: Langfuse ships a catalog of managed evaluators, built with partners such as Ragas, covering dimensions like hallucination, context relevance, toxicity, and helpfulness. For experiments with ground truth, map the dataset item's expected output as the judge's reference. Evaluators and their rules can also be created through the stable [public API](https://api.reference.langfuse.com/#tag/evaluators), which is useful for version-controlling your evaluation setup.
 
 ## Scoring trajectories
 


### PR DESCRIPTION
## Summary

- add a changelog for the stable, ID-based evaluator and evaluation rules APIs
- update the current evaluation docs to reference `/api/public/v2`
- add migration callouts to the historical unstable API changelogs, including the November 16, 2026 deadline

Related implementation: https://github.com/langfuse/langfuse/pull/16608

## Testing

- `pnpm run format:check`
- `node scripts/check-h1-headings.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog-only changes with no runtime or API implementation in this repo.
> 
> **Overview**
> Documents the new **stable, ID-based** evaluator and evaluation-rules APIs under `/api/public/v2`, and retargets evaluation content away from the unstable public endpoints.
> 
> Adds a **2026-08-27 changelog** that lists the v2 CRUD routes, highlights stable IDs (names are no longer identifiers), cursor pagination, structured error codes, and migration from unstable APIs by `<V4CutoverDate />`.
> 
> **Older evaluator changelogs** (LLM-as-a-Judge API, MCP, delete templates) now open with an info callout linking to the stable API and noting unstable routes remain until the v4 cutover.
> 
> **Evaluation docs** are updated to match: LLM-as-a-Judge and code-evaluator pages point at stable API reference tags and describe ID-based versioning; the trace→observation migration FAQ now says the stable Evaluation Rules API can **read and deactivate/delete** legacy `trace`/`dataset` rules (not only via unstable APIs); the AI agent evaluation resource drops the “still unstable” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e552c4b2123f304e1bf22f4599a521e7f8f4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR announces the stable, ID-based evaluator and evaluation-rules APIs and updates evaluation documentation to direct users from unstable endpoints to `/api/public/v2`.

- Adds a changelog listing the stable evaluator and evaluation-rule endpoints and migration deadline.
- Adds migration notices to historical unstable-API changelogs.
- Updates evaluator guides, migration guidance, and an engineering resource to describe the stable API.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge with no concrete changed-code defect identified.

The new changelog satisfies the repository’s publication and MDX conventions, the internal route resolves through the content-derived changelog index, and the remaining edits consistently migrate references from the unstable API to the stable API.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add stable evaluator API changelog"](https://github.com/langfuse/langfuse-docs/commit/75e4648fd7213ad6840ab08dcdfea6cfd8032cba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57495276)</sub>

<!-- /greptile_comment -->