### PR TITLE
Fix FAQ tag filtering on the public API page

### DIFF
--- a/content/docs/api-and-data-platform/features/public-api.mdx
+++ b/content/docs/api-and-data-platform/features/public-api.mdx
@@ -295,7 +295,7 @@ You can also export data via:
 
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["platform"]} />
+<FaqPreview tags={["public-api"]} />
 
 ## Related API resources [#related-api-resources]
 

--- a/content/faq/all/api-524-http-errors.mdx
+++ b/content/faq/all/api-524-http-errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why do I see 524 errors on Langfuse API calls?
-tags: [platform]
+tags: [platform, public-api]
 ---
 
 # Why do I see 524 errors on Langfuse API calls?

--- a/content/faq/all/api-limits.mdx
+++ b/content/faq/all/api-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Are there any limits to the Langfuse API?
-tags: [platform]
+tags: [platform, public-api]
 ---
 
 # What are the limits to the Langfuse API?

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -2,7 +2,7 @@
 title: How do I migrate off the deprecated Langfuse APIs?
 sidebarTitle: Deprecated API migration
 description: Per-endpoint mapping from Langfuse's deprecated REST endpoints and SDK methods to their supported replacements, with parameter mappings, semantic differences, examples, and endpoint references.
-tags: [platform]
+tags: [platform, public-api]
 ---
 
 import { V4CutoverDate } from "@/components/V4CutoverDate";

--- a/content/faq/all/self-hosting-api-reference.mdx
+++ b/content/faq/all/self-hosting-api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Where can I find the API reference for self-hosted Langfuse?
-tags: [self-hosting, platform]
+tags: [self-hosting, platform, public-api]
 ---
 
 # Where can I find the API reference for self-hosted Langfuse?

--- a/content/faq/all/where-are-langfuse-api-keys.mdx
+++ b/content/faq/all/where-are-langfuse-api-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Where do I find my Langfuse API keys?
-tags: [platform, observability, administration]
+tags: [platform, observability, administration, public-api]
 ---
 
 # Where are my Langfuse API keys?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The FAQ preview on the Public API page used the broad `platform` tag, so it listed unrelated entries (password reset, account deletion, inviting users, etc.).

This change:

- Filters the page FAQ on a dedicated `public-api` tag
- Applies that tag to the API-related FAQ posts:
  - Are there any limits to the Langfuse API?
  - How do I migrate off the deprecated Langfuse APIs?
  - Where can I find the API reference for self-hosted Langfuse?
  - Where do I find my Langfuse API keys?
  - Why do I see 524 errors on Langfuse API calls?

## Test plan

- [x] Open `/docs/api-and-data-platform/features/public-api` and confirm the FAQ section lists only the five API-related entries above
- [x] Confirm unrelated `platform` FAQs (e.g. forgot password, delete account) no longer appear
- [x] Confirm those five FAQs still appear on other pages that filter by their existing tags (`platform`, `administration`, `self-hosting`, etc.)
- [x] Desktop and mobile layout check

![Public API FAQ section on desktop](https://cursor.com/artifacts/c/art-d583a8d0-98ed-449d-a27a-8f0aff00cf6c)
![Public API FAQ section on mobile](https://cursor.com/artifacts/c/art-238bb319-4678-4f2f-bd04-9aa70e495e92)
<a href="https://cursor.com/agents/bc-d4a61ac6-4965-439c-b8f2-a714d3083705/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_api_faq_filter_desktop_mobile.mp4"><img src="https://cursor.com/artifacts/c/art-2a23d258-8100-4a65-9e4e-9e56d80d8a25" alt="public_api_faq_filter_desktop_mobile.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2346](https://linear.app/clickhouse/issue/LFMKT-2346/fix-faq-component-tag-filtering-on-the-public-api-page)

<div><a href="https://cursor.com/agents/bc-d4a61ac6-4965-439c-b8f2-a714d3083705?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a61ac6-4965-439c-b8f2-a714d3083705&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows the Public API page’s FAQ preview to a dedicated tag while preserving each selected FAQ’s existing taxonomy.

- Replaces the broad `platform` filter with `public-api`.
- Adds `public-api` to the five API-related FAQ entries.
- Leaves existing tags intact so the entries remain visible in their previous categories.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The FAQ component supports exact matching against arbitrary string tags, and the new filter resolves to the five intended entries while their existing tags remain intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: filter public API page FAQ by publi..."](https://github.com/langfuse/langfuse-docs/commit/5e9c351167029d9ce6206f480592b9a73c93c001) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60061564)</sub>

<!-- /greptile_comment -->