### PR TITLE
Move Guides after Workshop in the docs top nav

### DIFF
--- a/components/layout/DocsSecondaryNav.tsx
+++ b/components/layout/DocsSecondaryNav.tsx
@@ -22,9 +22,9 @@ const SECTIONS = [
   { title: "Docs", path: "/docs", Icon: IconBook },
   { title: "Integrations", path: "/integrations", Icon: Unplug },
   { title: "Self Hosting", path: "/self-hosting", Icon: IconDesktopTower },
-  { title: "Guides", path: "/guides", Icon: IconCompass },
   { title: "Academy", path: "/academy", Icon: GraduationCap },
   { title: "Workshop", path: "/workshop", Icon: Presentation },
+  { title: "Guides", path: "/guides", Icon: IconCompass },
   { title: "AI Engineering Library", path: "/library", Icon: IconBookBookmark },
 ] as const;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move **Guides** in the docs secondary top nav so it sits between **Workshop** and **AI Engineering Library**.

The previous order was Docs → Integrations → Self Hosting → Guides → Academy → Workshop → AI Engineering Library. Guides now follows Workshop:

Docs → Integrations → Self Hosting → Academy → Workshop → **Guides** → AI Engineering Library

![Desktop docs nav with Guides after Workshop](https://cursor.com/artifacts/c/art-d7c683d4-3122-4cd1-a4cc-3caa4fc5c099)

<a href="https://cursor.com/agents/bc-cf5525ba-5dde-4519-ab27-41892f220551/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_nav_guides_between_workshop_and_library.mp4"><img src="https://cursor.com/artifacts/c/art-5190cd9a-e43f-44de-b3d5-a79dabe54aa3" alt="docs_nav_guides_between_workshop_and_library.mp4" /></a>

## Test plan

- [x] Open `/docs` and confirm the secondary nav order is Docs, Integrations, Self Hosting, Academy, Workshop, Guides, AI Engineering Library
- [x] Confirm Guides highlights on `/guides` and still sits between Workshop and AI Engineering Library
- [x] Check desktop and mobile viewports (mobile uses the same section list for the breadcrumb)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-140](https://linear.app/clickhouse/issue/LF-140/restructure-docs-top-nav-bar)

<div><a href="https://cursor.com/agents/bc-cf5525ba-5dde-4519-ab27-41892f220551?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf5525ba-5dde-4519-ab27-41892f220551&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorders the existing Guides entry in the documentation secondary navigation so it appears after Workshop and before AI Engineering Library.

- Moves one existing item within the static section list.
- Preserves its title, route, icon, highlighting, and mobile breadcrumb behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only makes the intended navigation-order change.

Section links and active states remain keyed by their unchanged paths, and no positional behavior depends on the previous order.
</details>

<sub>Reviews (1): Last reviewed commit: ["Move Guides after Workshop in the docs s..."](https://github.com/langfuse/langfuse-docs/commit/090852923bac514ec8620198c8d0e7ed025f1b01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58023852)</sub>

**Context used:**

- Knowledge Base — [MDX content rendering and navigation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/mdx-content-rendering-and-navigation.md)

<!-- /greptile_comment -->