### PR TITLE
docs(glossary): add Langfuse CLI and Instance Switcher entries

### DIFF
--- a/lib/glossary-data.js
+++ b/lib/glossary-data.js
@@ -58,7 +58,7 @@ const TERMS = [
       "Ways for AI agents to work with Langfuse data and workflows programmatically, via the Langfuse Agent Skill, CLI, or MCP server, across observability, evaluation, and prompt management.",
     link: "/docs/observability/features/agentic-access",
     categories: ["PLATFORM"],
-    relatedTerms: ["MCP Server", "Public API", "SDK"],
+    relatedTerms: ["MCP Server", "Public API", "SDK", "Langfuse CLI"],
   },
   {
     term: "Annotation Queue",
@@ -250,6 +250,15 @@ const TERMS = [
     synonyms: ["Observation Type"],
   },
   {
+    term: "Instance Switcher",
+    id: "instance-switcher",
+    definition:
+      "A self-hosted Enterprise Edition feature that lists your Langfuse deployments (e.g. development, staging, production) in the sidebar user menu so you can switch between them without keeping URLs elsewhere. Mirrors the region switcher on Langfuse Cloud.",
+    link: "/self-hosting/administration/ui-customization#instance-switcher",
+    categories: ["PLATFORM"],
+    relatedTerms: ["Organization", "Project"],
+  },
+  {
     term: "Instrumentation",
     id: "instrumentation",
     definition:
@@ -257,6 +266,15 @@ const TERMS = [
     link: "/docs/observability/sdk/instrumentation",
     categories: ["SDK", "OBSERVABILITY"],
     relatedTerms: ["SDK", "Trace", "Observation", "Flush"],
+  },
+  {
+    term: "Langfuse CLI",
+    id: "langfuse-cli",
+    definition:
+      "A command-line tool that wraps the Langfuse Public API, letting you manage prompts, evaluators, datasets, and other resources from the terminal or from AI coding agents. Supports pinning or auto-detecting a server's API version, so it works against self-hosted deployments running older releases.",
+    link: "/docs/api-and-data-platform/features/cli",
+    categories: ["API", "PLATFORM"],
+    relatedTerms: ["Public API", "MCP Server", "Agentic Access", "SDK"],
   },
   {
     term: "LLM Connection",
@@ -306,7 +324,7 @@ const TERMS = [
       "A Model Context Protocol server that enables AI-powered tools to interact with Langfuse data. Used for advanced integrations and AI-assisted workflows.",
     link: "/docs/api-and-data-platform/features/mcp-server",
     categories: ["PLATFORM"],
-    relatedTerms: ["Public API", "SDK"],
+    relatedTerms: ["Public API", "SDK", "Langfuse CLI"],
   },
   {
     term: "Metrics API",
@@ -434,7 +452,7 @@ const TERMS = [
       "The REST API that provides access to all Langfuse data and features. Used for custom integrations, workflows, and programmatic access.",
     link: "/docs/api-and-data-platform/features/public-api",
     categories: ["API"],
-    relatedTerms: ["SDK", "API Key", "MCP Server"],
+    relatedTerms: ["SDK", "API Key", "MCP Server", "Langfuse CLI"],
   },
   {
     term: "Pulse",


### PR DESCRIPTION
## Summary

- Adds a **Langfuse CLI** glossary entry. The CLI has its own docs page, blog post, and is cross-linked from the Agent Skill, MCP Server, and Custom Dashboards pages, but had no glossary entry despite sitting alongside SDK, MCP Server, and Public API — a gap that stood out again with this month's CLI 1.0 relaunch (`langfuse-cli-v1` changelog entry).
- Adds an **Instance Switcher** glossary entry for the self-hosted deployment switcher that shipped this month (`self-hosted-instance-switcher` changelog entry, `/self-hosting/administration/ui-customization#instance-switcher`).
- Cross-links the new Langfuse CLI entry from the existing `Agentic Access`, `MCP Server`, and `Public API` entries' `relatedTerms`.

## Context

Reviewed changelog entries and docs commits from the last month for new concepts that should be reflected in `/docs/glossary`. Most recent changelog items (deterministic evaluator sampling, evaluator template gallery, restored evaluator versions, stable evaluator API, bulk prompt import/export, responsive changelog timeline, self-hosted API reference) are feature-level additions to concepts already covered by existing glossary entries (`Rule`, `Evaluator`, `Prompt Management`, etc.) and didn't need new terms. The two additions here were the clearest gaps.

No inconsistent terminology was found for existing glossary terms in this month's changes (e.g. `Filter Search Bar`, `Pulse`, `Rule`/`Evaluator` naming all matches the glossary consistently in the pages that reference them).

## Test plan

- [x] `node -e "require('./lib/glossary-data.js')"` — data loads without errors, 62 terms total
- [x] `npx prettier --check lib/glossary-data.js` — passes
- [x] `node scripts/check-h1-headings.js` — passes
- [x] Verified `lib/markdown-component-renderers.js` renders the glossary from the same `TERMS` array, so the new entries automatically appear in the Markdown/PDF mirror of `/docs/glossary`


---
_Generated by [Claude Code](https://claude.ai/code/session_011wGoaQsTasSsyuiPZMbKzP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only glossary data; no runtime or API behavior changes.
> 
> **Overview**
> Expands **`lib/glossary-data.js`** with two new terms and tighter cross-links for programmatic access concepts.
> 
> **Langfuse CLI** is added as an API/Platform term (Public API wrapper for terminal and agent workflows, including version pinning for self-hosted). **Instance Switcher** documents the self-hosted Enterprise sidebar control for jumping between deployments, analogous to Cloud’s region switcher.
> 
> Existing entries **Agentic Access**, **MCP Server**, and **Public API** now list **Langfuse CLI** in `relatedTerms`, so the glossary graph matches how those features are documented elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872524f78413202663e7989015ba69c9bd7d95d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds glossary entries for the Langfuse CLI and self-hosted Instance Switcher.
- Cross-links the CLI from Agentic Access, MCP Server, and Public API.
- Provides links, categories, definitions, and related terms for both new concepts.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with valid glossary links, anchors, related terms, and descriptions.

The new entries conform to the glossary data shape, all referenced terms and documentation targets resolve, and the product claims are supported by repository documentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(glossary): add Langfuse CLI and Ins..."](https://github.com/langfuse/langfuse-docs/commit/872524f78413202663e7989015ba69c9bd7d95d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58974963)</sub>

<!-- /greptile_comment -->