### PR TITLE
Document the self-hosted API reference

### DIFF
--- a/content/changelog/2026-09-01-self-hosted-api-reference.mdx
+++ b/content/changelog/2026-09-01-self-hosted-api-reference.mdx
@@ -17,4 +17,4 @@ You can use it to:
 - **Test requests against your deployment** directly from the browser.
 - **Generate clients and validate integrations** using the OpenAPI YAML at `/api/openapi.yaml`.
 
-The existing `/generated/api/openapi.yml` endpoint remains available.
+The existing `/generated/api/openapi.yml` endpoint remains available. See the [self-hosting FAQ](/faq/all/self-hosting-api-reference) for details.

--- a/content/faq/all/self-hosting-api-reference.mdx
+++ b/content/faq/all/self-hosting-api-reference.mdx
@@ -1,0 +1,12 @@
+---
+title: Where can I find the API reference for self-hosted Langfuse?
+tags: [self-hosting, platform]
+---
+
+# Where can I find the API reference for self-hosted Langfuse?
+
+Open `/api/docs` on your Langfuse instance (for example, `https://langfuse.example.com/api/docs`) to explore and test the API. The reference uses the OpenAPI specification bundled with your running deployment, so it matches your installed version and works in air-gapped environments.
+
+To generate a client or validate an integration, download the specification from `/api/openapi.yaml`. The existing `/generated/api/openapi.yml` endpoint remains available.
+
+For authentication and examples, see the [Public API documentation](/docs/api-and-data-platform/features/public-api).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a concise self-hosting FAQ for the built-in API reference.

- Documents `/api/docs`, `/api/openapi.yaml`, and the existing OpenAPI endpoint
- Explains version matching and air-gapped availability
- Links the API reference changelog entry to the FAQ

## Checks

- `pnpm run format`
- `pnpm run format:check`
- `node scripts/check-h1-headings.js`
- Rendered FAQ and changelog link verified on the local site
- FAQ checked at desktop (`1280×800`) and mobile (`375×812`) viewports

## Walkthrough

<a href="https://cursor.com/agents/bc-01a05def-eab0-7a9b-8058-d86895ce93c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fself_hosted_api_reference_responsive.mp4"><img src="https://cursor.com/artifacts/c/art-a0f6891c-89af-445c-ab4f-c27111c8585b" alt="self_hosted_api_reference_responsive.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05def-eab0-7a9b-8058-d86895ce93c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05def-eab0-7a9b-8058-d86895ce93c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a self-hosting FAQ describing the deployment-local Public API reference and links the related changelog entry to it.

- Documents the interactive `/api/docs` route and downloadable OpenAPI endpoints.
- Explains deployment-version matching and air-gapped use.
- Directs readers to existing Public API authentication guidance.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new FAQ resolves at the linked route, uses valid frontmatter and existing tag-generation behavior, and no concrete broken link, build failure, or misleading reachable behavior was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document self-hosted API reference"](https://github.com/langfuse/langfuse-docs/commit/d583885947f1aaba0b0d318c2b742180e7c2a38d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59132412)</sub>

<!-- /greptile_comment -->