### PR TITLE
Improve /cloud region picker text spacing

### DIFF
--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -1,20 +1,13 @@
 "use client";
 
-import {
-  Suspense,
-  useCallback,
-  useMemo,
-  type MouseEvent,
-  type ReactNode,
-} from "react";
+import { useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { ArrowRight, ShieldCheck } from "lucide-react";
 import { CornerBox } from "@/components/ui/corner-box";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
 import { Logo } from "@/components/Logo";
-import { cn } from "@/lib/utils";
 import {
   cloudRegionSelectorOrder,
   cloudRegions,
@@ -53,51 +46,6 @@ const regionCards: Record<
 };
 
 const CLOUD_ROUTE_PREFIX = "/cloud";
-
-/**
- * Spacing previews for /cloud. Append `?opt=a|b|c` to compare.
- * Default is B (title-led). Remove the switcher once a direction is chosen.
- */
-const SPACING_OPTIONS = {
-  a: {
-    stack: "gap-10",
-    header: "gap-6",
-    brand: "gap-3",
-    listBlock: "gap-10",
-    headingInHeader: true,
-    taglineSize: "m" as const,
-    taglineClassName: undefined as string | undefined,
-    regionRow: "px-4 py-4 sm:px-5",
-    regionText: "gap-1",
-  },
-  b: {
-    stack: "gap-10",
-    header: "gap-8",
-    brand: "gap-1",
-    listBlock: "gap-10",
-    headingInHeader: true,
-    taglineSize: "s" as const,
-    taglineClassName: "tracking-[0.01em]",
-    regionRow: "px-4 py-4 sm:px-5",
-    regionText: "gap-1",
-  },
-  c: {
-    stack: "gap-10",
-    header: "gap-0",
-    brand: "gap-2.5",
-    listBlock: "gap-3",
-    headingInHeader: false,
-    taglineSize: "s" as const,
-    taglineClassName: undefined as string | undefined,
-    regionRow: "px-4 py-5 sm:px-5",
-    regionText: "gap-1.5",
-  },
-} as const;
-
-type SpacingOptionKey = keyof typeof SPACING_OPTIONS;
-
-const isSpacingOptionKey = (value: string | null): value is SpacingOptionKey =>
-  value === "a" || value === "b" || value === "c";
 
 const stripControlChars = (value: string) =>
   value.replace(/[\u0000-\u001F\u007F]/g, "");
@@ -143,14 +91,9 @@ const SignedInBadge = () => (
 
 const getCloudHost = (url: string) => new URL(url).host;
 
-function CloudRegionSelectorPage() {
+export default function CloudRegionSelectorPage() {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { signedInRegions } = useCloudRegionSignIn();
-  const spacingKey = isSpacingOptionKey(searchParams.get("opt"))
-    ? searchParams.get("opt")
-    : "b";
-  const s = SPACING_OPTIONS[spacingKey as SpacingOptionKey];
 
   const { cloudSubpath } = useMemo(
     () => getCloudRedirectPartsFromPathname(pathname || ""),
@@ -183,93 +126,76 @@ function CloudRegionSelectorPage() {
     [cloudSubpath],
   );
 
-  const heading = (
-    <Heading as="h1" size="normal" className="text-center">
-      Select a region
-    </Heading>
-  );
-
-  const regionList = (
-    <CornerBox className="w-full">
-      <div className="divide-y divide-line-structure">
-        {cloudRegionSelectorOrder.map((regionKey) => {
-          const region = cloudRegions[regionKey];
-          const card = regionCards[regionKey];
-          const host = getCloudHost(region.url);
-          const href = buildCloudRedirectUrl({
-            region: regionKey,
-            cloudSubpath,
-            search: "",
-            hash: "",
-          });
-          const isSignedIn = signedInRegions[regionKey];
-
-          return (
-            <a
-              key={regionKey}
-              href={href}
-              data-launch-app-cta=""
-              onClick={(event) => handleRegionSelect(regionKey, event)}
-              className={cn(
-                "group flex items-center gap-4 transition-colors hover:bg-surface-1",
-                s.regionRow,
-              )}
-            >
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[2px] border border-line-structure bg-surface-1">
-                {card.icon}
-              </span>
-
-              <div className={cn("min-w-0 flex-1 flex flex-col", s.regionText)}>
-                <div className="flex items-center gap-2">
-                  <span className="font-analog text-[15px] font-medium leading-none text-text-primary">
-                    {card.title}
-                  </span>
-                  {isSignedIn && <SignedInBadge />}
-                </div>
-                <Text
-                  size="s"
-                  as="span"
-                  className="block text-left leading-[150%] text-text-tertiary lg:leading-[150%]"
-                >
-                  {host}
-                  <span className="mx-1.5 text-text-disabled">&middot;</span>
-                  AWS {card.awsRegion}
-                </Text>
-              </div>
-
-              <ArrowRight className="h-4 w-4 shrink-0 text-text-tertiary transition-[transform,color] group-hover:translate-x-0.5 group-hover:text-text-secondary" />
-            </a>
-          );
-        })}
-      </div>
-    </CornerBox>
-  );
-
   return (
     <main
       translate="no"
       className="flex min-h-screen flex-col items-center justify-center bg-surface-bg px-4 py-10 sm:px-6 lg:px-8 notranslate"
     >
-      <div
-        className={cn(
-          "flex w-full max-w-[480px] flex-col items-center",
-          s.stack,
-        )}
-      >
-        <div className={cn("flex flex-col items-center", s.header)}>
-          <div className={cn("flex flex-col items-center", s.brand)}>
+      <div className="flex w-full max-w-[480px] flex-col items-center gap-10">
+        <div className="flex flex-col items-center gap-8">
+          <div className="flex flex-col items-center gap-1">
             <Logo variant="byClickHouse" />
-            <Text size={s.taglineSize} className={s.taglineClassName}>
+            <Text size="s" className="tracking-[0.01em]">
               Agent Observability and Evals
             </Text>
           </div>
-          {s.headingInHeader && heading}
+          <Heading as="h1" size="normal" className="text-center">
+            Select a region
+          </Heading>
         </div>
 
-        <div className={cn("flex w-full flex-col items-center", s.listBlock)}>
-          {!s.headingInHeader && heading}
-          {regionList}
-        </div>
+        <CornerBox className="w-full">
+          <div className="divide-y divide-line-structure">
+            {cloudRegionSelectorOrder.map((regionKey) => {
+              const region = cloudRegions[regionKey];
+              const card = regionCards[regionKey];
+              const host = getCloudHost(region.url);
+              const href = buildCloudRedirectUrl({
+                region: regionKey,
+                cloudSubpath,
+                search: "",
+                hash: "",
+              });
+              const isSignedIn = signedInRegions[regionKey];
+
+              return (
+                <a
+                  key={regionKey}
+                  href={href}
+                  data-launch-app-cta=""
+                  onClick={(event) => handleRegionSelect(regionKey, event)}
+                  className="group flex items-center gap-4 px-4 py-4 transition-colors hover:bg-surface-1 sm:px-5"
+                >
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[2px] border border-line-structure bg-surface-1">
+                    {card.icon}
+                  </span>
+
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-analog text-[15px] font-medium leading-none text-text-primary">
+                        {card.title}
+                      </span>
+                      {isSignedIn && <SignedInBadge />}
+                    </div>
+                    <Text
+                      size="s"
+                      as="span"
+                      className="block text-left leading-[150%] text-text-tertiary lg:leading-[150%]"
+                    >
+                      {host}
+                      <span className="mx-1.5 text-text-disabled">
+                        &middot;
+                      </span>
+                      AWS {card.awsRegion}
+                    </Text>
+                  </div>
+
+                  <ArrowRight className="h-4 w-4 shrink-0 text-text-tertiary transition-[transform,color] group-hover:translate-x-0.5 group-hover:text-text-secondary" />
+                </a>
+              );
+            })}
+          </div>
+        </CornerBox>
 
         <Text size="s">
           <Link
@@ -281,13 +207,5 @@ function CloudRegionSelectorPage() {
         </Text>
       </div>
     </main>
-  );
-}
-
-export default function CloudRegionSelectorPageWithSearchParams() {
-  return (
-    <Suspense>
-      <CloudRegionSelectorPage />
-    </Suspense>
   );
 }

--- a/app/cloud/[[...path]]/page.tsx
+++ b/app/cloud/[[...path]]/page.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
+import {
+  Suspense,
+  useCallback,
+  useMemo,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { ArrowRight, ShieldCheck } from "lucide-react";
 import { CornerBox } from "@/components/ui/corner-box";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
 import { Logo } from "@/components/Logo";
+import { cn } from "@/lib/utils";
 import {
   cloudRegionSelectorOrder,
   cloudRegions,
@@ -46,6 +53,51 @@ const regionCards: Record<
 };
 
 const CLOUD_ROUTE_PREFIX = "/cloud";
+
+/**
+ * Spacing previews for /cloud. Append `?opt=a|b|c` to compare.
+ * Default is B (title-led). Remove the switcher once a direction is chosen.
+ */
+const SPACING_OPTIONS = {
+  a: {
+    stack: "gap-10",
+    header: "gap-6",
+    brand: "gap-3",
+    listBlock: "gap-10",
+    headingInHeader: true,
+    taglineSize: "m" as const,
+    taglineClassName: undefined as string | undefined,
+    regionRow: "px-4 py-4 sm:px-5",
+    regionText: "gap-1",
+  },
+  b: {
+    stack: "gap-10",
+    header: "gap-8",
+    brand: "gap-1",
+    listBlock: "gap-10",
+    headingInHeader: true,
+    taglineSize: "s" as const,
+    taglineClassName: "tracking-[0.01em]",
+    regionRow: "px-4 py-4 sm:px-5",
+    regionText: "gap-1",
+  },
+  c: {
+    stack: "gap-10",
+    header: "gap-0",
+    brand: "gap-2.5",
+    listBlock: "gap-3",
+    headingInHeader: false,
+    taglineSize: "s" as const,
+    taglineClassName: undefined as string | undefined,
+    regionRow: "px-4 py-5 sm:px-5",
+    regionText: "gap-1.5",
+  },
+} as const;
+
+type SpacingOptionKey = keyof typeof SPACING_OPTIONS;
+
+const isSpacingOptionKey = (value: string | null): value is SpacingOptionKey =>
+  value === "a" || value === "b" || value === "c";
 
 const stripControlChars = (value: string) =>
   value.replace(/[\u0000-\u001F\u007F]/g, "");
@@ -91,9 +143,14 @@ const SignedInBadge = () => (
 
 const getCloudHost = (url: string) => new URL(url).host;
 
-export default function CloudRegionSelectorPage() {
+function CloudRegionSelectorPage() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { signedInRegions } = useCloudRegionSignIn();
+  const spacingKey = isSpacingOptionKey(searchParams.get("opt"))
+    ? searchParams.get("opt")
+    : "b";
+  const s = SPACING_OPTIONS[spacingKey as SpacingOptionKey];
 
   const { cloudSubpath } = useMemo(
     () => getCloudRedirectPartsFromPathname(pathname || ""),
@@ -126,74 +183,93 @@ export default function CloudRegionSelectorPage() {
     [cloudSubpath],
   );
 
+  const heading = (
+    <Heading as="h1" size="normal" className="text-center">
+      Select a region
+    </Heading>
+  );
+
+  const regionList = (
+    <CornerBox className="w-full">
+      <div className="divide-y divide-line-structure">
+        {cloudRegionSelectorOrder.map((regionKey) => {
+          const region = cloudRegions[regionKey];
+          const card = regionCards[regionKey];
+          const host = getCloudHost(region.url);
+          const href = buildCloudRedirectUrl({
+            region: regionKey,
+            cloudSubpath,
+            search: "",
+            hash: "",
+          });
+          const isSignedIn = signedInRegions[regionKey];
+
+          return (
+            <a
+              key={regionKey}
+              href={href}
+              data-launch-app-cta=""
+              onClick={(event) => handleRegionSelect(regionKey, event)}
+              className={cn(
+                "group flex items-center gap-4 transition-colors hover:bg-surface-1",
+                s.regionRow,
+              )}
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[2px] border border-line-structure bg-surface-1">
+                {card.icon}
+              </span>
+
+              <div className={cn("min-w-0 flex-1 flex flex-col", s.regionText)}>
+                <div className="flex items-center gap-2">
+                  <span className="font-analog text-[15px] font-medium leading-none text-text-primary">
+                    {card.title}
+                  </span>
+                  {isSignedIn && <SignedInBadge />}
+                </div>
+                <Text
+                  size="s"
+                  as="span"
+                  className="block text-left leading-[150%] text-text-tertiary lg:leading-[150%]"
+                >
+                  {host}
+                  <span className="mx-1.5 text-text-disabled">&middot;</span>
+                  AWS {card.awsRegion}
+                </Text>
+              </div>
+
+              <ArrowRight className="h-4 w-4 shrink-0 text-text-tertiary transition-[transform,color] group-hover:translate-x-0.5 group-hover:text-text-secondary" />
+            </a>
+          );
+        })}
+      </div>
+    </CornerBox>
+  );
+
   return (
     <main
       translate="no"
       className="flex min-h-screen flex-col items-center justify-center bg-surface-bg px-4 py-10 sm:px-6 lg:px-8 notranslate"
     >
-      <div className="flex w-full max-w-[480px] flex-col items-center gap-8">
-        <div className="flex flex-col items-center gap-5">
-          <div className="flex flex-col items-center gap-2">
+      <div
+        className={cn(
+          "flex w-full max-w-[480px] flex-col items-center",
+          s.stack,
+        )}
+      >
+        <div className={cn("flex flex-col items-center", s.header)}>
+          <div className={cn("flex flex-col items-center", s.brand)}>
             <Logo variant="byClickHouse" />
-            <Text>Agent Observability and Evals</Text>
+            <Text size={s.taglineSize} className={s.taglineClassName}>
+              Agent Observability and Evals
+            </Text>
           </div>
-          <Heading as="h1" size="normal" className="text-center">
-            Select a region
-          </Heading>
+          {s.headingInHeader && heading}
         </div>
 
-        <CornerBox className="w-full">
-          <div className="divide-y divide-line-structure">
-            {cloudRegionSelectorOrder.map((regionKey) => {
-              const region = cloudRegions[regionKey];
-              const card = regionCards[regionKey];
-              const host = getCloudHost(region.url);
-              const href = buildCloudRedirectUrl({
-                region: regionKey,
-                cloudSubpath,
-                search: "",
-                hash: "",
-              });
-              const isSignedIn = signedInRegions[regionKey];
-
-              return (
-                <a
-                  key={regionKey}
-                  href={href}
-                  data-launch-app-cta=""
-                  onClick={(event) => handleRegionSelect(regionKey, event)}
-                  className="group flex items-center gap-4 px-4 py-4 transition-colors hover:bg-surface-1 sm:px-5"
-                >
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[2px] border border-line-structure bg-surface-1">
-                    {card.icon}
-                  </span>
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="font-analog text-[15px] font-medium text-text-primary">
-                        {card.title}
-                      </span>
-                      {isSignedIn && <SignedInBadge />}
-                    </div>
-                    <Text
-                      size="s"
-                      as="span"
-                      className="mt-0.5 block text-left text-text-tertiary"
-                    >
-                      {host}
-                      <span className="mx-1.5 text-text-disabled">
-                        &middot;
-                      </span>
-                      AWS {card.awsRegion}
-                    </Text>
-                  </div>
-
-                  <ArrowRight className="h-4 w-4 shrink-0 text-text-tertiary transition-[transform,color] group-hover:translate-x-0.5 group-hover:text-text-secondary" />
-                </a>
-              );
-            })}
-          </div>
-        </CornerBox>
+        <div className={cn("flex w-full flex-col items-center", s.listBlock)}>
+          {!s.headingInHeader && heading}
+          {regionList}
+        </div>
 
         <Text size="s">
           <Link
@@ -205,5 +281,13 @@ export default function CloudRegionSelectorPage() {
         </Text>
       </div>
     </main>
+  );
+}
+
+export default function CloudRegionSelectorPageWithSearchParams() {
+  return (
+    <Suspense>
+      <CloudRegionSelectorPage />
+    </Suspense>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ships the title-led spacing on `/cloud` (option B from the earlier comparison).

- Tagline is a 14px caption under the ClickHouse lockup
- More space before “Select a region”
- 4px between region name and host line (was 2px)
- Stack gap 40px (was 32px)

The `?opt=` preview switcher is gone, so the picker renders in static HTML again.

![Option B spacing on /cloud](https://cursor.com/artifacts/c/art-333f2e16-52cf-4680-9011-d130ee897f52)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd386495-96ae-425e-a77f-432900356213?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd386495-96ae-425e-a77f-432900356213&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds three query-selectable spacing treatments to the `/cloud` region picker and makes option B the default.
- Refactors the header and region list into reusable layout blocks.
- Adjusts typography, row spacing, and heading placement per option.
- Reads `?opt=a|b|c` through `useSearchParams()` and adds a Suspense boundary.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The initial-render regression should be fixed before merging so the cloud region selector does not disappear while the new search-parameter component hydrates.

The complete region-selection interface now sits behind a Suspense boundary that renders nothing while `useSearchParams()` requires client rendering.

**Files Needing Attention:** app/cloud/[[...path]]/page.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/cloud/[[...path]]/page.tsx:288-290
**Empty selector during suspension**

When `/cloud` is initially rendered before hydration, `useSearchParams()` sends the complete selector through this Suspense boundary, whose omitted fallback renders no region links and leaves the page blank until client rendering completes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improve /cloud text spacing with three p..."](https://github.com/langfuse/langfuse-docs/commit/99240065bfd75990bd6d02d67df5cc594919d285) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60050221)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content-driven site delivery](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-driven-site-delivery.md)

<!-- /greptile_comment -->