### PR TITLE
Add redirects for paths AI coding agents guess

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1616,6 +1616,56 @@ const brokenLinksCleanup202608 = [
   ],
 ];
 
+// Paths that AI coding agents guess when integrating Langfuse - September 2026
+//
+// These URLs have never existed, but they are the ones agents construct from
+// the shape of the docs when they need an answer: data residency, masking,
+// billing units, trace best practices, and language-scoped SDK pages. Each was
+// observed 404ing in a run of the armature.tech evals-sector benchmark, where
+// agents guess a URL rather than search again. The `.md` twins are included
+// because agents request the markdown representation of the same path.
+const agentGuessedPaths202609 = [
+  // Data residency lives under /security, alongside /faq/all/cloud-data-regions
+  ["/docs/data-regions", "/security/data-regions"],
+  ["/docs/data-regions.md", "/security/data-regions.md"],
+  // Masking is an observability feature, not an FAQ entry
+  ["/faq/all/data-masking", "/docs/observability/features/masking"],
+  ["/faq/all/data-masking.md", "/docs/observability/features/masking.md"],
+  // "What am I billed for" is answered by the billable-units definition
+  ["/faq/all/cloud-billing-and-usage", "/docs/administration/billable-units"],
+  [
+    "/faq/all/cloud-billing-and-usage.md",
+    "/docs/administration/billable-units.md",
+  ],
+  // Best practices is a single page, not a folder
+  [
+    "/docs/observability/best-practices/trace-best-practices",
+    "/docs/observability/best-practices",
+  ],
+  [
+    "/docs/observability/best-practices/trace-best-practices.md",
+    "/docs/observability/best-practices.md",
+  ],
+  // SDK pages are language-agnostic; the language variants are tabs within them
+  [
+    "/docs/observability/sdk/typescript/advanced-features",
+    "/docs/observability/sdk/advanced-features",
+  ],
+  [
+    "/docs/observability/sdk/typescript/advanced-features.md",
+    "/docs/observability/sdk/advanced-features.md",
+  ],
+  // Reverse of the existing /sdk/python/instrumentation redirect
+  [
+    "/docs/observability/sdk/instrumentation/python",
+    "/docs/observability/sdk/instrumentation",
+  ],
+  [
+    "/docs/observability/sdk/instrumentation/python.md",
+    "/docs/observability/sdk/instrumentation.md",
+  ],
+];
+
 // Guides section cleanup (2026-08): outdated cookbooks and videos removed from
 // /guides, integration cookbooks moved to /integrations, benchmarks moved to
 // /resources/engineering.
