### PR TITLE
Fix Q&A chatbot submit button alignment

### DIFF
--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -146,6 +146,7 @@ export const PromptInputButton = ({
 
 export type PromptInputSubmitProps = ComponentProps<typeof Button> & {
   status?: ChatStatus;
+  onStop?: () => void;
 };
 
 export const PromptInputSubmit = ({
@@ -154,8 +155,12 @@ export const PromptInputSubmit = ({
   size = "small",
   status,
   children,
+  onStop,
+  onClick,
+  type,
   ...props
 }: PromptInputSubmitProps) => {
+  const canStop = status === "streaming" && Boolean(onStop);
   let Icon = <SendIcon className="size-3.5" />;
   let ariaLabel = "Send";
 
@@ -164,7 +169,7 @@ export const PromptInputSubmit = ({
     ariaLabel = "Sending";
   } else if (status === "streaming") {
     Icon = <SquareIcon className="size-3 fill-current" />;
-    ariaLabel = "Stop";
+    ariaLabel = canStop ? "Stop" : "Send";
   } else if (status === "error") {
     Icon = <XIcon className="size-3.5" />;
     ariaLabel = "Error";
@@ -172,13 +177,14 @@ export const PromptInputSubmit = ({
 
   return (
     <Button
+      {...props}
       className={className}
       size={size}
-      type="submit"
+      type={canStop ? "button" : (type ?? "submit")}
       variant={variant}
       icon={children ? undefined : Icon}
       aria-label={children ? undefined : ariaLabel}
-      {...props}
+      onClick={canStop ? onStop : onClick}
     >
       {children}
     </Button>

--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -150,31 +150,37 @@ export type PromptInputSubmitProps = ComponentProps<typeof Button> & {
 
 export const PromptInputSubmit = ({
   className,
-  variant = "default",
-  size = "icon",
+  variant = "primary",
+  size = "small",
   status,
   children,
   ...props
 }: PromptInputSubmitProps) => {
-  let Icon = <SendIcon className="size-4" />;
+  let Icon = <SendIcon className="size-3.5" />;
+  let ariaLabel = "Send";
 
   if (status === "submitted") {
-    Icon = <Loader2Icon className="size-4 animate-spin" />;
+    Icon = <Loader2Icon className="size-3.5 animate-spin" />;
+    ariaLabel = "Sending";
   } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-4" />;
+    Icon = <SquareIcon className="size-3 fill-current" />;
+    ariaLabel = "Stop";
   } else if (status === "error") {
-    Icon = <XIcon className="size-4" />;
+    Icon = <XIcon className="size-3.5" />;
+    ariaLabel = "Error";
   }
 
   return (
     <Button
-      className={cn("gap-1.5 rounded-lg", className)}
+      className={className}
       size={size}
       type="submit"
       variant={variant}
+      icon={children ? undefined : Icon}
+      aria-label={children ? undefined : ariaLabel}
       {...props}
     >
-      {children ?? Icon}
+      {children}
     </Button>
   );
 };

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -341,20 +341,18 @@ export const Chat = ({ className, ...props }: ChatProps) => {
           onSubmit={handleSubmit}
           className="mt-4 rounded-[2px] border-line-structure bg-surface-bg shadow-sm relative z-10 focus-within:border-line-cta transition-colors"
         >
-          <div className="flex items-end gap-2">
+          <div className="flex items-end gap-1 p-1">
             <PromptInputTextarea
               ref={textareaRef}
               onChange={(e) => setInput(e.target.value)}
               value={input}
               placeholder="Ask a question about Langfuse..."
-              className="flex-1 pr-2 min-h-[40px] max-h-[300px] leading-5 pt-[10px] pb-[10px] overflow-y-auto text-sm"
+              className="flex-1 min-h-[32px] max-h-[300px] leading-5 py-1.5 px-2 overflow-y-auto text-sm"
               style={{ height: "auto" }}
-              minHeight={40}
+              minHeight={32}
               maxHeight={300}
             />
-            <div className="pr-3 pb-[10px]">
-              <PromptInputSubmit disabled={!input || !userId} status={status} />
-            </div>
+            <PromptInputSubmit disabled={!input || !userId} status={status} />
           </div>
         </PromptInput>
         <p className="mt-6 text-xs text-muted-foreground text-center relative z-10 italic">

--- a/components/qaChatbot/index.tsx
+++ b/components/qaChatbot/index.tsx
@@ -82,13 +82,14 @@ export const Chat = ({ className, ...props }: ChatProps) => {
     });
   }, []);
 
-  const { messages, sendMessage, status, regenerate } = useChat<ChatMessage>({
-    messages: [],
-    transport: new DefaultChatTransport({
-      api: "/api/qa-chatbot",
-      body: { chatId, userId },
-    }),
-  });
+  const { messages, sendMessage, status, regenerate, stop } =
+    useChat<ChatMessage>({
+      messages: [],
+      transport: new DefaultChatTransport({
+        api: "/api/qa-chatbot",
+        body: { chatId, userId },
+      }),
+    });
 
   // Check if user has submitted any messages
   const hasUserMessages = messages.some((message) => message.role === "user");
@@ -352,7 +353,11 @@ export const Chat = ({ className, ...props }: ChatProps) => {
               minHeight={32}
               maxHeight={300}
             />
-            <PromptInputSubmit disabled={!input || !userId} status={status} />
+            <PromptInputSubmit
+              disabled={status === "streaming" ? !userId : !input || !userId}
+              status={status}
+              onStop={stop}
+            />
           </div>
         </PromptInput>
         <p className="mt-6 text-xs text-muted-foreground text-center relative z-10 italic">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the send button in the example-project Q&A chatbot sitting flush with the top of the input field.

The button wrapper only had bottom padding, so in a flex row it became taller than the textarea and the visible control sat at the top of that column. `PromptInputSubmit` also used shadcn `size="icon"` / `variant="default"` against the site’s custom Button, which does not support those values.

## Changes
- Use even inner padding and align the send control with the textarea
- Render `PromptInputSubmit` as an icon-only small Button (same pattern as the docs chat widget)

## Test plan
- Open `/docs/demo` and confirm the send button is vertically centered in the empty input, with even inset from the top, bottom, and right edges
- Type a multi-line question and confirm the button stays at the bottom-right as the textarea grows

Verified locally on `/docs/demo`: empty/single-line state is vertically centered; growing the textarea with Shift+Enter keeps the paper-plane button at the bottom-right with even padding.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2318](https://linear.app/clickhouse/issue/LFMKT-2318/fix-the-alignment-of-this-button-in-the-langfuse-demo)

<div><a href="https://cursor.com/agents/bc-8900cdc3-e089-410b-bd38-dbea2befc319?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8900cdc3-e089-410b-bd38-dbea2befc319&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects the Q&A chatbot submit-button alignment and updates `PromptInputSubmit` to use the custom Button component’s supported API.
- Applies even padding and bottom alignment to keep the submit control inset beside both single-line and growing textarea states.
- Uses supported `primary` and `small` Button values and supplies status-specific icons and accessible labels for the icon-only control.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defects identified.

The sole current submit-button caller exercises the new icon-only path correctly, the new Button values match the custom component’s supported contract, and the layout changes preserve the chatbot’s input and submission behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Q&amp;A chatbot submit button alignment"](https://github.com/langfuse/langfuse-docs/commit/e57f2c85a9251d5d06da65b05fc604e470400ec5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57517857)</sub>

<!-- /greptile_comment -->