### PR TITLE
docs(handbook): update the Linear process, and say that agents may write to it

### DIFF
--- a/content/handbook/how-we-work/productivity-and-ai.mdx
+++ b/content/handbook/how-we-work/productivity-and-ai.mdx
@@ -92,7 +92,7 @@ Several non-AI tools are critical to our workflow:
 
 ## 2. Team productivity
 
-- AI vendors: We generally prefer to use external vendors as this is usually more cost-effective than maintaining the process ourselves. Examples: [Ask AI](/ask-ai) on langfuse.com is powered by Inkeep; pull requests get automated review from Claude, Greptile and Codex.
+- AI vendors: We generally prefer to use external vendors as this is usually more cost-effective than maintaining the process ourselves. Examples: [Ask AI](/ask-ai) on langfuse.com is powered by Inkeep; pull requests get automated review from Claude and Greptile.
 - Internally built tools:
   - Code: You can use our company OpenAI/Anthropic accounts
   - Dogfood Langfuse
@@ -103,6 +103,6 @@ Several non-AI tools are critical to our workflow:
 - **Where to use it**: Use Codex in terminal/IDE for direct implementation work, and **Codex Web** when you want server-side sessions that can keep running while you focus on other work.
 - **Connectors**: Connect **Linear** and **Slack** so agents can pick up context from tickets/threads and propose scoped code/documentation updates faster.
 - **Context quality**: Keep `AGENTS.md` files up to date (especially in active repos) so coding agents reliably follow current conventions, workflows, and documentation standards.
-- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions rather than general ones — how to slice a large change into reviewable pull requests, what a green check actually proves, and what an agent may write to Linear. Start with `langfuse-onboarding`, which works out who you are and points you at the rest.
+- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions rather than general ones — how to slice a large change into reviewable pull requests, which CI checks can pass without having run, and what an agent may write to Linear. Start with `langfuse-onboarding`, which works out who you are and points you at the rest.
 
 You can find some examples in this blog post: [How we use LLMs to scale Langfuse](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)

--- a/content/handbook/how-we-work/productivity-and-ai.mdx
+++ b/content/handbook/how-we-work/productivity-and-ai.mdx
@@ -92,7 +92,7 @@ Several non-AI tools are critical to our workflow:
 
 ## 2. Team productivity
 
-- AI vendors: We generally prefer to use external vendors as this is usually more cost-effective than maintaining the process ourselves. Examples: [Ask AI](/ask-ai) on langfuse.com is powered by Inkeep; PR code review is powered by Ellipsis and Greptile
+- AI vendors: We generally prefer to use external vendors as this is usually more cost-effective than maintaining the process ourselves. Examples: [Ask AI](/ask-ai) on langfuse.com is powered by Inkeep; pull requests get automated review from Claude, Greptile and Codex.
 - Internally built tools:
   - Code: You can use our company OpenAI/Anthropic accounts
   - Dogfood Langfuse
@@ -103,5 +103,6 @@ Several non-AI tools are critical to our workflow:
 - **Where to use it**: Use Codex in terminal/IDE for direct implementation work, and **Codex Web** when you want server-side sessions that can keep running while you focus on other work.
 - **Connectors**: Connect **Linear** and **Slack** so agents can pick up context from tickets/threads and propose scoped code/documentation updates faster.
 - **Context quality**: Keep `AGENTS.md` files up to date (especially in active repos) so coding agents reliably follow current conventions, workflows, and documentation standards.
+- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions rather than general ones — how to slice a large change into reviewable pull requests, what a green check actually proves, and what an agent may write to Linear. Start with `langfuse-onboarding`, which works out who you are and points you at the rest.
 
 You can find some examples in this blog post: [How we use LLMs to scale Langfuse](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -9,7 +9,7 @@ description: How the engineering team prioritizes, plans, builds, and ships at L
 
 To avoid spending hours each week triaging and prioritizing tickets, everyone manages their own priorities and escalates to their lead when work piles up. This only works if we share an understanding of SLAs and the quarterly [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping).
 
-When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear project or issue for your current main task, and the [bug view](https://linear.app/langfuse/view/bugs-confirmedopen-97856f9f745c) or "My issues" for smaller work. Every ticket has a priority.
+When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear project or issue for your current main task, and the team's open-bugs view or "My issues" for smaller work. Every ticket has a priority.
 
 ### Priority levels [#priority-levels]
 
@@ -24,7 +24,7 @@ When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear proj
 
 We balance busy work with making progress on the most important project we're driving forward. To keep that balance, we hold ourselves to a few response times:
 
-- **Linear inbox**: clear once a day.
+- **Linear inbox**: clear at least twice per working day. See [Using Linear](/handbook/tools-and-processes/using-linear).
 - **Pylon inbox**: clear twice a day. Acknowledge a user's request ASAP, then look into it or work on a fix.
 - **PR reviews**: if you're a reviewer, turn it around within 24h; if it lands in the morning, review the same day. See [Code review](/handbook/product-engineering/how-we-work/code-review) for details.
 - **Bug fixes and support**: spend at most ~2h/day on bug fixes, support tickets, and similar. Fixing bugs is sometimes critical for the company, but if you consistently spend more than 2h/day, talk to your lead to get buy-in or distribute the work across the team.
@@ -125,13 +125,15 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 | **Triage**             | - Unassigned, no labels or priority<br/>- Created via the GitHub Issue integration, or in Linear by non-engineering team members<br/>- Marc/Max subscribe, triage, assign, add labels, and refine the title<br/>- After assignment, the engineer dedupes against existing tickets and handles communication with users |
 | **Backlog**            | - Everyone manages their own backlog in Linear<br/>- Only backlog what you plan or hope to do over the next 1–2 quarters; send the rest to [GitHub Discussions](https://langfuse.com/ideas)<br/>- See the [conventions below](#linear-conventions) for titles, labels, and Pylon links                                 |
 | **Todo / In progress** | See [Priority levels](#priority-levels) for handling guidelines                                                                                                                                                                                                                                                        |
+| **Merged**             | - Set automatically when the linked pull request merges<br/>- A staging step, not the end: check whether the change needs a docs page, a changelog entry, or a word to a customer who asked for it                                                                                                                     |
+| **Done**               | - Moved by hand, once the change is deployed and those follow-ups are tracked or finished<br/>- See [definition of done](/handbook/tools-and-processes/using-linear#definition-of-done)                                                                                                                                |
 
 #### Conventions [#linear-conventions]
 
 - **Titles**: keep them precise and brief, so any engineer scanning a list of tickets roughly understands each one. Descriptions are optional; when you add one, keep it short and precise.
-- **Labels**: every issue has a label, and you can use Linear views to see all tickets for a label. Use labels for product areas, and the "feat-..." labels for most issues. Before creating a new label, check that no existing one fits ([labels](https://linear.app/langfuse/settings/issue-labels)); move new labels to the workspace/organization level, since they're created at the project level by default.
+- **Labels**: every issue carries a type label — `bug`, `improvement` or `feature` — plus a well-known label for the product area, so filters and shared views work. Use the "feat-..." labels for most issues. Before creating a new label, check the workspace label list for one that already fits; move new labels to the workspace/organization level, since they're created at the project level by default.
 - **Assignment**: enable "assign to self on creation", and assign to self when creating from third-party tools.
-- **Projects**: only create a project for work with a clear end (no endless bucket of tickets).
+- **Projects**: multi-step work belongs in a project; small improvements and fixes stay issues. Only create a project for work with a clear end (no endless bucket of tickets), and see [projects and issues](/handbook/tools-and-processes/using-linear#projects-and-issues).
 - **Pylon**: link Pylon threads to Linear issues with "Thread links". When you close a Linear ticket, resolve the Pylon thread to tell the user we shipped the fix or request. It's two minutes of effort that shows we ship fast. Snooze threads you want to revisit (e.g. next week).
 - **Internal Slack messages**: for internal (non-user-facing) messages, use the Linear app in Slack to create an issue. This links the Slack thread to the issue, and people are notified when the ticket changes state.
 

--- a/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
+++ b/content/handbook/product-engineering/how-we-work/how-we-ship.mdx
@@ -9,7 +9,9 @@ description: How the engineering team prioritizes, plans, builds, and ships at L
 
 To avoid spending hours each week triaging and prioritizing tickets, everyone manages their own priorities and escalates to their lead when work piles up. This only works if we share an understanding of SLAs and the quarterly [roadmapping process](/handbook/product-engineering/how-we-work/roadmapping).
 
-When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear project or issue for your current main task, and the team's open-bugs view or "My issues" for smaller work. Every ticket has a priority.
+When in doubt, tag anyone who can help — we would always rather you tagged someone than sat on a question. Use the team's open-bugs view or "My issues" for smaller work, and give every ticket a priority.
+
+Multi-stage work belongs in a Linear **project**, and a project gets a project update whenever things change. We read those updates together at the engineering weekly and plan the coming week from them, so an out-of-date project is a gap in the plan. For a general update about what you are working on that does not belong to one project, post it to your own `<Your Name> Housekeeping` project — those are read in the same pass.
 
 ### Priority levels [#priority-levels]
 
@@ -25,7 +27,7 @@ When in doubt, tag your lead (24h SLA on the Linear inbox). Keep one Linear proj
 We balance busy work with making progress on the most important project we're driving forward. To keep that balance, we hold ourselves to a few response times:
 
 - **Linear inbox**: clear at least twice per working day. See [Using Linear](/handbook/tools-and-processes/using-linear).
-- **Pylon inbox**: clear twice a day. Acknowledge a user's request ASAP, then look into it or work on a fix.
+- **Pylon inbox**: acknowledge a user's request quickly, then look into it or work on a fix. We are moving towards Linear as the single inbox, so this one matters slightly less than it did.
 - **PR reviews**: if you're a reviewer, turn it around within 24h; if it lands in the morning, review the same day. See [Code review](/handbook/product-engineering/how-we-work/code-review) for details.
 - **Bug fixes and support**: spend at most ~2h/day on bug fixes, support tickets, and similar. Fixing bugs is sometimes critical for the company, but if you consistently spend more than 2h/day, talk to your lead to get buy-in or distribute the work across the team.
 
@@ -131,7 +133,7 @@ We use Linear as our internal project planning and ticketing tool. It helps us:
 #### Conventions [#linear-conventions]
 
 - **Titles**: keep them precise and brief, so any engineer scanning a list of tickets roughly understands each one. Descriptions are optional; when you add one, keep it short and precise.
-- **Labels**: every issue carries a type label — `bug`, `improvement` or `feature` — plus a well-known label for the product area, so filters and shared views work. Use the "feat-..." labels for most issues. Before creating a new label, check the workspace label list for one that already fits; move new labels to the workspace/organization level, since they're created at the project level by default.
+- **Labels**: every issue carries one label from the `Kind` group — `bug`, `improvement` or `feature` — plus a well-known label for the product area, so filters and shared views work. Use the "feat-..." labels for most issues. Before creating a new label, check the workspace label list for one that already fits; move new labels to the workspace/organization level, since they're created at the project level by default.
 - **Assignment**: enable "assign to self on creation", and assign to self when creating from third-party tools.
 - **Projects**: multi-step work belongs in a project; small improvements and fixes stay issues. Only create a project for work with a clear end (no endless bucket of tickets), and see [projects and issues](/handbook/tools-and-processes/using-linear#projects-and-issues).
 - **Pylon**: link Pylon threads to Linear issues with "Thread links". When you close a Linear ticket, resolve the Pylon thread to tell the user we shipped the fix or request. It's two minutes of effort that shows we ship fast. Snooze threads you want to revisit (e.g. next week).

--- a/content/handbook/product-engineering/how-we-work/onboarding.mdx
+++ b/content/handbook/product-engineering/how-we-work/onboarding.mdx
@@ -27,7 +27,8 @@ At Langfuse, we lead with context, not control. We share the "why" and "what's i
 **Goal:** Understand company priorities and get set up for work.
 
 - **Welcome meeting with Max (CTO)** — Context on company status, top priorities, challenges, and decision-making
-- **Setup and access** — GitHub, Linear, Slack, Datadog, Sentry, PostHog, AWS, a local development environment, and AI tooling — Codex, Claude and Cursor, all via ClickHouse ConductorOne
+- **Setup and access** — GitHub, Slack, a local development environment, and AI tooling: Codex, Claude and Cursor, all via ClickHouse ConductorOne
+- **Connect the integrations** — Linear, Datadog, AWS SSO, incident.io, PostHog, Sentry, Pylon, Hex. Your coding agent's skills depend on these, and an unauthorized one does not produce an error: the agent simply cannot answer. Connect them on day one rather than discovering a gap mid-task
 - **Clone both repositories** — `langfuse/langfuse` and `langfuse/langfuse-docs`. The docs repo carries the documentation, the changelog and this handbook, and shipped work regularly needs a change in it
 - **Meet the repo's agent** — in a `langfuse/langfuse` checkout, ask your coding agent to "onboard me". It works out what access you have, records it, and walks you through the pages here
 - **First task** — Small starter task to explore codebase and workflows. Goal: merge something within the first few days

--- a/content/handbook/product-engineering/how-we-work/onboarding.mdx
+++ b/content/handbook/product-engineering/how-we-work/onboarding.mdx
@@ -27,7 +27,9 @@ At Langfuse, we lead with context, not control. We share the "why" and "what's i
 **Goal:** Understand company priorities and get set up for work.
 
 - **Welcome meeting with Max (CTO)** — Context on company status, top priorities, challenges, and decision-making
-- **Setup and access** — GitHub, Datadog, AWS, Slack, local development environment, and AI tooling access (including OpenAI Codex via ClickHouse ConductorOne)
+- **Setup and access** — GitHub, Linear, Datadog, AWS, Slack, local development environment, and AI tooling access (including OpenAI Codex via ClickHouse ConductorOne)
+- **Clone both repositories** — `langfuse/langfuse` and `langfuse/langfuse-docs`. The docs repo carries the documentation, the changelog and this handbook, and shipped work regularly needs a change in it
+- **Meet the repo's agent** — in a `langfuse/langfuse` checkout, ask your coding agent to "onboard me". It works out what access you have, records it, and walks you through the pages here
 - **First task** — Small starter task to explore codebase and workflows. Goal: merge something within the first few days
 
 ## Week 1 — Making Your First Contribution

--- a/content/handbook/product-engineering/how-we-work/onboarding.mdx
+++ b/content/handbook/product-engineering/how-we-work/onboarding.mdx
@@ -27,7 +27,7 @@ At Langfuse, we lead with context, not control. We share the "why" and "what's i
 **Goal:** Understand company priorities and get set up for work.
 
 - **Welcome meeting with Max (CTO)** — Context on company status, top priorities, challenges, and decision-making
-- **Setup and access** — GitHub, Linear, Datadog, AWS, Slack, local development environment, and AI tooling access (including OpenAI Codex via ClickHouse ConductorOne)
+- **Setup and access** — GitHub, Linear, Slack, Datadog, Sentry, PostHog, AWS, a local development environment, and AI tooling — Codex, Claude and Cursor, all via ClickHouse ConductorOne
 - **Clone both repositories** — `langfuse/langfuse` and `langfuse/langfuse-docs`. The docs repo carries the documentation, the changelog and this handbook, and shipped work regularly needs a change in it
 - **Meet the repo's agent** — in a `langfuse/langfuse` checkout, ask your coding agent to "onboard me". It works out what access you have, records it, and walks you through the pages here
 - **First task** — Small starter task to explore codebase and workflows. Goal: merge something within the first few days

--- a/content/handbook/product-engineering/incident-response.mdx
+++ b/content/handbook/product-engineering/incident-response.mdx
@@ -53,4 +53,4 @@ The incident lead keeps the [status page](https://status.langfuse.com) up to dat
 
 ### Post-mortem
 
-After mitigation, find and fix the root cause. Complete the post-mortem in Linear, in the incidents view, using the auto-generated timeline, covering: summary, impact, root cause, contributing factors, and action items with owners. Track follow-ups in the Linear ticket. Share in **#team-engineering**.
+After mitigation, find and fix the root cause. Complete the post-mortem in Linear, in the incidents view, using the auto-generated timeline, covering: summary, impact, root cause, contributing factors, and action items with owners. Track follow-ups in the Linear ticket. Share in **#lf-team-engineering** in the ClickHouse Slack.

--- a/content/handbook/product-engineering/incident-response.mdx
+++ b/content/handbook/product-engineering/incident-response.mdx
@@ -53,4 +53,4 @@ The incident lead keeps the [status page](https://status.langfuse.com) up to dat
 
 ### Post-mortem
 
-After mitigation, find and fix the root cause. Complete the post-mortem in [Linear](https://linear.app/langfuse/view/incidents-952de24cfbb8) using the auto-generated timeline, covering: summary, impact, root cause, contributing factors, and action items with owners. Track follow-ups in the Linear ticket. Share in **#team-engineering**.
+After mitigation, find and fix the root cause. Complete the post-mortem in Linear, in the incidents view, using the auto-generated timeline, covering: summary, impact, root cause, contributing factors, and action items with owners. Track follow-ups in the Linear ticket. Share in **#team-engineering**.

--- a/content/handbook/product-engineering/principles.mdx
+++ b/content/handbook/product-engineering/principles.mdx
@@ -18,7 +18,7 @@ title: Principles
 
 This requires
 
-- Inbox 0 on Linear Inbox and Pylon (once a day is enough)
+- Inbox 0 on Linear Inbox and Pylon — see [Using Linear](/handbook/tools-and-processes/using-linear) for the Linear inbox SLA
 - Write docs/changelog posts when shipping something
 
 ## What we don't do

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -9,14 +9,14 @@ We use Linear for all internal ticketing / task management.
 
 Linear is the backbone of our [product ops](/handbook/product-engineering/how-we-work/product-ops) that allows us to move fast as a small team while working with a large community of customers and OSS users.
 
-Our workspace is `clickhouse`, shared with the wider ClickHouse organisation. Langfuse work lives in the Langfuse teams within it.
+Our workspace is `clickhouse`. Engineering work lives in `LFE` (Langfuse Engineering), part of `Langfuse (LF)`.
 
 ## Principles
 
 - Linear is the source of truth for executing work. Do not keep a parallel status tracker in Slack, spreadsheets, or Figma — the one exception is the long-term [roadmap](/handbook/product-engineering/how-we-work/roadmapping), which stays in Figma.
 - Everyone maintains their own issues and projects
-  - We do not have someone on the team that manages the backlog centrally → There should be no issues that are not assigned to someone.
-- Every active project and issue has one lead, for its whole lifecycle.
+  - We do not have someone on the team that manages the backlog centrally → outside the triage queue, there should be no issues that are not assigned to someone.
+- Every active project and issue has one lead.
 - Create Linear issues for tasks that are likely to happen within the next 6 months. Everything beyond that can be tracked on the [roadmap](/docs/roadmap) and [GitHub ideas](/ideas). Close, cancel, or backlog anything that is no longer likely within six months.
 
 ## How to use Linear
@@ -64,33 +64,32 @@ If you lead an active project, post an update before Monday planning. Nothing re
 - Blockers, or decisions you need from someone else
 - Any change to the target date
 
-Monday meetings then spend their time on decisions, risks and dependencies rather than round-robin status.
-
-Separately, look through your own open bugs once a week to catch anything slipping.
+Separately, look through your own open bugs regularly to catch anything slipping.
 
 ## Definition of done [#definition-of-done]
 
 An engineering issue moves to `merged` automatically when its pull request merges. It does **not** go straight to `done`.
 
-`merged` is deliberately a staging step: it is your chance to capture what you do not want to forget before the issue leaves your view. Before moving it to `done` by hand, check whether the change needs
+`merged` is deliberately a staging step: it is your chance to capture what you do not want to forget before the issue leaves your view. Once the change is deployed to production, and before moving it to `done` by hand, check whether it needs
 
 - a documentation page or edit,
 - a changelog entry,
-- a word to any customer whose request is linked to it.
+- a word to any customer whose request is linked to it,
+- the reasoning behind it written onto the issue, so that whoever picks the surface up next does not have to reconstruct it. If an agent did the work, the `linear-context-handover` skill is how it leaves that behind.
 
 Complete a **project** when its intended outcome is delivered — including docs, changelog and customer follow-up where relevant.
 
 ## Labels
 
-- Every issue carries a type label: `bug`, `improvement`, or `feature`.
+- Every issue carries one label from the `Kind` group: `bug`, `improvement`, or `feature`.
 - On top of that, use a well-known label for the product area, so filters and shared views work. See the [conventions in how we ship](/handbook/product-engineering/how-we-work/how-we-ship#linear-conventions).
 - Do not recreate owner, status, priority, dates, initiatives, or customer links as labels — Linear already has fields for those.
 
 ## Bugs and feature requests
 
-Bugs and feature requests arrive through integrations rather than being typed in by hand: GitHub Issues from `langfuse/langfuse` land in the engineering team automatically, and internal requests come in through Linear Asks. Customer requests are evidence linking a customer to an issue, not a separate execution issue — when several map to one issue, preserve all of the evidence on it.
+Most work arrives rather than being typed in: GitHub Issues from `langfuse/langfuse` land in the engineering team automatically, customer reports come in through Pylon, and we often create an issue straight from the Slack thread where something came up. A customer request is evidence linking a customer to an issue, not a second issue to execute — when several point at the same thing, keep all of the evidence on it.
 
-Feature owners clear triage continuously and normally decide within one working day: link or merge with an existing issue, accept it as a new issue, add it to a relevant backlog project, re-route it to the right owner, or close it as not planned.
+Feature owners clear triage continuously and normally decide within one working day: merge it with an existing issue, accept it, put it in a backlog project, re-route it, or close it as not planned.
 
 ## Agents may write to Linear [#agents]
 

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -9,25 +9,108 @@ We use Linear for all internal ticketing / task management.
 
 Linear is the backbone of our [product ops](/handbook/product-engineering/how-we-work/product-ops) that allows us to move fast as a small team while working with a large community of customers and OSS users.
 
+Our workspace is `clickhouse`, shared with the wider ClickHouse organisation. Langfuse work lives in the Langfuse teams within it.
+
 ## Principles
 
+- Linear is the source of truth for executing work. Do not keep a parallel status tracker in Slack, spreadsheets, or Figma — the one exception is the long-term [roadmap](/handbook/product-engineering/how-we-work/roadmapping), which stays in Figma.
 - Everyone maintains their own issues and projects
   - We do not have someone on the team that manages the backlog centrally → There should be no issues that are not assigned to someone.
-- Create Linear issues for tasks that are likely to happen within the next 6 months. Everything beyond that can be tracked on the [roadmap](/docs/roadmap) and [GitHub ideas](/ideas).
+- Every active project and issue has one lead, for its whole lifecycle.
+- Create Linear issues for tasks that are likely to happen within the next 6 months. Everything beyond that can be tracked on the [roadmap](/docs/roadmap) and [GitHub ideas](/ideas). Close, cancel, or backlog anything that is no longer likely within six months.
 
 ## How to use Linear
 
-- SLA: Clear out Linear Inbox multiple times a day. This is the main on-topic discussion channel.
+- SLA: Clear out the Linear Inbox at least twice per working day. This is the main on-topic discussion channel. Triage for importance, and reply immediately when the reply takes less than two minutes. Use `H` to snooze anything you want to come back to.
+- Use Linear comments for durable, on-topic discussion and decisions. Link a Slack thread when you need a faster turnaround.
 - Git:
   - When making a change, copy the branch name from Linear issue, which leads to automatic linking of PR to Linear issue.
-  - Once PR is merged, issue is moved to the `merged` state. Move to `done` once the change is deployed to production and all potential follow-up work is tracked/done.
+  - Once PR is merged, issue is moved to the `merged` state. See [definition of done](#definition-of-done) for what happens next.
+
+## Projects and issues [#projects-and-issues]
+
+Use the smallest primitive that fits the work.
+
+| Primitive      | When to use it                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Issue**      | One concrete deliverable with one owner. The default. Small improvements and fixes stay issues and never need a project.                                           |
+| **Project**    | Multi-step work that needs several issues, coordination, progress reporting, or delivery stages. Projects need project management, so only open one for real work. |
+| **Milestone**  | Optional, for larger projects: a meaningful delivery phase such as "planning complete" or "minimum viable release" — not a checklist.                              |
+| **Initiative** | Rare. A broad, multi-quarter outcome spanning several projects. Projects and issues are usually enough.                                                            |
+
+Do not create a project just to group loosely related issues — use a label and a saved view for that. A project normally has zero or one RFC; if it needs two, it is probably two projects. Where there is an RFC, it belongs in the project description.
+
+### Project lifecycle
+
+| Status          | What it needs                                                                                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Backlog**     | Likely within six months. Owner, priority, pod/function label, a short outcome.                                                                              |
+| **Planned**     | Owner, priority, a quarter-level target date, pod/function label, a brief and a definition of done, and known dependencies.                                  |
+| **In Progress** | A specific target date, current health, weekly updates, linked issues — plus milestones if the project is large.                                             |
+| **Completed**   | The intended outcome is delivered, not merely that the issue list is empty. Follow-ups captured; docs, changelog and customer follow-up done where relevant. |
+| **Canceled**    | Intentionally stopped, with a short reason.                                                                                                                  |
+
+Target dates are internal planning signals, not external commitments. The public roadmap stays directional.
+
+At quarter-end every remaining backlog project is deliberately re-prioritised, moved to a new quarter, or cancelled. Nothing rolls forward silently.
+
+### Weekly project updates
+
+If you lead an active project, post an update before Monday planning. Nothing reminds you, so make it part of your Friday or Monday morning:
+
+- Health
+- Progress since the last update
+- Next step
+- Blockers, or decisions you need from someone else
+- Any change to the target date
+
+Monday meetings then spend their time on decisions, risks and dependencies rather than round-robin status.
+
+Separately, look through your own open bugs once a week to catch anything slipping.
+
+## Definition of done [#definition-of-done]
+
+An engineering issue moves to `merged` automatically when its pull request merges. It does **not** go straight to `done`.
+
+`merged` is deliberately a staging step: it is your chance to capture what you do not want to forget before the issue leaves your view. Before moving it to `done` by hand, check whether the change needs
+
+- a documentation page or edit,
+- a changelog entry,
+- a word to any customer whose request is linked to it.
+
+Complete a **project** when its intended outcome is delivered — including docs, changelog and customer follow-up where relevant.
+
+## Labels
+
+- Every issue carries a type label: `bug`, `improvement`, or `feature`.
+- On top of that, use a well-known label for the product area, so filters and shared views work. See the [conventions in how we ship](/handbook/product-engineering/how-we-work/how-we-ship#linear-conventions).
+- Do not recreate owner, status, priority, dates, initiatives, or customer links as labels — Linear already has fields for those.
+
+## Bugs and feature requests
+
+Bugs and feature requests arrive through integrations rather than being typed in by hand: GitHub Issues from `langfuse/langfuse` land in the engineering team automatically, and internal requests come in through Linear Asks. Customer requests are evidence linking a customer to an issue, not a separate execution issue — when several map to one issue, preserve all of the evidence on it.
+
+Feature owners clear triage continuously and normally decide within one working day: link or merge with an existing issue, accept it as a new issue, add it to a relevant backlog project, re-route it to the right owner, or close it as not planned.
+
+## Agents may write to Linear [#agents]
+
+Agents are allowed to write to Linear directly — there is no longer a rule that one must stop and ask a human first. They comment, append their reasoning to an issue description, and create issues.
+
+They do have to follow rules, and **the rules are not repeated here.** They live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
+
+- `linear-agent-writes` — what an agent may write and how each write must be marked. Read this one before your first agentic write.
+- `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
+- `linear-context-handover` — recovering the history behind a piece of work, and leaving your reasoning on the issue when you finish.
+
+Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
 
 ## Setup Linear
 
 ### Mandatory
 
 - Connect to Slack and GitHub
-- Join Engineering, Langfuse, GTM teams
+- Join the Langfuse teams you need: `Engineering (LF)`, `Langfuse`, and whichever of `Marketing (LF)`, `Sales (LF)`, `Ops (LF)` and `General (LF)` apply to your work
+- Set "assign to self on creation" so issues you create are owned from the start
 
 ### Optional
 


### PR DESCRIPTION
## TL;DR

The handbook's Linear pages described a process the team has moved on from, and three of them linked to a workspace that no longer exists. This brings them up to date and adds a short section saying agents may now write to Linear — pointing at the rules rather than restating them. Handbook only, 5 files.

## Why

A new engineer starts on Monday. Following the handbook as written, they would have joined teams that do not exist, clicked three dead links, and replied to the wrong review bots. Underneath that, the parts of the process that actually changed — the project lifecycle, weekly updates, the definition of done — were not written down anywhere public.

The pages also disagreed with each other. The Linear inbox had three different SLAs across three pages, and the issue-states table stopped at "In progress" while the page next door already told you to move things from `merged` to `done`.

## What

**Process that changed, now written down** — in `tools-and-processes/using-linear.mdx`, which grows from 33 lines into the page it was named for:

- **The primitives and when to use each.** Issue by default; a project for multi-step work that needs coordination; milestones optional; initiatives rare. Explicitly *not* a project merely to group loosely related issues.
- **The project lifecycle**, with what each state requires — owner, priority, target date and pod label at Planned; a specific target date, health and weekly updates once In Progress; the intended outcome rather than an empty issue list at Completed.
- **Weekly project updates before Monday planning**, and their five parts. Nothing in Linear reminds you, which is exactly why it belongs in the handbook.
- **The definition of done.** `merged` is set automatically on merge and is deliberately *not* the end: it is the moment to notice whether the change needs a docs page, a changelog entry, or a word to the customer who asked for it. `done` is moved by hand afterwards.
- **Labels** need a type — `bug` / `improvement` / `feature` — as well as a product area.
- **Where work comes from**, and that triage normally gets a decision within one working day.

**Corrections**

- The workspace is named. It was not, anywhere, so a new joiner had no way to find it.
- Team names match the ones that exist; there is no team called GTM.
- The issue-states table gains `Merged` and `Done`, the two states the Linear page already depended on.
- Three private Linear view URLs are described instead of linked. They 404 from the wrong workspace, and a private view URL in a public repository is not much use to a reader outside it either.
- The automated reviewer list credited a vendor with no configuration in either repository, and omitted the ones that do run.
- One inbox SLA, in one place, with the other pages pointing at it.

**Agents may write to Linear** — a short section, deliberately not a policy. It says they write directly now, that they follow rules, and that the rules and the tooling are agent skills in `langfuse/langfuse` under `.agents/skills/` (`linear-agent-writes`, `linear-planning`, `linear-context-handover`). Restating them here would make a second copy to keep correct, and the repository is where an agent actually loads them. The only thing the handbook asserts itself is the property a reader needs: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell whose words are whose — and changing state stays with a human.

**Day 1** gains Linear in the access list, a prompt to clone the docs repo as well as the app repo, and the agent entry point.

## Result

The handbook matches how the team works, agrees with itself on the points where it previously did not, and a new joiner can follow it on Monday without hitting a dead end.

<details>
<summary>How this was found and checked</summary>

Not by reading it top to bottom. Two of these errors surfaced when an agent was asked to walk a new joiner through onboarding and cross-checked the handbook's claims against the repositories — it found the vendor that is not configured, and that the checkout it was reading from was **576 commits behind**. That prompted a full audit of all 67 handbook paths at `origin/main`, which produced 25 findings; this pull request lands the ones that are simply true or false, plus the process that has actually changed.

Every claim here was verified first-hand rather than taken from the audit: the workspace slug and team names against the live workspace, the reviewer list against `.github/workflows`, and each of the three dead links and the SLA conflict quoted from `origin/main`.

**Left out on purpose.** The full working agreement is longer than what is here and carries internal links and a personal email address, so it cannot be pasted into a public repository — the parts above are the publishable half. Two further findings are deliberately not in this change because they are decisions rather than corrections: `how-we-work/principles.mdx` still says "we never implemented processes as we trust every team member to do the right thing", which is in tension with a mandatory weekly update; and the new-joiner review window is "at least 1 month" on one page and "~2 months" on another. Both want a person to choose, not a patch.

Checked locally: `prettier --check` clean on all five files, the H1 check passes, and every internal link and anchor added here resolves to a real page or an explicitly declared anchor.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to internal handbook MDX; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR **refreshes handbook pages** so they match the current ClickHouse Linear workspace, shipping workflow, and AI tooling — handbook-only, no application code.
> 
> **`using-linear.mdx` is the main change:** it names the `clickhouse` workspace and `LFE` team, documents when to use issues vs projects (and lifecycle states), **weekly project updates**, **definition of done** (`merged` → deploy → follow-ups → `done`), **Kind** labels, triage expectations, and a section that **agents may write to Linear** under rules in `langfuse/langfuse` `.agents/skills/` (with state changes still human-only).
> 
> **Cross-page alignment:** `how-we-ship.mdx` adds project-update expectations, `Merged`/`Done` states, updated label/project conventions, and a **twice-daily Linear inbox** SLA with a link to the Linear page; dead private Linear URLs and obsolete team names are removed. **Onboarding** expands day-one access (integrations, both repos, “onboard me” agent flow). Smaller fixes: **incident post-mortem** channel/workspace wording, **PR review bots** (Claude and Greptile, not Ellipsis), and **Codex** skills pointer in productivity docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c2224565b96be9f5e0ce625b9d74fc63fe8321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR substantially refreshes the handbook’s Linear guidance and related onboarding references.

- Documents issue and project selection, project lifecycle, weekly updates, labels, triage, and definition of done.
- Replaces obsolete private Linear links with workspace-neutral view descriptions and updates team setup guidance.
- Adds agent-assisted Linear workflows and onboarding instructions.
- Updates issue states and automated-reviewer documentation.
- The expanded process currently contains conflicting requirements for deployment, inbox frequency, and unassigned triage issues.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the definition of done and Linear inbox SLA agree with the other handbook pages.

The new authoritative definition can move issues to done before deployment, and the new twice-daily inbox requirement directly conflicts with a surviving once-daily instruction; the unassigned-issue principle also needs qualification for normal triage intake.

**Files Needing Attention:** content/handbook/tools-and-processes/using-linear.mdx, content/handbook/product-engineering/how-we-work/how-we-ship.mdx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Work[Work identified] --> Choice{Single deliverable?}
  Choice -->|Yes| Issue[Linear issue]
  Choice -->|No, coordinated multi-step work| Project[Linear project]
  Issue --> PR[Pull request]
  PR --> Merge[PR merged]
  Merge --> Merged[Issue: Merged]
  Merged --> Deploy[Deploy change]
  Deploy --> Followups[Complete or track docs, changelog, and customer follow-up]
  Followups --> Done[Issue: Done]
  Project --> Planned[Planned]
  Planned --> Active[In Progress]
  Active --> Updates[Weekly updates]
  Updates --> Completed[Completed when intended outcome is delivered]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/handbook/tools-and-processes/using-linear.mdx:73-79
**Deployment requirement is missing**

This definition of done lets readers move an issue to `done` after checking documentation, changelog, and customer follow-ups, without requiring deployment. The new `Done` row in `how-we-ship.mdx` still requires deployment first, so engineers following this section could close work before it is deployed.

```suggestion
An engineering issue moves to `merged` automatically when its pull request merges. It does **not** go straight to `done`.

`merged` is deliberately a staging step: it is your chance to capture what you do not want to forget before the issue leaves your view. Once the change is deployed to production, before moving it to `done` by hand, check whether it needs

- a documentation page or edit,
- a changelog entry,
- a word to any customer whose request is linked to it.
```

### Issue 2
content/handbook/tools-and-processes/using-linear.mdx:24
**Inbox SLAs conflict**

This page now requires clearing the Linear inbox at least twice per working day, while `product-engineering/principles.mdx` still says once per day is enough. Engineers reading both pages receive incompatible minimum frequencies and cannot tell which expectation governs.

### Issue 3
content/handbook/tools-and-processes/using-linear.mdx:18
**Triage breaks assignment rule**

The absolute rule that no issue may be unassigned conflicts with the documented `Triage` state in `how-we-ship.mdx`, where incoming issues remain unassigned until triage. Without an exception for pending triage, the normal integrated issue intake process immediately violates this guidance.

```suggestion
  - We do not have someone on the team that manages the backlog centrally → Outside the pending triage queue, there should be no issues that are not assigned to someone.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): update the Linear proces..."](https://github.com/langfuse/langfuse-docs/commit/4da6746e2b5cb73aa12608fe7275301fa2e38ccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60322491)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->