@@ -1868,6 +1918,7 @@ const permanentRedirects = [
   ...goodTraceBestPracticesMove202607,
   ...promptMcpPageRemoval202607,
   ...brokenLinksCleanup202608,
+  ...agentGuessedPaths202609,
   ...guidesCleanup202608,
   ...monitorsToAlertsRename202608,
   ...alertsMoveToObservability202608,


### PR DESCRIPTION
Adds redirects for six URLs that have never existed on langfuse.com but that AI coding agents repeatedly request. Each was observed returning a 404 in runs of the armature.tech evals-sector benchmark (288 coding-agent runs across claude-code, cursor and codex).

The pattern behind them: when an agent needs a fact it does not find on the page it opened, it often constructs a plausible URL instead of searching again. The guesses are systematic, not random — data residency is assumed to live under `/docs`, masking and billing are assumed to be FAQ entries, best practices is assumed to be a folder, and SDK pages are assumed to be scoped per language.

## Redirects added

| Guessed path | Destination | Why this destination |
| --- | --- | --- |
| `/docs/data-regions` | `/security/data-regions` | Where data residency actually lives; matches the existing `/faq/all/cloud-data-regions` redirect |
| `/faq/all/data-masking` | `/docs/observability/features/masking` | Masking is an observability feature; matches the existing `/docs/tracing-features/masking` redirect |
| `/faq/all/cloud-billing-and-usage` | `/docs/administration/billable-units` | The page that defines a billable unit and links to pricing and the calculator |
| `/docs/observability/best-practices/trace-best-practices` | `/docs/observability/best-practices` | Best practices is a single page, not a folder |
| `/docs/observability/sdk/typescript/advanced-features` | `/docs/observability/sdk/advanced-features` | SDK pages are language-agnostic; language variants are tabs within them |
| `/docs/observability/sdk/instrumentation/python` | `/docs/observability/sdk/instrumentation` | Mirror image of the existing `/docs/observability/sdk/python/instrumentation` redirect |

Added as a new `agentGuessedPaths202609` section in `lib/redirects.js`, following the structure of the neighbouring `brokenLinksCleanup202608` block, and spread into `permanentRedirects`.

## Note for reviewers: the `.md` twins

Each of the six paths is paired with its `.md` twin, so 12 entries in total. Agents request the markdown representation of the same URL — 25 such fetches appear in the benchmark, 5 of which 404'd on invented paths — and `brokenLinksCleanup202608` already does this for `v4-installation.md`. Redirects run before rewrites in Next.js, so these fire ahead of the `/:path*.md` → `/md-src/...` rewrite. **This is the one part of the change that goes beyond the six paths requested; happy to drop the six `.md` lines if you would rather keep the section minimal.**

## Verification

Checked locally against a dev server:

- All 12 sources return `308` to the intended destination.
- All 12 destinations return `200`, both as HTML and as the generated `md-src` markdown mirror.
- No destination is itself a redirect source, so none of these creates a redirect chain.
- No duplicate redirect sources introduced (`625` total redirects parse cleanly).
- `pnpm exec prettier --check lib/redirects.js` passes.

`pnpm build` was not run locally — CI covers it, and this change touches only the redirect table.

## Related paths not included

Three further `.md` 404s showed up in the same benchmark data but are outside the requested set, so they are left for a follow-up if wanted: `/docs/observability/sdk/typescript/setup.md`, `/docs/observability/sdk/python/instrumentation.md`, and `/docs/observability/sdk/instrumentation/js/overview.md`. The first two have working non-`.md` equivalents, so only the `.md` form is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h4DPx2ffUZHmUCnDYnuPW

---
_Generated by [Claude Code](https://claude.ai/code/session_016h4DPx2ffUZHmUCnDYnuPW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only redirect table entries with no application logic, auth, or data handling changes.
> 
> **Overview**
> Adds **12 permanent redirects** (six guessed paths plus `.md` twins) so coding agents that invent plausible Langfuse doc URLs stop hitting 404s.
> 
> New block `agentGuessedPaths202609` in `lib/redirects.js` maps common guesses—e.g. `/docs/data-regions`, FAQ-style masking/billing paths, nested “trace best practices” and language-scoped SDK URLs—to the real locations (`/security/data-regions`, observability masking, billable units, unified SDK pages). The list is merged into `permanentRedirects`, matching the existing dated redirect sections and prior `.md` redirect pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce417a1c4407c974b74f377f50eb02bf8a2bb7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds permanent redirects for six systematically guessed documentation URLs and their `.md` equivalents.
- Routes guessed data-residency, masking, billing, best-practices, and language-scoped SDK paths to canonical content.
- Integrates all twelve entries into the existing permanent redirect table.
- Preserves markdown access through the existing redirect-before-rewrite flow.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the redirect sources are unique and all destinations resolve through established routing behavior.

No actionable failure was found: the new routes do not collide with existing redirect rules, create redirect chains, or target missing content, and the `.md` variants correctly proceed through the markdown rewrite after redirecting.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add redirects for paths AI coding agents..."](https://github.com/langfuse/langfuse-docs/commit/ce417a1c4407c974b74f377f50eb02bf8a2bb7ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60428994)</sub>

<!-- /greptile_comment -->