### PR TITLE
Update Docker pulls metric to 38 million

### DIFF
--- a/lib/usage-stats.ts
+++ b/lib/usage-stats.ts
@@ -1,7 +1,7 @@
 /** Marketing usage stats. Update these when public metrics change. */
 
 export const SDK_INSTALLS_PER_MONTH = 130_000_000;
-export const DOCKER_PULLS = 6_000_000;
+export const DOCKER_PULLS = 38_000_000;
 export const FORTUNE_500_COMPANIES = 129;
 export const FORTUNE_50_COMPANIES = 21;
 /** Companies using Langfuse (Cloud + self-hosted), not paying customers. */


### PR DESCRIPTION
## Summary
- Update the public Docker pulls metric from 6 million to 38 million

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single marketing constant change with no logic, auth, or data-handling impact.
> 
> **Overview**
> Updates the public **Docker pulls** marketing constant in `lib/usage-stats.ts` from **6 million** to **38 million**.
> 
> Any UI or copy that reads `DOCKER_PULLS` or `formatDockerPulls()` will show the new figure (e.g. **38M+**) without further code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf7cec19de29afbdcad584bcb5857dd70db0213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the shared public Docker pull count from 6 million to 38 million.
- Existing consumers automatically render the updated count in their expected formats.
- No behavioral, security, or repository-rule issues were identified.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The updated constant remains compatible with every consumer, producing the intended `38M+` or `38,000,000` display without introducing functional issues.
</details>

<sub>Reviews (1): Last reviewed commit: ["Update Docker pulls metric to 38 million"](https://github.com/langfuse/langfuse-docs/commit/28a810e00e85e0ddc574ba5f6d0c1e5d3b2e64af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60414629)</sub>

<!-- /greptile_comment -->