### PR TITLE
Rename QA chatbot GenAI spans to model-agnostic names

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,9 @@
 import { registerTelemetry } from "ai";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import { LangfuseVercelAiSdkIntegration } from "@langfuse/vercel-ai-sdk";
+import { trace } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { createGenAiSpanRenamingTracer } from "./rename-gen-ai-spans";
 
 const realtimeIngestionHeaders = {
   "x-langfuse-ingestion-version": "4",
@@ -58,4 +60,8 @@ const tracerProvider = new NodeTracerProvider({
 
 tracerProvider.register();
 
-registerTelemetry(new LangfuseVercelAiSdkIntegration());
+registerTelemetry(
+  new LangfuseVercelAiSdkIntegration({
+    tracer: createGenAiSpanRenamingTracer(trace.getTracer("gen_ai")),
+  }),
+);

--- a/src/rename-gen-ai-spans.test.ts
+++ b/src/rename-gen-ai-spans.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createGenAiSpanRenamingTracer,
+  renameGenAiSpan,
+} from "./rename-gen-ai-spans.ts";
+import type { Span, Tracer } from "@opentelemetry/api";
+
+test("renameGenAiSpan maps invoke_agent and chat model spans to stable names", () => {
+  assert.equal(renameGenAiSpan("invoke_agent gpt-5"), "invoke agent");
+  assert.equal(renameGenAiSpan("invoke_agent gpt-5.4-mini"), "invoke agent");
+  assert.equal(renameGenAiSpan("chat gpt-5"), "chat completion");
+  assert.equal(renameGenAiSpan("chat gpt-4o"), "chat completion");
+});
+
+test("renameGenAiSpan leaves unrelated span names unchanged", () => {
+  assert.equal(
+    renameGenAiSpan("handle-chatbot-message"),
+    "handle-chatbot-message",
+  );
+  assert.equal(
+    renameGenAiSpan("execute_tool searchLangfuseDocs"),
+    "execute_tool searchLangfuseDocs",
+  );
+  assert.equal(renameGenAiSpan("step 1"), "step 1");
+  assert.equal(renameGenAiSpan("chat"), "chat");
+  assert.equal(renameGenAiSpan("invoke_agent"), "invoke_agent");
+});
+
+test("createGenAiSpanRenamingTracer renames startSpan names", () => {
+  const started: string[] = [];
+  const delegate = {
+    startSpan(name: string) {
+      started.push(name);
+      return {} as Span;
+    },
+    startActiveSpan() {
+      throw new Error("not used");
+    },
+  } as unknown as Tracer;
+
+  const tracer = createGenAiSpanRenamingTracer(delegate);
+  tracer.startSpan("invoke_agent gpt-5");
+  tracer.startSpan("chat gpt-5");
+  tracer.startSpan("get-langfuse-prompt");
+
+  assert.deepEqual(started, [
+    "invoke agent",
+    "chat completion",
+    "get-langfuse-prompt",
+  ]);
+});

--- a/src/rename-gen-ai-spans.ts
+++ b/src/rename-gen-ai-spans.ts
@@ -1,0 +1,32 @@
+import type { Context, Span, SpanOptions, Tracer } from "@opentelemetry/api";
+
+/**
+ * AI SDK GenAI OTel names spans as `<operation> <modelId>` (e.g. `invoke_agent gpt-5`,
+ * `chat gpt-5`). Keep observation names model-agnostic so evaluators/dashboards stay
+ * stable when the model changes — the model is already a separate generation attribute.
+ */
+export function renameGenAiSpan(name: string): string {
+  if (name.startsWith("invoke_agent ")) {
+    return "invoke agent";
+  }
+  if (name.startsWith("chat ")) {
+    return "chat completion";
+  }
+  return name;
+}
+
+export function createGenAiSpanRenamingTracer(delegate: Tracer): Tracer {
+  return {
+    startSpan(name: string, options?: SpanOptions, context?: Context): Span {
+      return delegate.startSpan(renameGenAiSpan(name), options, context);
+    },
+    startActiveSpan(name: string, ...args: unknown[]) {
+      return (
+        delegate.startActiveSpan as (
+          name: string,
+          ...rest: unknown[]
+        ) => unknown
+      )(renameGenAiSpan(name), ...args);
+    },
+  } as Tracer;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AI SDK GenAI OpenTelemetry names spans as `invoke_agent <model>` and `chat <model>` (e.g. `invoke_agent gpt-5`, `chat gpt-5`). That embeds the model into observation names, which breaks stable filtering/evaluators when the model changes — and conflicts with our own [best practice](https://langfuse.com/docs/observability/best-practices) of keeping dynamic values (including model names) out of observation names.

This PR wraps the GenAI tracer used by `@langfuse/vercel-ai-sdk` so those spans are renamed to:

- `invoke_agent <model>` → `invoke agent`
- `chat <model>` → `chat completion`

Unrelated spans (`execute_tool …`, `handle-chatbot-message`, step spans, etc.) are left unchanged. The model remains available as a generation attribute.

## Test plan

- [x] Unit tests for `renameGenAiSpan` and the renaming tracer (`node --experimental-strip-types --test src/rename-gen-ai-spans.test.ts`)
- [ ] After deploy: send a message through the docs QA chatbot and confirm the trace tree shows `invoke agent` / `chat completion` instead of `invoke_agent gpt-5` / `chat gpt-5`

## Evidence

[rename_gen_ai_spans_tests.log](https://cursor.com/artifacts/c/art-8becaf41-1ea2-4102-bf6f-d8ae463f56c8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee6ec855-f60b-4e25-b074-e1f679631e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee6ec855-f60b-4e25-b074-e1f679631e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

