### PR TITLE
Add government hardening documentation and plan visibility

### DIFF
--- a/components/Availability.tsx
+++ b/components/Availability.tsx
@@ -15,10 +15,6 @@ const availabilities: {
     label: "Enterprise Edition",
   },
   {
-    id: "ee-development",
-    label: "Enterprise Edition, in development",
-  },
-  {
     id: "team-add-on",
     label: "Teams Add-on required",
   },

--- a/components/Availability.tsx
+++ b/components/Availability.tsx
@@ -15,6 +15,10 @@ const availabilities: {
     label: "Enterprise Edition",
   },
   {
+    id: "ee-development",
+    label: "Enterprise Edition, in development",
+  },
+  {
     id: "team-add-on",
     label: "Teams Add-on required",
   },

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -247,6 +247,12 @@ const tiers: Record<DeploymentOption, Tier[]> = {
         "Solutions architect support during evaluation and rollout",
         "Direct access to the product team for feedback",
         "SOC 2 Type II and ISO 27001 reports",
+        <Link
+          href="/self-hosting/configuration/hardening#hardening-for-government"
+          className="underline underline-offset-2 hover:text-primary"
+        >
+          Hardening for Government (in development)
+        </Link>,
         "Support SLA",
         "Billing via AWS Marketplace or invoice",
       ],
@@ -1114,6 +1120,13 @@ const sections: Section[] = [
             Enterprise: true,
           },
           selfHosted: { "Open Source": true, Enterprise: true },
