### PR TITLE
fix(seo): give /integrations a descriptive page title

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -30,6 +30,9 @@ export async function generateMetadata({
   const canonical = changelogPageHref(currentPage, totalPages) ?? "/changelog";
 
   return {
+    title: currentPage > 1 ? `Changelog (page ${currentPage})` : "Changelog",
+    description:
+      "Latest product updates from the Langfuse team: new features, improvements, and release notes.",
     alternates: {
       canonical,
     },

--- a/content/docs/evaluation/core-concepts.mdx
+++ b/content/docs/evaluation/core-concepts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Concepts
+seoTitle: LLM Evaluation Concepts
 description: Learn the fundamental concepts behind LLM evaluation in Langfuse - Scores, Evaluation Methods, Datasets, and Experiments.
 ---
 

--- a/content/docs/evaluation/scores/overview.mdx
+++ b/content/docs/evaluation/scores/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+seoTitle: LLM Evaluation Scores
 description: Scores are Langfuse's universal data object for storing evaluation results. Learn about score types, how to create scores, and when to use them.
 sidebarTitle: Overview
 ---

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+seoTitle: Open Source AI Engineering Platform
 description: Langfuse is an open-source AI engineering platform (GitHub) that helps teams collaboratively debug, analyze, and iterate on their AI agent applications. All platform features are natively integrated to accelerate the development workflow.
 ---
 

--- a/content/docs/metrics/overview.mdx
+++ b/content/docs/metrics/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+seoTitle: "LLM Metrics & Analytics"
 description: Improve your LLM application with open source metrics tracking latency, cost, and quality across various dimensions.
 ---
 

--- a/content/docs/observability/data-model.mdx
+++ b/content/docs/observability/data-model.mdx
@@ -1,5 +1,6 @@
 ---
 title: Concepts
+seoTitle: Observability Data Model
 description: Langfuse (open source) helps you trace and analyze LLM applications. Learn how traces and observations are structured in Langfuse.
 ---
 

--- a/content/docs/observability/get-started.mdx
+++ b/content/docs/observability/get-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Get Started
+seoTitle: Get Started with LLM Tracing
 description: Get started with LLM observability with Langfuse in minutes before diving into all platform features.
 ---
 

--- a/content/docs/observability/sdk/overview.mdx
+++ b/content/docs/observability/sdk/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+seoTitle: "Python & JS/TS Observability SDKs"
 description: Fully typed SDKs for Python and JavaScript/TypeScript with unified setup, instrumentation, and advanced guidance.
 category: SDKs
 ---

--- a/content/docs/prompt-management/data-model.mdx
+++ b/content/docs/prompt-management/data-model.mdx
@@ -1,6 +1,7 @@
 ---
 title: Concepts
 sidebarTitle: Concepts
+seoTitle: Prompt Management Concepts
 description: Core concepts of Langfuse Prompt Management including prompt types, versioning, labels, and configuration.
 ---
 

--- a/content/docs/prompt-management/get-started.mdx
+++ b/content/docs/prompt-management/get-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Get Started
 sidebarTitle: Get Started
+seoTitle: Get Started with Prompt Management
 description: Get started with Langfuse Prompt Management.
 ---
 

--- a/content/integrations/index.mdx
+++ b/content/integrations/index.mdx
@@ -1,12 +1,14 @@
 ---
-title: "Overview"
+title: Overview
+seoTitle: LLM Observability Integrations
 sidebarTitle: Overview
+description: Connect Langfuse with 100+ LLM providers, frameworks, and tools. Trace OpenAI, LangChain, LlamaIndex, Vercel AI SDK, and more via native SDKs or OpenTelemetry.
 ---
 
 import { IntegrationCategory } from "@/components/integrations/IntegrationIndex";
 import { AskAiLink } from "@/components/inkeep/AskAiLink";
 
-# Overview
+# Integrations
 
 Langfuse is designed to be the most open and flexible platform for LLM engineering that integrates with all the major LLM providers, frameworks, and tools.
 See a full list of integrations below.

--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Overview
 sidebarTitle: Overview
+seoTitle: "Security & Compliance"
 description: Overview of Langfuse's commitment to data privacy, security, and compliance, including links to detailed pages on specific measures and certifications.
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `/integrations` index used `title: Overview`, so the document title rendered as **Overview - Langfuse**.

This adds `seoTitle` (and a meta description where missing) so core landing pages no longer share generic titles. Sidebar labels stay the same.

| Page | `<title>` |
| --- | --- |
| `/integrations` | LLM Observability Integrations - Langfuse |
| `/docs` | Open Source AI Engineering Platform - Langfuse |
| `/docs/observability/get-started` | Get Started with LLM Tracing - Langfuse |
| `/docs/prompt-management/get-started` | Get Started with Prompt Management - Langfuse |
| `/docs/metrics` | LLM Metrics & Analytics - Langfuse |
| `/docs/observability/sdk/overview` | Python & JS/TS Observability SDKs - Langfuse |
| `/docs/evaluation/scores/overview` | LLM Evaluation Scores - Langfuse |
| `/docs/observability/data-model` | Observability Data Model - Langfuse |
| `/docs/evaluation/core-concepts` | LLM Evaluation Concepts - Langfuse |
| `/docs/prompt-management/data-model` | Prompt Management Concepts - Langfuse |
| `/security` | Security & Compliance - Langfuse |
| `/changelog` | Changelog - Langfuse |

On-page H1 for `/integrations` is now `Integrations` (sidebar stays `Overview`). Changelog page 2+ uses `Changelog (page N)`.

## Test plan

- [x] Confirm `/integrations` `<title>` and meta description
- [x] Confirm the other pages' `<title>` tags
- [x] Confirm sidebar labels are unchanged
- [x] Check desktop and mobile layout of `/integrations`
- [x] Spot-check `/docs` desktop and mobile

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07151235-4b90-459c-be8b-4dd687b7fbe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07151235-4b90-459c-be8b-4dd687b7fbe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the `/integrations` page with a descriptive SEO title and meta description while preserving its existing sidebar label.
- Changes the on-page H1 from “Overview” to “Integrations.”
- Sets the document title to “LLM Observability Integrations.”
- Adds a description summarizing supported providers, frameworks, SDKs, and OpenTelemetry.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The integrations schema accepts the added metadata, the metadata builder prioritizes `seoTitle` as intended, and `sidebarTitle` preserves the existing navigation label independently of the new H1.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seo): give /integrations a descripti..."](https://github.com/langfuse/langfuse-docs/commit/576636b1738581f7ddb25451002e86891eeee684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59060264)</sub>

<!-- /greptile_comment -->