### PR TITLE
Add self-hosted API reference changelog

### DIFF
--- a/content/changelog/2026-09-01-self-hosted-api-reference.mdx
+++ b/content/changelog/2026-09-01-self-hosted-api-reference.mdx
@@ -1,0 +1,20 @@
+---
+date: 2026-09-01
+title: Built-in interactive API reference for self-hosted deployments
+description: Explore and test the API directly from your Langfuse deployment, including air-gapped installations.
+author: Tobias Wochinger
+---
+
+import { ChangelogHeader } from "@/components/changelog/ChangelogHeader";
+
+<ChangelogHeader />
+
+Self-hosted Langfuse deployments now include an interactive API reference at `/api/docs`. It renders the OpenAPI specification bundled with your running deployment, so it also works in air-gapped environments.
+
+You can use it to:
+
+- **Explore available endpoints** without switching to an external API reference.
+- **Test requests against your deployment** directly from the browser.
+- **Generate clients and validate integrations** using the OpenAPI YAML at `/api/openapi.yaml`.
+
+The existing `/generated/api/openapi.yml` endpoint remains available.


### PR DESCRIPTION
Adds a short changelog entry for the built-in API reference in self-hosted deployments.

- Covers `/api/docs` and `/api/openapi.yaml`
- Calls out support for air-gapped deployments
- Links the change to [langfuse/langfuse#16845](https://github.com/langfuse/langfuse/pull/16845)

## Checks

- `pnpm run format`
- `node scripts/check-h1-headings.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure changes.
> 
> **Overview**
> Adds a **2026-09-01 changelog post** announcing built-in interactive API docs for self-hosted Langfuse.
> 
> The entry describes **`/api/docs`** (OpenAPI UI from the running deployment, including air-gapped installs), **`/api/openapi.yaml`** for client generation and integration checks, and notes that **`/generated/api/openapi.yml`** stays available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69951b6155ca933837d8ed3fb931b810d38bf9fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a changelog entry announcing the built-in API reference for self-hosted and air-gapped deployments.

- Documents the interactive reference at `/api/docs`.
- Documents the OpenAPI specification at `/api/openapi.yaml`.
- Notes continued availability of `/generated/api/openapi.yml`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The changelog entry satisfies the repository’s metadata and rendering contracts, and no concrete incorrect or broken behavior was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add self-hosted API reference chan..."](https://github.com/langfuse/langfuse-docs/commit/5a4f981b12919b45ab18bded7e8b7af4c8f18d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58968680)</sub>

<!-- /greptile_comment -->