### PR TITLE
Update SDK install metrics across the site

### DIFF
--- a/components/home/Enterprise.tsx
+++ b/components/home/Enterprise.tsx
@@ -29,7 +29,7 @@ const architecture = [
 ];
 
 const openApis = [
-  { label: "50M+ SDK installs/month", href: "/careers#public-metrics" },
+  { label: "130M+ SDK installs/month", href: "/careers#public-metrics" },
   { label: "90B+ observations processed per month" },
   {
     label: `${formatCompanyCount()} companies using Langfuse`,

--- a/components/home/WhyLangfuse.tsx
+++ b/components/home/WhyLangfuse.tsx
@@ -44,7 +44,7 @@ const reasons = [
   },
   {
     title: "Production-proven",
-    body: `${formatCompanyCount()} companies using Langfuse. Billions of events processed per month. 50M+ SDK installs/month. Fortune 50 deployments.`,
+    body: `${formatCompanyCount()} companies using Langfuse. Billions of events processed per month. 130M+ SDK installs/month. Fortune 50 deployments.`,
   },
   {
     title: "Shipping velocity",

--- a/components/role-finder/role-finder-data.ts
+++ b/components/role-finder/role-finder-data.ts
@@ -105,7 +105,7 @@ export const ROLES: Record<RoleKey, Role> = {
     title: "Senior Software Engineer (SDK)",
     url: "https://jobs.ashbyhq.com/langfuse/891eda0a-a9f6-45e6-8750-71874db8cc11",
     pitch:
-      "Build SDKs downloaded 26M+ times/month. Performance, versioning, and DX in code that runs in other people's production.",
+      "Build SDKs downloaded 130M+ times/month. Performance, versioning, and DX in code that runs in other people's production.",
     youll: [
       "Profile & minimize overhead in hot paths",
       "Think about versioning & backwards compatibility",

--- a/lib/usage-stats.ts
+++ b/lib/usage-stats.ts
@@ -1,6 +1,6 @@
 /** Marketing usage stats. Update these when public metrics change. */
 
-export const SDK_INSTALLS_PER_MONTH = 50_000_000;
+export const SDK_INSTALLS_PER_MONTH = 130_000_000;
 export const DOCKER_PULLS = 6_000_000;
 export const FORTUNE_500_COMPANIES = 129;
 export const FORTUNE_50_COMPANIES = 21;

--- a/md-override/index.md
+++ b/md-override/index.md
@@ -66,7 +66,7 @@ Markdown versions of any page on this site are available by appending `.md` to t
 Traditional observability handles many small spans. LLM systems run differently: every step carries rich, verbose I/O that legacy platforms cannot handle at scale. Langfuse ingests and queries LLM traces reliably at enterprise scale while following strict compliance frameworks.
 
 - **Architecture** — ClickHouse OLAP database, async ingestion via Redis queue, S3/blob storage for large payloads, and edge-cached prompts.
-- **Reliability at scale** — 50M+ SDK installs per month, 90B+ observations processed per month, 50,000+ companies using Langfuse, 99.9% uptime.
+- **Reliability at scale** — 130M+ SDK installs per month, 90B+ observations processed per month, 50,000+ companies using Langfuse, 99.9% uptime.
 - **Security and compliance** — [SOC 2 Type II & ISO 27001](/security), [EU and US data regions](/security/data-regions), a [HIPAA-ready region](/security/hipaa), [Hardening for Gov (soon)](/self-hosting/configuration/hardening#hardening-for-government), and [GDPR](/security/gdpr). See the [security overview](/security).
 
 [Enterprise](/enterprise) · [Talk to us](/talk-to-us)


### PR DESCRIPTION
## Summary

- Update the public SDK install metric from 50M+ to 130M+ per month
- Synchronize homepage, role finder, usage stats, and Markdown override content

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and a single marketing constant only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Raises the published **SDK installs per month** figure from **50M+** to **130M+** and keeps marketing copy aligned.
> 
> The canonical value in `lib/usage-stats.ts` (`SDK_INSTALLS_PER_MONTH`) is updated to `130_000_000`, which flows through any UI that reads that constant (e.g. usage/credibility blocks). Homepage **Enterprise** and **Why Langfuse** bullets, the **Senior Software Engineer (SDK)** role-finder pitch (previously **26M+**), and the **md-override** enterprise reliability line are updated to **130M+** so hardcoded text matches the new public metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7482633c03fbbd6b9517d90294d608f823e6edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR synchronizes the public monthly SDK install metric at 130M+ across marketing, recruiting, usage-stat, and Markdown content.

- Updates homepage Enterprise and Why Langfuse messaging.
- Updates the SDK engineering role pitch.
- Raises the shared usage-stat constant to 130,000,000.
- Aligns the Markdown homepage override with the new metric.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the updated metric consistent across current site surfaces and existing formatters.

The changes only synchronize static and shared SDK install metrics, and the updated numeric constant renders correctly through every identified consumer without leaving conflicting current claims.
</details>

<sub>Reviews (1): Last reviewed commit: ["Update SDK install metrics to 130M per m..."](https://github.com/langfuse/langfuse-docs/commit/a7482633c03fbbd6b9517d90294d608f823e6edb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60234647)</sub>

<!-- /greptile_comment -->