### PR TITLE
docs: reference the Agent Skill on the Docs MCP page

### DIFF
--- a/content/docs/docs-mcp.mdx
+++ b/content/docs/docs-mcp.mdx
@@ -14,9 +14,9 @@ This is the public MCP server for the Langfuse documentation. There is also an a
 
 </Callout>
 
-## Pair with the Agent Skill [#agent-skill]
+### Pair with the Agent Skill [#agent-skill]
 
-The Docs MCP server works much better when your agent also has the [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill). The skill is a playbook that tells your agent which MCP tools to call, which pages to fetch, and how to follow Langfuse best practices.
+You'll get better results when your agent also has the [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill) installed, next to the MCP server.
 
 Install it from [GitHub](https://github.com/langfuse/skills) or follow the [Agent Skill setup](/docs/api-and-data-platform/features/agent-skill).
 

--- a/content/docs/docs-mcp.mdx
+++ b/content/docs/docs-mcp.mdx
@@ -14,6 +14,12 @@ This is the public MCP server for the Langfuse documentation. There is also an a
 
 </Callout>
 
+## Pair with the Agent Skill [#agent-skill]
+
+The Docs MCP server works much better when your agent also has the [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill). The skill is a playbook that tells your agent which MCP tools to call, which pages to fetch, and how to follow Langfuse best practices.
+
+Install it from [GitHub](https://github.com/langfuse/skills) or follow the [Agent Skill setup](/docs/api-and-data-platform/features/agent-skill).
+
 ## Install
 
 import DocsMcpServerInstallation from "@/components-mdx/docs-mcp-server-installation.mdx";
@@ -36,6 +42,7 @@ The [MCP Reference](https://mcp.reference.langfuse.com) is the canonical source 
 
 - Implementation of the MCP server: [route.ts](https://github.com/langfuse/langfuse-docs/blob/main/app/api/mcp/route.ts)
 - [MCP Reference](https://mcp.reference.langfuse.com): reference for MCP servers, setup snippets, tools, schemas, and requests
+- [Langfuse Agent Skill](/docs/api-and-data-platform/features/agent-skill): playbook that teaches coding agents how to use the Docs MCP server
 - [Agentic Onboarding](/docs/get-started) powered by the MCP server
 - [Ask AI](/docs/ask-ai): RAG chat with the Langfuse docs to get answers to your questions
 - [langfuse.com/llms.txt](https://langfuse.com/llms.txt): concise overview with page titles and links to detailed sub-files ([llms-docs.txt](https://langfuse.com/llms-docs.txt), [llms-integrations.txt](https://langfuse.com/llms-integrations.txt), [llms-self-hosting.txt](https://langfuse.com/llms-self-hosting.txt))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Docs MCP server works much better when the Langfuse Agent Skill is installed — the skill teaches agents which MCP tools to call and how to follow Langfuse best practices. That pairing was missing from `/docs/docs-mcp`.

This adds:

- A **Pair with the Agent Skill** section with links to the [Agent Skill docs](/docs/api-and-data-platform/features/agent-skill) and the [skills repo](https://github.com/langfuse/skills)
- A matching item in the page's References list

## Test plan

- [x] Open `/docs/docs-mcp` and confirm the new section appears above Install
- [x] Confirm both skill links resolve (`/docs/api-and-data-platform/features/agent-skill` → 200, `https://github.com/langfuse/skills` → 200)
- [x] Confirm the page still has a single H1 and the `#agent-skill` heading anchor works
- [x] Check desktop and mobile layout of the new section

![Docs MCP page with Pair with the Agent Skill section on desktop](https://cursor.com/artifacts/c/art-2f22c261-812f-40d2-84d2-8219afbf2354)
![Docs MCP page with Pair with the Agent Skill section on mobile](https://cursor.com/artifacts/c/art-e25392d4-d594-4dc2-b52c-8e525768aab5)
<a href="https://cursor.com/agents/bc-2b354279-867d-4399-b0c7-9955631853e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_mcp_skill_reference_desktop_and_mobile.mp4"><img src="https://cursor.com/artifacts/c/art-67dfdeee-1e20-47ec-a93b-02af7bdf0e44" alt="docs_mcp_skill_reference_desktop_and_mobile.mp4" /></a>

Resolves LFE-9133
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9133](https://linear.app/clickhouse/issue/LFE-9133/reference-skill-on-the-docs-mcp-page)

<div><a href="https://cursor.com/agents/bc-2b354279-867d-4399-b0c7-9955631853e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b354279-867d-4399-b0c7-9955631853e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds guidance recommending that users pair the Docs MCP server with the Langfuse Agent Skill.

- Links to the Agent Skill documentation and GitHub repository.
- Adds the Agent Skill to the page’s references list.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new heading uses the repository’s established explicit-anchor syntax, and the internal links target an existing, registered documentation page.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: reference the Agent Skill on the D..."](https://github.com/langfuse/langfuse-docs/commit/cdf1f0beb14946e32b3d3b91d7783b2a02206d07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60046917)</sub>

<!-- /greptile_comment -->