### PR TITLE
fix(seo): stop marketing pages serving every deep path with a 200

### DIFF
--- a/app/[section]/[[...slug]]/page.tsx
+++ b/app/[section]/[[...slug]]/page.tsx
@@ -36,6 +36,11 @@ export default async function SectionDocPage(props: PageProps) {
 
   if (!SECTION_SLUGS.includes(section)) notFound();
   if (DEDICATED_APP_SECTIONS.has(section)) notFound();
+  // Marketing entries are single pages: the slug is ignored when building
+  // `effectiveSlug`, so without this guard every `/{marketing}/{anything}`
+  // path rendered the parent page with a 200 and became an indexable
+  // duplicate of it.
+  if (isMarketing && slug.length > 0) notFound();
 
   const config = SECTION_CONFIG[section as keyof typeof SECTION_CONFIG];
   const result = await loadPage(config.source, effectiveSlug);
@@ -99,6 +104,11 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const effectiveSlug = isMarketing ? [section] : slug;
 
   if (!SECTION_SLUGS.includes(section)) {
+    return { title: "Not Found" };
+  }
+  // Matches the guard in the page component, so a deep path under a marketing
+  // page does not advertise a canonical URL for a route that 404s.
+  if (isMarketing && slug.length > 0) {
     return { title: "Not Found" };
   }
   const config = SECTION_CONFIG[section];

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1791,6 +1791,17 @@ const alertsMoveToObservability202608 = [
   ],
 ];
 
