### PR TITLE
Document government and air-gapped deployment support

### DIFF
--- a/content/security/compliance-faq.mdx
+++ b/content/security/compliance-faq.mdx
@@ -27,6 +27,10 @@ We have policies in place data protection, classification, and retention. See [p
 
 Independent penetration tests occur annually, plus continuous vulnerability scans. See [penetration testing](/security/penetration-testing) for more details and past results.
 
+> **Does Langfuse support government and air-gapped deployments?**
+
+We are actively developing additional hardening capabilities for Langfuse Self-Hosted Enterprise, including FIPS-compatible deployment support, hardened deployment images, and documentation for operating Langfuse and its required subcomponents as a complete air-gapped deployment stack. See [Hardening for Government](/self-hosting/configuration/hardening#hardening-for-government) for details and current availability.
+
 > **How does Langfuse manage risk?**
 
 Langfuse manages risk through a formal process of identifying threats and vulnerabilities to our assets. We then assess the potential impact and likelihood of each risk to calculate a score, which determines its priority. All high and critical risks must be treated, and our entire risk management framework is reviewed at least annually to adapt to new threats.


### PR DESCRIPTION
## Summary

- Add a compliance FAQ entry covering government and air-gapped deployment support
- Link readers to the hardening guidance and current availability details

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the compliance FAQ with no application or security logic impact.
> 
> **Overview**
> Adds a new **Compliance FAQ** question on whether Langfuse supports government and air-gapped deployments. The answer states that **Self-Hosted Enterprise** hardening is in active development (FIPS-compatible deployments, hardened images, air-gapped stack documentation) and points readers to **[Hardening for Government](/self-hosting/configuration/hardening#hardening-for-government)** for availability details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f04b0abc16b7dad697661f0128a6f8bafd415f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a compliance FAQ entry explaining Langfuse’s work toward government and air-gapped deployment support.
- Identifies planned FIPS-compatible deployment support and hardened images.
- Links to the government hardening documentation for current availability.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The new wording is consistent with the linked hardening documentation, clearly presents the capabilities as under development, and uses a valid route and anchor.
</details>

<sub>Reviews (1): Last reviewed commit: ["Document government and air-gapped deplo..."](https://github.com/langfuse/langfuse-docs/commit/35f04b0abc16b7dad697661f0128a6f8bafd415f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60384904)</sub>

<!-- /greptile_comment -->