### PR TITLE
docs: remove duplicate S3 export link from data platform nav

### DIFF
--- a/content/integrations/data-platform/meta.json
+++ b/content/integrations/data-platform/meta.json
@@ -2,7 +2,6 @@
   "title": "Data Platform",
   "pages": [
     "[Public API](/docs/api-and-data-platform/overview)",
-    "[Exports to S3](/docs/api-and-data-platform/features/export-to-blob-storage)",
     "[Metrics API](/docs/metrics/features/metrics-api)",
     "[Prompt Webhooks](/docs/prompt-management/features/webhooks-slack-integrations)",
     "[Export to Blob Storage (e.g., S3)](/docs/api-and-data-platform/features/export-to-blob-storage)"


### PR DESCRIPTION
## Summary

The **Data Platform** integrations nav (`content/integrations/data-platform/meta.json`) listed two entries that both linked to the same page:

- "Exports to S3" → `/docs/api-and-data-platform/features/export-to-blob-storage`
- "Export to Blob Storage (e.g., S3)" → `/docs/api-and-data-platform/features/export-to-blob-storage`

These originally pointed to different pages, but the two links have since converged on the same target, leaving a confusing duplicate in the sidebar. This removes the redundant "Exports to S3" entry and keeps the clearer "Export to Blob Storage (e.g., S3)".

## Changes

- Remove the duplicate "Exports to S3" nav entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation navigation only; no runtime or API behavior changes.
> 
> **Overview**
> Removes the redundant **"Exports to S3"** item from the Data Platform integrations sidebar in `meta.json`, which pointed to the same URL as **"Export to Blob Storage (e.g., S3)"** (`/docs/api-and-data-platform/features/export-to-blob-storage`). The clearer blob-storage label remains so the nav no longer shows two links to one page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a1408866d7091a703e4cde62b118f2ce412067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes a duplicate S3 export link from the Data Platform integration navigation while preserving the clearer blob-storage entry.

- Removes the redundant “Exports to S3” navigation item.
- Retains access to the same export documentation through “Export to Blob Storage (e.g., S3).”
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the export documentation remains reachable through the retained navigation entry.

The change removes only a redundant label and leaves the intended Data Platform routes and valid JSON structure intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove duplicate S3 export link fr..."](https://github.com/langfuse/langfuse-docs/commit/c9a1408866d7091a703e4cde62b118f2ce412067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58587273)</sub>

<!-- /greptile_comment -->