### PR TITLE
fix: strip Steps wrappers from plain Markdown output

### DIFF
--- a/lib/stripMdxForPlainMarkdown.js
+++ b/lib/stripMdxForPlainMarkdown.js
@@ -167,6 +167,9 @@ function stripMdxJsxArtifacts(s, opts) {
     );
     // Unwrap React-style layout divs while preserving their Markdown content.
     out = out.replace(/<\/?div\b[^>]*>/gi, "");
+    // Step wrappers provide visual structure only. Keep their headings and
+    // content in plain Markdown without leaking raw MDX tags.
+    out = out.replace(/<\/?(?:Steps|Step)\b[^>]*>/g, "");
   } while (out !== prev);
   return out;
 }


### PR DESCRIPTION
## Summary

`<Steps>` and `<Step>` are layout-only wrappers, but `stripMdxForPlainMarkdown` never unwrapped them, so every page using them emitted raw MDX tags into `public/md-src/`. That is the output Markdown and PDF consumers read.

Unwrap them the same way `div` is already unwrapped one line above: drop the tags, keep the headings and content.

## Impact

Measured by regenerating `public/md-src` with and without the change:

| | Files leaking | Raw tags |
| --- | --- | --- |
| Before | **150** | **332** |
| After | 0 | 0 |

Affected pages include the v3 to v4 upgrade guide, both Docker Compose deployment guides, and the instance management API page.

## Safety

- Fenced code blocks are unaffected. The converter splits on fences and only strips outside them (`lib/stripMdxForPlainMarkdown.js:16`), and no page currently has a literal `<Step` inside a code fence.
- Headings and body content are preserved. Spot-checked the v3 to v4 guide: all 21 `###` headings intact.
- Scope is limited to `Steps`/`Step`. Other paired components with children (`Tabs`, `Frame`, `Cards`) are deliberately left as-is by the existing design and are unchanged here.

Split out of #3619, where this was originally noticed. It is unrelated to those docs and fixes the whole site, so it should not wait on that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single regex addition in the MDX stripper with no auth or data changes; behavior matches the existing div-unwrap path and is limited to layout-only step components.
> 
> **Overview**
> **Fixes raw `<Steps>` / `<Step>` MDX tags leaking into plain Markdown** used for `public/md-src/` and the PDF pipeline.
> 
> `stripMdxForPlainMarkdown` now removes opening and closing `Steps` and `Step` tags (same pattern as existing `div` unwrapping) while **keeping inner headings and body text**. Fenced code blocks are still untouched because stripping only runs outside triple-backtick fences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit badf4407058cede9f0ff09a020722cc8758954ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates plain-Markdown conversion to remove layout-only `<Steps>` and `<Step>` wrappers while preserving their headings and body content.

- Adds wrapper stripping alongside the existing `div` unwrapping.
- Keeps fenced code blocks unaffected through the converter’s existing fence segmentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new replacement handles the repository’s current bare Steps and Step wrapper forms, while existing fenced-code segmentation preserves literal tags in code blocks.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: strip Steps wrappers from plain Mar..."](https://github.com/langfuse/langfuse-docs/commit/badf4407058cede9f0ff09a020722cc8758954ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59512344)</sub>

<!-- /greptile_comment -->