### PR TITLE
Use Langfuse by ClickHouse logo on /cloud

### DIFF
--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -133,7 +133,7 @@ export default function CloudRegionSelectorPage() {
     >
       <div className="flex w-full max-w-[480px] flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-5">
-          <Logo />
+          <Logo variant="byClickHouse" />
           <Heading as="h1" size="normal" className="text-center">
             Select your region
           </Heading>

--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -133,11 +133,13 @@ export default function CloudRegionSelectorPage() {
     >
       <div className="flex w-full max-w-[480px] flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-5">
-          <Logo variant="byClickHouse" />
+          <div className="flex flex-col items-center gap-2">
+            <Logo variant="byClickHouse" />
+            <Text>Agent Observability and Evals</Text>
+          </div>
           <Heading as="h1" size="normal" className="text-center">
-            Select your region
+            Select a region
           </Heading>
-          <Text className="max-w-xs">Choose a cloud region to continue.</Text>
         </div>
 
         <CornerBox className="w-full">

--- a/app/cloud/layout.tsx
+++ b/app/cloud/layout.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Select Cloud Region",
-  description:
-    "Select the Langfuse Cloud region and continue to your destination.",
+  title: "Select a region",
+  description: "Select a Langfuse Cloud region to continue.",
 };
 
 export default function CloudLayout({

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -9,31 +9,56 @@ const ContextMenu = dynamic(() => import("./LogoContextMenu"), {
   ssr: false,
 });
 
+const WORDMARKS = {
+  langfuse: {
+    light: "/langfuse-wordart.svg",
+    dark: "/langfuse-wordart-white.svg",
+    alt: "Langfuse Logo",
+    width: 120,
+    height: 20,
+    className: "h-auto max-w-28 sm:max-w-none",
+  },
+  byClickHouse: {
+    light:
+      "/brand-assets/wordmark/Langfuse%20by%20ClickHouse/light/langfuse-by-clickhouse.svg",
+    dark: "/brand-assets/wordmark/Langfuse%20by%20ClickHouse/dark/langfuse-by-clickhouse-white.svg",
+    alt: "Langfuse by ClickHouse",
+    // Lockup is taller (includes "by ClickHouse"); size it as a page hero mark.
+    width: 220,
+    height: 59,
+    className: "h-auto max-w-[200px] sm:max-w-[220px]",
+  },
+} as const;
+
 export function Logo({
   wrapInLink = true,
   showAffiliation = false,
+  variant = "langfuse",
 }: {
   /** When false, render only the image block (use when already inside a link, e.g. NavbarLogo). */
   wrapInLink?: boolean;
   /** When true, show the "by ClickHouse" affiliation link next to the logo. */
   showAffiliation?: boolean;
+  /** Use the co-branded "Langfuse by ClickHouse" wordmark lockup. */
+  variant?: keyof typeof WORDMARKS;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const wordmark = WORDMARKS[variant];
   const images = (
     <div className="logo-images flex gap-2 items-center cursor-pointer shrink-0">
       <Image
-        src="/langfuse-wordart-white.svg"
-        alt="Langfuse Logo"
-        width={120}
-        height={20}
-        className="hidden h-auto dark:block max-w-28 sm:max-w-none"
+        src={wordmark.dark}
+        alt={wordmark.alt}
+        width={wordmark.width}
+        height={wordmark.height}
+        className={`hidden dark:block ${wordmark.className}`}
       />
       <Image
-        src="/langfuse-wordart.svg"
-        alt="Langfuse Logo"
-        width={120}
-        height={20}
-        className="block h-auto dark:hidden max-w-28 sm:max-w-none"
+        src={wordmark.light}
+        alt={wordmark.alt}
+        width={wordmark.width}
+        height={wordmark.height}
+        className={`block dark:hidden ${wordmark.className}`}
       />
       <style jsx>{`
       .logo-images {
@@ -91,7 +116,7 @@ export function Logo({
             {images}
           </div>
         )}
-        {showAffiliation && byClickHouse}
+        {showAffiliation && variant !== "byClickHouse" && byClickHouse}
       </div>
       {menuOpen && <ContextMenu open={menuOpen} setOpen={setMenuOpen} />}
     </>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -52,6 +52,7 @@ export function Logo({
         width={wordmark.width}
         height={wordmark.height}
         className={`hidden dark:block ${wordmark.className}`}
+        priority={variant === "byClickHouse"}
       />
       <Image
         src={wordmark.light}
@@ -59,6 +60,7 @@ export function Logo({
         width={wordmark.width}
         height={wordmark.height}
         className={`block dark:hidden ${wordmark.className}`}
+        priority={variant === "byClickHouse"}
       />
       <style jsx>{`
       .logo-images {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The cloud region picker at `/cloud` now uses the co-branded Langfuse by ClickHouse wordmark lockup instead of the plain Langfuse wordmark, with copy matching the region-picker design.

## Changes

- Add a `byClickHouse` variant to `Logo` that renders the official light/dark lockup assets.
- Use that variant on the `/cloud` region selector, sized as a page hero mark so the affiliation stays readable.
- Mark the lockup images as `priority` so they load eagerly as the page LCP.
- Replace “Select your region” / “Choose a cloud region to continue.” with the “Agent Observability and Evals” tagline and “Select a region” heading.

Navbar and docs logos are unchanged.

![Desktop /cloud page with Langfuse by ClickHouse logo, Agent Observability and Evals tagline, and Select a region heading](https://cursor.com/artifacts/c/art-2975a35e-d427-4bfe-98a1-62652a4ac5af)

<a href="https://cursor.com/agents/bc-98fa294a-e3db-4918-bc16-a6b01171b5c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloud_page_updated_copy.mp4"><img src="https://cursor.com/artifacts/c/art-d3789592-6de1-42d8-9caf-e938f758cfb6" alt="cloud_page_updated_copy.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98fa294a-e3db-4918-bc16-a6b01171b5c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98fa294a-e3db-4918-bc16-a6b01171b5c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a co-branded Langfuse by ClickHouse variant to the shared logo component and uses it as the hero mark on the cloud region selector.

- Centralizes logo asset metadata and sizing in a variant map.
- Selects theme-specific light and dark co-branded SVG assets.
- Prioritizes the new cloud-page logo images while leaving existing logo callers unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The new variant references existing static assets using an established URL form, preserves current logo defaults for existing callers, and changes only the intended cloud-page presentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["Prioritize the ClickHouse lockup as LCP ..."](https://github.com/langfuse/langfuse-docs/commit/b18e9406973a762fd29521cc7c7d26c0fb12b1fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59052243)</sub>

<!-- /greptile_comment -->