### PR TITLE
Document Postgres and ClickHouse timezone checks

### DIFF
--- a/content/faq/all/self-hosting-timezone-errors.mdx
+++ b/content/faq/all/self-hosting-timezone-errors.mdx
@@ -7,12 +7,26 @@ tags: [self-hosting]
 
 **Langfuse requires all infrastructure components (ClickHouse and Postgres) to run in the UTC timezone.** Non-UTC timezones are not supported and will cause queries to return incorrect or empty results.
 
-If you are seeing missing traces or observations, verify that your ClickHouse instance is running in UTC:
+If you are seeing missing traces or observations, verify that both databases are running in UTC.
+
+## Postgres
+
+Check the effective timezone for the Postgres connection:
+
+```sql
+SHOW timezone;
+```
+
+This should return `UTC`. If it returns a different timezone, set the [`timezone`](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TIMEZONE) parameter to `UTC` for the Postgres connections used by Langfuse, then restart Langfuse so that it opens new database connections.
+
+## ClickHouse
+
+Check the ClickHouse server timezone:
 
 ```sql
 SELECT timezone()
 ```
 
-This should return `UTC`. If it returns a different timezone, update your ClickHouse server configuration to remove any custom [`timezone`](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#timezone) setting and restart the server. The same applies to your [Postgres timezone setting](/self-hosting/deployment/infrastructure/postgres).
+This should return `UTC`. If it returns a different timezone, update your ClickHouse server configuration to remove any custom [`timezone`](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#timezone) setting and restart the server.
 
 If you would like us to consider supporting other timezones, please vote on this [GitHub Discussion](https://github.com/orgs/langfuse/discussions/5046).


### PR DESCRIPTION
## Summary

- Expand the self-hosting timezone FAQ to cover both Postgres and ClickHouse.
- Add commands and remediation guidance for verifying UTC configuration.

## Testing

Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only FAQ update with no runtime, security, or data-handling changes.
> 
> **Overview**
> **Expands the self-hosting timezone FAQ** so operators verify **both Postgres and ClickHouse**, not only ClickHouse.
> 
> The intro now tells readers to confirm both databases are on UTC. **Postgres** gets its own section with `SHOW timezone;`, expected `UTC`, and remediation via the `timezone` GUC on Langfuse’s connections plus a Langfuse restart. **ClickHouse** keeps `SELECT timezone()` and server config guidance, but Postgres remediation is no longer deferred to the infrastructure Postgres page (that cross-link was removed from the ClickHouse paragraph).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6de115893dfa30de9d34f779f1d4333271a0879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Expands the self-hosting timezone FAQ with separate PostgreSQL and ClickHouse checks and remediation guidance.
- Adds `SHOW timezone;` as the PostgreSQL verification command.
- Retains the ClickHouse server-timezone query and configuration guidance.
- The PostgreSQL check should account for UTC-equivalent identifiers rather than requiring one literal name.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, though the PostgreSQL guidance could unnecessarily flag valid UTC-equivalent configurations.

The documentation is otherwise coherent and actionable, but its literal comparison against `UTC` can misdiagnose PostgreSQL configurations that use an equivalent UTC timezone identifier.

**Files Needing Attention:** content/faq/all/self-hosting-timezone-errors.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/faq/all/self-hosting-timezone-errors.mdx:20
**UTC aliases appear invalid**

PostgreSQL can report UTC-equivalent timezone identifiers such as `Etc/UTC`, `UTC0`, or `+00`. Treating every value other than the literal `UTC` as a misconfiguration can send operators through unnecessary remediation even though the database uses UTC. Please clarify that equivalent fixed UTC identifiers are acceptable, or recommend checking the effective offset instead of the identifier.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Document Postgres and ClickHouse timezon..."](https://github.com/langfuse/langfuse-docs/commit/a6de115893dfa30de9d34f779f1d4333271a0879) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60388127)</sub>

<!-- /greptile_comment -->