### PR TITLE
Simplify self-hosting support guidance

### DIFF
--- a/components-mdx/self-host-community-deployment.mdx
+++ b/components-mdx/self-host-community-deployment.mdx
@@ -2,6 +2,6 @@
 
 This deployment path is built on a template that is maintained outside the Langfuse organization.
 We do not systematically test it, support is best-effort, and fixes often depend on community contributions.
-See [deployment support levels](/self-hosting#support) for the officially supported alternatives.
+See the [self-hosting overview](/self-hosting) for officially supported alternatives.
 
 </Callout>

--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -40,26 +40,7 @@ For production-scale deployments, we recommend one of the following options:
 - [Render](/self-hosting/deployment/render) (community)
 - [Railway (v3)](/self-hosting/deployment/railway) (community)
 
-### Official and Community Support [#support]
-
-Deployment options differ in who maintains and tests the deployment tooling they rely on:
-
-| Option                                                        | Support Level |
-| ------------------------------------------------------------- | ------------- |
-| [Docker Compose](/self-hosting/deployment/docker-compose)     | Official      |
-| [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm) | Official      |
-| [AWS (Terraform)](/self-hosting/deployment/aws)               | Official      |
-| [Azure (Terraform)](/self-hosting/deployment/azure)           | Official      |
-| [GCP (Terraform)](/self-hosting/deployment/gcp)               | Official      |
-| [Render](/self-hosting/deployment/render)                     | Community     |
-| [Railway](/self-hosting/deployment/railway)                   | Community     |
-
-Officially supported options are built on deployment tooling that the Langfuse team maintains in the [Langfuse GitHub organization](https://github.com/langfuse): the `docker-compose.yml` in [langfuse/langfuse](https://github.com/langfuse/langfuse), the [langfuse-k8s](https://github.com/langfuse/langfuse-k8s) Helm chart, and the `langfuse-terraform-*` modules.
-The Render Blueprint and the Railway template are maintained in third-party repositories, so they follow the community support level.
-
-import SelfHostSupportLevels from "@/components-mdx/self-host-support-levels.mdx";
-
-<SelfHostSupportLevels />
+Unless marked as community-supported, these deployment options are maintained and tested by the Langfuse team. Community-supported options are maintained in third-party repositories and supported on a best-effort basis. Report problems via [GitHub issues](/issues).
 
 ## Architecture [#architecture]
 


### PR DESCRIPTION
## Summary
- Replace the detailed support-level table with concise guidance on the self-hosting overview.
- Update the community deployment callout to link to the self-hosting overview.
- Direct users to GitHub issues for support problems.

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or deployment behavior changes.
> 
> **Overview**
> **Self-hosting docs** no longer use a dedicated “Official and Community Support” section with a support-level table and the `SelfHostSupportLevels` embed. That content is replaced by a short paragraph on the overview: Langfuse-maintained options unless labeled community-supported, best-effort for third-party templates, and **GitHub issues** for reporting problems.
> 
> The **community deployment callout** now points readers to the [self-hosting overview](/self-hosting) instead of the removed `#support` anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152091f222c094d22998f77b5dfe607e16261ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR condenses the self-hosting support-level documentation and directs users to GitHub issues for support problems.
- Replaces the detailed official/community support table with concise guidance.
- Updates community-deployment callouts to link to the self-hosting overview.
- Removes the overview’s existing `#support` deep-link target.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking concern that existing external links to the support section will no longer scroll to their intended destination.

The new GitHub issues link resolves through an established redirect, while the only identified concern is loss of backward compatibility for the removed public fragment.

**Files Needing Attention:** content/self-hosting/index.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/index.mdx:43
**Preserve the support anchor**

Removing the public `#support` fragment makes existing bookmarks, cached search results, and third-party deep links land at the top of the overview instead of the support guidance. Retain a compatibility anchor when replacing this section.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Simplify self-hosting support guidance"](https://github.com/langfuse/langfuse-docs/commit/152091f222c094d22998f77b5dfe607e16261ce0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60227224)</sub>

<!-- /greptile_comment -->