### PR TITLE
Add a back link on customer story headers

### DIFF
--- a/components/blog/BlogHeader.tsx
+++ b/components/blog/BlogHeader.tsx
@@ -1,5 +1,8 @@
 import Image from "next/image";
-import { CustomerStoryBackNav } from "@/components/customers/CustomerStoryBackNav";
+import {
+  CustomerStoryBackNav,
+  companyLabelFromLogo,
+} from "@/components/customers/CustomerStoryBackNav";
 import { Authors, allAuthors } from "../Authors";
 
 export const BlogHeader = ({
@@ -19,7 +22,9 @@ export const BlogHeader = ({
 }) => {
   return (
     <div className="my-4 md:my-6 flex flex-col gap-3">
-      {customerLogo ? <CustomerStoryBackNav /> : null}
+      {customerLogo ? (
+        <CustomerStoryBackNav current={companyLabelFromLogo(customerLogo)} />
+      ) : null}
       <div className="flex flex-col gap-1 items-center text-center">
         {image && (
           <Image

--- a/components/blog/BlogHeader.tsx
+++ b/components/blog/BlogHeader.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { CustomerStoryBackNav } from "@/components/customers/CustomerStoryBackNav";
 import { Authors, allAuthors } from "../Authors";
 
 export const BlogHeader = ({
@@ -17,33 +18,38 @@ export const BlogHeader = ({
   customerLogo?: string;
 }) => {
   return (
-    <div className="flex flex-col gap-1 items-center my-4 md:my-6 text-center">
-      {image && (
-        <Image
-          src={image}
-          alt={title}
-          width={1200}
-          height={630}
-          className="rounded mb-6 md:mb-14 my-0"
-        />
-      )}
-      <span className="text-primary/60">{date}</span>
-      {customerLogo && (
-        <div className="not-prose bg-white rounded-lg p-4 shadow-sm border my-0">
+    <div className="my-4 md:my-6 flex flex-col gap-3">
+      {customerLogo ? <CustomerStoryBackNav /> : null}
+      <div className="flex flex-col gap-1 items-center text-center">
+        {image && (
           <Image
-            src={customerLogo}
-            alt={`${title} logo`}
-            width={160}
-            height={40}
-            className="h-10 w-auto object-contain my-0"
+            src={image}
+            alt={title}
+            width={1200}
+            height={630}
+            className="rounded mb-6 md:mb-14 my-0"
           />
-        </div>
-      )}
-      <h1 className="mt-3 font-medium leading-snug text-balance text-foreground">
-        {title}
-      </h1>
-      <p className="mt-2 text-primary/60 text-xl text-balance">{description}</p>
-      <Authors authors={authors} />
+        )}
+        <span className="text-primary/60">{date}</span>
+        {customerLogo && (
+          <div className="not-prose bg-white rounded-lg p-4 shadow-sm border my-0">
+            <Image
+              src={customerLogo}
+              alt={`${title} logo`}
+              width={160}
+              height={40}
+              className="h-10 w-auto object-contain my-0"
+            />
+          </div>
+        )}
+        <h1 className="mt-3 font-medium leading-snug text-balance text-foreground">
+          {title}
+        </h1>
+        <p className="mt-2 text-primary/60 text-xl text-balance">
+          {description}
+        </p>
+        <Authors authors={authors} />
+      </div>
     </div>
   );
 };

--- a/components/customers/CustomerStoryBackNav.tsx
+++ b/components/customers/CustomerStoryBackNav.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type CustomerStoryNavVariant = "back-link" | "centered" | "breadcrumb";
+
+/** Default while comparing options. Override with `?nav=centered` or `?nav=breadcrumb`. */
+const DEFAULT_VARIANT: CustomerStoryNavVariant = "back-link";
+
+const INDEX_HREF = "/users";
+const INDEX_LABEL = "Customer stories";
+
+function titleFromSlug(pathname: string): string {
+  const slug = pathname.split("/").filter(Boolean).pop() ?? "";
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function resolveVariant(raw: string | null): CustomerStoryNavVariant {
+  if (raw === "back-link" || raw === "centered" || raw === "breadcrumb") {
+    return raw;
+  }
+  return DEFAULT_VARIANT;
+}
+
+function BackLink() {
+  return (
+    <Link
+      href={INDEX_HREF}
+      className="mb-1 text-[15px] text-text-primary no-underline hover:text-text-secondary hover:no-underline"
+    >
+      ← Back to customer stories
+    </Link>
+  );
+}
+
+function CenteredLink() {
+  return (
+    <Link
+      href={INDEX_HREF}
+      className="inline-flex items-center gap-0.5 text-[13px] font-[430] tracking-[-0.26px] text-text-tertiary no-underline transition-colors hover:text-text-primary hover:no-underline"
+    >
+      <ChevronLeft className="size-3.5 shrink-0" aria-hidden />
+      {INDEX_LABEL}
+    </Link>
+  );
+}
+
+function BreadcrumbTrail({ current }: { current: string }) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex items-center gap-1.5 text-sm text-text-tertiary">
+        <li>
+          <Link
+            href={INDEX_HREF}
+            className="truncate no-underline transition-colors hover:text-text-primary hover:no-underline"
+          >
+            {INDEX_LABEL}
+          </Link>
+        </li>
+        <li aria-hidden>
+          <ChevronRight className="size-3.5 shrink-0" />
+        </li>
+        <li
+          className="truncate font-medium text-text-primary"
+          aria-current="page"
+        >
+          {current}
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+function CustomerStoryBackNavInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const variant = resolveVariant(searchParams.get("nav"));
+  const current = titleFromSlug(pathname ?? "");
+
+  return (
+    <div
+      className={cn(
+        "not-prose",
+        variant === "centered" ? "self-center" : "self-start",
+      )}
+    >
+      {variant === "back-link" ? (
+        <BackLink />
+      ) : variant === "centered" ? (
+        <CenteredLink />
+      ) : (
+        <BreadcrumbTrail current={current} />
+      )}
+    </div>
+  );
+}
+
+export function CustomerStoryBackNav() {
+  return (
+    <Suspense fallback={null}>
+      <CustomerStoryBackNavInner />
+    </Suspense>
+  );
+}

--- a/components/customers/CustomerStoryBackNav.tsx
+++ b/components/customers/CustomerStoryBackNav.tsx
@@ -1,61 +1,28 @@
-"use client";
-
-import { Suspense } from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-
-import { cn } from "@/lib/utils";
-
-export type CustomerStoryNavVariant = "back-link" | "centered" | "breadcrumb";
-
-/** Default while comparing options. Override with `?nav=centered` or `?nav=breadcrumb`. */
-const DEFAULT_VARIANT: CustomerStoryNavVariant = "back-link";
+import { ChevronRight } from "lucide-react";
 
 const INDEX_HREF = "/users";
 const INDEX_LABEL = "Customer stories";
 
-function titleFromSlug(pathname: string): string {
-  const slug = pathname.split("/").filter(Boolean).pop() ?? "";
+const SLUG_LABELS: Record<string, string> = {
+  merckgroup: "Merck",
+  sumup: "SumUp",
+  "magic-patterns-ai-design-tools": "Magic Patterns",
+};
+
+export function companyLabelFromLogo(customerLogo: string): string {
+  const slug = customerLogo.match(/\/customers\/([^/]+)\//)?.[1] ?? "";
+  if (!slug) return "Story";
+  if (SLUG_LABELS[slug]) return SLUG_LABELS[slug];
   return slug
     .split("-")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 }
 
-function resolveVariant(raw: string | null): CustomerStoryNavVariant {
-  if (raw === "back-link" || raw === "centered" || raw === "breadcrumb") {
-    return raw;
-  }
-  return DEFAULT_VARIANT;
-}
-
-function BackLink() {
+export function CustomerStoryBackNav({ current }: { current: string }) {
   return (
-    <Link
-      href={INDEX_HREF}
-      className="mb-1 text-[15px] text-text-primary no-underline hover:text-text-secondary hover:no-underline"
-    >
-      ← Back to customer stories
-    </Link>
-  );
-}
-
-function CenteredLink() {
-  return (
-    <Link
-      href={INDEX_HREF}
-      className="inline-flex items-center gap-0.5 text-[13px] font-[430] tracking-[-0.26px] text-text-tertiary no-underline transition-colors hover:text-text-primary hover:no-underline"
-    >
-      <ChevronLeft className="size-3.5 shrink-0" aria-hidden />
-      {INDEX_LABEL}
-    </Link>
-  );
-}
-
-function BreadcrumbTrail({ current }: { current: string }) {
-  return (
-    <nav aria-label="Breadcrumb">
+    <nav className="not-prose self-start" aria-label="Breadcrumb">
       <ol className="flex items-center gap-1.5 text-sm text-text-tertiary">
         <li>
           <Link
@@ -76,37 +43,5 @@ function BreadcrumbTrail({ current }: { current: string }) {
         </li>
       </ol>
     </nav>
-  );
-}
-
-function CustomerStoryBackNavInner() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const variant = resolveVariant(searchParams.get("nav"));
-  const current = titleFromSlug(pathname ?? "");
-
-  return (
-    <div
-      className={cn(
-        "not-prose",
-        variant === "centered" ? "self-center" : "self-start",
-      )}
-    >
-      {variant === "back-link" ? (
-        <BackLink />
-      ) : variant === "centered" ? (
-        <CenteredLink />
-      ) : (
-        <BreadcrumbTrail current={current} />
-      )}
-    </div>
-  );
-}
-
-export function CustomerStoryBackNav() {
-  return (
-    <Suspense fallback={null}>
-      <CustomerStoryBackNavInner />
-    </Suspense>
   );
 }

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -54,6 +54,10 @@ function replaceComponentsWithMarkdown(fileContent) {
       /<CustomerStoryCTA\s*\/>/g,
       () => `\n${renderCustomerStoryCta()}\n`,
     )
+    .replace(/<BlogHeader\b([\s\S]*?)\/>/g, (_, attributes) => {
+      const rendered = renderBlogHeader(attributes);
+      return rendered ? `\n${rendered}\n` : "";
+    })
     .replace(
       /<(ManualGuideCallout(?:Ja)?)\b([\s\S]*?)\/>/g,
       (_, componentName, attributes) =>
@@ -238,6 +242,11 @@ function renderCustomerIndex(attributes = "") {
     lines.push("");
   }
   return lines.join("\n").trim();
+}
+
+function renderBlogHeader(attributes = "") {
+  if (!/\bcustomerLogo=/.test(attributes)) return "";
+  return "[← Back to customer stories](/users)";
 }
 
 function renderCustomerStoryCta() {

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -244,9 +244,26 @@ function renderCustomerIndex(attributes = "") {
   return lines.join("\n").trim();
 }
 
+function companyLabelFromLogoPath(logoPath) {
+  const slug = logoPath.match(/\/customers\/([^/]+)\//)?.[1];
+  if (!slug) return "Story";
+  const labels = {
+    merckgroup: "Merck",
+    sumup: "SumUp",
+    "magic-patterns-ai-design-tools": "Magic Patterns",
+  };
+  if (labels[slug]) return labels[slug];
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 function renderBlogHeader(attributes = "") {
-  if (!/\bcustomerLogo=/.test(attributes)) return "";
-  return "[← Back to customer stories](/users)";
+  const logoMatch = attributes.match(/\bcustomerLogo=["']([^"']+)["']/);
+  if (!logoMatch) return "";
+  const current = companyLabelFromLogoPath(logoMatch[1]);
+  return `[Customer stories](/users) › ${current}`;
 }
 
 function renderCustomerStoryCta() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Customer story pages had no way back to the `/users` index. Stories now show a docs-style breadcrumb in the article header:

`Customer stories › Canva`

`Customer stories` links to `/users`. The current crumb is the company name, derived from the story’s logo path (with a few brand-name exceptions like SumUp and Magic Patterns).

This is the breadcrumb treatment chosen from the three header options. The comparison query param and unused variants are gone.

Blog posts without `customerLogo` are unchanged. Markdown conversion emits `[Customer stories](/users) › Company`.

![Breadcrumb on the Canva customer story](https://cursor.com/artifacts/c/art-59918833-aa54-4f0a-bf7b-9c55b1074ad5)

![Breadcrumb on Magic Patterns uses the company name, not the slug](https://cursor.com/artifacts/c/art-20a75fd5-d4ba-4011-9ca9-ac57b8a1e7ee)

<a href="https://cursor.com/agents/bc-f2fd60fb-bd37-4f4e-9396-5d9f14649792/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreadcrumb_click_to_customer_stories.mp4"><img src="https://cursor.com/artifacts/c/art-853ed722-df00-4275-a951-80ae7ab95ef3" alt="breadcrumb_click_to_customer_stories.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2fd60fb-bd37-4f4e-9396-5d9f14649792?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2fd60fb-bd37-4f4e-9396-5d9f14649792&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a customer-story breadcrumb linking individual stories back to `/users`, while leaving ordinary blog headers unchanged.

- Introduces a reusable customer-story breadcrumb component.
- Derives human-readable company labels from customer logo paths.
- Emits equivalent breadcrumbs in generated plain-Markdown content.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue was identified.

The new breadcrumb is limited to headers with customer logos, all existing customer-story logo paths resolve to their intended labels, and ordinary blog Markdown behavior remains unchanged from the base revision.
</details>

<sub>Reviews (1): Last reviewed commit: ["Ship docs-style breadcrumb on customer s..."](https://github.com/langfuse/langfuse-docs/commit/1192b2496c6a71fded50abce67dc66bc2661fab1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57647261)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [MDX content rendering and navigation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/mdx-content-rendering-and-navigation.md)
- Knowledge Base — [Content publishing automation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-publishing-automation.md)
- Knowledge Base — [Commercial and community experiences](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/commercial-and-community-experiences.md)
</details>


<!-- /greptile_comment -->