### PR TITLE
Set Vercel Insights sampling to 10 percent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -125,7 +125,7 @@ export default function RootLayout({
             />
           </>
         )}
-        <SpeedInsights />
+        <SpeedInsights sampleRate={0.1} />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Configure Vercel Speed Insights to sample 10% of traffic.
- Reduce telemetry volume while retaining representative performance data.

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single telemetry sampling tweak in `app/layout.tsx` with no auth, data, or product logic impact.
> 
> **Overview**
> **Vercel Speed Insights** in the root layout now passes **`sampleRate={0.1}`**, so only about **10% of page loads** send performance telemetry instead of the default full sampling.
> 
> This cuts Speed Insights volume while still keeping a representative slice of real-user metrics. No other analytics or layout behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b182f7f755ffb334fbc6fc148fea1cffd6a548a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Configures Vercel Speed Insights to sample 10% of site traffic, reducing telemetry volume while retaining performance data.

- Passes `sampleRate={0.1}` to the root `SpeedInsights` component.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The installed Speed Insights API accepts a numeric sampling rate between zero and one, and the new value correctly configures 10% sampling.
</details>

<sub>Reviews (1): Last reviewed commit: ["Set Vercel Insights sample rate to 10 pe..."](https://github.com/langfuse/langfuse-docs/commit/b182f7f755ffb334fbc6fc148fea1cffd6a548a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60178541)</sub>

<!-- /greptile_comment -->