### PR TITLE
docs: capitalize Langfuse in why Langfuse links

### DIFF
--- a/content/docs/api-and-data-platform/overview.mdx
+++ b/content/docs/api-and-data-platform/overview.mdx
@@ -6,7 +6,7 @@ description: Langfuse is designed to be extensible and flexible. People using La
 
 # API & Data Platform
 
-**Langfuse is designed to be open, extensible and flexible** (see [_why langfuse?_](/why)). People using Langfuse are building all kinds of workflows and customizations on top of it. This is powered by our open data platform.
+**Langfuse is designed to be open, extensible and flexible** (see [_why Langfuse?_](/why)). People using Langfuse are building all kinds of workflows and customizations on top of it. This is powered by our open data platform.
 
 Example use cases:
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: Langfuse is an open-source AI engineering platform (GitHub) that he
 
 # Langfuse Overview
 
-Langfuse is an open-source AI engineering platform ([GitHub](https://github.com/langfuse/langfuse)) that helps teams collaboratively debug, analyze, and iterate on their AI agent applications. All platform features are natively integrated to accelerate the development workflow. Langfuse is open, self-hostable, and extensible ([_why langfuse?_](/why)).
+Langfuse is an open-source AI engineering platform ([GitHub](https://github.com/langfuse/langfuse)) that helps teams collaboratively debug, analyze, and iterate on their AI agent applications. All platform features are natively integrated to accelerate the development workflow. Langfuse is open, self-hostable, and extensible ([_why Langfuse?_](/why)).
 
 import { FeatureOverview } from "@/components/FeatureOverview";
 import {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Capitalizes the product name in the “why Langfuse?” link on `/docs` (first paragraph) and the matching link on the API & Data Platform overview.

## Changes

- `content/docs/index.mdx`: `_why langfuse?_` → `_why Langfuse?_`
- `content/docs/api-and-data-platform/overview.mdx`: same capitalization for consistency

The `/why` destination is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05ba2-e340-7209-8797-f1e90b0668ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05ba2-e340-7209-8797-f1e90b0668ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Capitalizes the Langfuse product name in two “why Langfuse?” links while preserving their `/why` destination.

- Updates the link text on the documentation overview.
- Applies the same capitalization to the API & Data Platform overview.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The changes only correct product-name capitalization in two link labels and leave link destinations and rendering syntax unchanged.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: capitalize Langfuse in why Langfus..."](https://github.com/langfuse/langfuse-docs/commit/6fd56a7a121748f7fedeb65d8221935bbc15d345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58937492)</sub>

<!-- /greptile_comment -->