### PR TITLE
Improve the self-hosting page layout and deployment guidance

### DIFF
--- a/components/SelfHostScaleMetrics.tsx
+++ b/components/SelfHostScaleMetrics.tsx
@@ -1,5 +1,6 @@
 import {
   FORTUNE_50_COMPANIES,
+  formatDockerPulls,
   formatObservationsPerMonth,
 } from "@/lib/usage-stats";
 
@@ -10,6 +11,8 @@ export function SelfHostScaleMetrics() {
       Langfuse processes{" "}
       <strong>{formatObservationsPerMonth()} observations per month</strong> and
       is trusted by <strong>{FORTUNE_50_COMPANIES} of the Fortune 50</strong>.
+      Its Docker images have been pulled{" "}
+      <strong>{formatDockerPulls()} times</strong>.
     </p>
   );
 }

--- a/components/SelfHostScaleMetrics.tsx
+++ b/components/SelfHostScaleMetrics.tsx
@@ -1,0 +1,15 @@
+import {
+  FORTUNE_50_COMPANIES,
+  formatObservationsPerMonth,
+} from "@/lib/usage-stats";
+
+export function SelfHostScaleMetrics() {
+  return (
+    <p>
+      Langfuse OSS and Enterprise use the same codebase as Langfuse Cloud.
+      Langfuse processes{" "}
+      <strong>{formatObservationsPerMonth()} observations per month</strong> and
+      is trusted by <strong>{FORTUNE_50_COMPANIES} of the Fortune 50</strong>.
+    </p>
+  );
+}

--- a/components/customers/CustomerStatsBar.tsx
+++ b/components/customers/CustomerStatsBar.tsx
@@ -1,4 +1,8 @@
 import { getGitHubStars } from "@/lib/github-stars";
