### PR TITLE
Persist GitHub contributor data in the scheduled update workflow

### DIFF
--- a/.github/workflows/update-github-discussions.yml
+++ b/.github/workflows/update-github-discussions.yml
@@ -1,4 +1,4 @@
-name: Update GitHub Discussions JSON
+name: Update GitHub data
 
 on:
   schedule:
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 permissions:
+  contents: read
   discussions: read
 
 jobs:
@@ -18,6 +19,17 @@ jobs:
         with:
           token: ${{ secrets.UPDATE_DOCS_MAIN_BRANCH_PAT }}
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Generate contributors
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/authors/generate-contributors.js
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -33,7 +45,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
-          git add src/langfuse_github_discussions.json public/github-discussions-sitemap.xml
-          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update GitHub discussions JSON and sitemap" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "${GITHUB_REF#refs/heads/}")
+          git add data/generated/contributors.json src/langfuse_github_discussions.json public/github-discussions-sitemap.xml
+          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update GitHub data and sitemap" && git push "https://x-access-token:${UPDATE_DOCS_MAIN_BRANCH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "${GITHUB_REF#refs/heads/}")
         env:
           UPDATE_DOCS_MAIN_BRANCH_PAT: ${{ secrets.UPDATE_DOCS_MAIN_BRANCH_PAT }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --experimental-cli --write .",
     "format:check": "prettier --experimental-cli --check .",
     "postinstall": "bash scripts/postinstall.sh",
-    "prebuild": "node scripts/sync-wordmark-png-for-og.mjs && node scripts/generate_brand_assets_zip.js && node scripts/generate-default-og-png.mjs && node scripts/authors/generate-contributors.js && pnpm workshop:sync && node scripts/copy_md_sources.js && node scripts/generate-sitemap-excludes.js && node scripts/sync-design-tokens.js",
+    "prebuild": "node scripts/sync-wordmark-png-for-og.mjs && node scripts/generate_brand_assets_zip.js && node scripts/generate-default-og-png.mjs && node scripts/authors/validate-contributors.js && pnpm workshop:sync && node scripts/copy_md_sources.js && node scripts/generate-sitemap-excludes.js && node scripts/sync-design-tokens.js",
     "build": "next build",
     "postbuild": "pnpm run postbuild:sitemap && pnpm run postbuild:cleanup && pnpm run postbuild:llms-txt",
     "build:static": "cross-env STATIC_EXPORT=true pnpm run prebuild && cross-env STATIC_EXPORT=true next build && pnpm run postbuild:static",

--- a/scripts/authors/README.md
+++ b/scripts/authors/README.md
@@ -56,22 +56,26 @@ node scripts/authors/generate-contributors.js
 
 ## Automated Process
 
-The `contributors.json` file is **automatically generated** during the build process by:
+The `contributors.json` file is automatically refreshed by the scheduled GitHub data workflow. Deployments validate and consume the committed snapshot without calling the GitHub contributors API.
+
+The scheduled refresh:
 
 1. Reading configuration from `config.js` (sections to analyze, paths, settings)
 2. Scanning current documentation files across all configured sections
 3. Running a single optimized git command for all historical data (~0.2s)
-4. Filtering to only include pages that currently exist
-5. Mapping commit emails to author keys using `data/authors.json`
+4. Resolving each unique non-noreply email with at most one GitHub API request
+5. Filtering to only include pages that currently exist
 6. Ordering contributors by most recent contribution (descending)
-7. Creating the page-to-contributors mapping for all sections
+7. Merging the result into the committed page-to-contributors mapping
+
+The refresh fails without committing partial output when GitHub returns an error. A successful response without a linked GitHub username is cached only for the duration of that refresh.
 
 ## Workflow
 
 1. **Check for new contributors:** `node scripts/authors/update-authors.js analyze` (analyzes all documentation sections)
 2. **For existing team members:** Map new email to existing author
 3. **For new contributors:** Add author profile to `data/authors.json` first
-4. **Contributors.json updates automatically** on next build
+4. **Contributors.json updates automatically** during the next scheduled GitHub data refresh
 
 ## Author Profile Format (data/authors.json)
 

--- a/scripts/authors/generate-contributors.js
+++ b/scripts/authors/generate-contributors.js
@@ -23,28 +23,29 @@ async function fetchFromGitHub(endpoint) {
     headers["Authorization"] = `token ${process.env.GITHUB_ACCESS_TOKEN}`;
   }
 
+  let response;
   try {
-    const response = await fetch(`${CONFIG.github.apiBase}${endpoint}`, {
-      headers,
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) return null;
-      throw new Error(`GitHub API: ${response.status} ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    cache.set(endpoint, data);
-    return data;
+    response = await fetch(`${CONFIG.github.apiBase}${endpoint}`, { headers });
   } catch (error) {
-    console.warn(`GitHub API failed for ${endpoint}:`, error.message);
-    return null;
+    throw new Error(
+      `GitHub API request failed for ${endpoint}: ${error.message}`,
+    );
   }
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed for ${endpoint}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = await response.json();
+  cache.set(endpoint, data);
+  return data;
 }
 
 // Contributor resolution helpers
 const extractGitHubUsernameFromEmail = (email) => {
-  const match = email.match(/^\d+\+([^@]+)@users\.noreply\.github\.com$/);
+  const match = email.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/);
   return match ? match[1] : null;
 };
 
@@ -57,10 +58,7 @@ const resolveContributor = async (email, commitSha) => {
 
   // Check if we have cached the GitHub username for this email
   if (emailToUsernameCache.has(email)) {
-    const cachedUsername = emailToUsernameCache.get(email);
-    if (cachedUsername) {
-      return cachedUsername;
-    }
+    return emailToUsernameCache.get(email);
   }
 
   // Use GitHub API to get the actual GitHub username
@@ -330,4 +328,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { analyzeContributors };
+module.exports = { analyzeContributors, resolveContributor };

--- a/scripts/authors/generate-contributors.test.js
+++ b/scripts/authors/generate-contributors.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { resolveContributor } = require("./generate-contributors");
+
+test("caches a successful response without a linked GitHub username", async (t) => {
+  const originalFetch = global.fetch;
+  let requestCount = 0;
+
+  global.fetch = async () => {
+    requestCount += 1;
+    return {
+      ok: true,
+      json: async () => ({ author: null }),
+    };
+  };
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  assert.equal(await resolveContributor("unlinked@example.com", "first"), null);
+  assert.equal(
+    await resolveContributor("unlinked@example.com", "second"),
+    null,
+  );
+  assert.equal(requestCount, 1);
+});
+
+test("resolves both GitHub noreply email formats without an API request", async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error("GitHub should not be called");
+  };
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  assert.equal(
+    await resolveContributor(
+      "2834609+marcklingen@users.noreply.github.com",
+      "unused",
+    ),
+    "marcklingen",
+  );
+  assert.equal(
+    await resolveContributor("DABH@users.noreply.github.com", "unused"),
+    "DABH",
+  );
+});
+
+test("fails when GitHub returns a non-success response", async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: false,
+    status: 403,
+    statusText: "Forbidden",
+  });
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  await assert.rejects(
+    resolveContributor("rate-limited@example.com", "rate-limited"),
+    /403 Forbidden/,
+  );
+});

--- a/scripts/authors/validate-contributors.js
+++ b/scripts/authors/validate-contributors.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const { CONFIG } = require("./config");
+
+function validateContributors(filePath = CONFIG.contributors) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Contributor snapshot is missing: ${filePath}`);
+  }
+
+  let contributors;
+  try {
+    contributors = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Contributor snapshot is not valid JSON: ${error.message}`);
+  }
+
+  if (
+    contributors === null ||
+    Array.isArray(contributors) ||
+    typeof contributors !== "object"
+  ) {
+    throw new Error("Contributor snapshot must be an object");
+  }
+
+  for (const [pagePath, usernames] of Object.entries(contributors)) {
+    if (!pagePath.startsWith("/")) {
+      throw new Error(`Contributor page path must start with "/": ${pagePath}`);
+    }
+    if (!Array.isArray(usernames)) {
+      throw new Error(`Contributors for ${pagePath} must be an array`);
+    }
+    if (
+      usernames.some(
+        (username) => typeof username !== "string" || username.length === 0,
+      )
+    ) {
+      throw new Error(
+        `Contributors for ${pagePath} must contain non-empty usernames`,
+      );
+    }
+  }
+
+  return contributors;
+}
+
+if (require.main === module) {
+  try {
+    const contributors = validateContributors();
+    console.log(
+      `Validated contributors.json (${Object.keys(contributors).length} pages)`,
+    );
+  } catch (error) {
+    console.error(`Contributor snapshot validation failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { validateContributors };

--- a/scripts/authors/validate-contributors.test.js
+++ b/scripts/authors/validate-contributors.test.js
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { validateContributors } = require("./validate-contributors");
+
+function writeFixture(t, contents) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "contributors-"));
+  const filePath = path.join(directory, "contributors.json");
+  fs.writeFileSync(filePath, contents);
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return filePath;
+}
+
+test("accepts a valid contributor snapshot", (t) => {
+  const filePath = writeFixture(
+    t,
+    JSON.stringify({ "/docs/example": ["contributor"] }),
+  );
+
+  assert.deepEqual(validateContributors(filePath), {
+    "/docs/example": ["contributor"],
+  });
+});
+
+test("rejects invalid contributor snapshot JSON", (t) => {
+  const filePath = writeFixture(t, "{");
+  assert.throws(() => validateContributors(filePath), /not valid JSON/);
+});
+
+test("rejects invalid contributor snapshot structure", (t) => {
+  const filePath = writeFixture(
+    t,
+    JSON.stringify({ "/docs/example": "contributor" }),
+  );
+  assert.throws(() => validateContributors(filePath), /must be an array/);
+});
+
+test("rejects a missing contributor snapshot", () => {
+  assert.throws(
+    () => validateContributors("/missing/contributors.json"),
+    /is missing/,
+  );
+});


### PR DESCRIPTION
## Summary

- Generate and commit contributor data alongside GitHub discussions data
- Validate the committed contributor snapshot during builds
- Cache unresolved contributor lookups and fail the refresh on GitHub API errors
- Add coverage for caching, noreply email formats, API failures, and snapshot validation

## Testing

- Added Node.js unit tests for contributor resolution and snapshot validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI contributor refresh and build-time validation of a JSON snapshot; no runtime auth or user data paths are touched.
> 
> **Overview**
> **Contributor attribution moves off the deploy path** and into the existing six-hour **Update GitHub data** workflow, which now runs Node 22, full git history (`fetch-depth: 0`), `generate-contributors.js`, and commits `data/generated/contributors.json` together with discussions JSON and the sitemap.
> 
> **Builds no longer call the GitHub API** for contributors: `prebuild` runs new `validate-contributors.js` instead of generating the file. The generator is stricter (API failures abort the refresh), supports both GitHub noreply email shapes without extra requests, and caches “no linked username” lookups for the duration of a run. Unit tests cover resolution caching, noreply parsing, API errors, and snapshot validation; the authors README documents the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5503d3bf5d6ee9d686ba2a5fcccd01c49665c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves contributor-data generation from every build into the scheduled GitHub-data workflow, makes GitHub lookup failures fatal, caches unresolved contributors, and adds structural validation and unit coverage for the committed snapshot. The main remaining gap is that builds can accept a structurally valid snapshot that predates the current documentation.

- Generates and commits contributor and discussion data together.
- Uses the committed contributor snapshot during builds.
- Adds coverage for lookup caching, noreply addresses, API failures, and malformed snapshots.
- Leaves a refresh window in which newly added or renamed pages can deploy without contributor attribution.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap that can temporarily omit contributor attribution from newly added or renamed pages.

Contributor generation is no longer part of prebuild, while the replacement validator checks only JSON shape; therefore a build between a documentation merge and the next scheduled refresh can publish without current contributor mappings.

**Files Needing Attention:** package.json, scripts/authors/validate-contributors.js
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Schedule[Scheduled workflow every 6 hours] --> Generate[Generate contributor snapshot]
  Generate --> Commit[Commit generated GitHub data]
  Commit --> Repository[Main branch snapshot]
  Repository --> Validate[Prebuild structural validation]
  Validate --> Build[Next.js build]
  DocsChange[Documentation merge] --> Repository
  DocsChange -. may precede refresh .-> Build
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
package.json:13
**Snapshot Can Lag Content**

Replacing build-time generation with shape-only validation allows a documentation deployment to use the previous contributor snapshot. When a page is added or renamed after the last six-hourly refresh, validation still succeeds because it does not compare the snapshot with current pages. The contributor footer then silently omits attribution until the scheduled workflow runs. Consider validating snapshot completeness or refreshing it before deployment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Persist GitHub contributor data between ..."](https://github.com/langfuse/langfuse-docs/commit/5b5503d3bf5d6ee9d686ba2a5fcccd01c49665c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60425157)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content publishing automation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-publishing-automation.md)

<!-- /greptile_comment -->