### PR TITLE
docs(pricing): rename "Dedicated support engineer" to "Named lead support engineer"

### DIFF
--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -197,7 +197,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
         "Custom rate limits",
         "Uptime SLA",
         "Support SLA",
-        "Dedicated support engineer",
+        "Named lead support engineer",
       ],
       addOn: {
         name: "Yearly Commitment",
@@ -243,7 +243,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
         "All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs",
         "Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private",
         "Langfuse pricing is additive to your ClickHouse commercial plan",
-        "Dedicated support engineer for deployment and hosting guidance",
+        "Named lead support engineer for deployment and hosting guidance",
         "Solutions architect support during evaluation and rollout",
         "Direct access to the product team for feedback",
         "SOC 2 Type II and ISO 27001 reports",
@@ -995,7 +995,7 @@ const sections: Section[] = [
         },
       },
       {
-        name: "Dedicated Support Engineer",
+        name: "Named Lead Support Engineer",
         href: "/support#onboarding",
         description:
           "Includes deployment and hosting guidance for your dedicated Langfuse environment.",

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -30,7 +30,7 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 - All Open Source features plus management APIs, project-level RBAC, data retention policies, and audit logs
 - Bundled with ClickHouse Cloud, ClickHouse BYOC, or ClickHouse Private
 - Langfuse pricing is additive to your ClickHouse commercial plan
-- Dedicated support engineer for deployment and hosting guidance
+- Named lead support engineer for deployment and hosting guidance
 - Solutions architect support during evaluation and rollout
 - Direct access to the product team for feedback
 - SOC 2 Type II and ISO 27001 reports
@@ -104,7 +104,7 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 | [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                                        |
 | [In-app support](/support#in-app)                                                                   | --                          | Yes                                        |
 | [Private Slack channel](/support#slack)                                                             | --                          | Yes                                        |
-| [Dedicated support engineer](/support#onboarding)                                                   | --                          | Yes                                        |
+| [Named lead support engineer](/support#onboarding)                                                  | --                          | Yes                                        |
 | [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                                        |
 | Solutions architect support                                                                         | --                          | Yes                                        |
 | Product team feedback channel                                                                       | --                          | Yes                                        |

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -70,7 +70,7 @@ For large-scale teams. Enterprise-grade support and security.
 - Custom rate limits
 - Uptime SLA
 - Support SLA
-- Dedicated support engineer
+- Named lead support engineer
 
 Optional **Yearly Commitment**:
 
@@ -148,7 +148,7 @@ Optional **Yearly Commitment**:
 | [Community (GitHub)](/support#community)                                                            | Yes                 | Yes                 | Yes                 | Yes                          |
 | [In-app support](/support#in-app)                                                                   | --                  | Yes                 | Yes                 | Yes                          |
 | [Private Slack channel](/support#slack)                                                             | --                  | --                  | Teams add-on        | Yes                          |
-| [Dedicated support engineer](/support#onboarding)                                                   | --                  | --                  | --                  | Yes                          |
+| [Named lead support engineer](/support#onboarding)                                                  | --                  | --                  | --                  | Yes                          |
 | [Onboarding & architectural guidance](/support#onboarding)                                          | --                  | --                  | --                  | Yes                          |
 | Response time SLO                                                                                   | n/a                 | 48h                 | 48h (Teams: 24h)    | Custom                       |
 | [Support SLA](/enterprise#faq)                                                                      | --                  | --                  | --                  | Yes                          |


### PR DESCRIPTION
## What changed

Renames the Enterprise support line item from "Dedicated support engineer" to "Named lead support engineer" on the pricing pages.

- `components/home/pricing/PricingTable.tsx`: Cloud Enterprise bullet, Self-hosted Enterprise bullet, and the comparison-table row ("Named Lead Support Engineer", linking to `/support#onboarding` as before).
- `md-override/pricing.md` and `md-override/pricing-self-host.md`: mirrored so the Markdown overrides stay in sync with the rendered pages.

## Why

"Named lead support engineer" is the ClickHouse support terminology and was the intended wording for the offering. A named lead support engineer has oversight of the account, joins regular calls, and acts as the escalation contact, but does not personally handle every ticket. The previous "dedicated" wording could be read by customers as a single person being their only support contact.

## Reviewer notes

- Copy-only change, no layout or logic changes.
- No other pages in the repo used the old phrase; the linked `/support#onboarding` section needed no change.
- `prettier --check` passes on all three files; Markdown table column widths were preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only marketing text updates with no application behavior or entitlement changes.
> 
> **Overview**
> Replaces Enterprise pricing copy **"Dedicated support engineer"** with **"Named lead support engineer"** on cloud and self-hosted pricing surfaces so wording matches ClickHouse support terminology and avoids implying a single engineer handles every ticket.
> 
> Updates mirror the same text in `PricingTable.tsx` (Enterprise plan bullets and the Support comparison row, still linking to `/support#onboarding`) and in `md-override/pricing.md` and `md-override/pricing-self-host.md`. No logic, layout, or link targets change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27d09049ee9d4c5c15ea25db8fbac6ea187347e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Renames the Enterprise support offering from “Dedicated support engineer” to “Named lead support engineer” across the rendered pricing component and Markdown overrides.

- Updates Cloud and Self-Hosted Enterprise plan bullets.
- Updates both pricing comparison tables while preserving their existing support links.
- Keeps the rendered pricing data and Markdown overrides synchronized.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the terminology change is consistent across all three pricing sources and preserves existing links and behavior.

The changes are limited to synchronized copy replacements and introduce no observable logic, rendering, routing, or contract failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(pricing): rename &quot;Dedicated support..."](https://github.com/langfuse/langfuse-docs/commit/c27d09049ee9d4c5c15ea25db8fbac6ea187347e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59525470)</sub>

<!-- /greptile_comment -->