+// Locale landing pages were reachable at a doubled path (/kr/kr, /cn/cn) because
+// the marketing catch-all ignored the slug. Google indexed the doubled URLs and
+// ranked them above the real ones, so these keep the accumulated signal while
+// the route itself now 404s any other deep path under a marketing page.
+const localeDoubledPaths202609 = [
+  ["/kr/kr", "/kr"],
+  ["/kr/kr.md", "/kr.md"],
+  ["/cn/cn", "/cn"],
+  ["/cn/cn.md", "/cn.md"],
+];
+
 const permanentRedirects = [
   // The adopters wall now lives on the main Customers page (2026-08)
   ["/users/adopters", "/users#adopters"],
@@ -1860,6 +1871,7 @@ const permanentRedirects = [
   ...guidesCleanup202608,
   ...monitorsToAlertsRename202608,
   ...alertsMoveToObservability202608,
+  ...localeDoubledPaths202609,
 ];
 
 module.exports = { nonPermanentRedirects, permanentRedirects };


### PR DESCRIPTION
Marketing entries are single pages, and the `[section]` catch-all ignores the slug when resolving them:

```ts
const effectiveSlug = isMarketing ? [section] : slug;
```

So `/{marketing}/{anything}` rendered the parent page with a **200** instead of 404ing. That is an unlimited surface of indexable duplicates across all 24 marketing pages, and it is live in production today:

```
$ for p in /kr/total-garbage /cn/xyz /oss-friends/oss-friends; do
    curl -so /dev/null -w "%{http_code}  $p\n" "https://langfuse.com$p"; done
200  /kr/total-garbage
200  /cn/xyz
200  /oss-friends/oss-friends
```

Google found two of them and **ranks the duplicates above the real pages** (last 90 days, Search Console):

| URL | Clicks |
| --- | --- |
| `/kr/kr` | **2,321** |
| `/kr` | 910 |
| `/cn/cn` | **2,032** |
| `/cn` | 1,162 |

Both duplicates already carry a self-referencing canonical pointing at `/kr` and `/cn`; it is not being honoured. `/japan/japan` correctly 404s because `/japan` is a `DEDICATED_MARKETING_SLUG` with its own route, which is why this only surfaced on the catch-all pages.

## The fix

1. **The page component and `generateMetadata` now 404 a marketing section that carries a slug.** That closes the surface for all 24 pages. The metadata guard matters too — without it a deep path would still advertise a canonical URL for a route that 404s.
2. **`/kr/kr` and `/cn/cn` get permanent redirects** (plus their `.md` variants) rather than 404s, so the traffic those two have accumulated moves to the real pages instead of being dropped. Everything else 404s, which is the correct answer for a URL that never existed — redirecting arbitrary paths to a parent is a soft 404 in its own right.

## Verification

Against the dev server.

**All 24 marketing pages still serve:**

```
/kr 200   /cn 200   /oss-friends 200   /wrapped 200   /about 200   /enterprise 200
/careers 200   /pricing 200   /pricing-self-host 200   /japan 200   /talk-to-us 200
/research 200   /imprint 200   /privacy 200
```

**The two indexed duplicates redirect:**

```
/kr/kr     308 -> /kr
/cn/cn     308 -> /cn
/kr/kr.md  308 -> /kr.md
/cn/cn.md  308 -> /cn.md
```

**Arbitrary deep paths now 404 (all were 200):**

```
/kr/total-garbage 404   /cn/xyz 404   /oss-friends/oss-friends 404
/about/team 404         /careers/anything 404   /wrapped/2024 404
```

**No regression on non-marketing sections**, which legitimately have subpages:

```
/docs/observability/overview 200            /self-hosting/deployment/docker-compose 200
/faq/all/llm-observability 200              /integrations/frameworks/langchain 200
/users/slite 200                            /changelog/2026-08-17-langfuse-v4 200
/handbook/how-we-hire/hiring-process 200    /security/auth 200
```

**Build:** `npx next build` compiled successfully, 966 static pages generated, no route conflicts. `node -e 'require("./lib/redirects.js")'` loads clean at 464 permanent redirects, no duplicate sources introduced. `prettier --write` no-ops on both files.

Found while triaging the September Ahrefs crawl; companion to #3716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and redirect changes are scoped to marketing single-page sections; nested docs and other sections are unchanged, with a small SEO-sensitive surface.
> 
> **Overview**
> Fixes an SEO duplicate-content bug where **any** `/{marketing-section}/{extra-segments}` URL returned **200** with the parent marketing page, because marketing routes ignore the catch-all slug when resolving content.
> 
> The catch-all page and **`generateMetadata`** now **404** when a marketing section has a non-empty slug, so bogus deep URLs are not indexable and metadata does not claim a canonical for routes that 404.
> 
> **Permanent redirects** send indexed doubled locale paths (`/kr/kr`, `/cn/cn`, plus `.md` variants) to `/kr` and `/cn` so existing search traffic is preserved; other invalid marketing deep paths 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e175b76341dee3b04174d8cd9e9256b9dd9584f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes an SEO duplicate-content surface by rejecting nested paths beneath single-page marketing sections and preserving accumulated traffic for the known Korean and Chinese doubled paths.
- Adds matching page and metadata guards for nested marketing URLs.
- Adds permanent redirects for `/kr/kr`, `/cn/cn`, and their markdown variants.
- Leaves legitimate nested routes in non-marketing sections unchanged.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with only non-blocking automated regression coverage recommended for the new routing and redirect behavior.

The guards are aligned for marketing deep paths, optional slugs are handled safely, and all redirect destinations resolve through existing markdown and page routing; the remaining concern is that these SEO-sensitive contracts are protected only by manual verification.

**Files Needing Attention:** app/[section]/[[...slug]]/page.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/[section]/[[...slug]]/page.tsx:43
**Routing Regression Coverage Missing**

This SEO-sensitive routing change is covered only by manual verification. The page and metadata guards must remain aligned, while the four redirect exceptions must continue to work before nested marketing paths return 404. Add route-level tests for a valid marketing root, an arbitrary nested marketing path, both doubled-locale redirects and their `.md` variants, and a valid nested non-marketing page; otherwise a future routing change could silently reopen the duplicate-content surface.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seo): stop marketing pages serving e..."](https://github.com/langfuse/langfuse-docs/commit/31254edc7405098dff02effcb458ee156d3cbc66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60394650)</sub>

**Context used:**

- Knowledge Base — [Route resolution and layouts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/route-resolution-and-layouts.md)

<!-- /greptile_comment -->