+import {
+  FORTUNE_50_COMPANIES,
+  formatObservationsPerMonth,
+} from "@/lib/usage-stats";
 import { cn } from "@/lib/utils";
 
 function formatCompact(value: number): string {
@@ -14,8 +18,8 @@ function formatCompact(value: number): string {
 }
 
 const stats = [
-  { value: "90B+", label: "Observations / month" },
-  { value: "21", label: "of the Fortune 50" },
+  { value: formatObservationsPerMonth(), label: "Observations / month" },
+  { value: String(FORTUNE_50_COMPANIES), label: "of the Fortune 50" },
   {
     value: formatCompact(getGitHubStars()),
     label: "GitHub stars",

--- a/components/home/HeroStatsStrip.tsx
+++ b/components/home/HeroStatsStrip.tsx
@@ -4,6 +4,10 @@ import { Fragment } from "react";
 import { motion } from "framer-motion";
 import { Text } from "@/components/ui/text";
 import { Dot } from "@/components/ui/dot";
+import {
+  FORTUNE_50_COMPANIES,
+  formatObservationsPerMonth,
+} from "@/lib/usage-stats";
 
 /** Slower than Integrations marquee rows (40–48s) for short hero copy */
 const MARQUEE_DURATION_SEC = 40;
@@ -12,11 +16,13 @@ function StatItems() {
   return (
     <>
       <Text size="s" className="whitespace-nowrap shrink-0">
-        Used by <b className="text-primary">21</b> of Fortune 50
+        Used by <b className="text-primary">{FORTUNE_50_COMPANIES}</b> of
+        Fortune 50
       </Text>
       <Dot />
       <Text size="s" className="whitespace-nowrap shrink-0">
-        <b className="text-primary">90B+</b> observations/month
+        <b className="text-primary">{formatObservationsPerMonth()}</b>{" "}
+        observations/month
       </Text>
       <Dot />
       <Text size="s" className="whitespace-nowrap shrink-0">

--- a/content/self-hosting/deployment/railway.mdx
+++ b/content/self-hosting/deployment/railway.mdx
@@ -21,6 +21,12 @@ You can deploy Langfuse v3 on [Railway](https://railway.app/) via the prebuilt t
 The template contains all the necessary services and configurations to get you started.
 See [architecture overview](/self-hosting#architecture) for more details.
 
+<Callout type="warning">
+  After deployment, verify that PostgreSQL and ClickHouse use UTC. See the
+  [timezone requirements and verification
+  steps](/faq/all/self-hosting-timezone-errors).
+</Callout>
+
 ## Deploy
 
 Use the following button to deploy the Langfuse v3 template on Railway:

--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -7,38 +7,17 @@ label: "Version: v4"
 
 # Self-host Langfuse
 
-<Callout type="info">
-  Looking for a managed solution? Consider [Langfuse
-  Cloud](https://cloud.langfuse.com) maintained by the Langfuse team.
-</Callout>
-
-Langfuse is open source and can be self-hosted using Docker.
-This section contains guides for different deployment scenarios.
-Some add-on features require a [license key](/self-hosting/license-key).
+Langfuse is open source and can be self-hosted using Docker on your own infrastructure. Some add-on features require a [license key](/self-hosting/license-key).
 
 When self-hosting Langfuse, you run the same infrastructure that powers Langfuse Cloud. Read ["Why Langfuse?"](/why) to learn more about why this is important to us.
 
-## Deployment Options [#deployment-options]
+## Deployment options [#deployment-options]
 
-### Langfuse Cloud
-
-[Langfuse Cloud](https://cloud.langfuse.com) is a fully managed version of Langfuse that is hosted and maintained by the Langfuse team. Generally, it is the easiest and fastest way to get started with Langfuse at affordable [pricing](/pricing).
-
-### Low-scale deployments
-
-You can [run Langfuse on a VM or locally using Docker Compose](/self-hosting/deployment/docker-compose).
-This is recommended for testing and low-scale deployments and lacks high-availability, scaling capabilities, and backup functionality.
-
-### Production-scale deployments
-
-For production-scale deployments, we recommend one of the following options:
-
-- [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm)
-- [AWS (Terraform)](/self-hosting/deployment/aws)
-- [Azure (Terraform)](/self-hosting/deployment/azure)
-- [GCP (Terraform)](/self-hosting/deployment/gcp)
-- [Render](/self-hosting/deployment/render) (community)
-- [Railway (v3)](/self-hosting/deployment/railway) (community)
+| Best for                | Deployment                                                                                                                                                                                                                                                                                          | Responsibility                                           |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Fastest start           | [Langfuse Cloud](https://cloud.langfuse.com)                                                                                                                                                                                                                                                        | Fully managed by the Langfuse team                       |
+| Local use and testing   | [Docker Compose](/self-hosting/deployment/docker-compose)                                                                                                                                                                                                                                           | Single VM without high availability, scaling, or backups |
+| Production self-hosting | [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), [AWS](/self-hosting/deployment/aws), [Azure](/self-hosting/deployment/azure), [GCP](/self-hosting/deployment/gcp), [Render](/self-hosting/deployment/render) (community), or [Railway](/self-hosting/deployment/railway) (community) | Your infrastructure                                      |
 
 Unless marked as community-supported, these deployment options are maintained and tested by the Langfuse team. Community-supported options are maintained in third-party repositories and supported on a best-effort basis. Report problems via [GitHub issues](/issues).
 
@@ -52,22 +31,23 @@ import ArchitectureDiagram from "@/components-mdx/architecture-diagram-v3.mdx";
 
 import ArchitectureDescription from "@/components-mdx/architecture-description-v3.mdx";
 
+<details>
+<summary>View architecture components</summary>
+
 <ArchitectureDescription />
 
-## Timezone Requirement
-
-All infrastructure components (ClickHouse and Postgres) **must** run with their timezone set to UTC. Non-UTC timezones will cause queries to return incorrect or empty results. See the [timezone troubleshooting FAQ](/faq/all/self-hosting-timezone-errors) for how to verify this.
+</details>
 
 ## Optimized for performance, reliability, and uptime
 
-Langfuse self-hosted is optimized for production environments. It is the exact same codebase as Langfuse Cloud, just deployed on your own infrastructure. The Langfuse teams serves thousands of teams with Langfuse Cloud with high availability ([status page](https://status.langfuse.com)) and performance.
+Langfuse self-hosted is optimized for production environments. It is the exact same codebase as Langfuse Cloud, just deployed on your own infrastructure. The Langfuse team serves thousands of teams with Langfuse Cloud with high availability ([status page](https://status.langfuse.com)) and performance.
 
 Some of the optimizations include:
 
 - **Queued trace ingestion**: All traces are received in batches by the Langfuse Web container and immediately written to S3. Only a reference is persisted in Redis for queueing. Afterwards, the Langfuse Worker will pick up the traces from S3 and ingest them into Clickhouse. This ensures that high spikes in request load do not lead to timeouts or errors constrained by the database.
 - **Caching of API keys**: API keys are cached in-memory in Redis. Thereby, the database is not hit on every API call and unauthorized requests can be rejected with very low resource usage.
 - **Caching of prompts (SDKs and API)**: Even though prompts are cached client-side by the Langfuse SDKs and only revalidated in the background ([docs](/docs/prompts)), they need to be fetched from the Langfuse on first use. Thus, API response times are very important. Prompts are cached in a read-through cache in Redis. Thereby, hot prompts can be fetched from Langfuse without hitting a database.
-- **OLAP database**: All read-heavy analytical operations are offloaded to an OLAP database (Clickhouse) for fast query performance.
+- **Hyper-optimized ClickHouse schema**: Read-heavy analytical operations use a wide, mostly immutable observations table that avoids read-time joins and deduplication while taking advantage of ClickHouse's most performant access patterns. Read how we [simplified Langfuse for scale](/blog/2026-03-10-simplify-langfuse-for-scale).
 - **Multi-modal traces in S3**: Multi-modal traces can include large videos or arbitrary files. To enable support for these, they are directly uploaded to S3/Blob Storage from the client SDKs. Learn more [here](/docs/tracing-features/multi-modality).
 - **Recoverability of events**: All incoming tracing and evaluation events are persisted in S3/Blob Storage first. Only after successful processing, the events are written to the database. This ensures that even if the database is temporarily unavailable, the events are not lost and can be processed later.
 - **Background migrations**: Long-running migrations that are required by an upgrade but not blocking for regular operations are offloaded to a background job. This massively reduces the downtime during an upgrade. Learn more [here](/self-hosting/upgrade/background-migrations).

--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -40,7 +40,12 @@ import ArchitectureDescription from "@/components-mdx/architecture-description-v
 
 ## Optimized for performance, reliability, and uptime
 
-Langfuse self-hosted is optimized for production environments. It is the exact same codebase as Langfuse Cloud, just deployed on your own infrastructure. The Langfuse team serves thousands of teams with Langfuse Cloud with high availability ([status page](https://status.langfuse.com)) and performance.
+import { SelfHostScaleMetrics } from "@/components/SelfHostScaleMetrics";
+
+<SelfHostScaleMetrics />
+
+<details>
+<summary>How Langfuse is optimized for scale and reliability</summary>
 
 Some of the optimizations include:
 
@@ -52,7 +57,7 @@ Some of the optimizations include:
 - **Recoverability of events**: All incoming tracing and evaluation events are persisted in S3/Blob Storage first. Only after successful processing, the events are written to the database. This ensures that even if the database is temporarily unavailable, the events are not lost and can be processed later.
 - **Background migrations**: Long-running migrations that are required by an upgrade but not blocking for regular operations are offloaded to a background job. This massively reduces the downtime during an upgrade. Learn more [here](/self-hosting/upgrade/background-migrations).
 
-If you have any feedback or questions regarding the architecture, please reach out to us.
+</details>
 
 ## Features
 

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -14,6 +14,7 @@ const {
   FORTUNE_500_COMPANIES,
   SDK_INSTALLS_PER_MONTH,
   formatCompanyCount,
+  formatObservationsPerMonth,
 } = require("./usage-stats.ts");
 
 const ADOPTERS_TABLE_PATH = path.join(
@@ -115,10 +116,15 @@ function replaceComponentsWithMarkdown(fileContent) {
       /<ImpactChart\b([\s\S]*?)\/>/g,
       (_, attributes) => `\n${renderImpactChart(attributes)}\n`,
     )
+    .replace(/<LoopDiagram\b([\s\S]*?)\/>/g, () => `\n${renderLoopDiagram()}\n`)
     .replace(
-      /<LoopDiagram\b([\s\S]*?)\/>/g,
-      () => `\n${renderLoopDiagram()}\n`,
+      /<SelfHostScaleMetrics\s*\/>/g,
+      () => `\n${renderSelfHostScaleMetrics()}\n`,
     );
+}
+
+function renderSelfHostScaleMetrics() {
+  return `Langfuse OSS and Enterprise use the same codebase as Langfuse Cloud. Langfuse processes **${formatObservationsPerMonth()} observations per month** and is trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50**.`;
 }
 
 const AVAILABILITY_PLANS = [

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -14,6 +14,7 @@ const {
   FORTUNE_500_COMPANIES,
   SDK_INSTALLS_PER_MONTH,
   formatCompanyCount,
+  formatDockerPulls,
   formatObservationsPerMonth,
 } = require("./usage-stats.ts");
 
@@ -124,7 +125,7 @@ function replaceComponentsWithMarkdown(fileContent) {
 }
 
 function renderSelfHostScaleMetrics() {
-  return `Langfuse OSS and Enterprise use the same codebase as Langfuse Cloud. Langfuse processes **${formatObservationsPerMonth()} observations per month** and is trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50**.`;
+  return `Langfuse OSS and Enterprise use the same codebase as Langfuse Cloud. Langfuse processes **${formatObservationsPerMonth()} observations per month** and is trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50**. Its Docker images have been pulled **${formatDockerPulls()} times**.`;
 }
 
 const AVAILABILITY_PLANS = [

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -307,8 +307,8 @@ function renderCustomerStatsBar() {
       : String(GITHUB_STARS);
 
   return [
-    "- **90B+** Observations / month",
-    "- **21** of the Fortune 50",
+    `- **${formatObservationsPerMonth()}** Observations / month`,
+    `- **${FORTUNE_50_COMPANIES}** of the Fortune 50`,
     `- **${githubStars}** GitHub stars`,
     "- **100+** Integrations",
   ].join("\n");

--- a/lib/usage-stats.ts
+++ b/lib/usage-stats.ts
@@ -2,6 +2,7 @@
 
 export const SDK_INSTALLS_PER_MONTH = 130_000_000;
 export const DOCKER_PULLS = 6_000_000;
+export const OBSERVATIONS_PER_MONTH = 90_000_000_000;
 export const FORTUNE_500_COMPANIES = 129;
 export const FORTUNE_50_COMPANIES = 21;
 /** Companies using Langfuse (Cloud + self-hosted), not paying customers. */
@@ -9,4 +10,8 @@ export const COMPANIES = 50_000;
 
 export function formatCompanyCount(): string {
   return `${COMPANIES.toLocaleString("en-US")}+`;
+}
+
+export function formatObservationsPerMonth(): string {
+  return `${(OBSERVATIONS_PER_MONTH / 1_000_000_000).toFixed(0)}B+`;
 }

--- a/lib/usage-stats.ts
+++ b/lib/usage-stats.ts
@@ -12,6 +12,10 @@ export function formatCompanyCount(): string {
   return `${COMPANIES.toLocaleString("en-US")}+`;
 }
 
+export function formatDockerPulls(): string {
+  return `${(DOCKER_PULLS / 1_000_000).toFixed(0)}M+`;
+}
+
 export function formatObservationsPerMonth(): string {
   return `${(OBSERVATIONS_PER_MONTH / 1_000_000_000).toFixed(0)}B+`;
 }


### PR DESCRIPTION
## Summary

- Replace deployment option sections with a scannable comparison table.
- Make architecture details collapsible.
- Add a Railway warning about verifying UTC timezones.
- Update performance copy and link to the scale architecture post.

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing the overview-level UTC callout may make a critical Postgres/ClickHouse requirement harder to find for operators who never open Railway or infrastructure pages, though UTC guidance still exists in infra docs and on Railway.
> 
> **Overview**
> **Self-hosting overview** is reorganized for scanning: deployment paths move from long sections into a **comparison table** (Cloud vs Docker Compose vs production options), architecture prose sits behind a collapsible **“View architecture components”** block, and the scale/reliability section leads with a new **`SelfHostScaleMetrics`** blurb while the optimization bullet list moves into a collapsible details section. The ClickHouse performance bullet is rewritten to highlight the wide observations schema and links to the scale blog post. The **standalone UTC requirement** on the overview page is removed; **Railway** gains a post-deploy warning that points to the timezone FAQ.
> 
> **Marketing numbers** (observations/month, Fortune 50, Docker pulls) are centralized in `lib/usage-stats.ts` with `formatObservationsPerMonth()` and `formatDockerPulls()`, then wired through the home hero strip, customer stats bar, MDX markdown fallbacks, and the new self-host metrics component so copy stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2815212c72b0f572999bf2da882f0d2c252d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restructures the self-hosting overview into a deployment comparison table, collapses architecture details, adds Railway-specific timezone verification guidance, and refreshes the ClickHouse performance description.

- Makes deployment choices easier to compare.
- Adds a correct UTC warning to the Railway deployment flow.
- Removes the shared UTC warning without carrying it into the other deployment flows.
- Links the performance discussion to the current scale-architecture article.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because mandatory UTC guidance becomes undiscoverable from most documented deployment paths.

Non-UTC PostgreSQL or ClickHouse configurations can return incorrect or empty results, but the revised overview removes the shared warning while only Railway receives a replacement.

**Files Needing Attention:** content/self-hosting/index.mdx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
content/self-hosting/index.mdx:39
**UTC Guidance Becomes Undiscoverable**

Removing the global UTC requirement leaves this warning only in the Railway guide. The Kubernetes, AWS, Azure, GCP, Render, and Docker Compose guides neither state nor link to the requirement. Operators following those deployment paths may configure PostgreSQL or ClickHouse with a non-UTC timezone, which the infrastructure documentation confirms can cause incorrect or empty query results. The UTC requirement should remain discoverable from the shared self-hosting flow.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improve self-hosting deployment guidance"](https://github.com/langfuse/langfuse-docs/commit/f53245a0c6ab8c00d702100bb2a93d7c33a5c4eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60390602)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->