### PR TITLE
docs: document self-hosted IAM role fallback for S3 blob storage exports

### DIFF
--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -31,12 +31,6 @@ Schedule exports to Amazon S3, S3-compatible storage, Google Cloud Storage, or A
 3. Choose the file format, schedule, export mode, and field groups.
 4. Enable the integration and save. The first run starts shortly afterward.
 
-<Callout type="info">
-
-Self-hosted AWS S3 integrations can leave **Access Key ID** and **Secret Access Key** blank to authenticate with the host's [IAM role](/self-hosting/deployment/infrastructure/blobstorage#amazon-s3) (EC2 instance profile, ECS task role, or IRSA) instead of static credentials. Not available on Langfuse Cloud or for other providers.
-
-</Callout>
-
 <Frame className="my-10" fullWidth>
   ![Blob storage integration setup](/images/docs/blob-storage.png)
 </Frame>

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -27,9 +27,15 @@ Schedule exports to Amazon S3, S3-compatible storage, Google Cloud Storage, or A
 ### Create the integration
 
 1. Open **Project Settings > Integrations > Blob Storage**.
-2. Select your provider and enter its bucket, path, and credentials. Self-hosters can find per-vendor bucket and credential setup on the [blob storage deployment page](/self-hosting/deployment/infrastructure/blobstorage). For self-hosted AWS S3, you can leave **Access Key ID** and **Secret Access Key** blank to authenticate with the host's [IAM role](/self-hosting/deployment/infrastructure/blobstorage#amazon-s3) (EC2 instance profile, ECS task role, or IRSA) instead of static credentials. This fallback is not available on Langfuse Cloud or for other providers.
+2. Select your provider and enter its bucket, path, and credentials. Self-hosters can find per-vendor bucket and credential setup on the [blob storage deployment page](/self-hosting/deployment/infrastructure/blobstorage).
 3. Choose the file format, schedule, export mode, and field groups.
 4. Enable the integration and save. The first run starts shortly afterward.
+
+<Callout type="info">
+
+Self-hosted AWS S3 integrations can leave **Access Key ID** and **Secret Access Key** blank to authenticate with the host's [IAM role](/self-hosting/deployment/infrastructure/blobstorage#amazon-s3) (EC2 instance profile, ECS task role, or IRSA) instead of static credentials. Not available on Langfuse Cloud or for other providers.
+
+</Callout>
 
 <Frame className="my-10" fullWidth>
   ![Blob storage integration setup](/images/docs/blob-storage.png)

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -27,7 +27,7 @@ Schedule exports to Amazon S3, S3-compatible storage, Google Cloud Storage, or A
 ### Create the integration
 
 1. Open **Project Settings > Integrations > Blob Storage**.
