### PR TITLE
Drop redundant step prefixes from ElevenLabs cookbook

### DIFF
--- a/content/integrations/no-code/elevenlabs.mdx
+++ b/content/integrations/no-code/elevenlabs.mdx
@@ -9,20 +9,20 @@ category: Integrations
 
 # Trace ElevenLabs Agents with Langfuse
 
-This notebook shows how to forward **OpenTelemetry traces** of [ElevenLabs Agents](https://elevenlabs.io/agents) conversations to **Langfuse**. You get each conversation as a full trace next to your other LLM application traces: transcript turns, LLM generations with token usage and cost, tool calls, and RAG retrievals. The notebook is self-contained: it creates a demo agent with a tool and a knowledge base, runs a text-only conversation, and forwards the resulting trace.
+This notebook shows how to forward **OpenTelemetry traces** of [ElevenLabs Agents](https://elevenlabs.io/agents) conversations to **Langfuse**. You get each conversation as a full trace next to your other LLM application traces, including transcript turns, LLM generations with token usage and cost, tool calls, and RAG retrievals. The notebook is self-contained. It creates a demo agent with a tool and a knowledge base, runs a text-only conversation, and forwards the resulting trace.
 
 > **What is ElevenLabs Agents?** [ElevenLabs Agents](https://elevenlabs.io/agents) is a platform for building voice-based conversational AI agents that handle calls, answer questions, and execute tools on behalf of users.
 
 > **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source AI engineering platform that helps teams trace, debug, and evaluate their LLM applications.
 
 <Steps>
-## Step 1: Install dependencies
+## Install dependencies
 
 ```python
 %pip install elevenlabs requests -U
 ```
 
-## Step 2: Set up environment variables
+## Set up environment variables
 
 Get your Langfuse keys from the project settings in [Langfuse Cloud](https://langfuse.com/cloud) or set up [self-hosting](https://langfuse.com/self-hosting).
 
@@ -38,7 +38,7 @@ os.environ["LANGFUSE_BASE_URL"] = "https://cloud.langfuse.com" # 🇪🇺 EU reg
 os.environ["ELEVENLABS_API_KEY"] = "sk_..."  # ElevenLabs API key with Eleven Agents read + write permissions
 ```
 
-## Step 3: Create a demo agent
+## Create a demo agent
 
 We create a small agent with two data sources, so the trace contains a real tool call and a real RAG flow:
 
@@ -119,7 +119,7 @@ AGENT_ID = agent.agent_id
 print(f"Created agent: {AGENT_ID}")
 ```
 
-## Step 4: Run a text-only conversation
+## Run a text-only conversation
 
 ElevenLabs agents support [chat mode](https://elevenlabs.io/docs/eleven-agents/guides/chat-mode): with `text_only` enabled on the agent, the SDK's `Conversation` runs without microphone or speakers. This creates a **real conversation** in your call history, exactly like a voice call.
 
@@ -163,14 +163,14 @@ conversation_id = conversation.wait_for_session_end()
 print(f"Conversation ID: {conversation_id}")
 ```
 
-## Step 5: Fetch the conversation as an OpenTelemetry trace
+## Fetch the conversation as an OpenTelemetry trace
 
 ElevenLabs does not push traces to Langfuse. It hands you a complete trace as **OTLP JSON** (a `resourceSpans` object) on three surfaces, and you forward it:
 
 | Surface                                                                                     | When you get data                        | Best for                                    |
 | ------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------- |
 | [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get)          | On demand, after the conversation exists | Backfill, debugging (used in this notebook) |
-| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks)  | After the conversation ends              | Production pipelines (see Step 9)           |
+| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks)  | After the conversation ends              | Production pipelines (see the production setup step below)           |
 | [Monitoring WebSocket](https://elevenlabs.io/docs/eleven-agents/guides/realtime-monitoring) | Live, during the conversation            | Live dashboards (Enterprise feature)        |
 
 All three surfaces share the same trace ID per conversation and the same `elevenlabs.*` span attributes. We poll until ElevenLabs has processed the conversation, then request it in OpenTelemetry format.
@@ -184,7 +184,7 @@ headers = {"xi-api-key": os.environ["ELEVENLABS_API_KEY"]}
 url = f"https://api.elevenlabs.io/v1/convai/conversations/{conversation_id}"
 
 # Wait until ElevenLabs has finished processing the conversation.
-# Keep the regular conversation JSON, Step 7 needs its transcript.
+# Keep the regular conversation JSON, attach_rag_chunks (below) needs its transcript.
 for _ in range(30):
     conversation = requests.get(url, headers=headers).json()
     if conversation.get("status") == "done":
@@ -205,18 +205,18 @@ print(f"Fetched {len(span_names)} spans:")
 print("\n".join(f"- {name}" for name in span_names))
 ```
 
-## Step 6: Enrich the spans with Langfuse attributes
+## Enrich the spans with Langfuse attributes
 
 ElevenLabs spans only carry `elevenlabs.*` attributes. Langfuse would ingest them as generic spans with empty input/output and all details buried in metadata. This transformation adds [`langfuse.*` mapped attributes](https://langfuse.com/integrations/native/opentelemetry#property-mapping) so the trace becomes readable and filterable:
 
 - The **root conversation span** becomes an `agent` observation with the first user message as input, the last agent response as output, and the call summary in the trace metadata.
 - The **conversation ID** becomes the Langfuse [session ID](https://langfuse.com/docs/observability/features/sessions), so application-side traces that know the conversation ID group together with the voice trace.
-- **Agent turns backed by an LLM call** (`elevenlabs.producing_llm`) become `generation` observations with the user message they respond to as input, plus model name, token usage, and cost parsed from `elevenlabs.llm_usage.*`. Evaluators see the full exchange, and cost dashboards work out of the box.
-- **Tool call spans** become `tool` observations with parameters as input and results as output.
-- **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. Step 7 adds the retrieved chunks as output.
+- **Agent turns backed by an LLM call** (`elevenlabs.producing_llm`) become `generation` observations with the user message they respond to as input, plus model name, token usage, and cost parsed from `elevenlabs.llm_usage.*`. Evaluators see the full exchange, and cost dashboards populate automatically.
+- **Tool call spans** turn into `tool` observations with parameters as input and results as output.
+- **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. The next step adds the retrieved chunks as output.
 - **Transcript turns** get the user/agent text as observation input/output.
 - The **ElevenLabs environment** maps to the Langfuse [environment](https://langfuse.com/docs/observability/features/environments), keeping test and production traces separate.
-- **Empty agent turns** (no text, no LLM call, no children) are dropped as noise.
+- **Empty agent turns** (no text, LLM call, or children) are dropped as noise.
 - **Turn order is restored**: ElevenLabs exports timestamps with one-second granularity, so spans within the same second would render in arbitrary order. Each span is nudged by its `elevenlabs.turn.index` in milliseconds.
 
 All original `elevenlabs.*` attributes (latency metrics, analysis results, dynamic variables) stay available in each observation's metadata. The mapping follows the [trace best practices](https://langfuse.com/docs/observability/best-practices). If your application knows the end user, also map a user identifier to `langfuse.user.id` (see the commented line in the code).
@@ -369,9 +369,9 @@ def enrich_for_langfuse(otlp_traces: dict) -> dict:
     return otlp_traces
 ```
 
-## Step 7: Add retrieved chunks to the retriever observations
+## Add retrieved chunks to the retriever observations
 
-The OTLP export records that retrieval happened (query, embedding model, latency) but not what was retrieved. The conversation JSON from Step 5 has the missing piece: each agent turn carries `rag_retrieval_info` with the retrieved chunk IDs and vector distances, and the [knowledge base API](https://elevenlabs.io/docs/api-reference/knowledge-base) returns the chunk text.
+The OTLP export records that retrieval happened (query, embedding model, latency) but not what was retrieved. The conversation JSON fetched earlier has the missing piece: each agent turn carries `rag_retrieval_info` with the retrieved chunk IDs and vector distances, and the [knowledge base API](https://elevenlabs.io/docs/api-reference/knowledge-base) returns the chunk text.
 
 This step joins them into the `retriever` observations, so the retrieved text becomes the observation output. You can then check the agent's answer against the exact text it retrieved, e.g. with an [LLM-as-a-judge evaluator](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge) for faithfulness.
 
@@ -415,7 +415,7 @@ def attach_rag_chunks(otlp_traces: dict, conversation: dict, client: ElevenLabs)
     return otlp_traces
 ```
 
-## Step 8: Forward the trace to Langfuse
+## Forward the trace to Langfuse
 
 Langfuse accepts [OTLP over HTTP in JSON format](https://langfuse.com/integrations/native/opentelemetry#opentelemetry-endpoint), so the payload can be sent as-is with a single POST request. No OpenTelemetry SDK or protobuf encoding needed. The `x-langfuse-ingestion-version: 4` header enables real-time ingestion on the v4 data model.
 
@@ -445,7 +445,7 @@ send_to_langfuse(enriched)
 print("Forwarded conversation to Langfuse")
 ```
 
-## Step 9: Production setup with a post-call webhook
+## Production setup with a post-call webhook
 
 In production, don't poll the GET API. Configure an [ElevenLabs post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks) with the **Transcript** event and **OpenTelemetry transcript payloads** enabled (in [Agents settings](https://elevenlabs.io/app/agents/settings)). ElevenLabs then POSTs a `post_call_transcription_otel` event with the same `otlp_traces` object after every completed call.
 
@@ -481,7 +481,7 @@ async def post_call(request: Request, elevenlabs_signature: str = Header(...)):
     return {"ok": True}
 ```
 
-To include the retrieved chunks (Step 7) in production, fetch the transcript once via the [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get) when the event arrives and run `attach_rag_chunks` before `send_to_langfuse`. (The webhook's regular `post_call_transcription` event also carries the transcript with `rag_retrieval_info`, but it is a separate delivery, so joining it with the OTel event requires buffering one of the two.)
+To include the retrieved chunks in production, fetch the transcript once via the [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get) when the event arrives and run `attach_rag_chunks` before `send_to_langfuse`. (The webhook's regular `post_call_transcription` event also carries the transcript with `rag_retrieval_info`, but it is a separate delivery, so joining it with the OTel event requires buffering one of the two.)
 
 **Forward each conversation exactly once.** The trace ID is stable per conversation, but ElevenLabs generates fresh span IDs on every export. Re-exporting a conversation via the GET API and forwarding it again duplicates all observations inside the same trace. Re-sending the **same** payload (e.g. your own retry around a failed POST) is idempotent. If you need retries, persist the exported payload and re-send that exact payload.
 
@@ -493,11 +493,11 @@ For live use cases (supervisor dashboards, real-time alerting), the [monitoring 
 - **No trace context propagation**: ElevenLabs mints its own trace IDs, so the conversation cannot be nested inside an existing application trace. Use the conversation ID (mapped to the Langfuse session ID above) to correlate application-side traces with the voice conversation.
 - **LLM cost only**: per-turn token usage and cost cover the LLM calls. The total conversation cost including voice (TTS/ASR) is in the `elevenlabs.cost_fiat` attribute in the root observation's metadata.
 - **4 KB truncation**: ElevenLabs truncates long tool parameters and results at 4 KB per span attribute.
-- **RAG chunk contents require a join**: the OTLP trace only carries the retrieval query, embedding model, and latency. Step 7 joins the retrieved chunk IDs and distances from the conversation transcript and the chunk text from the knowledge base API.
+- **RAG chunk contents require a join**: the OTLP trace only carries the retrieval query, embedding model, and latency. `attach_rag_chunks` joins the retrieved chunk IDs and distances from the conversation transcript and the chunk text from the knowledge base API.
 
-## Step 10: View the trace in Langfuse
+## View the trace in Langfuse
 
-Open [Langfuse Cloud](https://langfuse.com/cloud) to see the full conversation trace: the conversation as the root `agent` observation, transcript turns, LLM generations with token usage and cost, the tool call with its parameters and result, and the RAG retrievals with their queries and retrieved chunks. The conversation ID is the Langfuse session ID, so all traces of the same conversation group together in the [Sessions view](https://langfuse.com/docs/observability/features/sessions).
+Open [Langfuse Cloud](https://langfuse.com/cloud) to see the full conversation trace, from the root `agent` observation down to the tool call and the RAG retrievals with their retrieved chunks. The conversation ID is the Langfuse session ID, so all traces of the same conversation group together in the [Sessions view](https://langfuse.com/docs/observability/features/sessions).
 
 ![Example ElevenLabs trace in Langfuse](https://langfuse.com/images/cookbook/integration_elevenlabs/elevenlabs-example-trace.png)
 

--- a/content/integrations/no-code/elevenlabs.mdx
+++ b/content/integrations/no-code/elevenlabs.mdx
@@ -216,7 +216,7 @@ ElevenLabs spans only carry `elevenlabs.*` attributes. Langfuse would ingest the
 - **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. The next step adds the retrieved chunks as output.
 - **Transcript turns** get the user/agent text as observation input/output.
 - The **ElevenLabs environment** maps to the Langfuse [environment](https://langfuse.com/docs/observability/features/environments), keeping test and production traces separate.
-- **Empty agent turns** (no text, LLM call, or children) are dropped as noise.
+- **Empty agent turns** (without text, an LLM call, or children) are dropped as noise.
 - **Turn order is restored**: ElevenLabs exports timestamps with one-second granularity, so spans within the same second would render in arbitrary order. Each span is nudged by its `elevenlabs.turn.index` in milliseconds.
 
 All original `elevenlabs.*` attributes (latency metrics, analysis results, dynamic variables) stay available in each observation's metadata. The mapping follows the [trace best practices](https://langfuse.com/docs/observability/best-practices). If your application knows the end user, also map a user identifier to `langfuse.user.id` (see the commented line in the code).
@@ -329,7 +329,7 @@ def enrich_for_langfuse(otlp_traces: dict) -> dict:
                 elif name.endswith(".agent_response"):
                     text = _get(attributes, "elevenlabs.agent.text")
                     model = _get(attributes, "elevenlabs.producing_llm")
-                    # Drop empty agent turns (no text, no LLM call, no children)
+                    # Drop empty agent turns (without text, an LLM call, or children)
                     if not text and not model and span.get("spanId") not in parent_ids:
                         continue
                     _set(attributes, "langfuse.observation.output", text)

--- a/content/integrations/no-code/elevenlabs.mdx
+++ b/content/integrations/no-code/elevenlabs.mdx
@@ -167,11 +167,11 @@ print(f"Conversation ID: {conversation_id}")
 
 ElevenLabs does not push traces to Langfuse. It hands you a complete trace as **OTLP JSON** (a `resourceSpans` object) on three surfaces, and you forward it:
 
-| Surface                                                                                     | When you get data                        | Best for                                    |
-| ------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------- |
-| [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get)          | On demand, after the conversation exists | Backfill, debugging (used in this notebook) |
-| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks)  | After the conversation ends              | Production pipelines (see the production setup step below)           |
-| [Monitoring WebSocket](https://elevenlabs.io/docs/eleven-agents/guides/realtime-monitoring) | Live, during the conversation            | Live dashboards (Enterprise feature)        |
+| Surface                                                                                     | When you get data                        | Best for                                                   |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get)          | On demand, after the conversation exists | Backfill, debugging (used in this notebook)                |
+| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks)  | After the conversation ends              | Production pipelines (see the production setup step below) |
+| [Monitoring WebSocket](https://elevenlabs.io/docs/eleven-agents/guides/realtime-monitoring) | Live, during the conversation            | Live dashboards (Enterprise feature)                       |
 
 All three surfaces share the same trace ID per conversation and the same `elevenlabs.*` span attributes. We poll until ElevenLabs has processed the conversation, then request it in OpenTelemetry format.
 

--- a/cookbook/integration_elevenlabs.ipynb
+++ b/cookbook/integration_elevenlabs.ipynb
@@ -309,7 +309,7 @@
         "- **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. The next step adds the retrieved chunks as output.\n",
         "- **Transcript turns** get the user/agent text as observation input/output.\n",
         "- The **ElevenLabs environment** maps to the Langfuse [environment](https://langfuse.com/docs/observability/features/environments), keeping test and production traces separate.\n",
-        "- **Empty agent turns** (no text, LLM call, or children) are dropped as noise.\n",
+        "- **Empty agent turns** (without text, an LLM call, or children) are dropped as noise.\n",
         "- **Turn order is restored**: ElevenLabs exports timestamps with one-second granularity, so spans within the same second would render in arbitrary order. Each span is nudged by its `elevenlabs.turn.index` in milliseconds.\n",
         "\n",
         "All original `elevenlabs.*` attributes (latency metrics, analysis results, dynamic variables) stay available in each observation's metadata. The mapping follows the [trace best practices](https://langfuse.com/docs/observability/best-practices). If your application knows the end user, also map a user identifier to `langfuse.user.id` (see the commented line in the code)."
@@ -427,7 +427,7 @@
         "                elif name.endswith(\".agent_response\"):\n",
         "                    text = _get(attributes, \"elevenlabs.agent.text\")\n",
         "                    model = _get(attributes, \"elevenlabs.producing_llm\")\n",
-        "                    # Drop empty agent turns (no text, no LLM call, no children)\n",
+        "                    # Drop empty agent turns (without text, an LLM call, or children)\n",
         "                    if not text and not model and span.get(\"spanId\") not in parent_ids:\n",
         "                        continue\n",
         "                    _set(attributes, \"langfuse.observation.output\", text)\n",

--- a/cookbook/integration_elevenlabs.ipynb
+++ b/cookbook/integration_elevenlabs.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "# Trace ElevenLabs Agents with Langfuse\n",
         "\n",
-        "This notebook shows how to forward **OpenTelemetry traces** of [ElevenLabs Agents](https://elevenlabs.io/agents) conversations to **Langfuse**. You get each conversation as a full trace next to your other LLM application traces: transcript turns, LLM generations with token usage and cost, tool calls, and RAG retrievals. The notebook is self-contained: it creates a demo agent with a tool and a knowledge base, runs a text-only conversation, and forwards the resulting trace.\n",
+        "This notebook shows how to forward **OpenTelemetry traces** of [ElevenLabs Agents](https://elevenlabs.io/agents) conversations to **Langfuse**. You get each conversation as a full trace next to your other LLM application traces, including transcript turns, LLM generations with token usage and cost, tool calls, and RAG retrievals. The notebook is self-contained. It creates a demo agent with a tool and a knowledge base, runs a text-only conversation, and forwards the resulting trace.\n",
         "\n",
         "> **What is ElevenLabs Agents?** [ElevenLabs Agents](https://elevenlabs.io/agents) is a platform for building voice-based conversational AI agents that handle calls, answer questions, and execute tools on behalf of users.\n",
         "\n",
@@ -29,7 +29,7 @@
       },
       "source": [
         "<!-- STEPS_START -->\n",
-        "## Step 1: Install dependencies"
+        "## Install dependencies"
       ],
       "id": "d940b3cb"
     },
@@ -51,7 +51,7 @@
         }
       },
       "source": [
-        "## Step 2: Set up environment variables\n",
+        "## Set up environment variables\n",
         "\n",
         "Get your Langfuse keys from the project settings in [Langfuse Cloud](https://langfuse.com/cloud) or set up [self-hosting](https://langfuse.com/self-hosting)."
       ],
@@ -83,7 +83,7 @@
         }
       },
       "source": [
-        "## Step 3: Create a demo agent\n",
+        "## Create a demo agent\n",
         "\n",
         "We create a small agent with two data sources, so the trace contains a real tool call and a real RAG flow:\n",
         "\n",
@@ -180,7 +180,7 @@
         }
       },
       "source": [
-        "## Step 4: Run a text-only conversation\n",
+        "## Run a text-only conversation\n",
         "\n",
         "ElevenLabs agents support [chat mode](https://elevenlabs.io/docs/eleven-agents/guides/chat-mode): with `text_only` enabled on the agent, the SDK's `Conversation` runs without microphone or speakers. This creates a **real conversation** in your call history, exactly like a voice call.\n",
         "\n",
@@ -240,14 +240,14 @@
         }
       },
       "source": [
-        "## Step 5: Fetch the conversation as an OpenTelemetry trace\n",
+        "## Fetch the conversation as an OpenTelemetry trace\n",
         "\n",
         "ElevenLabs does not push traces to Langfuse. It hands you a complete trace as **OTLP JSON** (a `resourceSpans` object) on three surfaces, and you forward it:\n",
         "\n",
         "| Surface | When you get data | Best for |\n",
         "| --- | --- | --- |\n",
         "| [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get) | On demand, after the conversation exists | Backfill, debugging (used in this notebook) |\n",
-        "| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks) | After the conversation ends | Production pipelines (see Step 9) |\n",
+        "| [Post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks) | After the conversation ends | Production pipelines (see the production setup step below) |\n",
         "| [Monitoring WebSocket](https://elevenlabs.io/docs/eleven-agents/guides/realtime-monitoring) | Live, during the conversation | Live dashboards (Enterprise feature) |\n",
         "\n",
         "All three surfaces share the same trace ID per conversation and the same `elevenlabs.*` span attributes. We poll until ElevenLabs has processed the conversation, then request it in OpenTelemetry format."
@@ -266,7 +266,7 @@
         "url = f\"https://api.elevenlabs.io/v1/convai/conversations/{conversation_id}\"\n",
         "\n",
         "# Wait until ElevenLabs has finished processing the conversation.\n",
-        "# Keep the regular conversation JSON, Step 7 needs its transcript.\n",
+        "# Keep the regular conversation JSON, attach_rag_chunks (below) needs its transcript.\n",
         "for _ in range(30):\n",
         "    conversation = requests.get(url, headers=headers).json()\n",
         "    if conversation.get(\"status\") == \"done\":\n",
@@ -298,18 +298,18 @@
         }
       },
       "source": [
-        "## Step 6: Enrich the spans with Langfuse attributes\n",
+        "## Enrich the spans with Langfuse attributes\n",
         "\n",
         "ElevenLabs spans only carry `elevenlabs.*` attributes. Langfuse would ingest them as generic spans with empty input/output and all details buried in metadata. This transformation adds [`langfuse.*` mapped attributes](https://langfuse.com/integrations/native/opentelemetry#property-mapping) so the trace becomes readable and filterable:\n",
         "\n",
         "- The **root conversation span** becomes an `agent` observation with the first user message as input, the last agent response as output, and the call summary in the trace metadata.\n",
         "- The **conversation ID** becomes the Langfuse [session ID](https://langfuse.com/docs/observability/features/sessions), so application-side traces that know the conversation ID group together with the voice trace.\n",
-        "- **Agent turns backed by an LLM call** (`elevenlabs.producing_llm`) become `generation` observations with the user message they respond to as input, plus model name, token usage, and cost parsed from `elevenlabs.llm_usage.*`. Evaluators see the full exchange, and cost dashboards work out of the box.\n",
-        "- **Tool call spans** become `tool` observations with parameters as input and results as output.\n",
-        "- **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. Step 7 adds the retrieved chunks as output.\n",
+        "- **Agent turns backed by an LLM call** (`elevenlabs.producing_llm`) become `generation` observations with the user message they respond to as input, plus model name, token usage, and cost parsed from `elevenlabs.llm_usage.*`. Evaluators see the full exchange, and cost dashboards populate automatically.\n",
+        "- **Tool call spans** turn into `tool` observations with parameters as input and results as output.\n",
+        "- **RAG retrievals** become `retriever` observations nested under the generation that used them, with the rewritten retrieval query as input plus embedding model and latency. ElevenLabs reports RAG as `elevenlabs.rag.*` attributes on the turn rather than a separate span, so the transformation synthesizes a child span with a deterministic ID. The next step adds the retrieved chunks as output.\n",
         "- **Transcript turns** get the user/agent text as observation input/output.\n",
         "- The **ElevenLabs environment** maps to the Langfuse [environment](https://langfuse.com/docs/observability/features/environments), keeping test and production traces separate.\n",
-        "- **Empty agent turns** (no text, no LLM call, no children) are dropped as noise.\n",
+        "- **Empty agent turns** (no text, LLM call, or children) are dropped as noise.\n",
         "- **Turn order is restored**: ElevenLabs exports timestamps with one-second granularity, so spans within the same second would render in arbitrary order. Each span is nudged by its `elevenlabs.turn.index` in milliseconds.\n",
         "\n",
         "All original `elevenlabs.*` attributes (latency metrics, analysis results, dynamic variables) stay available in each observation's metadata. The mapping follows the [trace best practices](https://langfuse.com/docs/observability/best-practices). If your application knows the end user, also map a user identifier to `langfuse.user.id` (see the commented line in the code)."
@@ -474,9 +474,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Step 7: Add retrieved chunks to the retriever observations\n",
+        "## Add retrieved chunks to the retriever observations\n",
         "\n",
-        "The OTLP export records that retrieval happened (query, embedding model, latency) but not what was retrieved. The conversation JSON from Step 5 has the missing piece: each agent turn carries `rag_retrieval_info` with the retrieved chunk IDs and vector distances, and the [knowledge base API](https://elevenlabs.io/docs/api-reference/knowledge-base) returns the chunk text.\n",
+        "The OTLP export records that retrieval happened (query, embedding model, latency) but not what was retrieved. The conversation JSON fetched earlier has the missing piece: each agent turn carries `rag_retrieval_info` with the retrieved chunk IDs and vector distances, and the [knowledge base API](https://elevenlabs.io/docs/api-reference/knowledge-base) returns the chunk text.\n",
         "\n",
         "This step joins them into the `retriever` observations, so the retrieved text becomes the observation output. You can then check the agent's answer against the exact text it retrieved, e.g. with an [LLM-as-a-judge evaluator](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge) for faithfulness."
       ],
@@ -536,7 +536,7 @@
         }
       },
       "source": [
-        "## Step 8: Forward the trace to Langfuse\n",
+        "## Forward the trace to Langfuse\n",
         "\n",
         "Langfuse accepts [OTLP over HTTP in JSON format](https://langfuse.com/integrations/native/opentelemetry#opentelemetry-endpoint), so the payload can be sent as-is with a single POST request. No OpenTelemetry SDK or protobuf encoding needed. The `x-langfuse-ingestion-version: 4` header enables real-time ingestion on the v4 data model."
       ],
@@ -582,7 +582,7 @@
         }
       },
       "source": [
-        "## Step 9: Production setup with a post-call webhook\n",
+        "## Production setup with a post-call webhook\n",
         "\n",
         "In production, don't poll the GET API. Configure an [ElevenLabs post-call webhook](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks) with the **Transcript** event and **OpenTelemetry transcript payloads** enabled (in [Agents settings](https://elevenlabs.io/app/agents/settings)). ElevenLabs then POSTs a `post_call_transcription_otel` event with the same `otlp_traces` object after every completed call.\n",
         "\n",
@@ -618,7 +618,7 @@
         "    return {\"ok\": True}\n",
         "```\n",
         "\n",
-        "To include the retrieved chunks (Step 7) in production, fetch the transcript once via the [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get) when the event arrives and run `attach_rag_chunks` before `send_to_langfuse`. (The webhook's regular `post_call_transcription` event also carries the transcript with `rag_retrieval_info`, but it is a separate delivery, so joining it with the OTel event requires buffering one of the two.)\n",
+        "To include the retrieved chunks in production, fetch the transcript once via the [GET conversation API](https://elevenlabs.io/docs/api-reference/conversations/get) when the event arrives and run `attach_rag_chunks` before `send_to_langfuse`. (The webhook's regular `post_call_transcription` event also carries the transcript with `rag_retrieval_info`, but it is a separate delivery, so joining it with the OTel event requires buffering one of the two.)\n",
         "\n",
         "**Forward each conversation exactly once.** The trace ID is stable per conversation, but ElevenLabs generates fresh span IDs on every export. Re-exporting a conversation via the GET API and forwarding it again duplicates all observations inside the same trace. Re-sending the **same** payload (e.g. your own retry around a failed POST) is idempotent. If you need retries, persist the exported payload and re-send that exact payload.\n",
         "\n",
@@ -630,7 +630,7 @@
         "- **No trace context propagation**: ElevenLabs mints its own trace IDs, so the conversation cannot be nested inside an existing application trace. Use the conversation ID (mapped to the Langfuse session ID above) to correlate application-side traces with the voice conversation.\n",
         "- **LLM cost only**: per-turn token usage and cost cover the LLM calls. The total conversation cost including voice (TTS/ASR) is in the `elevenlabs.cost_fiat` attribute in the root observation's metadata.\n",
         "- **4 KB truncation**: ElevenLabs truncates long tool parameters and results at 4 KB per span attribute.\n",
-        "- **RAG chunk contents require a join**: the OTLP trace only carries the retrieval query, embedding model, and latency. Step 7 joins the retrieved chunk IDs and distances from the conversation transcript and the chunk text from the knowledge base API."
+        "- **RAG chunk contents require a join**: the OTLP trace only carries the retrieval query, embedding model, and latency. `attach_rag_chunks` joins the retrieved chunk IDs and distances from the conversation transcript and the chunk text from the knowledge base API."
       ],
       "id": "85a39849"
     },
@@ -642,9 +642,9 @@
         }
       },
       "source": [
-        "## Step 10: View the trace in Langfuse\n",
+        "## View the trace in Langfuse\n",
         "\n",
-        "Open [Langfuse Cloud](https://langfuse.com/cloud) to see the full conversation trace: the conversation as the root `agent` observation, transcript turns, LLM generations with token usage and cost, the tool call with its parameters and result, and the RAG retrievals with their queries and retrieved chunks. The conversation ID is the Langfuse session ID, so all traces of the same conversation group together in the [Sessions view](https://langfuse.com/docs/observability/features/sessions).\n",
+        "Open [Langfuse Cloud](https://langfuse.com/cloud) to see the full conversation trace, from the root `agent` observation down to the tool call and the RAG retrievals with their retrieved chunks. The conversation ID is the Langfuse session ID, so all traces of the same conversation group together in the [Sessions view](https://langfuse.com/docs/observability/features/sessions).\n",
         "\n",
         "![Example ElevenLabs trace in Langfuse](https://langfuse.com/images/cookbook/integration_elevenlabs/elevenlabs-example-trace.png)\n",
         "\n",


### PR DESCRIPTION
## Summary

Follow-up to #3630.

- Remove the "Step N:" prefixes from all headings in the ElevenLabs cookbook — the `<Steps>` component already numbers them visually, so the text was redundant (and the numbers had drifted: the last bubble showed 11 while the heading said "Step 10").
- Reword the six inline cross-references that pointed at step numbers ("see Step 9", "Step 7 joins ...") to descriptive references, so they also read correctly in the notebook rendering (GitHub/Colab) where there are no visual numbers.
- Small prose cleanups from a style review: break up repeated colon-into-list constructions, deduplicate the trace-contents enumeration between intro and final step, and reword "work out of the box".

Applied to the source notebook and the generated MDX in sync.

## Test plan

- [x] Verified on localhost that the page renders with clean numbered steps and no dangling step references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and heading changes; no runtime, API, or security impact.
> 
> **Overview**
> Updates the ElevenLabs Langfuse integration cookbook so step headings rely on the `<Steps>` component for numbering instead of repeating **Step N:** in every title, which had been redundant and out of sync with the UI.
> 
> Cross-references that pointed at step numbers (e.g. “see Step 9”, “Step 7 joins…”) are rewritten to descriptive anchors such as **the production setup step below**, **the next step**, and **`attach_rag_chunks`**, so the same text works on the docs site and in the raw notebook on GitHub/Colab. Minor prose edits tighten the intro, enrichment bullets, code comments, OTLP table note, limitations, and the closing “view trace” section.
> 
> The same wording is applied in **`cookbook/integration_elevenlabs.ipynb`** and **`content/integrations/no-code/elevenlabs.mdx`** with no change to sample code or integration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a835238cd6898a55faf0bfe9216e32590af5a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes redundant step-number prefixes from the ElevenLabs cookbook and rewrites numbered cross-references descriptively. It also applies small prose cleanups while keeping the source notebook and generated MDX synchronized.
- Simplifies all headings rendered inside the numbered steps component.
- Replaces inline step-number references with descriptive references suitable for both MDX and notebook rendering.
- Keeps equivalent content changes aligned across the notebook and published integration page.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The changes are limited to synchronized documentation wording and heading updates, and the notebook and generated MDX continue to describe the same executable learning path.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: drop redundant step prefixes from ..."](https://github.com/langfuse/langfuse-docs/commit/81f66408f224b18a906a802f196b2ad53acb686d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59456955)</sub>

**Context used:**

- Knowledge Base — [Integrations and developer ecosystem](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/integrations-and-developer-ecosystem.md)
- Knowledge Base — [Cookbook examples](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/cookbook-examples.md)

<!-- /greptile_comment -->