### PR TITLE
Variant B: clickable product-area names on homepage screenshots

### DIFF
--- a/components/home/FeatureTabsSection.tsx
+++ b/components/home/FeatureTabsSection.tsx
@@ -8,9 +8,16 @@ import { TextHighlight } from "../ui/text-highlight";
 import { mobileFeatureTabsData } from "./feature-tabs/data";
 
 export function FeatureTabsSection() {
+  const mobileFeature = featureTabsData[0];
+
   return (
     <HomeSection id="overview" className="pt-[120px]">
-      <div className="flex items-start mb-6 md:hidden">
+      <div className="flex flex-col items-start mb-6 md:hidden">
+        {mobileFeature?.name ? (
+          <p className="mb-1 text-sm font-medium text-primary">
+            {mobileFeature.name}
+          </p>
+        ) : null}
         <Heading className="text-left">
           Gain{" "}
           <TextHighlight className="whitespace-nowrap">

--- a/components/home/FeatureTabsSection.tsx
+++ b/components/home/FeatureTabsSection.tsx
@@ -3,35 +3,12 @@
 import { Suspense } from "react";
 import { HomeSection } from "./HomeSection";
 import { FeatureTabs, featureTabsData } from "./feature-tabs";
-import { Heading } from "../ui/heading";
-import { TextHighlight } from "../ui/text-highlight";
-import { mobileFeatureTabsData } from "./feature-tabs/data";
 
 export function FeatureTabsSection() {
-  const mobileFeature = featureTabsData[0];
-
   return (
     <HomeSection id="overview" className="pt-[120px]">
-      <div className="flex flex-col items-start mb-6 md:hidden">
-        {mobileFeature?.name ? (
-          <p className="mb-1 text-sm font-medium text-primary">
-            {mobileFeature.name}
-          </p>
-        ) : null}
-        <Heading className="text-left">
-          Gain{" "}
-          <TextHighlight className="whitespace-nowrap">
-            deep visibility
-          </TextHighlight>{" "}
-          into your traces
-        </Heading>
-      </div>
-
       <Suspense>
-        <FeatureTabs
-          features={featureTabsData}
-          mobileFeature={mobileFeatureTabsData}
-        />
+        <FeatureTabs features={featureTabsData} />
       </Suspense>
     </HomeSection>
   );

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -10,9 +10,11 @@ import {
 } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { TabButton } from "./TabButton";
 import { TabContent } from "./TabContent";
 import type { AutoAdvanceConfig, FeatureTabData } from "./types";
 import { CornerBox } from "@/components/ui/corner-box";
+import { cn } from "@/lib/utils";
 
 /** Soft ease-out (Emil Kowalski–style: calm deceleration, no snappy linear segments). */
 const CONTENT_EASE = [0.22, 1, 0.36, 1] as const;
@@ -336,8 +338,13 @@ export const FeatureTabs = ({
       ref={setContainerNode}
       className="overflow-hidden p-0 mt-0 bg-card border-radius-none"
     >
-      {/* Accessibility: Auto-advance status announcement */}
+      {/* Accessibility: Auto-advance status and current product area */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {activeFeature ? (
+          <span>
+            Showing {activeFeature.name}. {activeFeature.subtitle}
+          </span>
+        ) : null}
         {defaultAutoAdvance.enabled && (
           <span>
             Auto-advance is {state.isAutoAdvancePaused ? "paused" : "active"}.
@@ -377,15 +384,16 @@ export const FeatureTabs = ({
         })}
       </CornerBox>
 
-      {/* Title bar with corner box */}
-      <CornerBox
-        role="tablist"
-        aria-label="Feature navigation. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
-        className="px-4 py-2 hidden md:block"
-        onKeyDown={handleKeyDown}
-      >
-        <div ref={tabListScrollRef} className="flex flex-row items-center">
-          {/* Title — left-aligned */}
+      {/* Title bar with product-area name, pills, and caption */}
+      <CornerBox className="px-4 py-3 hidden md:block">
+        <div
+          ref={tabListScrollRef}
+          role="tablist"
+          aria-label="Product area screenshots. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
+          className="flex flex-row items-start gap-4"
+          onKeyDown={handleKeyDown}
+        >
+          {/* Product-area name + one-line description — left-aligned */}
           <div className="relative overflow-hidden min-w-0 flex-1">
             <div aria-hidden className="flex flex-col">
               {features.map((f) => (
@@ -393,28 +401,33 @@ export const FeatureTabs = ({
                   key={f.id}
                   className="whitespace-nowrap text-xl font-analog font-medium invisible h-0 block"
                 >
-                  {f.title}
+                  {f.name}
                 </span>
               ))}
             </div>
             <AnimatePresence mode="wait" initial={false}>
               {activeFeature && (
-                <motion.h3
+                <motion.div
                   key={activeFeature.id}
                   initial={{ opacity: 0, y: 4 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -4 }}
                   transition={{ duration: 0.12, ease: "easeOut" }}
-                  className="block whitespace-nowrap text-xl font-analog font-medium text-primary"
+                  className="flex flex-col gap-0.5"
                 >
-                  {activeFeature.title}
-                </motion.h3>
+                  <h3 className="block whitespace-nowrap text-xl font-analog font-medium text-primary">
+                    {activeFeature.name}
+                  </h3>
+                  <p className="text-sm leading-snug text-text-tertiary">
+                    {activeFeature.subtitle}
+                  </p>
+                </motion.div>
               )}
             </AnimatePresence>
           </div>
 
-          {/* Dot indicators — right-aligned */}
-          <div className="flex flex-row items-center gap-1.5 ml-auto shrink-0">
+          {/* Dot indicators — right-aligned, labeled via accessible names */}
+          <div className="flex flex-row items-center gap-1.5 ml-auto shrink-0 pt-1.5">
             {features.map((feature, index) => {
               const isActive = activeTab === feature.id;
 
@@ -426,7 +439,8 @@ export const FeatureTabs = ({
                   }}
                   role="tab"
                   aria-selected={isActive}
-                  aria-label={feature.title}
+                  aria-label={feature.name}
+                  title={feature.name}
                   aria-controls={`tabpanel-${feature.id}`}
                   id={`tab-${feature.id}`}
                   tabIndex={state.focusedIndex === index ? 0 : -1}
@@ -434,17 +448,49 @@ export const FeatureTabs = ({
                   className="group p-1 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
                 >
                   <span
-                    className={`block w-3 h-1.5 rounded-sm transition-colors duration-150 ease-out ${
+                    className={cn(
+                      "block w-3 h-1.5 rounded-sm transition-colors duration-150 ease-out",
                       isActive
                         ? "bg-primary"
-                        : "bg-line-structure group-hover:bg-primary"
-                    }`}
+                        : "bg-line-structure group-hover:bg-primary",
+                    )}
                   />
                 </button>
               );
             })}
           </div>
         </div>
+
+        {/* Caption of all product areas — legend, not a tab bar */}
+        <ul
+          className="mt-2 flex flex-wrap items-center text-xs leading-snug"
+          aria-label="Product areas"
+        >
+          {features.map((feature, index) => {
+            const isActive = activeTab === feature.id;
+
+            return (
+              <li key={feature.id} className="inline-flex items-center">
+                {index > 0 && (
+                  <span aria-hidden className="px-2 text-text-tertiary">
+                    ·
+                  </span>
+                )}
+                <span
+                  className={cn(
+                    "transition-colors duration-150",
+                    isActive
+                      ? "font-medium text-primary"
+                      : "text-text-tertiary",
+                  )}
+                  aria-current={isActive ? "true" : undefined}
+                >
+                  {feature.name}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
       </CornerBox>
 
       {/* Image box - desktop */}

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -48,7 +48,6 @@ const tabImageVariants = (reduceMotion: boolean) =>
 
 export interface FeatureTabsProps {
   features: FeatureTabData[];
-  mobileFeature: Pick<FeatureTabData, "image">;
   defaultTab?: string;
   autoAdvance?: AutoAdvanceConfig;
 }
@@ -97,7 +96,6 @@ const DEFAULT_AUTO_ADVANCE: AutoAdvanceConfig = {
 
 export const FeatureTabs = ({
   features,
-  mobileFeature,
   defaultTab = "observability",
   autoAdvance,
 }: FeatureTabsProps) => {
@@ -259,6 +257,7 @@ export const FeatureTabs = ({
 
     dispatch({ type: "SET_FOCUSED_INDEX", payload: newIndex });
     tabRefs.current[newIndex]?.focus();
+    handleTabChange(features[newIndex]!.id);
   };
 
   // Scroll active tab into view (for mobile)
@@ -383,117 +382,79 @@ export const FeatureTabs = ({
         })}
       </CornerBox>
 
-      {/* Title bar with product-area name, pills, and caption */}
-      <CornerBox className="px-4 py-3 hidden md:block">
+      {/* Clickable product-area names, then animated subtitle */}
+      <CornerBox className="px-4 py-3">
         <div
           ref={tabListScrollRef}
           role="tablist"
-          aria-label="Product area screenshots. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
-          className="flex flex-row items-start gap-4"
+          aria-label="Product area screenshots. Use arrow keys to navigate, Escape to toggle auto-advance."
+          className="flex flex-nowrap md:flex-wrap items-center overflow-x-auto md:overflow-visible [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden text-sm leading-snug"
           onKeyDown={handleKeyDown}
-        >
-          {/* Product-area name + one-line description — left-aligned */}
-          <div className="relative overflow-hidden min-w-0 flex-1">
-            <div aria-hidden className="flex flex-col">
-              {features.map((f) => (
-                <span
-                  key={f.id}
-                  className="whitespace-nowrap text-xl font-analog font-medium invisible h-0 block"
-                >
-                  {f.name}
-                </span>
-              ))}
-            </div>
-            <AnimatePresence mode="wait" initial={false}>
-              {activeFeature && (
-                <motion.div
-                  key={activeFeature.id}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  transition={{ duration: 0.12, ease: "easeOut" }}
-                  className="flex flex-col gap-0.5"
-                >
-                  <h3 className="block whitespace-nowrap text-xl font-analog font-medium text-primary">
-                    {activeFeature.name}
-                  </h3>
-                  <p className="text-sm leading-snug text-text-tertiary">
-                    {activeFeature.subtitle}
-                  </p>
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </div>
-
-          {/* Dot indicators — right-aligned, labeled via accessible names */}
-          <div className="flex flex-row items-center gap-1.5 ml-auto shrink-0 pt-1.5">
-            {features.map((feature, index) => {
-              const isActive = activeTab === feature.id;
-
-              return (
-                <button
-                  key={feature.id}
-                  ref={(el) => {
-                    tabRefs.current[index] = el;
-                  }}
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-label={feature.name}
-                  title={feature.name}
-                  aria-controls={`tabpanel-${feature.id}`}
-                  id={`tab-${feature.id}`}
-                  tabIndex={state.focusedIndex === index ? 0 : -1}
-                  onClick={() => handleTabChange(feature.id)}
-                  className="group p-1 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
-                >
-                  <span
-                    className={cn(
-                      "block w-3 h-1.5 rounded-sm transition-colors duration-150 ease-out",
-                      isActive
-                        ? "bg-primary"
-                        : "bg-line-structure group-hover:bg-primary",
-                    )}
-                  />
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Caption of all product areas — legend, not a tab bar */}
-        <ul
-          className="mt-2 flex flex-wrap items-center text-xs leading-snug"
-          aria-label="Product areas"
         >
           {features.map((feature, index) => {
             const isActive = activeTab === feature.id;
 
             return (
-              <li key={feature.id} className="inline-flex items-center">
+              <span
+                key={feature.id}
+                className="inline-flex items-center shrink-0"
+              >
                 {index > 0 && (
                   <span aria-hidden className="px-2 text-text-tertiary">
                     ·
                   </span>
                 )}
-                <span
+                <button
+                  ref={(el) => {
+                    tabRefs.current[index] = el;
+                  }}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls="tabpanel-product-area"
+                  id={`tab-${feature.id}`}
+                  tabIndex={state.focusedIndex === index ? 0 : -1}
+                  onClick={() => handleTabChange(feature.id)}
                   className={cn(
-                    "transition-colors duration-150",
+                    "cursor-pointer whitespace-nowrap rounded-sm py-0.5 transition-colors duration-150",
+                    "focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/50",
                     isActive
                       ? "font-medium text-primary"
-                      : "text-text-tertiary",
+                      : "text-text-tertiary hover:text-primary",
                   )}
-                  aria-current={isActive ? "true" : undefined}
                 >
                   {feature.name}
-                </span>
-              </li>
+                </button>
+              </span>
             );
           })}
-        </ul>
+        </div>
+
+        <div className="relative mt-2 min-h-[1.25rem] overflow-hidden">
+          <AnimatePresence mode="wait" initial={false}>
+            {activeFeature && (
+              <motion.p
+                key={activeFeature.id}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={{ duration: 0.12, ease: "easeOut" }}
+                className="text-sm leading-snug text-text-tertiary"
+              >
+                {activeFeature.subtitle}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
       </CornerBox>
 
-      {/* Image box - desktop */}
-      <CornerBox className="p-4 md:-mt-px hidden md:block" withStripes>
+      <CornerBox
+        className="p-4 -mt-px"
+        withStripes
+        role="tabpanel"
+        id="tabpanel-product-area"
+        aria-labelledby={activeFeature ? `tab-${activeFeature.id}` : undefined}
+      >
         <div className="relative w-full overflow-hidden aspect-[2205/1291] custom-card-shadow">
           <AnimatePresence mode="sync" initial={false}>
             {activeFeature ? (
@@ -508,22 +469,6 @@ export const FeatureTabs = ({
               </motion.div>
             ) : null}
           </AnimatePresence>
-        </div>
-      </CornerBox>
-
-      {/* Image box - mobile */}
-      <CornerBox className="pl-4 pt-4 block md:hidden" withStripes>
-        <div className="relative w-full overflow-hidden min-h-[410px]">
-          <Image
-            src={mobileFeature?.image.light}
-            alt={mobileFeature?.image.alt}
-            width={1360}
-            height={1640}
-            quality={100}
-            className="absolute left-0 top-0 min-w-full min-h-full object-cover object-top-left"
-            sizes="(min-width: 640px) 1360px"
-            priority
-          />
         </div>
       </CornerBox>
     </div>

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { TabButton } from "./TabButton";
 import { TabContent } from "./TabContent";
 import type { AutoAdvanceConfig, FeatureTabData } from "./types";
 import { CornerBox } from "@/components/ui/corner-box";

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -336,13 +336,8 @@ export const FeatureTabs = ({
       ref={setContainerNode}
       className="overflow-hidden p-0 mt-0 bg-card border-radius-none"
     >
-      {/* Accessibility: Auto-advance status and current product area */}
+      {/* Accessibility: announce pause/resume only, not every auto-advance */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {activeFeature ? (
-          <span>
-            Showing {activeFeature.name}. {activeFeature.subtitle}
-          </span>
-        ) : null}
         {defaultAutoAdvance.enabled && (
           <span>
             Auto-advance is {state.isAutoAdvancePaused ? "paused" : "active"}.
@@ -388,7 +383,7 @@ export const FeatureTabs = ({
           ref={tabListScrollRef}
           role="tablist"
           aria-label="Product area screenshots. Use arrow keys to navigate, Escape to toggle auto-advance."
-          className="flex flex-nowrap md:flex-wrap items-center overflow-x-auto md:overflow-visible [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden text-sm leading-snug"
+          className="flex !flex-nowrap md:!flex-wrap items-center overflow-x-auto md:overflow-visible [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden text-sm leading-snug"
           onKeyDown={handleKeyDown}
         >
           {features.map((feature, index) => {

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -420,7 +420,7 @@ export const FeatureTabs = ({
                     "focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/50",
                     isActive
                       ? "font-medium text-primary"
-                      : "text-text-tertiary hover:text-primary",
+                      : "font-normal text-text-tertiary hover:text-primary",
                   )}
                 >
                   {feature.name}
@@ -430,7 +430,7 @@ export const FeatureTabs = ({
           })}
         </div>
 
-        <div className="relative mt-2 min-h-[1.25rem] overflow-hidden">
+        <div className="relative mt-3 min-h-[1.125rem] overflow-hidden">
           <AnimatePresence mode="wait" initial={false}>
             {activeFeature && (
               <motion.p
@@ -439,7 +439,7 @@ export const FeatureTabs = ({
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -4 }}
                 transition={{ duration: 0.12, ease: "easeOut" }}
-                className="text-sm leading-snug text-text-tertiary"
+                className="text-xs leading-relaxed font-normal text-text-tertiary"
               >
                 {activeFeature.subtitle}
               </motion.p>

--- a/components/home/feature-tabs/data.ts
+++ b/components/home/feature-tabs/data.ts
@@ -10,20 +10,11 @@ import {
 import type { FeatureTabData } from "./types";
 
 import observabilityPng from "components/home/feature-tabs/img/observability-ui.png";
-import observabilityMobilePng from "components/home/feature-tabs/img/observability-mobile-ui.png";
 import metricsPng from "components/home/feature-tabs/img/cost-ui.png";
 import PromptPng from "components/home/feature-tabs/img/prompts-ui.png";
 import EvalsPng from "components/home/feature-tabs/img/evals-ui.png";
 import PlaygroundPng from "components/home/feature-tabs/img/playground-ui.png";
 import AnnotationPng from "components/home/feature-tabs/img/annotation-ui.png";
-
-export const mobileFeatureTabsData: Pick<FeatureTabData, "image"> = {
-  image: {
-    light: observabilityMobilePng,
-    dark: observabilityMobilePng,
-    alt: "Langfuse observability trace detail view showing nested observations with latency and cost",
-  },
-};
 
 export const featureTabsData: FeatureTabData[] = [
   {

--- a/components/home/feature-tabs/data.ts
+++ b/components/home/feature-tabs/data.ts
@@ -29,6 +29,7 @@ export const featureTabsData: FeatureTabData[] = [
   {
     id: "observability",
     icon: TextQuote,
+    name: "Observability",
     title: "Gain deep visibility into your traces",
     subtitle: "Trace every LLM call with cost and latency.",
     body: "Capture complete traces of your LLM applications/agents. Use traces to inspect failures and build eval datasets. Based on OpenTelemetry with support for all popular LLM/agent libraries.",
@@ -84,6 +85,7 @@ export default observe(handleRequest);`,
   {
     id: "metrics",
     icon: LineChart,
+    name: "Metrics",
     title: "Track model cost and latency",
     subtitle: "Track cost, latency, and quality.",
     body: "Monitor your LLM application's performance with comprehensive metrics dashboards and APIs. Track costs, latencies, token usage, and quality scores across models, users, and time periods.",
@@ -145,6 +147,7 @@ const res = await langfuse.api.metrics.metrics({query});`,
   {
     id: "prompt-management",
     icon: GitPullRequestArrow,
+    name: "Prompt Management",
     title: "Improve your prompts",
     subtitle: "Version and deploy prompts with low latency.",
     body: "Version-control prompts collaboratively, deploy/roll-back instantly to different environments, support for templates, variables, and A/B testing. Cached client-side for 0 latency/availability impact.",
@@ -208,6 +211,7 @@ async function handleRequest(userInput: string) {
   {
     id: "evaluation",
     icon: ThumbsUp,
+    name: "Evaluation",
     title: "Evaluate model outputs automatically",
     subtitle: "Collect feedback and run evaluations.",
     body: "Run online/offline evals, via UI (experiment with prompts/models) and via SDKs (experiment with end-to-end application). Build datasets from traces to continuously improve your evals. View results in UI.",
@@ -276,6 +280,7 @@ const result = await langfuse.experiment.run({
   {
     id: "annotations",
     icon: MessageSquare,
+    name: "Annotations",
     title: "Collaborate on human reviews",
     subtitle: "Add manual feedback and corrections.",
     body: "Create manual annotations to provide feedback, corrections, and improvements to your LLM outputs. Use annotations to build high-quality datasets and set a baseline for automated evals.",
@@ -290,6 +295,7 @@ const result = await langfuse.experiment.run({
   {
     id: "playground",
     icon: FlaskConical,
+    name: "Playground",
     title: "Iterate with structured experiments",
     subtitle: "Test prompts and models interactively.",
     body: "Experiment with different prompts, models, and parameters in an interactive playground. Compare outputs, iterate on prompts, and save successful configurations to prompt management.",

--- a/components/home/feature-tabs/types.ts
+++ b/components/home/feature-tabs/types.ts
@@ -20,6 +20,8 @@ export type TabDisplayMode =
 export interface FeatureTabData {
   id: string;
   icon: LucideIcon;
+  /** Product-area name shown on the homepage screenshot switcher. */
+  name: string;
   title: string;
   subtitle: string;
   body: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homepage experiment: **Variant B** (the chosen direction).

The screenshot switcher below the hero uses the middot name row as the navigator.

- Product-area names are clickable (`Observability · Metrics · Prompt Management · Evaluation · Annotations · Playground`)
- Active name is emphasized (medium/primary); inactive names stay muted
- Animated subtitle under the names is smaller and quieter so it reads as a description
- Large repeating product-area title and pill/dot indicators are removed
- Keyboard: arrows / Home / End; Escape pauses auto-advance
- Names stay visible on mobile (horizontal scroll / wrap)

Variants A (#3645) and C (#3646) are closed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6fd9080-4858-48c3-bf2a-fd629dd236a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6fd9080-4858-48c3-bf2a-fd629dd236a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR turns the homepage product-area name row into the responsive screenshot navigator and simplifies the accompanying title, subtitle, indicators, and image layout.
- Adds clickable, keyboard-navigable product-area tabs with active styling.
- Uses a shared responsive tabpanel and animated subtitle across viewport sizes.
- Extends feature-tab data with short product-area names.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only non-blocking cleanup needed for the orphaned mobile screenshot data.

The new navigation and shared tabpanel have no established blocking failure, but removal of the mobile rendering path leaves its former data object and image import unused.

**Files Needing Attention:** components/home/FeatureTabsSection.tsx, components/home/feature-tabs/data.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  N[Product-area name row] -->|Click or keyboard| S[Selected feature state]
  A[Auto-advance timer] --> S
  S --> T[Animated subtitle]
  S --> P[Shared screenshot tabpanel]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/home/FeatureTabsSection.tsx:11
**Orphaned mobile screenshot data**

Removing the `mobileFeature` prop leaves `mobileFeatureTabsData` and its image import without a consumer, creating misleading dead code that maintainers can continue updating even though it is no longer rendered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Differentiate homepage product-area tabs..."](https://github.com/langfuse/langfuse-docs/commit/2c9fc5140c886e179d62ec84f35682e90ecdb60f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57660654)</sub>

<!-- /greptile_comment -->