### PR TITLE
Add Vercel Speed Insights

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,7 @@ import { AdConsentGate } from "@/components/analytics/AdConsentGate";
 import { ClickIdPersistence } from "@/components/analytics/ClickIdPersistence";
 import { CommonRoom } from "@/components/analytics/common-room";
 import { AhrefsAnalytics } from "@/components/analytics/ahrefs";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "../style.css";
 import "@vidstack/react/player/styles/base.css";
 import "../src/overrides.css";
@@ -124,6 +125,7 @@ export default function RootLayout({
             />
           </>
         )}
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@vercel/functions": "^2.2.2",
     "@vercel/mcp-adapter": "^0.11.1",
     "@vercel/og": "^0.6.8",
+    "@vercel/speed-insights": "^2.0.0",
     "@vidstack/react": "^1.12.13",
     "ai": "^7.0.16",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@vercel/og':
         specifier: ^0.6.8
         version: 0.6.8
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vidstack/react':
         specifier: ^1.12.13
         version: 1.12.13(@types/react@19.2.14)(react@18.3.1)
@@ -2964,6 +2967,32 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vidstack/react@1.12.13':
     resolution: {integrity: sha512-zyNydy1+HtoK6cJ8EmqFNkPPGHIFMrr2KH+ef3654EqXx4IcJ8A5LCNMXBuALQE8IMxtk040JMoR9OKyeXjBOQ==}
@@ -9073,6 +9102,11 @@ snapshots:
       yoga-wasm-web: 0.3.3
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    optionalDependencies:
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   '@vidstack/react@1.12.13(@types/react@19.2.14)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Mount `@vercel/speed-insights` so Vercel can collect Core Web Vitals and other real-user performance metrics for this site.

## Changes

- Add `@vercel/speed-insights` (v2)
- Render `<SpeedInsights />` from `@vercel/speed-insights/next` in the root layout

The Next.js integration handles App Router route changes automatically. The package does not send data in local development; metrics appear in the Vercel Speed Insights dashboard after this is deployed and Speed Insights is enabled on the project.

## Enable in Vercel

After merge, open the project's **Speed Insights** tab in the Vercel dashboard if it is not already enabled. The free tier includes 10,000 events per team every 30 days.

## Verification

- Homepage, `/docs`, `/docs/observability`, and `/blog` compile and return 200
- Compiled RSC payload includes `@vercel/speed-insights@2.0.0` / `SpeedInsights`
- DevTools console: `[Vercel Speed Insights] Debug mode is enabled by default in development. No requests will be sent to the server.`
- Desktop and mobile homepage layouts unchanged

![Homepage at desktop after adding Speed Insights](https://cursor.com/artifacts/c/art-0da3d851-27c9-4e2a-8836-9bd6fe52ee5f)
![DevTools console showing Vercel Speed Insights debug mode](https://cursor.com/artifacts/c/art-db7008c5-25de-4b35-97a5-88882a2a3a64)
<a href="https://cursor.com/agents/bc-f7614b33-6169-4913-8f4d-005425508b9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeed_insights_homepage_console_desktop_mobile.mp4"><img src="https://cursor.com/artifacts/c/art-cbc94f6b-4eb4-41d9-aeb1-711cff7713d1" alt="speed_insights_homepage_console_desktop_mobile.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7614b33-6169-4913-8f4d-005425508b9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7614b33-6169-4913-8f4d-005425508b9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Vercel Speed Insights to collect real-user Core Web Vitals across the site.

- Adds `@vercel/speed-insights` version 2 as a runtime dependency.
- Mounts the Next.js `SpeedInsights` component in the root layout.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The new dependency is compatible with the repository’s framework versions, and the root-layout integration follows the package’s supported Next.js usage without violating an established repository contract.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Vercel Speed Insights for Core Web V..."](https://github.com/langfuse/langfuse-docs/commit/242cfd53c8ba5c38a784a088b414e67412e511e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58598709)</sub>

<!-- /greptile_comment -->