### PR TITLE
Replace outdated GitHub releases GIFs with MP4 videos

### DIFF
--- a/content/self-hosting/index.mdx
+++ b/content/self-hosting/index.mdx
@@ -93,7 +93,9 @@ Release notes are published on [GitHub](https://github.com/langfuse/langfuse/rel
 
 You can also watch the GitHub releases to get notified about new releases:
 
-<Frame className="max-w-md block">
-  ![Langfuse
-  releases](https://static.langfuse.com/docs-legacy-gifs/github-watch-changelog.gif)
-</Frame>
+<Video
+  src="https://static.langfuse.com/docs-videos/github-subscribe-releases.mp4"
+  aspectRatio={923 / 516}
+  gifStyle
+  className="max-w-md block"
+/>

--- a/content/self-hosting/upgrade/index.mdx
+++ b/content/self-hosting/upgrade/index.mdx
@@ -54,10 +54,12 @@ import SelfHostUpdateSignup from "@/components-mdx/self-host-update-signup.mdx";
 
 You can also watch the [GitHub releases](https://github.com/langfuse/langfuse/releases) for information about the changes in each version.
 
-<Frame className="max-w-md block">
-  ![Langfuse
-  releases](https://static.langfuse.com/docs-legacy-gifs/github-watch-changelog.gif)
-</Frame>
+<Video
+  src="https://static.langfuse.com/docs-videos/github-subscribe-releases.mp4"
+  aspectRatio={923 / 516}
+  gifStyle
+  className="max-w-md block"
+/>
 
 <span>_Watch the repository on GitHub to get notified about new releases_</span>
 

--- a/content/self-hosting/upgrade/versioning.mdx
+++ b/content/self-hosting/upgrade/versioning.mdx
@@ -232,10 +232,12 @@ Release notes are published on GitHub:
 
 You can watch the GitHub releases to get notified about new releases:
 
-<Frame className="max-w-md block">
-  ![Langfuse
-  releases](https://static.langfuse.com/docs-legacy-gifs/github-watch-changelog.gif)
-</Frame>
+<Video
+  src="https://static.langfuse.com/docs-videos/github-subscribe-releases.mp4"
+  aspectRatio={923 / 516}
+  gifStyle
+  className="max-w-md block"
+/>
 
 Also, you can subscribe to our mailing list to get notified about new releases and new major versions:
 

--- a/content/self-hosting/v2/deployment-guide.mdx
+++ b/content/self-hosting/v2/deployment-guide.mdx
@@ -343,10 +343,12 @@ During container startup, any necessary database migrations will be applied auto
 
 Langfuse is released through tagged semver releases. Check [GitHub releases](https://github.com/langfuse/langfuse/releases) for information about the changes in each version.
 
-<Frame className="max-w-md block">
-  ![Langfuse
-  releases](https://static.langfuse.com/docs-legacy-gifs/github-watch-changelog.gif)
-</Frame>
+<Video
+  src="https://static.langfuse.com/docs-videos/github-subscribe-releases.mp4"
+  aspectRatio={923 / 516}
+  gifStyle
+  className="max-w-md block"
+/>
 
 <span>_Watch the repository on GitHub to get notified about new releases_</span>
 


### PR DESCRIPTION
## Summary

- Replace outdated GitHub releases GIF embeds with the current MP4 video.
- Update self-hosting release, upgrade, versioning, and deployment documentation.

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only media swap with no application, API, or deployment logic changes.
> 
> **Overview**
> Updates the **“watch GitHub releases”** walkthrough on four self-hosting docs pages by swapping legacy **GIF-in-`Frame`** embeds for the shared **`Video`** component (`github-subscribe-releases.mp4`, `gifStyle`, same `max-w-md` layout).
> 
> Touched pages: self-hosting overview, upgrade guide, versioning, and v2 deployment guide. Copy and surrounding release-note/signup content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfb3a160d2ba5f207e4f911cdc1f1d206ee9cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces an outdated GitHub releases GIF with a consistently configured MP4 video across four self-hosting documentation pages.
- Uses the repository’s globally registered Video component and supported props.
- Preserves the existing display width while adding the video’s aspect ratio and GIF-style playback.
- Updates release-notification guidance consistently across current, upgrade, versioning, and v2 deployment documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only changes appear safe to merge.

All four pages use a supported, globally registered MDX Video component with consistent props and established repository conventions; no concrete regression or rule violation was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["Replace outdated release GIFs with video"](https://github.com/langfuse/langfuse-docs/commit/acfb3a160d2ba5f207e4f911cdc1f1d206ee9cfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60395587)</sub>

<!-- /greptile_comment -->