### PR TITLE
Variant C: labeled product-area chips on homepage screenshots

### DIFF
--- a/components/home/FeatureTabsSection.tsx
+++ b/components/home/FeatureTabsSection.tsx
@@ -3,23 +3,11 @@
 import { Suspense } from "react";
 import { HomeSection } from "./HomeSection";
 import { FeatureTabs, featureTabsData } from "./feature-tabs";
-import { Heading } from "../ui/heading";
-import { TextHighlight } from "../ui/text-highlight";
 import { mobileFeatureTabsData } from "./feature-tabs/data";
 
 export function FeatureTabsSection() {
   return (
     <HomeSection id="overview" className="pt-[120px]">
-      <div className="flex items-start mb-6 md:hidden">
-        <Heading className="text-left">
-          Gain{" "}
-          <TextHighlight className="whitespace-nowrap">
-            deep visibility
-          </TextHighlight>{" "}
-          into your traces
-        </Heading>
-      </div>
-
       <Suspense>
         <FeatureTabs
           features={featureTabsData}

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { TabButton } from "./TabButton";
 import { TabContent } from "./TabContent";
 import type { AutoAdvanceConfig, FeatureTabData } from "./types";
 import { CornerBox } from "@/components/ui/corner-box";
@@ -331,13 +332,23 @@ export const FeatureTabs = ({
     return new Set([prev, next]);
   }, [n, activeIndex]);
 
+  const mobileScreenshot =
+    activeFeature?.id === "observability"
+      ? mobileFeature.image
+      : activeFeature?.image;
+
   return (
     <div
       ref={setContainerNode}
       className="overflow-hidden p-0 mt-0 bg-card border-radius-none"
     >
-      {/* Accessibility: Auto-advance status announcement */}
+      {/* Accessibility: Auto-advance status and current product area */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {activeFeature ? (
+          <span>
+            Showing {activeFeature.name}. {activeFeature.subtitle}
+          </span>
+        ) : null}
         {defaultAutoAdvance.enabled && (
           <span>
             Auto-advance is {state.isAutoAdvancePaused ? "paused" : "active"}.
@@ -377,78 +388,35 @@ export const FeatureTabs = ({
         })}
       </CornerBox>
 
-      {/* Title bar with corner box */}
+      {/* Named product-area tabs on the screenshot frame */}
       <CornerBox
         role="tablist"
-        aria-label="Feature navigation. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
-        className="px-4 py-2 hidden md:block"
+        aria-label="Product area navigation. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
+        className="px-1 py-1 sm:px-2"
         onKeyDown={handleKeyDown}
       >
-        <div ref={tabListScrollRef} className="flex flex-row items-center">
-          {/* Title — left-aligned */}
-          <div className="relative overflow-hidden min-w-0 flex-1">
-            <div aria-hidden className="flex flex-col">
-              {features.map((f) => (
-                <span
-                  key={f.id}
-                  className="whitespace-nowrap text-xl font-analog font-medium invisible h-0 block"
-                >
-                  {f.title}
-                </span>
-              ))}
-            </div>
-            <AnimatePresence mode="wait" initial={false}>
-              {activeFeature && (
-                <motion.h3
-                  key={activeFeature.id}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  transition={{ duration: 0.12, ease: "easeOut" }}
-                  className="block whitespace-nowrap text-xl font-analog font-medium text-primary"
-                >
-                  {activeFeature.title}
-                </motion.h3>
-              )}
-            </AnimatePresence>
-          </div>
-
-          {/* Dot indicators — right-aligned */}
-          <div className="flex flex-row items-center gap-1.5 ml-auto shrink-0">
-            {features.map((feature, index) => {
-              const isActive = activeTab === feature.id;
-
-              return (
-                <button
-                  key={feature.id}
-                  ref={(el) => {
-                    tabRefs.current[index] = el;
-                  }}
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-label={feature.title}
-                  aria-controls={`tabpanel-${feature.id}`}
-                  id={`tab-${feature.id}`}
-                  tabIndex={state.focusedIndex === index ? 0 : -1}
-                  onClick={() => handleTabChange(feature.id)}
-                  className="group p-1 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
-                >
-                  <span
-                    className={`block w-3 h-1.5 rounded-sm transition-colors duration-150 ease-out ${
-                      isActive
-                        ? "bg-primary"
-                        : "bg-line-structure group-hover:bg-primary"
-                    }`}
-                  />
-                </button>
-              );
-            })}
-          </div>
+        <div
+          ref={tabListScrollRef}
+          className="flex flex-row flex-nowrap items-stretch overflow-x-auto snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {features.map((feature, index) => (
+            <TabButton
+              key={feature.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              feature={feature}
+              isActive={activeTab === feature.id}
+              onClick={() => handleTabChange(feature.id)}
+              tabIndex={state.focusedIndex === index ? 0 : -1}
+              className="snap-center"
+            />
+          ))}
         </div>
       </CornerBox>
 
       {/* Image box - desktop */}
-      <CornerBox className="p-4 md:-mt-px hidden md:block" withStripes>
+      <CornerBox className="p-4 -mt-px hidden md:block" withStripes>
         <div className="relative w-full overflow-hidden aspect-[2205/1291] custom-card-shadow">
           <AnimatePresence mode="sync" initial={false}>
             {activeFeature ? (
@@ -467,18 +435,30 @@ export const FeatureTabs = ({
       </CornerBox>
 
       {/* Image box - mobile */}
-      <CornerBox className="pl-4 pt-4 block md:hidden" withStripes>
+      <CornerBox className="pl-4 pt-4 -mt-px block md:hidden" withStripes>
         <div className="relative w-full overflow-hidden min-h-[410px]">
-          <Image
-            src={mobileFeature?.image.light}
-            alt={mobileFeature?.image.alt}
-            width={1360}
-            height={1640}
-            quality={100}
-            className="absolute left-0 top-0 min-w-full min-h-full object-cover object-top-left"
-            sizes="(min-width: 640px) 1360px"
-            priority
-          />
+          <AnimatePresence mode="sync" initial={false}>
+            {activeFeature && mobileScreenshot ? (
+              <motion.div
+                key={activeFeature.id}
+                variants={tabImageVariants(Boolean(reduceMotion))}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                className="absolute inset-0"
+              >
+                <Image
+                  src={mobileScreenshot.light}
+                  alt={mobileScreenshot.alt}
+                  fill
+                  quality={100}
+                  className="object-cover object-top-left"
+                  sizes="(min-width: 640px) 1360px"
+                  priority
+                />
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
         </div>
       </CornerBox>
     </div>

--- a/components/home/feature-tabs/FeatureTabs.tsx
+++ b/components/home/feature-tabs/FeatureTabs.tsx
@@ -10,10 +10,10 @@ import {
 } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { TabButton } from "./TabButton";
 import { TabContent } from "./TabContent";
 import type { AutoAdvanceConfig, FeatureTabData } from "./types";
 import { CornerBox } from "@/components/ui/corner-box";
+import { cn } from "@/lib/utils";
 
 /** Soft ease-out (Emil Kowalski–style: calm deceleration, no snappy linear segments). */
 const CONTENT_EASE = [0.22, 1, 0.36, 1] as const;
@@ -261,7 +261,7 @@ export const FeatureTabs = ({
     tabRefs.current[newIndex]?.focus();
   };
 
-  // Scroll active tab into view (for mobile)
+  // Scroll active chip into view (for mobile)
   useEffect(() => {
     if (tabListScrollRef.current && tabRefs.current[state.focusedIndex]) {
       const tabList = tabListScrollRef.current;
@@ -342,13 +342,8 @@ export const FeatureTabs = ({
       ref={setContainerNode}
       className="overflow-hidden p-0 mt-0 bg-card border-radius-none"
     >
-      {/* Accessibility: Auto-advance status and current product area */}
+      {/* Accessibility: Auto-advance status announcement */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {activeFeature ? (
-          <span>
-            Showing {activeFeature.name}. {activeFeature.subtitle}
-          </span>
-        ) : null}
         {defaultAutoAdvance.enabled && (
           <span>
             Auto-advance is {state.isAutoAdvancePaused ? "paused" : "active"}.
@@ -388,30 +383,49 @@ export const FeatureTabs = ({
         })}
       </CornerBox>
 
-      {/* Named product-area tabs on the screenshot frame */}
+      {/* Product-area chips — primary screenshot selector */}
       <CornerBox
         role="tablist"
-        aria-label="Product area navigation. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
-        className="px-1 py-1 sm:px-2"
+        aria-label="Product areas. Use arrow keys to navigate, Enter or Space to select, Escape to toggle auto-advance."
+        className="px-4 py-3"
         onKeyDown={handleKeyDown}
       >
         <div
           ref={tabListScrollRef}
-          className="flex flex-row flex-nowrap items-stretch overflow-x-auto snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="flex flex-nowrap md:flex-wrap items-center gap-2 overflow-x-auto md:overflow-visible [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
         >
-          {features.map((feature, index) => (
-            <TabButton
-              key={feature.id}
-              ref={(el) => {
-                tabRefs.current[index] = el;
-              }}
-              feature={feature}
-              isActive={activeTab === feature.id}
-              onClick={() => handleTabChange(feature.id)}
-              tabIndex={state.focusedIndex === index ? 0 : -1}
-              className="snap-center"
-            />
-          ))}
+          {features.map((feature, index) => {
+            const isActive = activeTab === feature.id;
+            const Icon = feature.icon;
+
+            return (
+              <button
+                key={feature.id}
+                ref={(el) => {
+                  tabRefs.current[index] = el;
+                }}
+                role="tab"
+                aria-selected={isActive}
+                aria-label={feature.name}
+                aria-controls={`tabpanel-${feature.id}`}
+                id={`tab-${feature.id}`}
+                tabIndex={state.focusedIndex === index ? 0 : -1}
+                onClick={() => handleTabChange(feature.id)}
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5",
+                  "font-sans text-[12px] font-[450] leading-[150%] tracking-[-0.06px]",
+                  "transition-colors duration-150 ease-out",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  isActive
+                    ? "border-text-secondary bg-text-primary text-surface-bg"
+                    : "border-line-structure bg-surface-bg text-text-secondary hover:border-line-cta hover:text-text-primary dark:border-line-cta",
+                )}
+              >
+                <Icon className="size-3.5 shrink-0" aria-hidden />
+                {feature.name}
+              </button>
+            );
+          })}
         </div>
       </CornerBox>
 

--- a/components/home/feature-tabs/data.ts
+++ b/components/home/feature-tabs/data.ts
@@ -29,6 +29,7 @@ export const featureTabsData: FeatureTabData[] = [
   {
     id: "observability",
     icon: TextQuote,
+    name: "Observability",
     title: "Gain deep visibility into your traces",
     subtitle: "Trace every LLM call with cost and latency.",
     body: "Capture complete traces of your LLM applications/agents. Use traces to inspect failures and build eval datasets. Based on OpenTelemetry with support for all popular LLM/agent libraries.",
@@ -84,6 +85,7 @@ export default observe(handleRequest);`,
   {
     id: "metrics",
     icon: LineChart,
+    name: "Metrics",
     title: "Track model cost and latency",
     subtitle: "Track cost, latency, and quality.",
     body: "Monitor your LLM application's performance with comprehensive metrics dashboards and APIs. Track costs, latencies, token usage, and quality scores across models, users, and time periods.",
@@ -145,6 +147,7 @@ const res = await langfuse.api.metrics.metrics({query});`,
   {
     id: "prompt-management",
     icon: GitPullRequestArrow,
+    name: "Prompt Management",
     title: "Improve your prompts",
     subtitle: "Version and deploy prompts with low latency.",
     body: "Version-control prompts collaboratively, deploy/roll-back instantly to different environments, support for templates, variables, and A/B testing. Cached client-side for 0 latency/availability impact.",
@@ -208,6 +211,7 @@ async function handleRequest(userInput: string) {
   {
     id: "evaluation",
     icon: ThumbsUp,
+    name: "Evaluation",
     title: "Evaluate model outputs automatically",
     subtitle: "Collect feedback and run evaluations.",
     body: "Run online/offline evals, via UI (experiment with prompts/models) and via SDKs (experiment with end-to-end application). Build datasets from traces to continuously improve your evals. View results in UI.",
@@ -276,6 +280,7 @@ const result = await langfuse.experiment.run({
   {
     id: "annotations",
     icon: MessageSquare,
+    name: "Annotations",
     title: "Collaborate on human reviews",
     subtitle: "Add manual feedback and corrections.",
     body: "Create manual annotations to provide feedback, corrections, and improvements to your LLM outputs. Use annotations to build high-quality datasets and set a baseline for automated evals.",
@@ -290,6 +295,7 @@ const result = await langfuse.experiment.run({
   {
     id: "playground",
     icon: FlaskConical,
+    name: "Playground",
     title: "Iterate with structured experiments",
     subtitle: "Test prompts and models interactively.",
     body: "Experiment with different prompts, models, and parameters in an interactive playground. Compare outputs, iterate on prompts, and save successful configurations to prompt management.",

--- a/components/home/feature-tabs/types.ts
+++ b/components/home/feature-tabs/types.ts
@@ -20,6 +20,8 @@ export type TabDisplayMode =
 export interface FeatureTabData {
   id: string;
   icon: LucideIcon;
+  /** Product-area name shown on labeled selector chips. */
+  name: string;
   title: string;
   subtitle: string;
   body: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homepage experiment: **Variant C — labeled product-area chips**.

The unlabeled pills under the hero are replaced with a product-switcher row of named chips. Each chip shows a product-area name and the existing icon (Observability, Metrics, Prompt Management, Evaluation, Annotations, Playground). The active chip is filled; the others are outline/muted. On mobile, chips scroll horizontally.

This is one of three visual variants for comparison via Vercel preview. Draft on purpose — do not merge until a direction is chosen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6fd9080-4858-48c3-bf2a-fd629dd236a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6fd9080-4858-48c3-bf2a-fd629dd236a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

