### PR TITLE
docs: add Open Multi-Agent integration guide

### DIFF
--- a/content/integrations/frameworks/meta.json
+++ b/content/integrations/frameworks/meta.json
@@ -26,6 +26,7 @@
     "mastra",
     "microsoft-agent-framework",
     "mirascope",
+    "open-multi-agent",
     "openai-agents",
     "pipecat",
     "pydantic-ai",

--- a/content/integrations/frameworks/open-multi-agent.mdx
+++ b/content/integrations/frameworks/open-multi-agent.mdx
@@ -1,0 +1,143 @@
+---
+title: Trace Open Multi-Agent (OMA) with Langfuse
+sidebarTitle: Open Multi-Agent
+logo: /images/integrations/open-multi-agent.svg
+description: Learn how to use Langfuse to monitor Open Multi-Agent runs to debug and evaluate your multi-agent workflows
+category: Integrations
+---
+
+# Tracing Open Multi-Agent with Langfuse
+
+This guide shows how to send [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) traces to Langfuse over OpenTelemetry, so you can inspect the agent, tool, and model spans of a multi-agent run.
+
+> **What is Open Multi-Agent?** [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) (OMA) is a TypeScript orchestration framework for multi-agent systems. You describe a goal and a coordinator turns it into a task DAG at runtime, or you declare the dependency graph yourself when the workflow has to stay fixed. It is provider neutral and runs on your own infrastructure and credentials, with approvals, budgets, checkpointing, and resumable runs built in. Documentation is available at [open-multi-agent.com](https://open-multi-agent.com).
+
+> **What is Langfuse?** [Langfuse](https://langfuse.com) is an open-source AI engineering platform. It offers tracing and monitoring capabilities for LLM applications.
+
+OMA emits OpenTelemetry spans through its optional `@open-multi-agent/otel` adapter, which maps run, agent, tool, and model spans onto the GenAI semantic conventions. Langfuse ingests those as agent, tool, and generation observations.
+
+## Integration
+
+<Steps>
+
+### Install dependencies
+
+The OTel adapter is a separate package, and your application owns the OpenTelemetry SDK and exporter.
+
+```bash
+npm install @open-multi-agent/core @open-multi-agent/otel
+npm install @opentelemetry/sdk-trace-node @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/api
+```
+
+### Configure environment and Langfuse credentials
+
+Get these from your Langfuse project settings, or from a [self-hosted](https://langfuse.com/self-hosting) instance.
+
+```bash
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+export LANGFUSE_HOST=https://cloud.langfuse.com  # US region: https://us.cloud.langfuse.com
+```
+
+### Send OMA traces to Langfuse
+
+Build the tracer provider your application owns, point an OTLP exporter at Langfuse, and hand the provider to OMA's sink.
+
+```typescript
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { createOtelTraceSink } from '@open-multi-agent/otel'
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const auth = Buffer.from(
+  `${process.env.LANGFUSE_PUBLIC_KEY}:${process.env.LANGFUSE_SECRET_KEY}`,
+).toString('base64')
+
+const exporter = new OTLPTraceExporter({
+  // Langfuse ingests OTLP at /api/public/otel, so the traces signal lands
+  // on /api/public/otel/v1/traces.
+  url: `${process.env.LANGFUSE_HOST}/api/public/otel/v1/traces`,
+  headers: {
+    authorization: `Basic ${auth}`,
+    'x-langfuse-ingestion-version': '4',
+  },
+})
+
+// service.name comes from the Resource. Without one, spans arrive under the
+// OpenTelemetry default of `unknown_service:node`.
+const provider = new NodeTracerProvider({
+  resource: resourceFromAttributes({ 'service.name': 'my-oma-app' }),
+  spanProcessors: [new BatchSpanProcessor(exporter)],
+})
+
+const sink = createOtelTraceSink({ tracerProvider: provider })
+
+const orchestrator = new OpenMultiAgent({
+  observability: { sinks: [sink] },
+})
+```
+
+### Run your agents
+
+```typescript
+const researcher = {
+  name: 'researcher',
+  model: 'claude-sonnet-4-6',
+  systemPrompt: 'You research topics and report concise, sourced findings.',
+  tools: ['file_read', 'grep'],
+}
+
+const writer = {
+  name: 'writer',
+  model: 'claude-sonnet-4-6',
+  systemPrompt: 'You turn research notes into a short structured summary.',
+  tools: ['file_write'],
+}
+
+const team = orchestrator.createTeam('research-team', {
+  name: 'research-team',
+  agents: [researcher, writer],
+  sharedMemory: true,
+})
+
+const result = await orchestrator.runTeam(
+  team,
+  'Compare the top three TypeScript agent frameworks and summarize the differences.',
+)
+
+// Drain OMA's sink before the application shuts down its own provider.
+await sink.forceFlush({ timeoutMs: 5_000 })
+await sink.shutdown({ timeoutMs: 5_000 })
+await provider.shutdown()
+```
+
+### View traces in Langfuse
+
+Open your Langfuse project. Each OMA run arrives as one trace whose observations mirror the structure of the run, including the root run span, an agent observation per agent, a tool observation per tool call, and a generation per model call carrying the model name and token usage. A `runTeam` call also records the orchestrator's routing decision as its own span.
+
+</Steps>
+
+## Capturing tool input and output
+
+OMA records no prompts, completions, tool arguments, or tool results by default. Tool arguments and results become span attributes only under an explicit capture policy:
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  observability: {
+    sinks: [createOtelTraceSink({
+      tracerProvider: provider,
+      contentCapture: { mode: 'upstream-policy' },
+    })],
+    capture: { toolInput: 'redacted', toolOutput: 'redacted' },
+  },
+})
+```
+
+Both opt-ins are required. The adapter setting alone exports nothing extra, because without the core policy the attributes are never recorded. Values have structured credentials stripped and are truncated before they leave the process. Reasoning and chain-of-thought content have no opt-in and are never exported.
+
+## Learn more
+
+- [OMA observability documentation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)
+- [Runnable OTLP export example](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/core/examples/integrations/observability-v2/otlp-backend.ts)

--- a/public/images/integrations/open-multi-agent.svg
+++ b/public/images/integrations/open-multi-agent.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 400 340" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M 100 80 C 150 50, 240 45, 300 95 C 350 135, 355 210, 310 250 C 260 290, 170 285, 120 250 C 75 215, 60 150, 75 115 C 82 98, 90 87, 100 80 Z" fill="#0A0908"></path>
+          <ellipse cx="230" cy="148" rx="32" ry="46" fill="#059669" transform="rotate(20 230 148)"></ellipse>
+          <circle cx="295" cy="118" r="7" fill="#059669"></circle>
+          <circle cx="330" cy="100" r="3" fill="#059669" opacity="0.5"></circle>
+        </svg>


### PR DESCRIPTION
Adds an integration guide for [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) (OMA), a TypeScript orchestration framework for multi-agent systems.

OMA ships an optional `@open-multi-agent/otel` adapter that maps its run, agent, tool, and model spans onto the GenAI semantic conventions, so it reaches Langfuse over plain OTLP without any Langfuse-specific code in the framework. The guide covers the exporter wiring, the Resource that sets `service.name`, and the opt-in that adds tool arguments and results to spans.

Three files: the guide, the logo, and the `meta.json` entry.

Everything in the guide was run end to end against Langfuse Cloud rather than written from the docs. A real `runTeam` call produced seven observations in the expected shape: two generations carrying model name and token usage, two tool observations, one agent observation, the root run span, and the orchestrator's routing-decision span. Two details in an earlier draft were corrected because that run disagreed with them.

Happy to adjust naming, placement, or wording to match your conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static assets only; no runtime, API, or auth code changes.
> 
> **Overview**
> Adds **Open Multi-Agent (OMA)** to the frameworks integrations catalog with a new guide, sidebar entry in `meta.json`, and integration logo.
> 
> The guide explains wiring OMA’s `@open-multi-agent/otel` sink to Langfuse via **OTLP HTTP** (Basic auth, `x-langfuse-ingestion-version`, `/api/public/otel/v1/traces`), setting `service.name` on the tracer resource, running a multi-agent `runTeam` example, and flushing/shutting down the sink and provider. A separate section documents the **dual opt-in** needed to export redacted tool inputs/outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d97156cff7637a49679b4013b13ba3b5d1b977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an Open Multi-Agent framework integration guide explaining direct OTLP trace export to Langfuse.

- Adds the framework to integration navigation.
- Documents exporter credentials, v4 ingestion configuration, service naming, and provider shutdown.
- Explains the opt-in policy for capturing redacted tool inputs and outputs.
- Adds the Open Multi-Agent integration logo.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new page is discoverable through matching framework metadata, references an included logo, and documents the required direct-OTLP endpoint and real-time ingestion header without an established blocking or actionable defect.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: register Open Multi-Agent in the f..."](https://github.com/langfuse/langfuse-docs/commit/f3d97156cff7637a49679b4013b13ba3b5d1b977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59880216)</sub>

**Context used:**

- Knowledge Base — [Integrations and developer ecosystem](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/integrations-and-developer-ecosystem.md)
- Knowledge Base — [Integration catalog](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/integration-catalog.md)

<!-- /greptile_comment -->