### PR TITLE
Center marketing nav independently of the hiring badge

### DIFF
--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -9,6 +9,7 @@ import { HoverCorners } from "@/components/ui/corner-box";
 const FULL_LABEL = "Hiring in Europe and SF";
 const COMPACT_LABEL = "Hiring";
 const HOVER_LABEL = "Looking for GOATS!";
+const COMPACT_HOVER_LABEL = "GOATS!";
 
 export function HiringBadge({
   className,
@@ -96,12 +97,22 @@ export function HiringBadge({
     FULL_LABEL
   );
 
+  const hoverLabel = adaptive ? (
+    <>
+      <span className="hidden @[13rem]/hiring:inline">{HOVER_LABEL}</span>
+      <span className="inline @[13rem]/hiring:hidden">
+        {COMPACT_HOVER_LABEL}
+      </span>
+    </>
+  ) : (
+    HOVER_LABEL
+  );
+
   const badge = (
     <div
       ref={containerRef}
       className={cn(
-        adaptive &&
-          "hidden w-fit max-w-full min-w-0 @[6.5rem]/hiring:block hover:max-w-none",
+        adaptive && "hidden w-fit max-w-full min-w-0 @[6.5rem]/hiring:block",
         !adaptive && className,
       )}
       onMouseMove={handleMouseMove}
@@ -117,8 +128,7 @@ export function HiringBadge({
           href="/careers"
           aria-label={FULL_LABEL}
           className={cn(
-            "inline-flex w-full min-w-0 max-w-full items-center gap-[6px]",
-            "overflow-hidden group-hover:overflow-visible",
+            "inline-flex w-full min-w-0 max-w-full items-center gap-[6px] overflow-hidden",
             "h-[26px] py-0.75 pl-[8px] pr-[8px] rounded-[2px]",
             "border border-line-structure dark:border-line-cta group-hover:border-line-cta",
             "bg-surface-bg text-text-secondary",
@@ -132,7 +142,7 @@ export function HiringBadge({
           </span>
           <span className="text-left">
             <span className="block whitespace-nowrap">
-              {isHovered ? HOVER_LABEL : idleLabel}
+              {isHovered ? hoverLabel : idleLabel}
             </span>
           </span>
         </NextLink>
@@ -147,9 +157,7 @@ export function HiringBadge({
   }
 
   return (
-    <div
-      className={cn("@container/hiring w-full min-w-0 hover:z-10", className)}
-    >
+    <div className={cn("@container/hiring w-full min-w-0", className)}>
       {badge}
     </div>
   );

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -87,11 +87,21 @@ export function HiringBadge({
         )
       : null;
 
+  const idleLabel = adaptive ? (
+    <>
+      <span className="hidden @[13rem]/hiring:inline">{FULL_LABEL}</span>
+      <span className="inline @[13rem]/hiring:hidden">{COMPACT_LABEL}</span>
+    </>
+  ) : (
+    FULL_LABEL
+  );
+
   const badge = (
     <div
       ref={containerRef}
       className={cn(
-        adaptive && "hidden w-fit max-w-full min-w-0 @[6.5rem]/hiring:block",
+        adaptive &&
+          "hidden w-fit max-w-full min-w-0 @[6.5rem]/hiring:block hover:max-w-none",
         !adaptive && className,
       )}
       onMouseMove={handleMouseMove}
@@ -107,7 +117,8 @@ export function HiringBadge({
           href="/careers"
           aria-label={FULL_LABEL}
           className={cn(
-            "inline-flex w-full min-w-0 max-w-full items-center gap-[6px] overflow-hidden",
+            "inline-flex w-full min-w-0 max-w-full items-center gap-[6px]",
+            "overflow-hidden group-hover:overflow-visible",
             "h-[26px] py-0.75 pl-[8px] pr-[8px] rounded-[2px]",
             "border border-line-structure dark:border-line-cta group-hover:border-line-cta",
             "bg-surface-bg text-text-secondary",
@@ -119,33 +130,9 @@ export function HiringBadge({
           <span className="text-xs shrink-0" aria-hidden>
             🐐
           </span>
-          <span className="relative min-w-0 flex-1 text-left">
-            <span
-              className={cn(
-                "block whitespace-nowrap",
-                isHovered && "invisible",
-              )}
-            >
-              {adaptive ? (
-                <>
-                  <span className="hidden @[13rem]/hiring:inline">
-                    {FULL_LABEL}
-                  </span>
-                  <span className="inline @[13rem]/hiring:hidden">
-                    {COMPACT_LABEL}
-                  </span>
-                </>
-              ) : (
-                FULL_LABEL
-              )}
-            </span>
-            <span
-              className={cn(
-                "absolute left-0 top-0 whitespace-nowrap",
-                !isHovered && "invisible",
-              )}
-            >
-              {HOVER_LABEL}
+          <span className="text-left">
+            <span className="block whitespace-nowrap">
+              {isHovered ? HOVER_LABEL : idleLabel}
             </span>
           </span>
         </NextLink>
@@ -160,7 +147,9 @@ export function HiringBadge({
   }
 
   return (
-    <div className={cn("@container/hiring w-full min-w-0", className)}>
+    <div
+      className={cn("@container/hiring w-full min-w-0 hover:z-10", className)}
+    >
       {badge}
     </div>
   );

--- a/components/HiringBadge.tsx
+++ b/components/HiringBadge.tsx
@@ -6,7 +6,23 @@ import NextLink from "next/link";
 import { cn } from "@/lib/utils";
 import { HoverCorners } from "@/components/ui/corner-box";
 
-export function HiringBadge({ className }: { className?: string }) {
+const FULL_LABEL = "Hiring in Europe and SF";
+const COMPACT_LABEL = "Hiring";
+const HOVER_LABEL = "Looking for GOATS!";
+
+export function HiringBadge({
+  className,
+  adaptive = false,
+}: {
+  className?: string;
+  /**
+   * Size the badge to leftover space left of a centered nav: full label when
+   * there is room, "Hiring" when space is tight, hidden when even that would
+   * collide. The parent must be a shrinking width constraint (e.g. a `1fr`
+   * grid column), not sized by this badge's content.
+   */
+  adaptive?: boolean;
+}) {
   const [isHovered, setIsHovered] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [goats, setGoats] = useState<
@@ -71,10 +87,13 @@ export function HiringBadge({ className }: { className?: string }) {
         )
       : null;
 
-  return (
+  const badge = (
     <div
       ref={containerRef}
-      className={className}
+      className={cn(
+        adaptive && "hidden w-fit max-w-full min-w-0 @[6.5rem]/hiring:block",
+        !adaptive && className,
+      )}
       onMouseMove={handleMouseMove}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => {
@@ -86,6 +105,7 @@ export function HiringBadge({ className }: { className?: string }) {
         <HoverCorners />
         <NextLink
           href="/careers"
+          aria-label={FULL_LABEL}
           className={cn(
             "inline-flex w-full min-w-0 max-w-full items-center gap-[6px] overflow-hidden",
             "h-[26px] py-0.75 pl-[8px] pr-[8px] rounded-[2px]",
@@ -100,8 +120,24 @@ export function HiringBadge({ className }: { className?: string }) {
             🐐
           </span>
           <span className="relative min-w-0 flex-1 text-left">
-            <span className={cn("block truncate", isHovered && "invisible")}>
-              Hiring in Europe and SF
+            <span
+              className={cn(
+                "block whitespace-nowrap",
+                isHovered && "invisible",
+              )}
+            >
+              {adaptive ? (
+                <>
+                  <span className="hidden @[13rem]/hiring:inline">
+                    {FULL_LABEL}
+                  </span>
+                  <span className="inline @[13rem]/hiring:hidden">
+                    {COMPACT_LABEL}
+                  </span>
+                </>
+              ) : (
+                FULL_LABEL
+              )}
             </span>
             <span
               className={cn(
@@ -109,13 +145,23 @@ export function HiringBadge({ className }: { className?: string }) {
                 !isHovered && "invisible",
               )}
             >
-              Looking for GOATS!
+              {HOVER_LABEL}
             </span>
           </span>
         </NextLink>
       </div>
 
       {goatOverlay}
+    </div>
+  );
+
+  if (!adaptive) {
+    return badge;
+  }
+
+  return (
+    <div className={cn("@container/hiring w-full min-w-0", className)}>
+      {badge}
     </div>
   );
 }

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -49,12 +49,12 @@ export function Navbar() {
         >
           <div className="absolute bottom-[-6px] left-0 w-[6px] h-[5px] bg-left-corner" />
           <div className="absolute hidden wide:block bottom-[-6px] right-0 w-[6px] h-[5px] bg-right-corner" />
-          <div className="flex flex-1 min-w-0 gap-2 items-center px-2.5 py-3 rounded-sm bg-surface-1">
-            {/* Hide below xl so the header CTAs stay visible. */}
-            <HiringBadge className="hidden shrink-0 xl:block" />
-            <div className="flex flex-1 justify-center items-center min-w-0 gap-4">
+          <div className="grid flex-1 min-w-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-2 items-center px-2.5 py-3 rounded-sm bg-surface-1">
+            {/* Left 1fr column: hiring sits in leftover space and must not shift the centered menu. */}
+            <HiringBadge adaptive />
+            <NavLinks sectionNavData={sectionNavData} />
+            <div className="min-w-0" aria-hidden="true">
               <InkeepSearchBar className="hidden" />
-              <NavLinks sectionNavData={sectionNavData} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The marketing header menu (Product, Resources, Customers, Docs, Changelog, Pricing) was centered in the leftover space *after* the hiring badge, so the badge pulled the whole menu off true center.

This keeps the 🐐 hiring badge in the same left slot, but lays the middle header out as `1fr / auto / 1fr` so the menu stays centered in the viewport. The badge then uses leftover space on the left:

- Full label (“Hiring in Europe and SF”) when there is room — hover: “Looking for GOATS!”
- Compact “Hiring” when the left gutter is tight — hover: “GOATS!”
- Hidden when even the compact label would collide with the menu

Headless measurements (offset of the Product–Pricing cluster from the viewport center):

- 1512 / 1440 / 1360: full badge, offset ~0px
- 1280 / 1200: compact “Hiring”, offset ~0px
- 1100 / 1024: badge hidden, offset ~0px
- Below `lg`: desktop mid-nav hides as before

Docs navbar is unchanged (search still sits in the middle; the badge is not competing with a centered menu).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05ba2-260b-75fc-9614-b7c452efad74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05ba2-260b-75fc-9614-b7c452efad74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR independently centers the marketing navigation by replacing its middle flex region with a symmetric three-column grid and makes the hiring badge responsive to its available gutter width.

- Adds full, compact, and hidden adaptive badge states using named container queries.
- Keeps the marketing navigation in the grid’s centered auto-width column.
- Preserves the separate docs navbar implementation.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The compact adaptive hiring badge should be fixed before merging because its hover message is visibly truncated at intermediate navbar widths.

The new compact state determines badge width from “Hiring,” while the longer absolute hover message is constrained by the same overflow-hidden link.

**Files Needing Attention:** components/HiringBadge.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/HiringBadge.tsx:142-149
**Compact badge clips hover label**

When the adaptive container is between 6.5rem and 13rem wide, the badge sizes itself from the compact “Hiring” label while the longer absolute hover label remains inside an `overflow-hidden` link, causing “Looking for GOATS!” to be visibly truncated.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Center the marketing nav independently o..."](https://github.com/langfuse/langfuse-docs/commit/38b90fcd492336a7428ca7c64838d15262e72e82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58945104)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->