+        },
+      },
+      {
+        name: "Hardening for Government (in development)",
+        href: "/self-hosting/configuration/hardening#hardening-for-government",
+        tiers: {
+          selfHosted: { "Open Source": false, Enterprise: true },
         },
       },
       {

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -247,12 +247,7 @@ const tiers: Record<DeploymentOption, Tier[]> = {
         "Solutions architect support during evaluation and rollout",
         "Direct access to the product team for feedback",
         "SOC 2 Type II and ISO 27001 reports",
-        <Link
-          href="/self-hosting/configuration/hardening#hardening-for-government"
-          className="underline underline-offset-2 hover:text-primary"
-        >
-          Hardening for Government (in development)
-        </Link>,
+        "Hardening for Government (in development)",
         "Support SLA",
         "Billing via AWS Marketplace or invoice",
       ],

--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -36,6 +36,8 @@ import EnterpriseCloudScale from "@/components-mdx/enterprise-cloud-scale.mdx";
 
 **Langfuse Cloud** is enterprise-ready with SOC 2 Type II and ISO 27001 certifications, GDPR compliance, and HIPAA alignment. For organizations with specific data residency requirements, Langfuse can also be [self-hosted](/self-hosting) as an [open source](/open-source) MIT-licensed project.
 
+For government and other highly regulated environments, we are extending Langfuse Self-Hosted Enterprise with FIPS-compatible deployment support, hardened deployment images, air-gapped operation, and end-to-end deployment documentation for Langfuse and its required subcomponents. See [Hardening for Government](/self-hosting/configuration/hardening#hardening-for-government) for details and current availability.
+
 <EnterpriseCloudScale />
 
 Langfuse **scales to the largest enterprise use cases** and platform deployment scenarios. Langfuse OSS and Langfuse Enterprise use the same codebase as Langfuse Cloud. Langfuse Cloud currently operates at:
@@ -137,6 +139,15 @@ We're here to help you find the right solution for your use case.
 
 1. Managed Cloud (cloud.langfuse.com), see [Pricing](/pricing) and [Security](/security) page for details.
 2. [Self-hosted](/self-hosting) on your own infrastructure. Contact us if you are interested in additional support.
+
+</Details>
+
+<Details>
+<Summary>Does Langfuse support government and air-gapped deployments?</Summary>
+
+We are actively developing additional hardening capabilities for Langfuse Self-Hosted Enterprise, including FIPS-compatible deployment support, hardened deployment images, air-gapped operation, and documentation for running the complete deployment stack and its required subcomponents.
+
+See [Hardening for Government](/self-hosting/configuration/hardening#hardening-for-government) for details, or [contact sales](/talk-to-us?deployment=self-hosted) to discuss your requirements and early access.
 
 </Details>
 

--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -38,7 +38,7 @@ We maintain internal policies in the [ClickHouse Trust Center](https://trust.cli
 
 import { ShieldCheck, BadgeCheck, HeartPulse, FileLock } from "lucide-react";
 
-<Cards num={4}>
+<Cards num={2}>
   <Cards.Card
     icon={<ShieldCheck size="24" />}
     title="SOC 2 Type II"

--- a/content/security/index.mdx
+++ b/content/security/index.mdx
@@ -38,7 +38,7 @@ We maintain internal policies in the [ClickHouse Trust Center](https://trust.cli
 
 import { ShieldCheck, BadgeCheck, HeartPulse, FileLock } from "lucide-react";
 
-<Cards num={3}>
+<Cards num={4}>
   <Cards.Card
     icon={<ShieldCheck size="24" />}
     title="SOC 2 Type II"
@@ -55,6 +55,12 @@ import { ShieldCheck, BadgeCheck, HeartPulse, FileLock } from "lucide-react";
     icon={<HeartPulse size="24" />}
     title="HIPAA"
     href="/security/hipaa"
+    arrow
+  />
+  <Cards.Card
+    icon={<FileLock size="24" />}
+    title="Hardening for Government"
+    href="/self-hosting/configuration/hardening#hardening-for-government"
     arrow
   />
 </Cards>

--- a/content/security/meta.json
+++ b/content/security/meta.json
@@ -13,6 +13,7 @@
     "encryption",
     "incident-and-breach",
     "networking",
+    "[Hardening for Government ↗](/self-hosting/configuration/hardening#hardening-for-government)",
     "penetration-testing",
     "responsible-disclosure",
     "security-faq",

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -19,7 +19,7 @@ For related operational guides, see [Authentication and SSO](/self-hosting/secur
     core: "not-available",
     pro: "not-available",
     enterprise: "not-available",
-    selfHosted: "ee-development",
+    selfHosted: "ee",
   }}
 />
 

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -27,7 +27,6 @@ We are extending Langfuse Self-Hosted Enterprise for government and other highly
 
 - **FIPS-compatible deployment support** for environments that require approved cryptographic implementations.
 - **Hardened deployment images** designed to reduce the attack surface and support security-focused deployment baselines.
-- **Air-gapped operation** for environments without direct internet access.
 - **End-to-end deployment documentation** for operating Langfuse and all required subcomponents as a complete government deployment stack.
 
 These capabilities are under active development. [Contact our sales team](/talk-to-us?deployment=self-hosted) to discuss your requirements and early access.

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -24,7 +24,7 @@ These capabilities are under active development. [Contact our sales team](/talk-
 
 ## Restrict who can sign in [#access]
 
-By default, anyone who can reach the Langfuse web container can sign up with email and password. Pick one of the following profiles before exposing the instance.
+By default, anyone who can reach the Langfuse web container can sign up with email and password. Pick one of the following profiles before exposing the instance. For more details on authentication configuration, see [Authentication and SSO](/self-hosting/security/authentication-and-sso).
 
 ### Disable open sign-up [#disable-signup]
 

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -11,6 +11,17 @@ Langfuse ships with safe defaults and is penetration-tested for the same configu
 
 For related operational guides, see [Authentication and SSO](/self-hosting/security/authentication-and-sso), [Networking](/self-hosting/security/networking), [Encryption](/self-hosting/configuration/encryption), and [Deployment Strategies](/self-hosting/security/deployment-strategies).
 
+## Hardening for Government [#hardening-for-government]
+
+We are extending Langfuse Self-Hosted Enterprise for government and other highly regulated environments. Current work includes:
+
+- **FIPS-compatible deployment support** for environments that require approved cryptographic implementations.
+- **Hardened deployment images** designed to reduce the attack surface and support security-focused deployment baselines.
+- **Air-gapped operation** for environments without direct internet access.
+- **End-to-end deployment documentation** for operating Langfuse and all required subcomponents as a complete government deployment stack.
+
+These capabilities are under active development. [Contact our sales team](/talk-to-us?deployment=self-hosted) to discuss your requirements and early access.
+
 ## Restrict who can sign in [#access]
 
 By default, anyone who can reach the Langfuse web container can sign up with email and password. Pick one of the following profiles before exposing the instance.

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -13,6 +13,16 @@ For related operational guides, see [Authentication and SSO](/self-hosting/secur
 
 ## Hardening for Government [#hardening-for-government]
 
+<AvailabilityBanner
+  availability={{
+    hobby: "not-available",
+    core: "not-available",
+    pro: "not-available",
+    enterprise: "not-available",
+    selfHosted: "ee-development",
+  }}
+/>
+
 We are extending Langfuse Self-Hosted Enterprise for government and other highly regulated environments. Current work includes:
 
 - **FIPS-compatible deployment support** for environments that require approved cryptographic implementations.

--- a/content/self-hosting/configuration/hardening.mdx
+++ b/content/self-hosting/configuration/hardening.mdx
@@ -27,7 +27,7 @@ We are extending Langfuse Self-Hosted Enterprise for government and other highly
 
 - **FIPS-compatible deployment support** for environments that require approved cryptographic implementations.
 - **Hardened deployment images** designed to reduce the attack surface and support security-focused deployment baselines.
-- **End-to-end deployment documentation** for operating Langfuse and all required subcomponents as a complete government deployment stack.
+- **End-to-end deployment documentation** for operating Langfuse and all required subcomponents as a complete air-gapped government deployment stack.
 
 These capabilities are under active development. [Contact our sales team](/talk-to-us?deployment=self-hosted) to discuss your requirements and early access.
 

--- a/content/self-hosting/security/meta.json
+++ b/content/self-hosting/security/meta.json
@@ -4,6 +4,7 @@
     "authentication-and-sso",
     "deployment-strategies",
     "networking",
+    "[Hardening ↗](/self-hosting/configuration/hardening)",
     "data-masking",
     "telemetry",
     "[RBAC (main docs)](/docs/administration/rbac)",

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -78,6 +78,10 @@ function replaceComponentsWithMarkdown(fileContent) {
       /<VersionTimeline\b([\s\S]*?)\/>/g,
       (_, attributes) => `\n${renderVersionTimeline(attributes)}\n`,
     )
+    .replace(
+      /<AvailabilityBanner\b([\s\S]*?)\/>/g,
+      (_, attributes) => `\n${renderAvailabilityBanner(attributes)}\n`,
+    )
     .replace(/<Glossary\s*\/>/g, () => `\n${renderGlossary()}\n`)
     .replace(
       /<JudgePromptExampleJa\s*\/>/g,
@@ -115,6 +119,43 @@ function replaceComponentsWithMarkdown(fileContent) {
       /<LoopDiagram\b([\s\S]*?)\/>/g,
       () => `\n${renderLoopDiagram()}\n`,
     );
+}
+
+const AVAILABILITY_PLANS = [
+  ["hobby", "Hobby"],
+  ["core", "Core"],
+  ["pro", "Pro"],
+  ["enterprise", "Enterprise"],
+  ["selfHosted", "Self Hosted"],
+];
+
+const AVAILABILITY_LABELS = {
+  ee: "Enterprise Edition",
+  "team-add-on": "Teams Add-on required",
+  full: "Available",
+  v4: "Langfuse v4+",
+  "v3.179": "Langfuse v3.179.0+",
+  "private-beta": "Private Beta",
+  "public-beta": "Public Beta",
+  "not-available": "Not Available",
+};
+
+function renderAvailabilityBanner(attributes) {
+  const rows = AVAILABILITY_PLANS.map(([id, plan]) => {
+    const match = attributes.match(new RegExp(`\\b${id}:\\s*["']([^"']+)["']`));
+    if (!match) return null;
+    return `| ${plan} | ${AVAILABILITY_LABELS[match[1]] ?? match[1]} |`;
+  }).filter(Boolean);
+
+  if (rows.length === 0) return "";
+
+  return [
+    "**Where is this feature available?**",
+    "",
+    "| Plan | Availability |",
+    "| --- | --- |",
+    ...rows,
+  ].join("\n");
 }
 
 // The AI Engineering Loop diagram (components/academy/LoopDiagram.tsx) is an

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -337,7 +337,8 @@ function replaceCardGroupsWithMarkdown(fileContent) {
 }
 
 /**
- * Finds each top-level `<Card ...>` element's [start, end) range in `cardsSource`
+ * Finds each top-level `<Card ...>` or `<Cards.Card ...>` element's [start, end)
+ * range in `cardsSource`
  * by tracking JSX nesting depth token-by-token, rather than a single regex.
  * A prior regex-only approach treated the first bare `/>` line as a Card's own
  * closing tag, which broke when a Card's `icon={...}` contained a multi-line
@@ -362,7 +363,8 @@ function findTopLevelCardRanges(cardsSource) {
         cardStart = null;
       }
     } else {
-      if (depth === 0 && token.slice(1) === "Card") {
+      const tagName = token.slice(1);
+      if (depth === 0 && (tagName === "Card" || tagName === "Cards.Card")) {
         cardStart = match.index;
       }
       depth++;
@@ -375,7 +377,8 @@ function renderSelfClosingCards(cardsSource) {
   const ranges = findTopLevelCardRanges(cardsSource);
   if (!ranges || ranges.length === 0) return null;
 
-  const cardTagCount = (cardsSource.match(/<Card\b/g) ?? []).length;
+  const cardTagCount = (cardsSource.match(/<(?:Card|Cards\.Card)\b/g) ?? [])
+    .length;
   // Partial matches silently drop unsupported siblings; only convert complete groups.
   if (ranges.length !== cardTagCount) return null;
 

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -34,7 +34,7 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 - Solutions architect support during evaluation and rollout
 - Direct access to the product team for feedback
 - SOC 2 Type II and ISO 27001 reports
-- [Hardening for Government (in development)](/self-hosting/configuration/hardening#hardening-for-government)
+- Hardening for Government (in development)
 - Support SLA
 - Billing via AWS Marketplace or invoice
 

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -34,6 +34,7 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 - Solutions architect support during evaluation and rollout
 - Direct access to the product team for feedback
 - SOC 2 Type II and ISO 27001 reports
+- [Hardening for Government (in development)](/self-hosting/configuration/hardening#hardening-for-government)
 - Support SLA
 - Billing via AWS Marketplace or invoice
 
@@ -41,92 +42,93 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 
 ## Feature Comparison (Self-Hosted)
 
-| Feature                                                                                             | Open Source                 | Enterprise                                 |
-| --------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
-| **LLM Application & Agent Tracing**                                                                 |                             |                                            |
-| [Traces and graphs (agents)](/docs/observability/overview)                                          | Yes                         | Yes                                        |
-| [Session tracking (chats/threads)](/docs/observability/features/sessions)                           | Yes                         | Yes                                        |
-| [User tracking](/docs/observability/features/users)                                                 | Yes                         | Yes                                        |
-| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                         | Yes                                        |
-| [Native framework integrations](/integrations)                                                      | Yes                         | Yes                                        |
-| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                         | Yes                                        |
-| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                         | Yes                                        |
-| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                         | Yes                                        |
-| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                         | Yes                                        |
-| Included usage                                                                                      | Unlimited                   | Unlimited                                  |
-| [Multi-modal](/docs/observability/features/multi-modality)                                          | Yes                         | Yes                                        |
-| **Langfuse AI**                                                                                     |                             |                                            |
-| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                       | --                          | --                                         |
-| **Prompt Management**                                                                               |                             |                                            |
-| [Prompt versioning](/docs/prompt-management/get-started)                                            | Yes                         | Yes                                        |
-| Prompt fetching                                                                                     | Unlimited                   | Unlimited                                  |
-| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                | Yes                         | Yes                                        |
-| [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                         | Yes                                        |
-| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                         | Yes                                        |
-| [Playground](/docs/prompt-management/features/playground)                                           | Yes                         | Yes                                        |
-| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                         | Yes                                        |
-| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                         | Yes                                        |
-| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                          | Yes                                        |
-| **Evaluation (online and offline)**                                                                 |                             |                                            |
-| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                         | Yes                                        |
-| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                         | Yes                                        |
-| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                         | Yes                                        |
-| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                         | Yes                                        |
-| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                         | Yes                                        |
-| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                         | Yes                                        |
-| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                         | Yes                                        |
-| [Human annotation](/docs/scores/annotation)                                                         | Yes                         | Yes                                        |
-| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | Yes                         | Yes                                        |
-| **Metrics**                                                                                         |                             |                                            |
-| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                         | Yes                                        |
-| [Alerts](/docs/observability/features/alerts)                                                       | Langfuse v4+                | Langfuse v4+                               |
-| **Collaboration**                                                                                   |                             |                                            |
-| Projects                                                                                            | Unlimited                   | Unlimited                                  |
-| Users                                                                                               | Unlimited                   | Unlimited                                  |
-| **API**                                                                                             |                             |                                            |
-| [Extensive public API](/docs/api-and-data-platform/features/public-api)                             | Yes                         | Yes                                        |
-| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                           | Langfuse v4+                | Langfuse v4+                               |
-| **Exports**                                                                                         |                             |                                            |
-| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                        | Yes                         | Yes                                        |
-| [PostHog integration](/integrations/analytics/posthog)                                              | Yes                         | Yes                                        |
-| [Mixpanel integration](/integrations/analytics/mixpanel)                                            | Yes                         | Yes                                        |
-| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage) | Yes                         | Yes                                        |
-| **Deployment**                                                                                      |                             |                                            |
-| ClickHouse deployment model                                                                         | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC / Private |
-| [Deployment templates](/self-hosting)                                                               | Yes                         | Yes                                        |
-| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                   | Yes                         | Yes                                        |
-| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                       | Yes                         | Yes                                        |
-| [AWS (Terraform)](/self-hosting/deployment/aws)                                                     | Yes                         | Yes                                        |
-| [Azure (Terraform)](/self-hosting/deployment/azure)                                                 | Yes                         | Yes                                        |
-| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                     | Yes                         | Yes                                        |
-| **Support**                                                                                         |                             |                                            |
-| [Ask AI](/docs/ask-ai)                                                                              | Yes                         | Yes                                        |
-| [Community (GitHub)](/support#community)                                                            | Yes                         | Yes                                        |
-| [In-app support](/support#in-app)                                                                   | --                          | Yes                                        |
-| [Private Slack channel](/support#slack)                                                             | --                          | Yes                                        |
-| [Named lead support engineer](/support#onboarding)                                                  | --                          | Yes                                        |
-| [Onboarding & architectural guidance](/support#onboarding)                                          | --                          | Yes                                        |
-| Solutions architect support                                                                         | --                          | Yes                                        |
-| Product team feedback channel                                                                       | --                          | Yes                                        |
-| [Support SLA](/enterprise#faq)                                                                      | --                          | Yes                                        |
-| **Security**                                                                                        |                             |                                            |
-| Sign in with Google, AzureAD, GitHub                                                                | Yes                         | Yes                                        |
-| [Organization-level RBAC](/docs/administration/rbac)                                                | Yes                         | Yes                                        |
-| Enterprise SSO (e.g. Okta, EntraID)                                                                 | Yes                         | Yes                                        |
-| SSO enforcement                                                                                     | Yes                         | Yes                                        |
-| [Client-side data masking](/docs/observability/features/masking)                                    | Yes                         | Yes                                        |
-| [Server-side data masking](/self-hosting/security/data-masking)                                     | --                          | Yes                                        |
-| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                 | --                          | Yes                                        |
-| [Data retention management](/docs/administration/data-retention)                                    | --                          | Yes                                        |
-| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                     | --                          | Yes                                        |
-| [Organization creators](/self-hosting/administration/organization-creators)                         | --                          | Yes                                        |
-| [UI customization](/self-hosting/administration/ui-customization)                                   | --                          | Yes                                        |
-| [Audit logs](/docs/administration/audit-logs)                                                       | --                          | Yes                                        |
-| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                       | --                          | Yes                                        |
-| [Instance management API](/self-hosting/administration/instance-management-api)                     | --                          | Yes                                        |
-| **Compliance**                                                                                      |                             |                                            |
-| SOC2 Type II & ISO27001 reports                                                                     | --                          | Yes                                        |
-| InfoSec/legal reviews                                                                               | --                          | Yes                                        |
+| Feature                                                                                                     | Open Source                 | Enterprise                                 |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
+| **LLM Application & Agent Tracing**                                                                         |                             |                                            |
+| [Traces and graphs (agents)](/docs/observability/overview)                                                  | Yes                         | Yes                                        |
+| [Session tracking (chats/threads)](/docs/observability/features/sessions)                                   | Yes                         | Yes                                        |
+| [User tracking](/docs/observability/features/users)                                                         | Yes                         | Yes                                        |
+| [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                             | Yes                         | Yes                                        |
+| [Native framework integrations](/integrations)                                                              | Yes                         | Yes                                        |
+| [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                               | Yes                         | Yes                                        |
+| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                         | Yes                         | Yes                                        |
+| [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                         | Yes                         | Yes                                        |
+| [Custom via API](/api-and-data-platform/features/public-api)                                                | Yes                         | Yes                                        |
+| Included usage                                                                                              | Unlimited                   | Unlimited                                  |
+| [Multi-modal](/docs/observability/features/multi-modality)                                                  | Yes                         | Yes                                        |
+| **Langfuse AI**                                                                                             |                             |                                            |
+| [Langfuse Assistant (in-app agent)](/docs/langfuse-assistant)                                               | --                          | --                                         |
+| **Prompt Management**                                                                                       |                             |                                            |
+| [Prompt versioning](/docs/prompt-management/get-started)                                                    | Yes                         | Yes                                        |
+| Prompt fetching                                                                                             | Unlimited                   | Unlimited                                  |
+| [Prompt release management](/docs/prompt-management/features/prompt-version-control)                        | Yes                         | Yes                                        |
+| [Prompt composability](/docs/prompt-management/features/composability)                                      | Yes                         | Yes                                        |
+| [Prompt caching (server and client)](/docs/prompt-management/features/caching)                              | Yes                         | Yes                                        |
+| [Playground](/docs/prompt-management/features/playground)                                                   | Yes                         | Yes                                        |
+| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                              | Yes                         | Yes                                        |
+| [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                            | Yes                         | Yes                                        |
+| [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)                  | --                          | Yes                                        |
+| **Evaluation (online and offline)**                                                                         |                             |                                            |
+| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                          | Yes                         | Yes                                        |
+| [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                                     | Yes                         | Yes                                        |
+| [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                                       | Yes                         | Yes                                        |
+| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                             | Yes                         | Yes                                        |
+| [User feedback tracking](/faq/all/user-feedback)                                                            | Yes                         | Yes                                        |
+| [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)                     | Yes                         | Yes                                        |
+| [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                               | Yes                         | Yes                                        |
+| [Human annotation](/docs/scores/annotation)                                                                 | Yes                         | Yes                                        |
+| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)                 | Yes                         | Yes                                        |
+| **Metrics**                                                                                                 |                             |                                            |
+| [Custom dashboards](/docs/metrics/features/custom-dashboards)                                               | Yes                         | Yes                                        |
+| [Alerts](/docs/observability/features/alerts)                                                               | Langfuse v4+                | Langfuse v4+                               |
+| **Collaboration**                                                                                           |                             |                                            |
+| Projects                                                                                                    | Unlimited                   | Unlimited                                  |
+| Users                                                                                                       | Unlimited                   | Unlimited                                  |
+| **API**                                                                                                     |                             |                                            |
+| [Extensive public API](/docs/api-and-data-platform/features/public-api)                                     | Yes                         | Yes                                        |
+| [Metrics & Observations APIs (v2)](/docs/metrics/features/metrics-api#v2)                                   | Langfuse v4+                | Langfuse v4+                               |
+| **Exports**                                                                                                 |                             |                                            |
+| [Batch export via UI](/docs/api-and-data-platform/features/query-via-sdk#ui)                                | Yes                         | Yes                                        |
+| [PostHog integration](/integrations/analytics/posthog)                                                      | Yes                         | Yes                                        |
+| [Mixpanel integration](/integrations/analytics/mixpanel)                                                    | Yes                         | Yes                                        |
+| [Scheduled export to blob storage](/docs/api-and-data-platform/features/query-via-sdk#blob-storage)         | Yes                         | Yes                                        |
+| **Deployment**                                                                                              |                             |                                            |
+| ClickHouse deployment model                                                                                 | Self-managed ClickHouse OSS | Bundled: ClickHouse Cloud / BYOC / Private |
+| [Deployment templates](/self-hosting)                                                                       | Yes                         | Yes                                        |
+| [Local (Docker Compose)](/self-hosting/deployment/docker-compose)                                           | Yes                         | Yes                                        |
+| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)                                               | Yes                         | Yes                                        |
+| [AWS (Terraform)](/self-hosting/deployment/aws)                                                             | Yes                         | Yes                                        |
+| [Azure (Terraform)](/self-hosting/deployment/azure)                                                         | Yes                         | Yes                                        |
+| [GCP (Terraform)](/self-hosting/deployment/gcp)                                                             | Yes                         | Yes                                        |
+| **Support**                                                                                                 |                             |                                            |
+| [Ask AI](/docs/ask-ai)                                                                                      | Yes                         | Yes                                        |
+| [Community (GitHub)](/support#community)                                                                    | Yes                         | Yes                                        |
+| [In-app support](/support#in-app)                                                                           | --                          | Yes                                        |
+| [Private Slack channel](/support#slack)                                                                     | --                          | Yes                                        |
+| [Named lead support engineer](/support#onboarding)                                                          | --                          | Yes                                        |
+| [Onboarding & architectural guidance](/support#onboarding)                                                  | --                          | Yes                                        |
+| Solutions architect support                                                                                 | --                          | Yes                                        |
+| Product team feedback channel                                                                               | --                          | Yes                                        |
+| [Support SLA](/enterprise#faq)                                                                              | --                          | Yes                                        |
+| **Security**                                                                                                |                             |                                            |
+| Sign in with Google, AzureAD, GitHub                                                                        | Yes                         | Yes                                        |
+| [Hardening for Government (in development)](/self-hosting/configuration/hardening#hardening-for-government) | --                          | Yes                                        |
+| [Organization-level RBAC](/docs/administration/rbac)                                                        | Yes                         | Yes                                        |
+| Enterprise SSO (e.g. Okta, EntraID)                                                                         | Yes                         | Yes                                        |
+| SSO enforcement                                                                                             | Yes                         | Yes                                        |
+| [Client-side data masking](/docs/observability/features/masking)                                            | Yes                         | Yes                                        |
+| [Server-side data masking](/self-hosting/security/data-masking)                                             | --                          | Yes                                        |
+| [Project-level RBAC](/docs/administration/rbac#project-level-roles)                                         | --                          | Yes                                        |
+| [Data retention management](/docs/administration/data-retention)                                            | --                          | Yes                                        |
+| [SCIM API (automated user provisioning)](/docs/administration/scim-and-org-api)                             | --                          | Yes                                        |
+| [Organization creators](/self-hosting/administration/organization-creators)                                 | --                          | Yes                                        |
+| [UI customization](/self-hosting/administration/ui-customization)                                           | --                          | Yes                                        |
+| [Audit logs](/docs/administration/audit-logs)                                                               | --                          | Yes                                        |
+| [Admin API (project management, SCIM)](/docs/administration/scim-and-org-api)                               | --                          | Yes                                        |
+| [Instance management API](/self-hosting/administration/instance-management-api)                             | --                          | Yes                                        |
+| **Compliance**                                                                                              |                             |                                            |
+| SOC2 Type II & ISO27001 reports                                                                             | --                          | Yes                                        |
+| InfoSec/legal reviews                                                                                       | --                          | Yes                                        |
 
 ## Discounts
 


### PR DESCRIPTION
## Summary
- Add a government hardening section covering FIPS-compatible deployments, hardened images, air-gapped operation, and deployment documentation
- Link the new content from security navigation and the self-hosted pricing comparison
- Preserve `Cards.Card` content in Markdown conversion

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, navigation, and markdown export only; no runtime product or auth behavior changes.
> 
> **Overview**
> Introduces **Hardening for Government (in development)** as a marketed Self-Hosted Enterprise capability—FIPS-compatible deployments, hardened images, air-gapped stack documentation—and surfaces it across docs, security navigation, enterprise FAQ, and self-hosted pricing.
> 
> The hardening guide gains a dedicated section with an `AvailabilityBanner` (Self-Hosted Enterprise only). Enterprise and security pages link to it; the security compliance cards add a **Hardening for Government** entry. `PricingTable` and `md-override/pricing-self-host.md` list the feature on Enterprise and in the security comparison row.
> 
> Supporting changes extend plain-Markdown export: `AvailabilityBanner` renders as a plan availability table, and `Cards.Card` is recognized alongside `Card` so security overview cards convert without dropping content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63f7b783aeea8a55c9b523026ee16bc58638514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an in-development government hardening offering to self-hosted Enterprise documentation, pricing, and security navigation.
- Documents planned FIPS-compatible deployment support, hardened images, air-gapped operation, and deployment guidance.
- Exposes the offering through security and self-hosted pricing surfaces.
- Extends plain-Markdown card conversion to preserve `Cards.Card` content.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or documentation-rendering defects identified.

The new links use established route and heading conventions, the two pricing representations remain synchronized, and ambiguous card structures continue to fall back to their original JSX rather than losing content.
</details>

<sub>Reviews (1): Last reviewed commit: ["codex: address PR review feedback (#3709..."](https://github.com/langfuse/langfuse-docs/commit/fd861822e44a221df2bd8208d00186a23b168761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60192806)</sub>

**Context used:**

- Knowledge Base — [MDX content rendering and navigation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/mdx-content-rendering-and-navigation.md)

<!-- /greptile_comment -->