### PR TITLE
docs(academy): add backlinks from docs and integrations to the academy

### DIFF
--- a/content/docs/evaluation/core-concepts.mdx
+++ b/content/docs/evaluation/core-concepts.mdx
@@ -16,11 +16,11 @@ Ready to start?
 
 ## The Evaluation Loop
 
-LLM applications often have a constant loop of testing and monitoring.
+LLM applications often have a constant [loop of testing and monitoring](/academy/ai-engineering-loop).
 
-**Offline evaluation** lets you test your application against a fixed dataset before you deploy. You run your new prompt or model against test cases, review the [scores](#scores), iterate until the results look good, then deploy your changes. In Langfuse, you can do that by running [Experiments](/docs/evaluation/core-concepts#experiments).
+**[Offline evaluation](/academy/evaluate)** lets you test your application against a fixed dataset before you deploy. You run your new prompt or model against test cases, review the [scores](#scores), iterate until the results look good, then deploy your changes. In Langfuse, you can do that by running [Experiments](/docs/evaluation/core-concepts#experiments).
 
-**Online evaluation** scores live traces to catch issues in real traffic. When you find edge cases your dataset didn't cover, you add them back to your dataset so future experiments will catch them.
+**[Online evaluation](/academy/monitoring)** scores live traces to catch issues in real traffic. When you find edge cases your dataset didn't cover, you add them back to your dataset so future experiments will catch them.
 
 <LoopDiagram />
 

--- a/content/docs/evaluation/core-concepts.mdx
+++ b/content/docs/evaluation/core-concepts.mdx
@@ -7,6 +7,8 @@ description: Learn the fundamental concepts behind LLM evaluation in Langfuse - 
 
 This page digs into the different concepts of evaluations, and what's available in Langfuse.
 
+If you are still deciding _what_ to measure, [Choosing what to evaluate in the Langfuse Academy](/academy/evaluate/choosing-what-to-evaluate) works through how to turn observed failures into a small set of metrics, and [Writing good evaluators](/academy/evaluate/writing-evaluators) covers how to make those checks trustworthy.
+
 Ready to start?
 
 - [Create a dataset](/docs/evaluation/experiments/datasets) to measure your LLM application's performance consistently

--- a/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
+++ b/content/docs/evaluation/evaluation-methods/llm-as-a-judge.mdx
@@ -189,7 +189,7 @@ Go to the Evaluators page and click **New evaluator**. In the template gallery, 
 
 ### Define the evaluator
 
-An evaluator defines how data is scored: its judge prompt, model, score definition, and default variable mappings. [Rules](/docs/evaluation/core-concepts#evaluators-and-rules) select the incoming observations on which it runs.
+An evaluator defines how data is scored: its [judge prompt](/academy/evaluate/writing-evaluators#writing-a-good-llm-as-a-judge), model, score definition, and default variable mappings. [Rules](/docs/evaluation/core-concepts#evaluators-and-rules) select the incoming observations on which it runs.
 
 1. Select the model to use. Use the [project default model](#project-default-model) or set a dedicated model for this evaluator.
 2. Write or edit the evaluation prompt with `{{variables}}` for the data the judge needs, such as `{{input}}`, `{{output}}`, or `{{ground_truth}}`.

--- a/content/docs/evaluation/experiments/datasets.mdx
+++ b/content/docs/evaluation/experiments/datasets.mdx
@@ -18,6 +18,8 @@ _Langfuse Dataset View_
 - Collaboratively create and collect dataset items with your team
 - Have a single source of truth for your test data
 
+For guidance on scoping a dataset, picking realistic inputs, and writing expected outputs you can actually evaluate against, read [Designing datasets in the Langfuse Academy](/academy/datasets/designing-great-datasets).
+
 ## Get Started
 
 <Steps>

--- a/content/docs/metrics/overview.mdx
+++ b/content/docs/metrics/overview.mdx
@@ -9,6 +9,8 @@ Langfuse metrics derive actionable insights from [observability](/docs/observabi
 
 Metrics can be sliced and diced via the [customizable dashboards](/docs/metrics/features/custom-dashboards) and the [metrics API](/docs/metrics/features/metrics-api). Set up [alerts](/docs/observability/features/alerts) to get notified when a metric crosses a threshold.
 
+For how to decide which metrics are worth tracking, and how to turn what you see into concrete fixes, read [Monitoring in the Langfuse Academy](/academy/monitoring) and its chapter on [error analysis](/academy/monitoring/error-analysis).
+
 <Frame fullWidth>
   <img src="/images/docs/llm-analytics.png" alt="LLM Analytics" />
 </Frame>

--- a/content/integrations/index.mdx
+++ b/content/integrations/index.mdx
@@ -15,6 +15,8 @@ Langfuse is based on OpenTelemetry. Use the Python SDK or JS/TS SDK to log trace
 
 Not sure which integration to use? Use <AskAiLink /> to discuss your options.
 
+New to instrumenting an LLM application? [Tracing in the Langfuse Academy](/academy/tracing) explains how traces are structured and what to capture, which applies whichever integration you pick.
+
 Cannot find the integration you are interested in? [Request an integration via GitHub discussions below.](#request-integration)
 
 ## Native [#native]

--- a/content/integrations/native/opentelemetry/index.mdx
+++ b/content/integrations/native/opentelemetry/index.mdx
@@ -480,6 +480,10 @@ with tracer.start_as_current_span("Langfuse Attributes") as span:
 
 </Callout>
 
+## Next steps
+
+Once spans are arriving in Langfuse, [Tracing in the Langfuse Academy](/academy/tracing) covers how traces are structured and which attributes make them useful downstream, and [Monitoring](/academy/monitoring) covers how to read them once they are there.
+
 ## Troubleshooting
 
 - If you encounter `4xx` errors while self-hosting Langfuse, please upgrade your deployment to the latest version. The OpenTelemetry endpoint was first introduced in Langfuse [v3.22.0](https://github.com/langfuse/langfuse/releases/tag/v3.22.0) and has seen significant improvements since then.


### PR DESCRIPTION
## Why

`/academy` is an island. Only **3 of 112** docs pages linked to it, **0 of 130** integration pages, and 0 from self-hosting, faq or changelog — while **129 of the 193** total `/academy` links in the repo are academy→academy.

It's also the least agent-consumed content section on the site by a wide margin: **8.9%** of its human pageviews, against docs 58%, faq 80%, guides 46%, resources 140%. Human traffic is healthy (7,083 pageviews/week, on par with changelog), so the gap is specifically in discovery from the surfaces agents and readers actually land on.

Split into two commits as requested.

## Commit 1 — quick fixes: link text that is already there

No new prose, only links added to existing sentences.

| Page | Existing text | Now links to |
|---|---|---|
| `evaluation/core-concepts` | "loop of testing and monitoring" | `/academy/ai-engineering-loop` |
| `evaluation/core-concepts` | "**Offline evaluation**" | `/academy/evaluate` |
| `evaluation/core-concepts` | "**Online evaluation**" | `/academy/monitoring` |
| `evaluation-methods/llm-as-a-judge` | "judge prompt" | `/academy/evaluate/writing-evaluators#writing-a-good-llm-as-a-judge` |

Worth noting on the first one: `core-concepts` already imports and renders the academy's own `LoopDiagram` component but never linked the chapter it comes from.

The judge-prompt link is at the point of need — that page already lists the academy pages under "Related Resources" at the very bottom, which a reader mid-page (or an agent retrieving a single chunk) never sees.

**There were fewer of these than expected.** I grepped docs and integrations for academy vocabulary with existing markdown links stripped out, and "error analysis" appears **zero times** in `content/docs`. The docs simply don't use the academy's terminology, which is itself consistent with the intent gap behind the low agent consumption.

## Commit 2 — new CTAs

New sentences, or additions to existing ones, in the house style already used elsewhere ("… in the Langfuse Academy"):

| Page | Added |
|---|---|
| `evaluation/core-concepts` | For readers who don't yet know *what* to measure → `choosing-what-to-evaluate` + `writing-evaluators` |
| `evaluation/experiments/datasets` | After the "Why use datasets?" list → `designing-great-datasets` |
| `metrics/overview` | → `monitoring` + `error-analysis`. This page had **no** academy link at all |
| `integrations` overview | → `tracing`, since it applies whichever integration is picked |
| `integrations/native/opentelemetry` | New `## Next steps` → `tracing` + `monitoring` |

The OpenTelemetry page is deliberate: at **897 assistant fetches in 7 days — 167% of its human pageviews** it is the single most agent-read page on the site, and it had zero academy links.

## Verified

- All 9 distinct `/academy` targets resolve to a real file, and the one deep anchor (`#writing-a-good-llm-as-a-judge`) is explicitly defined in `writing-evaluators.mdx`.
- `node scripts/check-h1-headings.js` passes (the new `## Next steps` is an H2).
- `prettier --write` clean.
- No `md-override/` file corresponds to any edited page (only `pricing.md` and `pricing-self-host.md` exist), so nothing to mirror per AGENTS.md rule 6.

## Notes for reviewers

- Scope was kept deliberately narrow — 6 high-traffic pages rather than spraying links across 130 integration pages. Happy to extend to more integration pages if you'd rather have breadth.
- Backlinks alone probably won't close the 8.9% gap. A separate audit found the bigger lever is that ~14 academy MDX components have no Markdown renderer, so academy `.md` files lose 10–36% of their content — the two worst-affected pages are also the two least-fetched. I can open that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cross-links with verified academy targets; no runtime, API, or product behavior changes.
> 
> **Overview**
> **Improves discovery of Langfuse Academy** by adding `/academy` links on six high-traffic docs and integration pages that previously had little or no cross-linking.
> 
> On **evaluation** docs, `core-concepts` gets an upfront pointer to choosing metrics and writing evaluators, plus inline links on the testing/monitoring loop, offline evaluation, and online evaluation. `llm-as-a-judge` links **judge prompt** to the academy section on writing a good LLM-as-a-Judge (in-page, not only bottom “Related Resources”). `datasets` adds a CTA after “Why use datasets?” to **designing great datasets**.
> 
> **Metrics overview** now points readers to academy **monitoring** and **error analysis** for picking metrics and acting on them. The **integrations** overview links newcomers to academy **tracing**; the **OpenTelemetry** page adds a **Next steps** section toward tracing and monitoring after setup—targeting a page that is heavily agent-fetched.
> 
> Most edits are new prose in the existing “…in the Langfuse Academy” style; a few only wrap existing phrases in links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b479e6b285b07083e6ce61fd5d5ff531d9e90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves discovery of Langfuse Academy material by adding contextual backlinks from evaluation, metrics, and integration documentation.
- Links evaluation concepts, dataset design, and LLM-as-a-Judge guidance to relevant Academy chapters.
- Connects metrics documentation to monitoring and error-analysis material.
- Adds tracing and monitoring next steps to the integrations overview and OpenTelemetry guide.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the documentation-only changes following established MDX and internal-link conventions.

The added links use supported syntax and established Academy routes, and no broken rendering, navigation, or repository-rule issue was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(academy): add academy CTAs to high-..."](https://github.com/langfuse/langfuse-docs/commit/30b479e6b285b07083e6ce61fd5d5ff531d9e90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58669049)</sub>

<!-- /greptile_comment -->