### PR TITLE
Add cloud-only Cursor rule to end tasks with a browser preview

### DIFF
--- a/.agents/cursor/rules/cloud-browser-preview.mdc
+++ b/.agents/cursor/rules/cloud-browser-preview.mdc
@@ -1,0 +1,24 @@
+---
+description: End Cloud Agent tasks with an in-app browser preview of the changed pages
+alwaysApply: true
+metadata:
+  environments: cloud
+---
+
+# End with an in-app browser preview
+
+When a Cloud Agent task changes something a reviewer can see in the site, finish by leaving the in-app browser open on that page. This rule applies only to Cursor Cloud Agents.
+
+## When to preview
+
+Open a preview if the change affects a rendered page: docs, blog, changelog, marketing, UI, layout, routing, or MDX components. Skip it for non-visual work (scripts, config, agent instructions) unless a page was still affected.
+
+## How to preview
+
+1. Use the already-running `pnpm dev` server. It is started from `.cursor/environment.json` on port 3333.
+2. Open the affected URL in the in-app browser at `http://127.0.0.1:3333/...` (not `localhost`).
+3. Wait for the first compile. After the server reports ready, the first request can take 20-40 seconds.
+4. Navigate to the changed page with the sidebar or a direct URL. Site search does not return results without Inkeep keys.
+5. Leave the browser on that page. Do not close the tab before ending the task.
+
+If several pages changed, leave the most important one open. Prefer the primary user-facing route over a secondary or admin-only view.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Agents that change a rendered page should finish with the in-app browser open on the affected URL, so a reviewer in Cursor can inspect the live preview.

This is a project Cursor rule (`alwaysApply: true`) scoped with `metadata.environments: cloud`, so local IDE chat ignores it. The source of truth is `.agents/cursor/rules/cloud-browser-preview.mdc`; `pnpm run agents:sync` projects it into `.cursor/rules/`.

The rule is not added to `AGENTS.md`, which is shared with Claude Code via `CLAUDE.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17bbef66-d922-4c6d-b988-a505093ec3b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17bbef66-d922-4c6d-b988-a505093ec3b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Cursor Cloud-only rule requiring tasks that modify rendered pages to finish with the affected page open in the in-app browser.

- Defines which visual changes require a preview.
- Documents the configured development-server address and expected initial compilation delay.
- Directs agents to leave the most important affected route open for review.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new rule matches the configured 127.0.0.1:3333 development endpoint, and committing only its `.agents` source is consistent with the repository’s generated `.cursor/rules` synchronization model.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add cloud-only Cursor rule to end tasks ..."](https://github.com/langfuse/langfuse-docs/commit/6fd9411fdd049709b7af7b2bc2e582661ad4473a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57649735)</sub>

<!-- /greptile_comment -->