-2. Select your provider and enter its bucket, path, and credentials. Self-hosters can find per-vendor bucket and credential setup on the [blob storage deployment page](/self-hosting/deployment/infrastructure/blobstorage).
+2. Select your provider and enter its bucket, path, and credentials. Self-hosters can find per-vendor bucket and credential setup on the [blob storage deployment page](/self-hosting/deployment/infrastructure/blobstorage). For self-hosted AWS S3, you can leave **Access Key ID** and **Secret Access Key** blank to authenticate with the host's [IAM role](/self-hosting/deployment/infrastructure/blobstorage#amazon-s3) (EC2 instance profile, ECS task role, or IRSA) instead of static credentials. This fallback is not available on Langfuse Cloud or for other providers.
 3. Choose the file format, schedule, export mode, and field groups.
 4. Enable the integration and save. The first run starts shortly afterward.
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -142,11 +142,7 @@ Ensure that both entities have the necessary permissions to access the bucket:
 }
 ```
 
-<Callout type="info">
-
-The same IAM role or user works for the project-level [Blob Storage Export integration](/docs/api-and-data-platform/features/export-to-blob-storage#set-up-an-export). On self-hosted deployments, leave **Access Key ID** and **Secret Access Key** blank in that integration's AWS S3 settings to use the IAM role instead of static credentials. This fallback only applies to the AWS S3 provider; it is not available on Langfuse Cloud or for Azure Blob Storage / S3 Compatible Storage.
-
-</Callout>
+The same IAM role or user also works for the project-level [Blob Storage Export integration](/docs/api-and-data-platform/features/export-to-blob-storage#set-up-an-export). On self-hosted deployments, leave **Access Key ID** and **Secret Access Key** blank in that integration's AWS S3 settings to use the IAM role instead of static credentials. This fallback only applies to the AWS S3 provider; it is not available on Langfuse Cloud or for Azure Blob Storage / S3 Compatible Storage.
 
 <Callout type="info">
 

--- a/content/self-hosting/deployment/infrastructure/blobstorage.mdx
+++ b/content/self-hosting/deployment/infrastructure/blobstorage.mdx
@@ -144,6 +144,12 @@ Ensure that both entities have the necessary permissions to access the bucket:
 
 <Callout type="info">
 
+The same IAM role or user works for the project-level [Blob Storage Export integration](/docs/api-and-data-platform/features/export-to-blob-storage#set-up-an-export). On self-hosted deployments, leave **Access Key ID** and **Secret Access Key** blank in that integration's AWS S3 settings to use the IAM role instead of static credentials. This fallback only applies to the AWS S3 provider; it is not available on Langfuse Cloud or for Azure Blob Storage / S3 Compatible Storage.
+
+</Callout>
+
+<Callout type="info">
+
 To use the [Data Retention](/docs/data-retention) feature in a self-hosted environment, you need to grant `s3:DeleteObject` to the Langfuse IAM role on all buckets.
 Note that Langfuse only issues delete statements on the API.
 If you use versioned buckets, delete markers and non-current versions need to be removed manually or with a lifecycle rule.


### PR DESCRIPTION
## What does this PR do?

The blob storage export integration already falls back to the AWS SDK's default credential provider chain (EC2 instance profile, ECS task role, or IRSA on EKS) when Access Key ID / Secret Access Key are left blank — but only for self-hosted AWS S3 integrations. This behavior existed in the code but was undocumented, so self-hosters had no way to discover it short of reading the source.

This adds:
- A note in the "Create the integration" steps of the export-to-blob-storage guide pointing out the blank-credentials fallback and its scope (self-hosted, AWS S3 only).
- A cross-referencing callout in the self-hosting blob storage infra doc, next to the existing IAM role guidance for the platform-level `LANGFUSE_S3_*` buckets, clarifying the same role also covers this per-project integration.

## Type of change

- [x] Documentation update

## Checklist

- [x] Verified against current source (`packages/shared/src/server/services/StorageService.ts`, `web/src/features/blobstorage-integration/service.ts`) in the langfuse/langfuse repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of existing runtime behavior; no code or configuration defaults change.
> 
> **Overview**
> Documents that the **same IAM role or user** used for platform `LANGFUSE_S3_*` buckets can authenticate the **project-level Blob Storage Export** integration on self-hosted AWS deployments.
> 
> The new note in the Amazon S3 self-hosting guide says to leave **Access Key ID** and **Secret Access Key** empty in the integration’s AWS S3 settings so Langfuse uses the instance/task role via the AWS SDK default credential chain instead of static keys. It links to the [export setup guide](/docs/api-and-data-platform/features/export-to-blob-storage#set-up-an-export) and states the behavior is **self-hosted AWS S3 only**—not Langfuse Cloud, Azure Blob, or S3-compatible providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddebb5a6ff58837d7895800c816f5c5909bfe96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR explains that self-hosted AWS S3 export integrations can use the AWS SDK default credential provider chain when static credentials are blank.

- Adds IAM-role fallback guidance to the project-level blob storage export setup.
- Cross-references that behavior from the self-hosted Amazon S3 infrastructure documentation.
- Clearly limits the fallback to self-hosted AWS S3 integrations.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the documentation changes are internally consistent and no actionable defect was identified.

The added guidance consistently limits default-chain authentication to self-hosted AWS S3 integrations and correctly cross-references the existing IAM role documentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document self-hosted IAM role fall..."](https://github.com/langfuse/langfuse-docs/commit/216ccb24cd6648c3cbe4816ade98e49c52c12309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58551526)</sub>

<!-- /greptile_comment -->