### PR TITLE
docs: add Morph inference tracing guide

### DIFF
--- a/content/integrations/model-providers/morph.mdx
+++ b/content/integrations/model-providers/morph.mdx
@@ -1,18 +1,78 @@
 ---
-title: Realtime Classification with Morph Reflex Evaluators
+title: Monitor Morph with Langfuse
 sidebarTitle: Morph
 logo: /images/integrations/morph_icon.svg
-description: Use Morph Reflex classifiers as LLM-as-a-judge evaluators in Langfuse to label your traces with a category in realtime.
+description: Trace Morph model calls and use Morph Reflex classifiers as LLM-as-a-judge evaluators in Langfuse.
 category: Integrations
 ---
 
-# Realtime Classification with Morph Reflex Evaluators
+# Monitor Morph with Langfuse
 
-This guide shows you how to use [Morph](https://morphllm.com) Reflex models as LLM-as-a-judge evaluators in Langfuse. Morph's API is OpenAI-compatible, so a Reflex plugs into Langfuse as a **categorical** evaluator — Langfuse runs it over each trace and attaches the predicted category as a score, with no extra inference code in your application.
+This guide shows you how to trace Morph model calls and use Morph Reflex models as LLM-as-a-judge evaluators in Langfuse. Morph's APIs are OpenAI-compatible, so you can use the Langfuse OpenAI integration for both workflows.
 
-> **What is Morph?** [Morph](https://morphllm.com) trains and serves Reflexes: small, fast classifier models for realtime classification of LLM inputs and outputs — for example jailbreak detection, guardrails, user frustration, or your own custom-trained categories.
+> **What is Morph?** [Morph](https://morphllm.com) serves open-weight language models through shared and [dedicated inference](https://www.morphllm.com/dedicated-inference) endpoints. Morph also trains and serves Reflexes: small, fast classifier models for realtime classification of LLM inputs and outputs, such as jailbreak detection, guardrails, user frustration, or your own custom-trained categories.
 
 > **What is Langfuse?** [Langfuse](https://langfuse.com) is an open source AI engineering platform that helps teams trace API calls, monitor performance, and debug issues in their LLM applications.
+
+## Trace Morph inference
+
+Morph exposes an OpenAI-compatible API at `https://api.morphllm.com/v1`. Use the Langfuse OpenAI drop-in replacement to capture prompts, responses, token usage, latency, and model metadata without changing the request format.
+
+### Install the dependencies
+
+```bash
+pip install openai langfuse
+```
+
+### Configure your credentials
+
+Create a Morph API key in the [Morph dashboard](https://morphllm.com/dashboard/api-keys), then set it alongside your Langfuse project keys:
+
+```bash
+export MORPH_API_KEY="sk-..."
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+export LANGFUSE_BASE_URL="https://cloud.langfuse.com"
+```
+
+### Call Morph through the traced client
+
+Replace the standard OpenAI import with `langfuse.openai`. The client keeps the OpenAI request and response types while automatically sending a generation trace to Langfuse.
+
+```python
+import os
+
+from langfuse.openai import openai
+
+client = openai.OpenAI(
+    api_key=os.environ["MORPH_API_KEY"],
+    base_url="https://api.morphllm.com/v1",
+)
+
+response = client.chat.completions.create(
+    model="morph-glm53flash",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain prefix caching in two sentences."},
+    ],
+    name="morph-inference",
+)
+
+print(response.choices[0].message.content)
+```
+
+Current recommended model IDs include `morph-kimik3`, `morph-glm53-744b`, `morph-glm53flash`, and `morph-dsv4flash`. To discover every model available to your key, call the OpenAI-compatible model listing:
+
+```python
+for model in client.models.list():
+    print(model.id)
+```
+
+The resulting generation appears in Langfuse with its input, output, token usage, latency, and model name. The same tracing setup works when your Morph account uses reserved dedicated capacity because the client interface remains OpenAI-compatible.
+
+## Use Morph Reflex evaluators
+
+Morph Reflexes plug into Langfuse as **categorical** evaluators. Langfuse runs a Reflex over each trace and attaches the predicted category as a score, with no extra inference code in your application.
 
 Since Reflexes are classifiers, they return exactly one category per evaluation (the top prediction) and no rationale — the returned reasoning is always `NA-Reflex`.
 


### PR DESCRIPTION
## Summary

Expand the existing Morph integration page beyond Reflex evaluators.

The guide now shows how to:

1. Trace Morph model calls with the Langfuse OpenAI wrapper
2. Configure the Morph endpoint and credentials
3. Discover models available to the current API key
4. Use the current Kimi, GLM, and DeepSeek model IDs
5. Learn about reserved dedicated inference capacity

The existing Reflex evaluator documentation remains intact.

## Validation

1. Verified authenticated model discovery against the live Morph API
2. Verified a live chat completion with `morph-glm53flash`
3. Ran Prettier and the H1 check
4. Generated and inspected the plain Markdown output
5. Ran the repository link check
6. Ran the production Next.js build and TypeScript checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `morph.mdx`; no application code, auth, or data paths.
> 
> **Overview**
> Reframes the Morph integration doc from a **Reflex-only** guide to **Monitor Morph with Langfuse**, covering both chat inference tracing and existing Reflex evaluator setup.
> 
> Adds a **Trace Morph inference** section: `pip install`, env vars for Morph and Langfuse, a `langfuse.openai` client pointed at `https://api.morphllm.com/v1`, sample chat completion, recommended model IDs, and `client.models.list()` for key-scoped discovery. Front matter and the Morph blurb now mention open-weight models and dedicated inference.
> 
> The Reflex LLM-as-a-judge walkthrough is unchanged in substance and moved under **Use Morph Reflex evaluators**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adec0beff45b544e08766077fce901e1fa938b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Expands the Morph integration guide from Reflex evaluators to inference tracing while preserving the existing evaluator documentation.

- Adds dependency and credential setup for the Langfuse OpenAI wrapper.
- Demonstrates traced Morph chat completions and authenticated model discovery.
- Documents current model identifiers and dedicated inference compatibility.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The tracing example follows the repository’s established Langfuse OpenAI wrapper pattern, and no concrete broken setup, API contract, or security issue remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Morph inference tracing guide"](https://github.com/langfuse/langfuse-docs/commit/adec0beff45b544e08766077fce901e1fa938b73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59307118)</sub>

<!-- /greptile_comment -->