### PR TITLE
Restore ClickHouse Private to self-hosted pricing

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -241,7 +241,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
       price: "Custom Pricing",
       mainFeatures: [
         "All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs",
-        "Bundled with ClickHouse Cloud or ClickHouse BYOC",
+        "Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private",
         "Langfuse pricing is additive to your ClickHouse commercial plan",
         "Dedicated support engineer for deployment and hosting guidance",
         "Solutions architect support during evaluation and rollout",
@@ -881,11 +881,11 @@ const sections: Section[] = [
       {
         name: "ClickHouse deployment model",
         description:
-          "Open Source assumes you operate ClickHouse yourself. Enterprise is bundled with ClickHouse Cloud or ClickHouse BYOC.",
+          "Open Source assumes you operate ClickHouse yourself. Enterprise is bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private.",
         tiers: {
           selfHosted: {
             "Open Source": "Self-managed ClickHouse OSS",
-            Enterprise: "Bundled: ClickHouse Cloud / BYOC",
+            Enterprise: "Bundled: ClickHouse Cloud / BYOC / Private",
           },
         },
       },

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -25,10 +25,10 @@ Self-host all core Langfuse features for free without any limitations.
 
 ### Self-Hosted Enterprise (Custom Pricing)
 
-Dedicated Langfuse deployment with enterprise capabilities and support. Bundled with ClickHouse Cloud or ClickHouse BYOC.
+Dedicated Langfuse deployment with enterprise capabilities and support. Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private.
 
 - All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs
-- Bundled with ClickHouse Cloud or ClickHouse BYOC
+- Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private
 - Langfuse pricing is additive to your ClickHouse commercial plan
 - Dedicated support engineer for deployment and hosting guidance
 - Solutions architect support during evaluation and rollout
@@ -41,92 +41,92 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 
 ## Feature Comparison (Self-Hosted)
 
-| Feature                                                                                             | Open Source                 | Enterprise                       |
-| --------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------- |
-| **LLM Application & Agent Tracing**                                                                 |                             |                                  |
-| [Traces and graphs (agents)](/docs/observability/overview)                                          | Yes                         | Yes                              |
-| [Session tracking (chats/threads)](/docs/observability/features/sessions)                           | Yes                         | Yes                              |
-| [User tracking](/docs/observability/features/users)                                                 | Yes                         | Yes                              |
-| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                         | Yes                              |
-| [Native framework integrations](/integrations)                                                      | Yes                         | Yes                              |
-| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                         | Yes                              |
-| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                         | Yes                              |
-| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                         | Yes                              |
-| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                         | Yes                              |
-| Included usage                                                                                      | Unlimited                   | Unlimited                        |
-| [Multi-modal](/docs/observability/features/multi-modality)                                          | Yes                         | Yes                              |
-| **Langfuse AI**                                                                                     |                             |                                  |
-| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                       | --                          | --                               |
-| **Prompt Management**                                                                               |                             |                                  |
-| [Prompt versioning](/docs/prompt-management/get-started)                                            | Yes                         | Yes                              |
-| Prompt fetching                                                                                     | Unlimited                   | Unlimited                        |
-| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                | Yes                         | Yes                              |
-| [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                         | Yes                              |
-| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                         | Yes                              |
-| [Playground](/docs/prompt-management/features/playground)                                           | Yes                         | Yes                              |
-| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                         | Yes                              |
-| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                         | Yes                              |
-| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                          | Yes                              |
-| **Evaluation (online and offline)**                                                                 |                             |                                  |
-| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                         | Yes                              |
-| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                         | Yes                              |
-| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                         | Yes                              |
-| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                         | Yes                              |
-| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                         | Yes                              |
-| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                         | Yes                              |
-| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                         | Yes                              |
-| [Human annotation](/docs/scores/annotation)                                                         | Yes                         | Yes                              |
-| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | Yes                         | Yes                              |
-| **Metrics**                                                                                         |                             |                                  |
-| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                         | Yes                              |
-| [Alerts](/docs/observability/features/alerts)                                                       | Langfuse v4+                | Langfuse v4+                     |
-| **Collaboration**                                                                                   |                             |                                  |
-| Projects                                                                                            | Unlimited                   | Unlimited                        |
-| Users                                                                                               | Unlimited                   | Unlimited                        |
-| **API**                                                                                             |                             |                                  |
-| [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                         | Yes                              |
-| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                           | Langfuse v4+                | Langfuse v4+                     |
-| **Exports**                                                                                         |                             |                                  |
-| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                         | Yes                              |
-| [PostHog integration](/integrations/analytics/posthog)                                              | Yes                         | Yes                              |
-| [Mixpanel integration](/integrations/analytics/mixpanel)                                            | Yes                         | Yes                              |
-| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage) | Yes                         | Yes                              |
-| **Deployment**                                                                                      |                             |                                  |
-| ClickHouse deployment model                                                                         | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC |
-| [Deployment templates](/self-hosting)                                                               | Yes                         | Yes                              |
-| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                   | Yes                         | Yes                              |
-| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                       | Yes                         | Yes                              |
-| [AWS (Terraform)](/self-hosting/deployment/aws)                                                     | Yes                         | Yes                              |
-| [Azure (Terraform)](/self-hosting/deployment/azure)                                                 | Yes                         | Yes                              |
-| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                     | Yes                         | Yes                              |
-| **Support**                                                                                         |                             |                                  |
-| [Ask AI](/docs/ask-ai)                                                                              | Yes                         | Yes                              |
-| [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                              |
-| [In-app support](/support#in-app)                                                                   | --                          | Yes                              |
-| [Private Slack channel](/support#slack)                                                             | --                          | Yes                              |
-| [Dedicated support engineer](/support#onboarding)                                                   | --                          | Yes                              |
-| [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                              |
-| Solutions architect support                                                                         | --                          | Yes                              |
-| Product team feedback channel                                                                       | --                          | Yes                              |
-| [Support SLA](/enterprise#faq)                                                                      | --                          | Yes                              |
-| **Security**                                                                                        |                             |                                  |
-| Sign in with Google, AzureAD, GitHub                                                                | Yes                         | Yes                              |
-| [Organization-level RBAC](/docs/administration/rbac)                                                | Yes                         | Yes                              |
-| Enterprise SSO (e.g. Okta, EntraID)                                                                 | Yes                         | Yes                              |
-| SSO enforcement                                                                                     | Yes                         | Yes                              |
-| [Client-side data masking](/docs/observability/features/masking)                                    | Yes                         | Yes                              |
-| [Server-side data masking](/self-hosting/security/data-masking)                                     | --                          | Yes                              |
-| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                 | --                          | Yes                              |
-| [Data retention management](/docs/administration/data-retention)                                    | --                          | Yes                              |
-| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                     | --                          | Yes                              |
-| [Organization creators](/self-hosting/administration/organization-creators)                         | --                          | Yes                              |
-| [UI customization](/self-hosting/administration/ui-customization)                                   | --                          | Yes                              |
-| [Audit logs](/docs/administration/audit-logs)                                                       | --                          | Yes                              |
-| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                       | --                          | Yes                              |
-| [Instance management API](/self-hosting/administration/instance-management-api)                     | --                          | Yes                              |
-| **Compliance**                                                                                      |                             |                                  |
-| SOC2 Type II & ISO27001 reports                                                                     | --                          | Yes                              |
-| InfoSec/legal reviews                                                                               | --                          | Yes                              |
+| Feature                                                                                             | Open Source                 | Enterprise                                 |
+| --------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
+| **LLM Application & Agent Tracing**                                                                 |                             |                                            |
+| [Traces and graphs (agents)](/docs/observability/overview)                                          | Yes                         | Yes                                        |
+| [Session tracking (chats/threads)](/docs/observability/features/sessions)                           | Yes                         | Yes                                        |
+| [User tracking](/docs/observability/features/users)                                                 | Yes                         | Yes                                        |
+| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                         | Yes                                        |
+| [Native framework integrations](/integrations)                                                      | Yes                         | Yes                                        |
+| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                         | Yes                                        |
+| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                         | Yes                                        |
+| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                         | Yes                                        |
+| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                         | Yes                                        |
+| Included usage                                                                                      | Unlimited                   | Unlimited                                  |
+| [Multi-modal](/docs/observability/features/multi-modality)                                          | Yes                         | Yes                                        |
+| **Langfuse AI**                                                                                     |                             |                                            |
+| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                       | --                          | --                                         |
+| **Prompt Management**                                                                               |                             |                                            |
+| [Prompt versioning](/docs/prompt-management/get-started)                                            | Yes                         | Yes                                        |
+| Prompt fetching                                                                                     | Unlimited                   | Unlimited                                  |
+| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                | Yes                         | Yes                                        |
+| [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                         | Yes                                        |
+| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                         | Yes                                        |
+| [Playground](/docs/prompt-management/features/playground)                                           | Yes                         | Yes                                        |
+| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                         | Yes                                        |
+| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                         | Yes                                        |
+| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                          | Yes                                        |
+| **Evaluation (online and offline)**                                                                 |                             |                                            |
+| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                         | Yes                                        |
+| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                         | Yes                                        |
+| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                         | Yes                                        |
+| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                         | Yes                                        |
+| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                         | Yes                                        |
+| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                         | Yes                                        |
+| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                         | Yes                                        |
+| [Human annotation](/docs/scores/annotation)                                                         | Yes                         | Yes                                        |
+| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | Yes                         | Yes                                        |
+| **Metrics**                                                                                         |                             |                                            |
+| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                         | Yes                                        |
+| [Alerts](/docs/observability/features/alerts)                                                       | Langfuse v4+                | Langfuse v4+                               |
+| **Collaboration**                                                                                   |                             |                                            |
+| Projects                                                                                            | Unlimited                   | Unlimited                                  |
+| Users                                                                                               | Unlimited                   | Unlimited                                  |
+| **API**                                                                                             |                             |                                            |
+| [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                         | Yes                                        |
+| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                           | Langfuse v4+                | Langfuse v4+                               |
+| **Exports**                                                                                         |                             |                                            |
+| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                         | Yes                                        |
+| [PostHog integration](/integrations/analytics/posthog)                                              | Yes                         | Yes                                        |
+| [Mixpanel integration](/integrations/analytics/mixpanel)                                            | Yes                         | Yes                                        |
+| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage) | Yes                         | Yes                                        |
+| **Deployment**                                                                                      |                             |                                            |
+| ClickHouse deployment model                                                                         | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC / Private |
+| [Deployment templates](/self-hosting)                                                               | Yes                         | Yes                                        |
+| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                   | Yes                         | Yes                                        |
+| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                       | Yes                         | Yes                                        |
+| [AWS (Terraform)](/self-hosting/deployment/aws)                                                     | Yes                         | Yes                                        |
+| [Azure (Terraform)](/self-hosting/deployment/azure)                                                 | Yes                         | Yes                                        |
+| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                     | Yes                         | Yes                                        |
+| **Support**                                                                                         |                             |                                            |
+| [Ask AI](/docs/ask-ai)                                                                              | Yes                         | Yes                                        |
+| [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                                        |
+| [In-app support](/support#in-app)                                                                   | --                          | Yes                                        |
+| [Private Slack channel](/support#slack)                                                             | --                          | Yes                                        |
+| [Dedicated support engineer](/support#onboarding)                                                   | --                          | Yes                                        |
+| [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                                        |
+| Solutions architect support                                                                         | --                          | Yes                                        |
+| Product team feedback channel                                                                       | --                          | Yes                                        |
+| [Support SLA](/enterprise#faq)                                                                      | --                          | Yes                                        |
+| **Security**                                                                                        |                             |                                            |
+| Sign in with Google, AzureAD, GitHub                                                                | Yes                         | Yes                                        |
+| [Organization-level RBAC](/docs/administration/rbac)                                                | Yes                         | Yes                                        |
+| Enterprise SSO (e.g. Okta, EntraID)                                                                 | Yes                         | Yes                                        |
+| SSO enforcement                                                                                     | Yes                         | Yes                                        |
+| [Client-side data masking](/docs/observability/features/masking)                                    | Yes                         | Yes                                        |
+| [Server-side data masking](/self-hosting/security/data-masking)                                     | --                          | Yes                                        |
+| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                 | --                          | Yes                                        |
+| [Data retention management](/docs/administration/data-retention)                                    | --                          | Yes                                        |
+| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                     | --                          | Yes                                        |
+| [Organization creators](/self-hosting/administration/organization-creators)                         | --                          | Yes                                        |
+| [UI customization](/self-hosting/administration/ui-customization)                                   | --                          | Yes                                        |
+| [Audit logs](/docs/administration/audit-logs)                                                       | --                          | Yes                                        |
+| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                       | --                          | Yes                                        |
+| [Instance management API](/self-hosting/administration/instance-management-api)                     | --                          | Yes                                        |
+| **Compliance**                                                                                      |                             |                                            |
+| SOC2 Type II & ISO27001 reports                                                                     | --                          | Yes                                        |
+| InfoSec/legal reviews                                                                               | --                          | Yes                                        |
 
 ## Discounts
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- restore ClickHouse Private as a bundled Self-Hosted Enterprise deployment model
- keep the rendered pricing table and Markdown override synchronized

## Testing

- `pnpm run format`
- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- verified `/pricing-self-host` at desktop and 375×812 mobile viewports
- confirmed the Enterprise card and deployment comparison include ClickHouse Private
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-001282d9-13ae-43ae-9da7-1224bdca03f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-001282d9-13ae-43ae-9da7-1224bdca03f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores ClickHouse Private as a bundled Self-Hosted Enterprise deployment option and keeps the rendered pricing UI synchronized with its Markdown override.

- Adds ClickHouse Private to the Enterprise plan’s bundled deployment models.
- Updates the deployment comparison copy in both pricing representations.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the two pricing representations remain synchronized and no concrete defect was identified.

The change is limited to consistent commercial-copy updates across the rendered self-hosted pricing table and its Markdown override.
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Remove ClickHouse Private from s..."](https://github.com/langfuse/langfuse-docs/commit/0e2d3efc6081a5dc559c4c8befba05fea1023261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58086323)</sub>

<!-- /greptile_comment -->