### PR TITLE
Add Lotte Verheyden's X profile to author hover cards

### DIFF
--- a/data/authors.json
+++ b/data/authors.json
@@ -138,6 +138,7 @@
     "name": "Lotte Verheyden",
     "title": "Developer Relations",
     "image": "/images/people/lotteverheyden.jpg",
+    "twitter": "lotte_verheyden",
     "github": "Lotte-Verheyden",
     "linkedin": "lotteverheyden"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Lotte's X handle (`lotte_verheyden`) to `data/authors.json` so her docs-site contributor/author hover card includes X alongside GitHub and LinkedIn.

The team page already listed this profile; the hover card reads social links from `authors.json`, which was missing the `twitter` field.

![Lotte Verheyden hover card with X, GitHub, and LinkedIn](https://cursor.com/artifacts/c/art-c4184807-5b39-4a5d-ab18-02c1237c1d0f)

<a href="https://cursor.com/agents/bc-e3094209-3825-4a3c-b53e-a4df1a25ee35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flotte_hover_card_shows_x_link.mp4"><img src="https://cursor.com/artifacts/c/art-4eeea42a-2f31-436b-a362-d2c0fc21c395" alt="lotte_hover_card_shows_x_link.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LF-141](https://linear.app/clickhouse/issue/LF-141/add-x-link-to-account-lotte-on-docs-site)

<div><a href="https://cursor.com/agents/bc-e3094209-3825-4a3c-b53e-a4df1a25ee35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3094209-3825-4a3c-b53e-a4df1a25ee35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Lotte Verheyden’s X handle to the author metadata so it appears in documentation author hover cards.

- Adds the existing `lotte_verheyden` handle to Lotte’s `data/authors.json` entry.
- Uses the hover card’s established optional `twitter` field and URL construction.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new handle matches the existing team-page profile, conforms to the author metadata type, and produces a valid hover-card link through the established renderer.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Lotte Verheyden&#39;s X profile to autho..."](https://github.com/langfuse/langfuse-docs/commit/458dc7600422a31f778d5341e4b40eb0144b2f73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58022960)</sub>

<!-- /greptile_comment -->