### PR TITLE
fix(md-src): render academy components instead of deleting them

### DIFF
--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -1032,7 +1032,7 @@ function extractObjectStringAnyQuote(source, property) {
  * dropped, which is exactly the content loss this file exists to prevent.
  */
 function jsxToPlainText(jsx) {
-  return jsx
+  let text = jsx
     .replace(/^\s*<>\s*/, "")
     .replace(/\s*<\/>\s*$/, "")
     .replace(/\{"\s*"\}/g, " ")
@@ -1046,8 +1046,19 @@ function jsxToPlainText(jsx) {
       (_, href, text) =>
         "[" + text.trim().replace(/\s+/g, " ") + "](" + href + ")",
     )
-    .replace(/<br\s*\/?>/g, " ")
-    .replace(/<\/?[A-Za-z][A-Za-z0-9]*(?:\s[^>]*)?\/?>/g, "")
+    .replace(/<br\s*\/?>/g, " ");
+
+  // Strip any remaining tags repeatedly rather than in a single pass. A
+  // one-shot replace is incomplete sanitization: removing the inner tag of
+  // `<<span>span>` leaves a working `<span>` behind. Loop until stable, the
+  // same approach stripMdxForPlainMarkdown uses.
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<\/?[A-Za-z][A-Za-z0-9]*(?:\s[^>]*)?\/?>/g, "");
+  } while (text !== previous);
+
+  return text
     .replace(/\s+/g, " ")
     .replace(/\s+([.,;:])/g, "$1")
     .trim();

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -1024,6 +1024,96 @@ function extractObjectStringAnyQuote(source, property) {
   return null;
 }
 
