### PR TITLE
fix(headers): declare Vary: Accept on markdown-negotiable paths

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -215,14 +215,18 @@ const nextConfig = {
       // Accept is part of the cache key, so a cached HTML response is never
       // served to a markdown request or vice versa.
       //
-      // Keep these sources in sync with the negotiation rewrites below.
+      // Static assets are excluded: they never negotiate, and declaring a Vary
+      // they do not honour would fragment CDN cache entries per Accept string
+      // for every asset on the site. The extension list mirrors the matcher in
+      // proxy.ts, plus `.md` — a `.md` URL is always markdown, so it does not
+      // vary on Accept either.
       {
         source: "/",
         headers: [{ key: "Vary", value: "Accept" }],
       },
       {
         source:
-          "/:path((?!api|_next|md-src|\\.well-known)(?!.*\\.md$)(?!.*\\.txt$)(?!.*\\.json$).*)",
+          "/:path((?!api|_next|md-src|\\.well-known)(?!.*\\.(?:md|txt|json|png|jpe?g|gif|svg|ico|webp|avif|css|js|mjs|map|woff2?|ttf|otf|eot|mp4|webm|mp3|zip|pdf|xml|webmanifest|ipynb)$).*)",
         headers: [{ key: "Vary", value: "Accept" }],
       },
       // Mark markdown endpoints as noindex and ensure correct content type

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -209,6 +209,22 @@ const nextConfig = {
           { key: "Cache-Control", value: "public, max-age=3600" },
         ],
       },
+      // Content negotiation: these paths return markdown instead of HTML when
+      // the request carries `Accept: text/markdown` (see the rewrites in
+      // `beforeFiles`). `Vary: Accept` tells caches and intermediaries that
+      // Accept is part of the cache key, so a cached HTML response is never
+      // served to a markdown request or vice versa.
+      //
+      // Keep these sources in sync with the negotiation rewrites below.
+      {
+        source: "/",
+        headers: [{ key: "Vary", value: "Accept" }],
+      },
+      {
+        source:
+          "/:path((?!api|_next|md-src|\\.well-known)(?!.*\\.md$)(?!.*\\.txt$)(?!.*\\.json$).*)",
+        headers: [{ key: "Vary", value: "Accept" }],
+      },
       // Mark markdown endpoints as noindex and ensure correct content type
       {
         source: "/:path*.md",


### PR DESCRIPTION
## Problem

Pages served through the markdown content-negotiation rewrite return **either HTML or markdown for the same URL**, depending on the request's `Accept` header — but the markdown responses carried **no `Vary` header at all**. Measured on production before this change:

| Request | `Vary` |
|---|---|
| `/docs/observability/overview` (HTML) | `rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch` |
| same URL, `Accept: text/markdown` | **(none)** |
| `/docs/observability/overview.md` | (none — correct, doesn't vary) |

Any cache or intermediary keying only on the URL could serve a markdown response to a request that asked for HTML. Vercel currently keys correctly (interleaved requests resolve right, and `x-vercel-cache: HIT` on both), so nothing is broken today — this is a latent correctness gap. For contrast, Anthropic's docs send `vary: …, Cookie, Accept`.

## Change

Declares `Vary: Accept` on the negotiable paths in `headers()`, mirroring the `source` patterns of the negotiation rewrites in `beforeFiles` (with a comment on both sides to keep them in sync).

## Verified on a dev server

| Request | `Vary` after change |
|---|---|
| `/docs/observability/overview` + `Accept: text/markdown` | ✅ `Accept, Accept-Encoding` |
| `/docs/observability/overview` (HTML) | ⚠️ `rsc, next-router-state-tree, …, Accept-Encoding` — no `Accept` |
| `/docs.md` | ✅ `Accept-Encoding` — unchanged, correctly no `Accept` |
| `/api/mcp` | ✅ `Accept-Encoding` — untouched |
| RSC prefetch (`RSC: 1`) | ✅ RSC `Vary` intact, `Content-Type: text/x-component` |

## Known limitation — please read

**This fixes the markdown representation but not the HTML one.** Next.js sets its own `Vary` on app-router responses and that value *replaces* the configured header, so `Accept` never appears on the HTML side. I also tried setting it from `proxy.ts` middleware with `headers.append("Vary", "Accept")` — same result, Next's value still won. There appears to be no user-space way to add `Accept` to an app-router HTML response's `Vary` on this Next version.

Net effect: the markdown response now correctly declares its dependency on `Accept` (it previously declared nothing), which closes the more dangerous direction. The HTML response remains as it is on main. Shipping the half that works seemed better than shipping nothing, but flagging it explicitly so nobody assumes full coverage.

## Adjacent bug found (not fixed here)

`/` with `Accept: text/markdown` **returns 404 in production today**, and `/index.md` is 404 too. The `/` negotiation rewrite points at `/md-src/index.md`, which `copy_md_sources.js` never generates — the rewrite's own comment even says *"remove if you don't have md-src/index.md"*. Pre-existing on main and unrelated to this change, but worth knowing: Claude-User requests markdown ~95% of the time, so agents asking about the homepage get a 404. Happy to fix in a follow-up — either generate `index.md` or drop the `/` rewrite.

## Note

Touches `next.config.mjs` `headers()`, same as the `rel="alternate"` PR — whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only HTTP header change with no auth or data-path impact; main residual risk is incomplete Vary coverage on HTML responses, which matches current production behavior.
> 
> **Overview**
> Adds **`Vary: Accept`** on URLs that can return HTML or markdown depending on `Accept: text/markdown`, so caches treat representation as part of the cache key and are less likely to serve the wrong format for the same URL.
> 
> **`next.config.mjs`** gets two header rules: one for **`/`** and one for the same negotiable path pattern used in **`beforeFiles`** rewrites (excluding API, Next internals, `md-src`, `.well-known`, and static file extensions so assets are not keyed on every `Accept` value). Inline comments document keeping these patterns aligned with the rewrites and **`proxy.ts`**.
> 
> Markdown responses now declare negotiation on **`Accept`**; HTML app-router responses may still omit **`Accept`** in **`Vary`** because Next.js overrides configured values—a known limitation called out in the PR, not fixed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ecbc134f53fa3c7553c4fc143cc77ccc6f373e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds `Vary: Accept` to the same URL patterns used by markdown content negotiation, improving cache handling for markdown responses while retaining the documented Next.js limitation on HTML responses.

- Adds a dedicated header rule for the root path.
- Adds the header to non-API, non-internal, extension-filtered negotiable paths.
- Keeps the header source patterns aligned with the existing `beforeFiles` rewrites.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the remaining HTML-side `Vary` limitation clearly documented and unchanged from the base branch.

The added header patterns match the existing markdown-negotiation rewrite patterns, and the investigation found no new blocking or independently actionable failure.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Request to negotiable URL] --> Accept{Accept includes text/markdown?}
  Accept -->|Yes| Rewrite[Rewrite to md-src path]
  Rewrite --> Markdown[Markdown response with Vary: Accept]
  Accept -->|No| AppRouter[Next.js App Router]
  AppRouter --> HTML[HTML response with framework-managed Vary]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(headers): declare Vary: Accept on ma..."](https://github.com/langfuse/langfuse-docs/commit/d9649e7cf32ca2d6c2369e7d0bacd0d7022fba1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58666072)</sub>

<!-- /greptile_comment -->