### PR TITLE
Show Start free on the header CTA when signed out

### DIFF
--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -93,7 +93,7 @@ const getCloudHost = (url: string) => new URL(url).host;
 
 export default function CloudRegionSelectorPage() {
   const pathname = usePathname();
-  const signedInRegions = useCloudRegionSignIn();
+  const { signedInRegions } = useCloudRegionSignIn();
 
   const { cloudSubpath } = useMemo(
     () => getCloudRedirectPartsFromPathname(pathname || ""),

--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -61,7 +61,7 @@ export const ToAppButton = ({
   signUpText = "Start free",
   dropdownText = "Launch App",
 }: ToAppButtonProps = {}) => {
-  const signedInRegions = useCloudRegionSignIn();
+  const { signedInRegions, resolved } = useCloudRegionSignIn();
 
   const signedInCount = Object.values(signedInRegions).filter(Boolean).length;
 
@@ -84,7 +84,15 @@ export const ToAppButton = ({
       <NavigatingButton href={signedInRegion[1].url} label={signedInText} />
     );
   } else {
-    return <NavigatingButton href="/cloud" label={signUpText} />;
+    // Regions start unsigned-in until the probe finishes. Treat that as
+    // unknown, not signed-out, so an already-signed-in visitor never flashes
+    // the signup label.
+    return (
+      <NavigatingButton
+        href="/cloud"
+        label={resolved ? signUpText : signedInText}
+      />
+    );
   }
 };
 

--- a/components/ToAppButton.tsx
+++ b/components/ToAppButton.tsx
@@ -58,7 +58,7 @@ interface ToAppButtonProps {
 
 export const ToAppButton = ({
   signedInText = "Launch App",
-  signUpText = "Launch App",
+  signUpText = "Start free",
   dropdownText = "Launch App",
 }: ToAppButtonProps = {}) => {
   const signedInRegions = useCloudRegionSignIn();

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -50,7 +50,7 @@ export function Navbar() {
           <div className="absolute bottom-[-6px] left-0 w-[6px] h-[5px] bg-left-corner" />
           <div className="absolute hidden wide:block bottom-[-6px] right-0 w-[6px] h-[5px] bg-right-corner" />
           <div className="flex flex-1 min-w-0 gap-2 items-center px-2.5 py-3 rounded-sm bg-surface-1">
-            {/* Hide below xl so Launch App / Get Demo stay visible. */}
+            {/* Hide below xl so the header CTAs stay visible. */}
             <HiringBadge className="hidden shrink-0 xl:block" />
             <div className="flex flex-1 justify-center items-center min-w-0 gap-4">
               <InkeepSearchBar className="hidden" />

--- a/lib/use-cloud-region-sign-in.ts
+++ b/lib/use-cloud-region-sign-in.ts
@@ -6,7 +6,8 @@ import {
 } from "@/lib/cloud-region-sign-in-store";
 
 // React binding for the shared cloud-region sign-in probe: every caller gets
-// the same answer from a single set of requests, however many components ask.
+// the same snapshot from a single set of requests, however many components ask.
+// Callers that treat signed-out as meaningful must wait for `resolved`.
 // See lib/cloud-region-sign-in-store.ts.
 export const useCloudRegionSignIn = (
   enabled = process.env.NODE_ENV === "production",
@@ -22,5 +23,5 @@ export const useCloudRegionSignIn = (
     );
   }, [enabled]);
 
-  return snapshot.signedInRegions;
+  return snapshot;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The header **Launch App** button now reads **Start free** when the visitor is not signed in to any Langfuse Cloud region. Signed-in visitors still see **Launch App**, including the multi-region dropdown.

The signed-out label waits until the cloud-region sign-in probe has finished, so an already-signed-in visitor never flashes **Start free**.

This is the main site CTA in the navbar (`ToAppButton`), used on marketing and docs pages.

## Testing

Signed-out (local default, after the probe resolves): header shows **Start free** and still links to `/cloud`.

![Homepage header Start free](https://cursor.com/artifacts/c/art-cbc50b69-5d89-4469-a8b4-61013627cc8f)

<a href="https://cursor.com/agents/bc-f2622c50-80da-4f4c-8558-9fba5d8b91b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_start_free_click_to_cloud.mp4"><img src="https://cursor.com/artifacts/c/art-ba628c60-6506-484d-a740-60eb99f864cc" alt="header_start_free_click_to_cloud.mp4" /></a>

While the sign-in probe is still unresolved: header keeps **Launch App**.

![Unresolved probe keeps Launch App](https://cursor.com/artifacts/c/art-304ff22e-f907-4b1a-a5a7-d33e9f44e779)

Signed-in (mocked US region locally): header shows **Launch App**.

![Signed-in homepage header Launch App](https://cursor.com/artifacts/c/art-e84dd770-2ca4-40bc-9a82-edd4f7aaa409)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15742](https://linear.app/clickhouse/issue/LFE-15742/update-website-cta-for-signed-out-visitors)

<div><a href="https://cursor.com/agents/bc-f2622c50-80da-4f4c-8558-9fba5d8b91b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2622c50-80da-4f4c-8558-9fba5d8b91b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the shared application CTA’s signed-out label from “Launch App” to “Start free” and generalizes the navbar comment.
- Keeps the signed-in and multi-region labels as “Launch App.”
- Updates the default label used by the shared `ToAppButton`.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The signed-in loading path should be corrected before merging because it temporarily presents signed-in visitors with the signed-out CTA.

The authentication store begins unresolved with all regions marked signed out, so the newly distinct label renders until the asynchronous probe identifies an existing session.

**Files Needing Attention:** components/ToAppButton.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/ToAppButton.tsx:61
**Unresolved auth shows signup**

When an already signed-in visitor loads the page, the unresolved region state initially renders `Start free` before the asynchronous sign-in probe changes it to `Launch App`, causing a visible and misleading CTA flash.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Show Start free on the header CTA when s..."](https://github.com/langfuse/langfuse-docs/commit/4b34b4bd7ff21b7fcf4c929740dbbabcaa191ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57850161)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->