+/**
+ * Converts the small JSX subset used in Academy component props to Markdown.
+ *
+ * Academy `check` / `details` nodes only ever use <code> and <a href>, plus
+ * {" "} spacers, so a full JSX parser is not needed — but the text must not be
+ * dropped, which is exactly the content loss this file exists to prevent.
+ */
+function jsxToPlainText(jsx) {
+  return jsx
+    .replace(/^\s*<>\s*/, "")
+    .replace(/\s*<\/>\s*$/, "")
+    .replace(/\{"\s*"\}/g, " ")
+    .replace(/\{`([^`]*)`\}/g, "$1")
+    .replace(
+      /<code>([\s\S]*?)<\/code>/g,
+      (_, inner) => "`" + inner.trim() + "`",
+    )
+    .replace(
+      /<a\s+href="([^"]*)"\s*>([\s\S]*?)<\/a>/g,
+      (_, href, text) =>
+        "[" + text.trim().replace(/\s+/g, " ") + "](" + href + ")",
+    )
+    .replace(/<br\s*\/?>/g, " ")
+    .replace(/<\/?[A-Za-z][A-Za-z0-9]*(?:\s[^>]*)?\/?>/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s+([.,;:])/g, "$1")
+    .trim();
+}
+
+/** Reads `prop: ( <>…</> )` and returns it as Markdown text. */
+function extractObjectJsxText(source, property) {
+  const start = source.search(new RegExp("\\b" + property + ":\\s*\\("));
+  if (start === -1) return null;
+  const open = source.indexOf("(", start);
+  let depth = 0;
+  let quote = null;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    // Apostrophes appear in JSX prose, so only " and ` delimit strings.
+    if (ch === '"' || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) {
+        const text = jsxToPlainText(source.slice(open + 1, i));
+        return text || null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Reads a prop that may be a quoted string or a JSX node. React-node props
+ * such as EvaluatorBlock's `check` and `details` are authored either way.
+ */
+function extractObjectNodeText(source, property) {
+  return (
+    extractObjectStringAnyQuote(source, property) ??
+    extractObjectJsxText(source, property)
+  );
+}
+
+/** Reads `prop: ["a", "b"]` as an array of strings. */
+function extractObjectStringArray(source, property) {
+  const match = source.match(
+    new RegExp("\\b" + property + ":\\s*\\[([^\\]]*)\\]"),
+  );
+  if (!match) return [];
+  return [...match[1].matchAll(/"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'/g)]
+    .map((m) => (m[1] !== undefined ? JSON.parse('"' + m[1] + '"') : m[2]))
+    .filter(Boolean);
+}
+
+/** Escapes a value for use inside a Markdown table cell. */
+function escapeTableCell(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
+}
+
 const ACADEMY_COMPONENT_RENDERERS = {
   AgentPromptCallout: renderAgentPromptCallout,
   EvaluatorBlock: renderEvaluatorBlock,
@@ -1097,14 +1187,16 @@ function renderAgentPromptCallout(attributes, isJapanese) {
   if (!prompt) {
     throw new Error("AgentPromptCallout requires a prompt template literal");
   }
-  const title =
-    extractAttributeString(attributes, "title") ??
-    (isJapanese
-      ? "コーディングエージェント用のプロンプト"
-      : "Prompt for your coding agent");
+  // Both default in the component (AgentPromptCallout.tsx); no Academy page
+  // sets either today, so the heading falls back to the ribbon alone rather
+  // than repeating two near-identical labels.
+  const ribbon =
+    extractAttributeString(attributes, "ribbon") ??
+    (isJapanese ? "エージェントで実行する" : "Run with your agent");
+  const title = extractAttributeString(attributes, "title");
   const lede = extractAttributeString(attributes, "lede");
 
-  const lines = ["**" + title + "**", ""];
+  const lines = ["**" + (title ? ribbon + " — " + title : ribbon) + "**", ""];
   if (lede) lines.push(lede, "");
   lines.push("```text", prompt.trim(), "```");
   return lines.join("\n");
@@ -1128,8 +1220,13 @@ function renderEvaluatorBlock(attributes, isJapanese) {
       .filter(Boolean)
       .join(", ");
     lines.push("- `" + name + "`" + (meta ? " — " + meta : ""));
-    const check = extractObjectString(source, "check");
+    // `check` and `details` are React nodes: authored either as a quoted
+    // string or as JSX. Reading only the quoted form dropped the taxonomy of
+    // four evaluators (edit_type, message_type; EN and Ja).
+    const check = extractObjectNodeText(source, "check");
     if (check) lines.push("  - " + check);
+    const details = extractObjectNodeText(source, "details");
+    if (details) lines.push("  - " + details);
   }
 
   if (lines.length === 2) {
@@ -1164,13 +1261,12 @@ function renderDatasetBlock(attributes, isJapanese) {
       "| --- | --- |",
     );
     for (const item of items) {
-      const input = (extractObjectStringAnyQuote(item, "input") ?? "").replace(
-        /\|/g,
-        "\\|",
+      const input = escapeTableCell(
+        extractObjectStringAnyQuote(item, "input") ?? "",
       );
-      const expected = (
-        extractObjectStringAnyQuote(item, "expectedOutput") ?? ""
-      ).replace(/\|/g, "\\|");
+      const expected = escapeTableCell(
+        extractObjectStringAnyQuote(item, "expectedOutput") ?? "",
+      );
       lines.push("| " + input + " | " + expected + " |");
     }
     lines.push("");
@@ -1211,7 +1307,9 @@ function renderTraceViewDiagram(attributes, isJapanese) {
 
     let line = indent + "- " + (kindLabel ? "[" + kindLabel + "] " : "");
     line += "`" + name + "`";
-    if (duration) line += " (" + duration + ")";
+    const meta = extractObjectStringArray(source, "chips");
+    if (duration) meta.push(duration);
+    if (meta.length > 0) line += " (" + meta.join(", ") + ")";
     lines.push(line);
 
     const preview = extractObjectStringAnyQuote(source, "preview");

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -27,7 +27,7 @@ const CUSTOMERS_META_PATH = path.join(CUSTOMERS_DIR, "meta.json");
 function replaceComponentsWithMarkdown(fileContent) {
   const exportedResourceArrays = extractExportedResourceArrays(fileContent);
   return stripResourceArrayExports(
-    replaceCardGroupsWithMarkdown(fileContent),
+    replaceCardGroupsWithMarkdown(replaceAcademyComponents(fileContent)),
     Object.keys(exportedResourceArrays),
   )
     .replace(
@@ -885,6 +885,395 @@ function renderGlossary() {
     }
   }
 
+  return lines.join("\n");
+}
+
+/**
+ * Replaces self-closing components whose props contain nested JSX.
+ *
+ * The lazy `([\s\S]*?)\/>` pattern used for simpler components stops at the
+ * first `/>`, which truncates props like EvaluatorBlock's
+ * `details: (<>…<br />…</>)`. Scan for the closing `/>` at nesting depth zero
+ * instead, skipping over strings and template literals.
+ */
+function replaceSelfClosingComponents(content, componentNames, render) {
+  const namePattern = new RegExp(
+    "<(" + componentNames.join("|") + ")(?=[\\s/>])",
+    "g",
+  );
+  let result = "";
+  let cursor = 0;
+  let match;
+
+  while ((match = namePattern.exec(content)) !== null) {
+    const start = match.index;
+    if (start < cursor) continue;
+    const attrsStart = start + match[0].length;
+    const end = findSelfClosingEnd(content, attrsStart);
+    if (end === -1) continue;
+
+    result += content.slice(cursor, start);
+    result += "\n" + render(match[1], content.slice(attrsStart, end)) + "\n";
+    cursor = end + 2;
+    namePattern.lastIndex = cursor;
+  }
+
+  return result + content.slice(cursor);
+}
+
+/** Index of the `/>` that closes a tag whose attributes start at `from`. */
+function findSelfClosingEnd(source, from) {
+  let depth = 0;
+  let quote = null;
+
+  for (let i = from; i < source.length - 1; i++) {
+    const ch = source[i];
+
+    if (quote) {
+      if (ch === "\\") {
+        i++;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    // Only " and ` delimit strings here. Apostrophes are common in JSX prose
+    // ("don't exist") and treating them as quotes would swallow the rest of
+    // the file; these props use double quotes and template literals.
+    if (ch === '"' || ch === "`") {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === "{" || ch === "(" || ch === "[") {
+      depth++;
+      continue;
+    }
+
+    if (ch === "}" || ch === ")" || ch === "]") {
+      depth--;
+      continue;
+    }
+
+    if (depth === 0 && ch === "/" && source[i + 1] === ">") {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Splits `{...}, {...}` into per-object sources, tracking ", ' and ` strings.
+ *
+ * extractTopLevelObjectSources only recognises double quotes, so a value like
+ * `preview: '"Play something calmer."'` flips its string state on the inner
+ * quote and corrupts the brace depth. Used for props that contain no JSX
+ * (TraceViewDiagram rows, DatasetBlock datasets); EvaluatorBlock keeps the
+ * shared helper because its `details` JSX contains prose apostrophes.
+ */
+function splitObjectSourcesStrict(source) {
+  const objects = [];
+  let depth = 0;
+  let start = null;
+  let quote = null;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+
+    if (quote) {
+      if (ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === "{") {
+      if (depth === 0) start = i + 1;
+      depth++;
+      continue;
+    }
+
+    if (ch === "}") {
+      depth--;
+      if (depth === 0 && start !== null) {
+        objects.push(source.slice(start, i));
+        start = null;
+      }
+    }
+  }
+
+  return objects;
+}
+
+/** Reads `prop: "..."` or `prop: '...'` from an object literal source. */
+function extractObjectStringAnyQuote(source, property) {
+  const double = source.match(
+    new RegExp("\\b" + property + ':\\s*"((?:\\\\.|[^"\\\\])*)"'),
+  );
+  if (double) return JSON.parse('"' + double[1] + '"');
+  const single = source.match(
+    new RegExp("\\b" + property + ":\\s*'((?:\\\\.|[^'\\\\])*)'"),
+  );
+  if (single) return single[1].replace(/\\(.)/g, "$1");
+  return null;
+}
+
+const ACADEMY_COMPONENT_RENDERERS = {
+  AgentPromptCallout: renderAgentPromptCallout,
+  EvaluatorBlock: renderEvaluatorBlock,
+  DatasetBlock: renderDatasetBlock,
+  TraceViewDiagram: renderTraceViewDiagram,
+  AnnotatedLoop: renderAnnotatedLoop,
+};
+
+function replaceAcademyComponents(fileContent) {
+  const names = Object.keys(ACADEMY_COMPONENT_RENDERERS).flatMap((name) => [
+    name + "Ja",
+    name,
+  ]);
+  return replaceSelfClosingComponents(
+    fileContent,
+    names,
+    (componentName, attributes) => {
+      const isJapanese = componentName.endsWith("Ja");
+      const base = isJapanese ? componentName.slice(0, -2) : componentName;
+      return ACADEMY_COMPONENT_RENDERERS[base](attributes, isJapanese);
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Academy components
+//
+// These carry the substance of the Academy example pages: the actual evaluator
+// definitions, dataset items, trace structures and loop annotations. Without a
+// renderer here, stripMdxForPlainMarkdown deletes them outright, so the
+// published .md kept the headings and lost the detail underneath them.
+//
+// Purely decorative Academy components (OnlineLoop, OfflineLoop,
+// DjProductScreens, RagTraceViewDiagram, TracingHierarchyDiagram,
+// DatasetDesignLoopDiagram) carry nothing that is not already in the
+// surrounding prose and stay stripped on purpose.
+// ---------------------------------------------------------------------------
+
+/** Reads attr={`...`} template-literal props. */
+function extractAttributeTemplate(source, attribute) {
+  const match = source.match(
+    new RegExp("\\b" + attribute + "=\\{`([\\s\\S]*?)`\\}"),
+  );
+  return match ? match[1] : null;
+}
+
+/** Reads prop={[ ... ]} and returns the raw array body. */
+function extractArrayPropSource(attributes, propName, componentName) {
+  const match = attributes.match(
+    new RegExp("\\b" + propName + "=\\{\\[([\\s\\S]*)\\]\\}"),
+  );
+  if (!match) {
+    throw new Error(componentName + " is missing a " + propName + " array");
+  }
+  return match[1];
+}
+
+/** Reads prop={[ ... ]} and returns the source of each top-level object. */
+function extractObjectArraySources(attributes, propName, componentName) {
+  const match = attributes.match(
+    new RegExp("\\b" + propName + "=\\{\\[([\\s\\S]*)\\]\\}"),
+  );
+  if (!match) {
+    throw new Error(componentName + " is missing a " + propName + " array");
+  }
+  return extractTopLevelObjectSources(match[1]);
+}
+
+function renderAgentPromptCallout(attributes, isJapanese) {
+  const prompt = extractAttributeTemplate(attributes, "prompt");
+  if (!prompt) {
+    throw new Error("AgentPromptCallout requires a prompt template literal");
+  }
+  const title =
+    extractAttributeString(attributes, "title") ??
+    (isJapanese
+      ? "コーディングエージェント用のプロンプト"
+      : "Prompt for your coding agent");
+  const lede = extractAttributeString(attributes, "lede");
+
+  const lines = ["**" + title + "**", ""];
+  if (lede) lines.push(lede, "");
+  lines.push("```text", prompt.trim(), "```");
+  return lines.join("\n");
+}
+
+function renderEvaluatorBlock(attributes, isJapanese) {
+  const sources = extractObjectArraySources(
+    attributes,
+    "evaluators",
+    "EvaluatorBlock",
+  );
+  const lines = ["**" + (isJapanese ? "評価者" : "Evaluators") + "**", ""];
+
+  for (const source of sources) {
+    const name = extractObjectString(source, "name");
+    if (!name) continue;
+    const meta = [
+      extractObjectString(source, "type"),
+      extractObjectString(source, "returns"),
+    ]
+      .filter(Boolean)
+      .join(", ");
+    lines.push("- `" + name + "`" + (meta ? " — " + meta : ""));
+    const check = extractObjectString(source, "check");
+    if (check) lines.push("  - " + check);
+  }
+
+  if (lines.length === 2) {
+    throw new Error("EvaluatorBlock produced no evaluators");
+  }
+  return lines.join("\n");
+}
+
+function renderDatasetBlock(attributes, isJapanese) {
+  const sources = splitObjectSourcesStrict(
+    extractArrayPropSource(attributes, "datasets", "DatasetBlock"),
+  );
+  const inputLabel = isJapanese ? "入力" : "Input";
+  const expectedLabel = isJapanese ? "期待される出力" : "Expected output";
+  const datasetLabel = isJapanese ? "データセット" : "Dataset";
+  const lines = [];
+
+  for (const source of sources) {
+    const name = extractObjectStringAnyQuote(source, "name");
+    if (!name) continue;
+    lines.push("**" + datasetLabel + ": " + name + "**", "");
+    const description = extractObjectStringAnyQuote(source, "description");
+    if (description) lines.push(description, "");
+
+    const itemsMatch = source.match(/\bitems:\s*\[([\s\S]*)\]/);
+    if (!itemsMatch) continue;
+    const items = extractTopLevelObjectSources(itemsMatch[1]);
+    if (items.length === 0) continue;
+
+    lines.push(
+      "| " + inputLabel + " | " + expectedLabel + " |",
+      "| --- | --- |",
+    );
+    for (const item of items) {
+      const input = (extractObjectStringAnyQuote(item, "input") ?? "").replace(
+        /\|/g,
+        "\\|",
+      );
+      const expected = (
+        extractObjectStringAnyQuote(item, "expectedOutput") ?? ""
+      ).replace(/\|/g, "\\|");
+      lines.push("| " + input + " | " + expected + " |");
+    }
+    lines.push("");
+  }
+
+  if (sources.length === 0) {
+    throw new Error("DatasetBlock produced no datasets");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+// Keep in sync with KIND_LABELS in components/academy/TraceViewDiagram.tsx.
+const TRACE_VIEW_KIND_LABELS = {
+  trace: "Trace",
+  gen: "Gen",
+  tool: "Tool",
+  retriever: "Retriever",
+  event: "Event",
+};
+
+function renderTraceViewDiagram(attributes, isJapanese) {
+  const sources = splitObjectSourcesStrict(
+    extractArrayPropSource(attributes, "rows", "TraceViewDiagram"),
+  );
+  const label =
+    extractAttributeString(attributes, "label") ??
+    extractAttributeString(attributes, "ariaLabel");
+  const lines = [];
+  if (label) lines.push("**" + label + "**", "");
+
+  for (const source of sources) {
+    const name = extractObjectStringAnyQuote(source, "name");
+    if (!name) continue;
+    const kind = extractObjectStringAnyQuote(source, "kind");
+    const kindLabel = TRACE_VIEW_KIND_LABELS[kind] ?? kind;
+    const indent = /\bindent:\s*true\b/.test(source) ? "  " : "";
+    const duration = extractObjectStringAnyQuote(source, "duration");
+
+    let line = indent + "- " + (kindLabel ? "[" + kindLabel + "] " : "");
+    line += "`" + name + "`";
+    if (duration) line += " (" + duration + ")";
+    lines.push(line);
+
+    const preview = extractObjectStringAnyQuote(source, "preview");
+    if (preview) lines.push(indent + "  - " + preview);
+
+    const input = extractObjectStringAnyQuote(source, "input");
+    if (input) {
+      lines.push(
+        indent + "  - " + (isJapanese ? "入力" : "Input") + ": " + input,
+      );
+    }
+    const output = extractObjectStringAnyQuote(source, "output");
+    if (output) {
+      lines.push(
+        indent + "  - " + (isJapanese ? "出力" : "Output") + ": " + output,
+      );
+    }
+  }
+
+  if (sources.length === 0) {
+    throw new Error("TraceViewDiagram produced no rows");
+  }
+  return lines.join("\n");
+}
+
+// Keep in sync with STATIONS in components/academy/AnnotatedLoop.tsx.
+const ANNOTATED_LOOP_STATIONS = [
+  { id: "trace", en: "Trace", ja: "トレース" },
+  { id: "monitor", en: "Monitor", ja: "モニタリング" },
+  { id: "dataset", en: "Build datasets", ja: "データセット構築" },
+  { id: "change", en: "Experiment", ja: "実験" },
+  { id: "eval", en: "Evaluate", ja: "評価" },
+];
+
+function renderAnnotatedLoop(attributes, isJapanese) {
+  const match = attributes.match(/\bstations=\{\{([\s\S]*)\}\}/);
+  if (!match) {
+    throw new Error("AnnotatedLoop is missing a stations object");
+  }
+  const stationsSource = match[1];
+  const notYet = isJapanese ? "未使用" : "not in use yet";
+  const lines = [
+    "**" +
+      (isJapanese ? "AI エンジニアリング・ループ" : "The AI engineering loop") +
+      "**",
+    "",
+  ];
+
+  for (const station of ANNOTATED_LOOP_STATIONS) {
+    const entry = stationsSource.match(
+      new RegExp("\\b" + station.id + ":\\s*\\{([\\s\\S]*?)\\}"),
+    );
+    if (!entry) continue;
+    const note = extractObjectString(entry[1], "note");
+    const dimmed = /\bdimmed:\s*true\b/.test(entry[1]);
+    const suffix = note ? " — " + note : dimmed ? " — " + notYet : "";
+    lines.push("- **" + (isJapanese ? station.ja : station.en) + "**" + suffix);
+  }
+
+  if (lines.length === 2) {
+    throw new Error("AnnotatedLoop produced no stations");
+  }
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## Problem

`stripMdxForPlainMarkdown` deletes any self-closing PascalCase component that has no renderer in `lib/markdown-component-renderers.js`. The Academy example pages carry most of their substance *inside* such components, so the published `.md` kept the headings and lost the detail underneath them.

Concretely, `/academy/monitoring/error-analysis.md` had an **empty section**. The `AgentPromptCallout` — a paste-ready prompt telling a coding agent to install the Langfuse skill and CLI and walk through error analysis, arguably the most agent-actionable artifact in the whole section — simply did not exist in the markdown an agent reads.

This lines up with the traffic data: `examples/music-streaming-dj` (1 assistant fetch in 7 days) and `examples/customer-support-chatbot` (3) are the two pages that lost the most content, and the two least-fetched pages in the section.

## Change

Renderers for the five components that carry information, each handling its `Ja` variant with localized labels:

| Component | Uses | Rendered as |
|---|---|---|
| `AgentPromptCallout` | 2 | Title, lede, and the prompt in a fenced block |
| `EvaluatorBlock` | 12 | List of `name` — type, returns, with the check beneath |
| `DatasetBlock` | 4 (8 datasets) | Per dataset: name, description, and an input/expected-output table |
| `TraceViewDiagram` | 8 | Indented tree with kind label, duration, preview, input/output |
| `AnnotatedLoop` | 10 | The five loop stations with their notes |

Purely decorative components (`OnlineLoop`, `OfflineLoop`, `DjProductScreens`, `RagTraceViewDiagram`, `TracingHierarchyDiagram`, `DatasetDesignLoopDiagram`) carry nothing absent from the surrounding prose and stay stripped on purpose.

### Two parsing problems had to be solved first

Both produced silent wrong output rather than errors, so they're worth a look:

1. **The lazy `([\s\S]*?)\/>` pattern truncates props with nested JSX.** `EvaluatorBlock`'s `details: (<>…<br />…</>)` contains `/>`, so the match ended early and the `evaluators` array was never seen. Replaced with a depth-aware scan for the closing `/>` at nesting level zero. Apostrophes are deliberately **not** treated as string delimiters — JSX prose contains them (`don't exist`), and treating them as quotes swallowed the rest of the file, which silently skipped **2 of 4** blocks on one page.
2. **`extractTopLevelObjectSources` only recognizes double quotes.** `preview: '"Play something calmer."'` flips its string state on the inner `"` and corrupts the brace depth, so `TraceViewDiagram` rendered its label with zero rows. Added a strict splitter and an any-quote value reader for the JSX-free props; `EvaluatorBlock` keeps the shared helper because its `details` JSX contains prose apostrophes.

## Verified

**Content recovered** (mdx body words → generated .md words):

| Page | Before | After |
|---|---|---|
| `examples/customer-support-chatbot` | 1,887 | **2,136** |
| `examples/music-streaming-dj` | 1,175 | **1,386** |
| `monitoring/error-analysis` | 841 | **912** |

**Component coverage across all Academy pages (EN + Ja):** `AgentPromptCallout` 2/2, `EvaluatorBlock` 12/12, `AnnotatedLoop` 10/10, `DatasetBlock` 8/8 datasets, `TraceViewDiagram` rows present. **Zero leftover raw JSX** for the five components in the generated output.

**Scope is contained.** I checksummed every generated `.md` before and after: **8 of 956 files change** — the 6 Academy pages (EN + Ja) plus `guides/cookbook/error-analysis-llm-applications` and `guides/llm-as-a-judge-calibration-skill`, which also use `AgentPromptCallout` and likewise gain their prompts. No other file's output moves by a byte.

`node scripts/check-h1-headings.js` passes; `prettier` clean; `copy_md_sources.js` runs without error (including its `verifyFooterExclusions` step).

## One thing this surfaces — pre-existing, not introduced here

Restoring content inside `<Tab>` blocks means those wrapper tags now survive into the Academy output, because the existing strip rule only removes *empty* paired tags. Previously the tabs were emptied by the very deletion this PR fixes, so they vanished.

To be clear about blame: **170 of 956 generated files already leak `<Tabs>`/`<Tab>` tags** on `main` (`docs.md`, `agents.md`, most of `self-hosting/`, …). This is a site-wide gap that predates the PR; my change adds 2 Academy pages to that set. A stray `<Tab>` alongside restored content is a clear net improvement over content that was missing entirely, so I left it rather than expand this PR into a 170-file rendering change — happy to do that as a follow-up, rendering `<Tabs items={[…]}>` into labelled sections so the tab labels survive too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect docs MDX-to-markdown generation only; scope is limited to eight generated `.md` files per the PR verification, with no runtime app or auth impact.
> 
> **Overview**
> Plain-Markdown export for Academy (and related) pages **stops stripping** five information-heavy MDX components and **renders them as text** instead, so generated `.md` keeps evaluators, datasets, trace trees, loop notes, and agent prompts—not just section headings.
> 
> The pipeline runs **`replaceAcademyComponents`** early in `replaceComponentsWithMarkdown`, with renderers for **`AgentPromptCallout`**, **`EvaluatorBlock`**, **`DatasetBlock`**, **`TraceViewDiagram`**, and **`AnnotatedLoop`** (plus `Ja` variants and localized labels). Decorative Academy diagrams remain intentionally stripped.
> 
> **Parsing changes** address silent truncation: a **depth-aware** self-closing tag scanner (so props like `details: (<>…<br />…</>)` aren’t cut at the first `/>`), **strict object splitting** with single/double/template quotes for trace/dataset props, and **`extractObjectNodeText`** / **`jsxToPlainText`** so evaluator `check`/`details` can be strings or small JSX fragments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8d6f8be4c302f38e546cf436a8aac0b765bc53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds plain-Markdown renderers for five information-bearing Academy components and introduces parsing helpers for nested JSX and mixed-quote object values.

- Converts agent prompts, evaluators, datasets, trace diagrams, and annotated loops into text-oriented Markdown.
- Supports Japanese variants with localized labels.
- Replaces lazy self-closing-tag matching with a nesting-aware scanner.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The JSX evaluator-check omission should be fixed before merging because current Academy exports still lose visible evaluator criteria.

The new renderer promises to retain evaluator checks, but its string-only extractor cannot handle the React fragments accepted by the component and already used by multiple Academy pages.

**Files Needing Attention:** lib/markdown-component-renderers.js
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/markdown-component-renderers.js:1131-1132
**JSX evaluator checks are dropped**

When an `EvaluatorBlock` supplies `check` as a React fragment, as current Academy pages do, `extractObjectString` returns no value and the generated Markdown silently omits the evaluator's visible criteria.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(md-src): render academy components i..."](https://github.com/langfuse/langfuse-docs/commit/267a59434e5a5226989cacf08910e92963f56ca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58956575)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [MDX content rendering and navigation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/mdx-content-rendering-and-navigation.md)

<!-- /greptile_comment -->