### PR TITLE
fix(llms.txt): include every content section, warn on unlisted ones

### DIFF
--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -11,10 +11,14 @@ const ALL_PAGES_PATH = path.join(repoRoot, ".sitemap-all-pages.json");
 const TITLE = "Langfuse";
 const INTRO_DESCRIPTION =
   "Langfuse is an **open-source AI engineering platform** ([GitHub](https://github.com/langfuse/langfuse)) that helps teams collaboratively debug, analyze, and iterate on their LLM applications. All platform features are natively integrated to accelerate the development workflow.";
-const MAIN_SECTIONS = ["docs", "integrations"];
-const OPTIONAL_SECTIONS = ["self-hosting"];
-
-// Map section keys to sub-file names and display names
+// Every content section that should appear in llms.txt, in output order.
+// Each entry gets its own llms-<section>.txt sub-file. Sections present in the
+// sitemap but missing from this map are reported by warnUnlistedSections()
+// instead of being dropped without a trace.
+//
+// `inlineTitles: false` omits the comma-separated page list from the main
+// llms.txt for sections large enough to drown out everything else; the
+// sub-file still lists every page.
 const SECTION_CONFIG = {
   docs: {
     file: "llms-docs.txt",
@@ -31,7 +35,126 @@ const SECTION_CONFIG = {
     heading: "Optional: Self-Hosting",
     subFileHeading: "Langfuse Self-Hosting",
   },
+  guides: {
+    file: "llms-guides.txt",
+    heading: "Guides and cookbooks",
+    subFileHeading: "Langfuse Guides",
+  },
+  academy: {
+    file: "llms-academy.txt",
+    heading: "Academy",
+    subFileHeading: "Langfuse Academy",
+  },
+  faq: {
+    file: "llms-faq.txt",
+    heading: "FAQ",
+    subFileHeading: "Langfuse FAQ",
+  },
+  resources: {
+    file: "llms-resources.txt",
+    heading: "Resources",
+    subFileHeading: "Langfuse Resources",
+  },
+  security: {
+    file: "llms-security.txt",
+    heading: "Security and compliance",
+    subFileHeading: "Langfuse Security",
+  },
+  handbook: {
+    file: "llms-handbook.txt",
+    heading: "Handbook",
+    subFileHeading: "Langfuse Handbook",
+  },
+  workshop: {
+    file: "llms-workshop.txt",
+    heading: "Workshop",
+    subFileHeading: "Langfuse Workshop",
+  },
+  library: {
+    file: "llms-library.txt",
+    heading: "Library",
+    subFileHeading: "Langfuse Library",
+  },
+  users: {
+    file: "llms-users.txt",
+    heading: "Customer stories",
+    subFileHeading: "Langfuse Customer Stories",
+  },
+  blog: {
+    file: "llms-blog.txt",
+    heading: "Blog",
+    subFileHeading: "Langfuse Blog",
+  },
+  changelog: {
+    file: "llms-changelog.txt",
+    heading: "Changelog",
+    subFileHeading: "Langfuse Changelog",
+    inlineTitles: false,
+  },
 };
+
+const SECTION_KEYS = Object.keys(SECTION_CONFIG);
+
+// Top-level sitemap paths that are single marketing/legal pages rather than
+// content sections. They are intentionally absent from llms.txt, so they must
+// not trigger the unlisted-section warning.
+const IGNORED_SECTION_PATHS = new Set([
+  "",
+  "pricing",
+  "pricing-self-host",
+  "enterprise",
+  "startups",
+  "non-profit",
+  "talk-to-us",
+  "demo",
+  "careers",
+  "about",
+  "imprint",
+  "terms",
+  "privacy",
+  "brand",
+  "press",
+  "research",
+  "events",
+  "agents",
+  "cloud",
+  "status",
+  "support",
+  "why-langfuse",
+  "cn",
+  "japan",
+  "kr",
+  "launch-week-5",
+  "customers",
+  "community",
+  "cookie-policy",
+  "oss-friends",
+  "partners",
+  "role-finder",
+  "wrapped",
+]);
+
+/**
+ * Sections that exist in the sitemap but have no SECTION_CONFIG entry are
+ * missing from llms.txt. This used to happen silently: unmatched URLs were
+ * collected into an `other` bucket that was never written to any file, so
+ * whole sections (academy, faq, guides, resources, ...) were absent from
+ * llms.txt without any signal. Warn loudly instead.
+ */
+function warnUnlistedSections(entriesByUnlistedSection) {
+  const sections = Object.keys(entriesByUnlistedSection).sort();
+  if (sections.length === 0) return;
+  console.warn(
+    "[llms.txt] These sitemap sections are not in SECTION_CONFIG and are " +
+      "absent from llms.txt. Add them to SECTION_CONFIG, or to " +
+      "IGNORED_SECTION_PATHS if that is intentional:",
+  );
+  sections.forEach((section) => {
+    console.warn(
+      `  - /${section} (${entriesByUnlistedSection[section].length} pages)`,
+    );
+  });
+}
 
 function generateTitle(url) {
   return url
@@ -81,13 +204,12 @@ async function generateLLMsList() {
     const result = await parser.parseStringPromise(sitemapContent);
 
     // Create a map to store URLs by section
-    const urlsBySection = {
-      other: [],
-      optional: [],
-    };
-    MAIN_SECTIONS.forEach((section) => {
+    const urlsBySection = {};
+    SECTION_KEYS.forEach((section) => {
       urlsBySection[section] = [];
     });
+    // section path -> entries, for sections with no SECTION_CONFIG entry
+    const unlistedSections = {};
 
     // Per-page metadata (real frontmatter title/description) keyed by pathname.
     const pageMeta = loadPageMeta();
@@ -104,23 +226,21 @@ async function generateLLMsList() {
         url,
       };
 
-      if (MAIN_SECTIONS.includes(urlPath)) {
+      if (urlsBySection[urlPath]) {
         urlsBySection[urlPath].push(entry);
-      } else if (OPTIONAL_SECTIONS.includes(urlPath)) {
-        urlsBySection.optional.push(entry);
-      } else {
-        urlsBySection.other.push(entry);
+      } else if (!IGNORED_SECTION_PATHS.has(urlPath)) {
+        unlistedSections[urlPath] = unlistedSections[urlPath] || [];
+        unlistedSections[urlPath].push(entry);
       }
     });
 
     const publicDir = path.join(repoRoot, "public");
 
     // Write sub-files for each section
-    const sectionEntries = {
-      docs: urlsBySection.docs || [],
-      integrations: urlsBySection.integrations || [],
-      "self-hosting": urlsBySection.optional || [],
-    };
+    const sectionEntries = {};
+    SECTION_KEYS.forEach((section) => {
+      sectionEntries[section] = urlsBySection[section] || [];
+    });
 
     for (const [sectionKey, entries] of Object.entries(sectionEntries)) {
       if (entries.length > 0) {
@@ -183,13 +303,21 @@ async function generateLLMsList() {
           markdownContent += `${sectionIntros[sectionKey]}\n\n`;
         }
         markdownContent += `For the full list with links to each page, see: https://langfuse.com/${config.file}\n\n`;
-        markdownContent += `Pages: ${titles}\n\n`;
+        if (config.inlineTitles !== false) {
+          markdownContent += `Pages: ${titles}\n\n`;
+        }
       }
     }
 
     fs.writeFileSync(path.join(publicDir, "llms.txt"), markdownContent);
 
-    console.log("Successfully generated llms.txt and sub-files");
+    warnUnlistedSections(unlistedSections);
+
+    const generated = Object.entries(sectionEntries)
+      .filter(([, entries]) => entries.length > 0)
+      .map(([section, entries]) => `${section} (${entries.length})`)
+      .join(", ");
+    console.log(`Successfully generated llms.txt and sub-files: ${generated}`);
   } catch (error) {
     console.error("Error generating llms.txt:", error);
   }

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -16,24 +16,29 @@ const INTRO_DESCRIPTION =
 // sitemap but missing from this map are reported by warnUnlistedSections()
 // instead of being dropped without a trace.
 //
-// `inlineTitles: false` omits the comma-separated page list from the main
-// llms.txt for sections large enough to drown out everything else; the
-// sub-file still lists every page.
+// `inlineTitles: true` lists every page title inline in the main llms.txt.
+// Reserved for the sections an agent most often needs to navigate directly.
+// Every other section still gets its own sub-file and is announced in
+// llms.txt as a heading plus a link to that sub-file, without its page
+// titles, so the main index stays small enough to be cheap context.
 const SECTION_CONFIG = {
   docs: {
     file: "llms-docs.txt",
     heading: "Docs",
     subFileHeading: "Langfuse Docs",
+    inlineTitles: true,
   },
   integrations: {
     file: "llms-integrations.txt",
     heading: "Integrations",
     subFileHeading: "Langfuse Integrations",
+    inlineTitles: true,
   },
   "self-hosting": {
     file: "llms-self-hosting.txt",
     heading: "Optional: Self-Hosting",
     subFileHeading: "Langfuse Self-Hosting",
+    inlineTitles: true,
   },
   guides: {
     file: "llms-guides.txt",
@@ -44,6 +49,7 @@ const SECTION_CONFIG = {
     file: "llms-academy.txt",
     heading: "Academy",
     subFileHeading: "Langfuse Academy",
+    inlineTitles: true,
   },
   faq: {
     file: "llms-faq.txt",
@@ -89,7 +95,6 @@ const SECTION_CONFIG = {
     file: "llms-changelog.txt",
     heading: "Changelog",
     subFileHeading: "Langfuse Changelog",
-    inlineTitles: false,
   },
 };
 
@@ -292,18 +297,19 @@ async function generateLLMsList() {
       integrations: `For the best results, install the [Langfuse skill](https://github.com/langfuse/skills/tree/main/skills/langfuse) before implementing any integration.`,
     };
 
-    // Add each section with sub-file link and comma-separated titles
+    // Add each section as a heading plus a link to its sub-file, and inline the
+    // page titles only for the sections that opt in via `inlineTitles`.
     for (const [sectionKey, entries] of Object.entries(sectionEntries)) {
       if (entries.length > 0) {
         const config = SECTION_CONFIG[sectionKey];
-        const titles = entries.map((e) => e.title).join(", ");
 
         markdownContent += `## ${config.heading}\n\n`;
         if (sectionIntros[sectionKey]) {
           markdownContent += `${sectionIntros[sectionKey]}\n\n`;
         }
         markdownContent += `For the full list with links to each page, see: https://langfuse.com/${config.file}\n\n`;
-        if (config.inlineTitles !== false) {
+        if (config.inlineTitles === true) {
+          const titles = entries.map((e) => e.title).join(", ");
           markdownContent += `Pages: ${titles}\n\n`;
         }
       }


### PR DESCRIPTION
## Problem

`llms.txt` listed only **Docs**, **Integrations** and **Optional: Self-Hosting**. Every other content section was silently missing.

The cause is in [scripts/generate_llms_txt.js](scripts/generate_llms_txt.js): sitemap URLs were sorted into `docs`, `optional` and `other` — and **the `other` bucket was collected but never written to any file**. So academy, faq, guides, resources, security, changelog, blog, handbook, workshop, library and customer stories were dropped with no warning, no log line, and nothing in the output to hint at it.

Found while investigating why `/academy` is consumed by AI assistants at a far lower rate than any other section (8.9% of its human pageviews, vs docs 58% / faq 80% / resources 140%).

## Change

**All 14 content sections now appear in `llms.txt` and each gets its own `llms-<section>.txt` sub-file.**

Page titles are inlined in the main index for **docs, integrations, self-hosting and academy** only — the sections an agent typically needs to navigate directly. Every other section is announced as a heading plus a link to its sub-file, without its page titles, so loading `llms.txt` for orientation doesn't pull 141 changelog entries and 77 blog posts into context.

```
## Academy

For the full list with links to each page, see: https://langfuse.com/llms-academy.txt

Pages: Academy, AI engineering loop, Datasets, Designing datasets, …

## FAQ

For the full list with links to each page, see: https://langfuse.com/llms-faq.txt
```

Implemented as an opt-in `inlineTitles: true` flag on those four sections, so adding a section defaults to the quiet behaviour.

Also: **sections in the sitemap with no `SECTION_CONFIG` entry now emit a build warning** naming them and their page count, so a newly added content section can't go missing silently again. Single marketing/legal pages are listed in `IGNORED_SECTION_PATHS` to keep that warning actionable rather than noisy. The success log now reports each section and its page count.

## Verified

Ran against the live production sitemap (829 URLs):

```
Successfully generated llms.txt and sub-files: docs (112), integrations (132),
self-hosting (48), guides (28), academy (28), faq (98), resources (36),
security (22), handbook (51), workshop (19), library (1), users (9),
blog (77), changelog (141)
```

- Exactly four sections inline their page titles: Docs, Integrations, Optional: Self-Hosting, Academy. All ten others render as heading + sub-file link only.
- All 14 `llms-*.txt` sub-files generate with correct content.
- `llms.txt` is **8,636 bytes** — roughly half the 16,958 bytes it would be with every section inlined, and ~3× the current 3-section file while covering all 14.
- The unlisted-section warning fired on the first run for `/community`, `/cookie-policy`, `/oss-friends`, `/partners`, `/role-finder`, `/wrapped`; those were added to `IGNORED_SECTION_PATHS` and the run is now clean.

## Notes for reviewers

- Output files (`public/llms*.txt`, `public/sitemap-0.xml`) are build artifacts and gitignored; nothing generated is committed.
- Page titles come from `.sitemap-all-pages.json` (real frontmatter titles) during a proper build. My standalone test ran without that file, so sample output showed slug-derived titles — pre-existing fallback, unchanged.
- **One judgement call worth a look:** the academy inline list includes the 14 pages of the `/academy/japan` locale, which doubles its length. In a real build those carry their Japanese frontmatter titles so they're distinguishable, but if you'd rather keep the English index clean I can exclude localized subtrees from the inline list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the postbuild llms.txt generator; no runtime app, auth, or data paths are touched.
> 
> **Overview**
> Fixes **silent omission** of most site sections from `llms.txt`: sitemap URLs that did not match docs/integrations/self-hosting used to land in an **`other` bucket that was never written**, so academy, FAQ, guides, blog, changelog, and similar content never appeared in the agent index.
> 
> **`scripts/generate_llms_txt.js`** is now driven by **`SECTION_CONFIG`**, which defines **14 content sections** (each with its own `public/llms-<section>.txt`), plus **`IGNORED_SECTION_PATHS`** for marketing/legal top-level routes so warnings stay actionable. Unmapped sitemap sections trigger **`warnUnlistedSections()`** at build time with page counts.
> 
> The main **`llms.txt`** still links every non-empty section; only sections with **`inlineTitles: true`** (docs, integrations, self-hosting, academy) keep the long **`Pages: …`** line—large sections like changelog get a heading and sub-file link only, keeping the index smaller. The success log now lists **section names and URL counts**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48baa71d7041acca0cd4493edf6bea7b313fdcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->