### PR TITLE
Improve CLS and first paint on /blog

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,6 +11,8 @@ import { Link } from "@/components/ui/link";
 import { Heading } from "@/components/ui/heading";
 import { Text } from "@/components/ui/text";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Blog",
   description:
@@ -35,7 +37,11 @@ export default function BlogIndexPage() {
         <BlogHatchBackground />
         <div className="relative z-1 mx-auto w-full px-6 py-8">
           <div className="flex flex-col gap-4 mb-8">
-            <Heading as="h1" size="large">
+            <Heading
+              as="h1"
+              size="large"
+              className="min-h-[32px] sm:min-h-[44px] md:min-h-[50px]"
+            >
               <TextHighlight>Langfuse Blog</TextHighlight>
             </Heading>
             <Text className="text-left">

--- a/components/blog/BlogAside.tsx
+++ b/components/blog/BlogAside.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { AsideShell } from "@/components/home/layout/AsideShell";
 import { RightSidebarHiringAndCommunity } from "@/components/home/layout/RightSidebarHiringAndCommunity";
 

--- a/components/blog/BlogCategoryDropdown.tsx
+++ b/components/blog/BlogCategoryDropdown.tsx
@@ -9,6 +9,14 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const itemClassName = cn(
+  "px-3 py-1.5 capitalize data-[state=checked]:text-text-primary",
+  // RadioItem draws an absolute indicator in a pl-8 gutter; compact px-3
+  // would otherwise let that circle overlap the label.
+  "[&>span.absolute]:hidden",
+);
 
 export function BlogCategoryDropdown() {
   const { selectedTag, setSelectedTag, tags, allPosts } = useBlogFilter();
@@ -33,7 +41,7 @@ export function BlogCategoryDropdown() {
           value={selectedTag ?? ""}
           onValueChange={(v) => setSelectedTag(v || null)}
         >
-          <DropdownMenuRadioItem value="" className="px-3 py-1.5 capitalize">
+          <DropdownMenuRadioItem value="" className={itemClassName}>
             <span className="flex-1">All</span>
             <span className="tabular-nums ml-3 text-text-tertiary">
               {allPosts.length}
@@ -43,7 +51,7 @@ export function BlogCategoryDropdown() {
             <DropdownMenuRadioItem
               key={tag.name}
               value={tag.name}
-              className="px-3 py-1.5 capitalize"
+              className={itemClassName}
             >
               <span className="flex-1">{tag.name}</span>
               <span className="tabular-nums ml-3 text-text-tertiary">

--- a/components/blog/BlogFilterContext.tsx
+++ b/components/blog/BlogFilterContext.tsx
@@ -6,6 +6,8 @@ import {
   useState,
   useEffect,
   useMemo,
+  useCallback,
+  Suspense,
   type ReactNode,
 } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
@@ -35,6 +37,31 @@ export function useBlogFilter() {
 
 const HIGHLIGHT_COUNT = 3;
 
+function tagFromSearchParams(searchParams: {
+  get: (key: string) => string | null;
+}): string | null {
+  return searchParams.get("tag") || null;
+}
+
+/**
+ * Reads `?tag=` without blocking the blog index HTML.
+ * Must stay in its own Suspense boundary — `useSearchParams()` would
+ * otherwise replace the whole page with a fallback during static render.
+ */
+function BlogUrlTagSync({
+  onTagFromUrl,
+}: {
+  onTagFromUrl: (tag: string | null) => void;
+}) {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    onTagFromUrl(tagFromSearchParams(searchParams));
+  }, [searchParams, onTagFromUrl]);
+
+  return null;
+}
+
 export function BlogFilterProvider({
   pages,
   children,
@@ -42,16 +69,14 @@ export function BlogFilterProvider({
   pages: BlogPageItem[];
   children: ReactNode;
 }) {
-  const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
   const [selectedTag, setSelectedTagLocal] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
-  useEffect(() => {
-    const tag = searchParams.get("tag") ?? null;
-    setSelectedTagLocal(tag || null);
-  }, [searchParams]);
+  const syncTagFromUrl = useCallback((tag: string | null) => {
+    setSelectedTagLocal((current) => (current === tag ? current : tag));
+  }, []);
 
   const allPosts = useMemo(() => {
     return pages
@@ -99,14 +124,18 @@ export function BlogFilterProvider({
 
   const setSelectedTag = (tag: string | null) => {
     setSelectedTagLocal(tag);
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(
+      typeof window !== "undefined" ? window.location.search : "",
+    );
     if (tag) {
       params.set("tag", tag);
     } else {
       params.delete("tag");
     }
     const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname);
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
   };
 
   return (
@@ -123,6 +152,9 @@ export function BlogFilterProvider({
         listPosts,
       }}
     >
+      <Suspense fallback={null}>
+        <BlogUrlTagSync onTagFromUrl={syncTagFromUrl} />
+      </Suspense>
       {children}
     </BlogFilterContext.Provider>
   );

--- a/components/blog/BlogHighlightCards.tsx
+++ b/components/blog/BlogHighlightCards.tsx
@@ -3,7 +3,7 @@
 import { Text } from "@/components/ui/text";
 import { HoverPostRow } from "@/components/lists/HoverPostRow";
 import type { BlogPageItem } from "./BlogIndex";
-import { formatDate, normalizeTags } from "./utils";
+import { formatAbsoluteDate, normalizeTags } from "./utils";
 
 export function BlogHighlightCards({ posts }: { posts: BlogPageItem[] }) {
   if (posts.length === 0) return null;
@@ -30,9 +30,9 @@ export function BlogHighlightCards({ posts }: { posts: BlogPageItem[] }) {
               <>
                 <Text
                   size="s"
-                  className="text-left md:text-right text-[12px] text-text-tertiary whitespace-nowrap"
+                  className="text-left md:text-right text-[12px] text-text-tertiary whitespace-nowrap tabular-nums md:min-w-[7.5rem]"
                 >
-                  {formatDate(post.frontMatter?.date)}
+                  {formatAbsoluteDate(post.frontMatter?.date)}
                 </Text>
                 {post.frontMatter?.author && (
                   <>

--- a/components/blog/BlogPageClient.tsx
+++ b/components/blog/BlogPageClient.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { Suspense, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { BlogFilterProvider } from "./BlogFilterContext";
 import type { BlogPageItem } from "./BlogIndex";
 
 /**
  * Client wrapper that provides BlogFilterContext so both the sidebar
  * and main content share filter state (tags, search query).
- * The actual layout is composed by the server page component.
+ *
+ * Do not wrap this tree in a Suspense fallback — `useSearchParams()`
+ * lives in a nested boundary so the index HTML can render on the server.
  */
 export function BlogPageClient({
   pages,
@@ -16,13 +18,5 @@ export function BlogPageClient({
   pages: BlogPageItem[];
   children: ReactNode;
 }) {
-  return (
-    <Suspense
-      fallback={
-        <div className="min-h-[400px] animate-pulse rounded-[2px] bg-surface-bg/50" />
-      }
-    >
-      <BlogFilterProvider pages={pages}>{children}</BlogFilterProvider>
-    </Suspense>
-  );
+  return <BlogFilterProvider pages={pages}>{children}</BlogFilterProvider>;
 }

--- a/components/blog/BlogPostList.tsx
+++ b/components/blog/BlogPostList.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import type { BlogPageItem } from "./BlogIndex";
 import { BlogCategoryDropdown } from "./BlogCategoryDropdown";
 import { useBlogFilter } from "./BlogFilterContext";
-import { formatDate, normalizeTags } from "./utils";
+import { formatAbsoluteDate, normalizeTags } from "./utils";
 import { HoverPostRow } from "@/components/lists/HoverPostRow";
 
 const PAGE_SIZE = 15;
@@ -64,9 +64,9 @@ export function BlogPostList({ posts }: { posts: BlogPageItem[] }) {
                   <>
                     <Text
                       size="s"
-                      className="text-left md:text-right text-[12px] text-text-tertiary whitespace-nowrap"
+                      className="text-left md:text-right text-[12px] text-text-tertiary whitespace-nowrap tabular-nums md:min-w-[7.5rem]"
                     >
-                      {formatDate(post.frontMatter?.date)}
+                      {formatAbsoluteDate(post.frontMatter?.date)}
                     </Text>
                     {post.frontMatter?.author && (
                       <>

--- a/components/blog/utils.test.ts
+++ b/components/blog/utils.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatAbsoluteDate, parseCalendarDate } from "./utils.ts";
+
+test("parseCalendarDate treats YYYY/MM/DD as a UTC calendar day", () => {
+  const parsed = parseCalendarDate("2026/04/24");
+  assert.ok(parsed);
+  assert.equal(parsed.toISOString(), "2026-04-24T00:00:00.000Z");
+});
+
+test("parseCalendarDate treats YYYY-MM-DD as a UTC calendar day", () => {
+  const parsed = parseCalendarDate("2026-04-24");
+  assert.ok(parsed);
+  assert.equal(parsed.toISOString(), "2026-04-24T00:00:00.000Z");
+});
+
+test("formatAbsoluteDate does not shift a day when formatted in UTC", () => {
+  assert.equal(formatAbsoluteDate("2026/04/24"), "Apr 24, 2026");
+  assert.equal(formatAbsoluteDate("2026-07-22"), "Jul 22, 2026");
+});
+
+test("parseCalendarDate rejects impossible calendar dates", () => {
+  assert.equal(parseCalendarDate("2026/02/31"), null);
+  assert.equal(formatAbsoluteDate("2026/02/31"), "");
+});

--- a/components/blog/utils.ts
+++ b/components/blog/utils.ts
@@ -27,11 +27,37 @@ export function computeTagCounts(
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Parse a calendar date as UTC midnight.
+ * Frontmatter uses `YYYY/MM/DD`, which `new Date()` treats as local time.
+ * Formatting that instant with `timeZone: "UTC"` then shifts a day east of UTC.
+ */
+export function parseCalendarDate(dateStr?: string): Date | null {
+  if (!dateStr) return null;
+  const calendar = dateStr.trim().match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  if (calendar) {
+    const year = Number(calendar[1]);
+    const month = Number(calendar[2]);
+    const day = Number(calendar[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+      parsed.getUTCFullYear() !== year ||
+      parsed.getUTCMonth() !== month - 1 ||
+      parsed.getUTCDate() !== day
+    ) {
+      return null;
+    }
+    return parsed;
+  }
+  const parsed = new Date(dateStr);
+  if (isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
 /** Stable UTC date for list rows. Avoids hydration/CLS from relative labels. */
 export function formatAbsoluteDate(dateStr?: string): string {
-  if (!dateStr) return "";
-  const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return "";
+  const d = parseCalendarDate(dateStr);
+  if (!d) return "";
   return d.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
@@ -41,9 +67,8 @@ export function formatAbsoluteDate(dateStr?: string): string {
 }
 
 export function formatDate(dateStr?: string): string {
-  if (!dateStr) return "";
-  const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return "";
+  const d = parseCalendarDate(dateStr);
+  if (!d) return "";
   const now = new Date();
   const diffDays = Math.round(
     (now.getTime() - d.getTime()) / (1000 * 60 * 60 * 24),
@@ -52,5 +77,10 @@ export function formatDate(dateStr?: string): string {
   if (diffDays === 1) return "1 Day Ago";
   if (diffDays < 14) return `${diffDays} Days Ago`;
   if (diffDays < 30) return `${Math.round(diffDays / 7)} Weeks Ago`;
-  return formatAbsoluteDate(dateStr);
+  return d.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/components/blog/utils.ts
+++ b/components/blog/utils.ts
@@ -27,6 +27,19 @@ export function computeTagCounts(
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Stable UTC date for list rows. Avoids hydration/CLS from relative labels. */
+export function formatAbsoluteDate(dateStr?: string): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 export function formatDate(dateStr?: string): string {
   if (!dateStr) return "";
   const d = new Date(dateStr);
@@ -39,10 +52,5 @@ export function formatDate(dateStr?: string): string {
   if (diffDays === 1) return "1 Day Ago";
   if (diffDays < 14) return `${diffDays} Days Ago`;
   if (diffDays < 30) return `${Math.round(diffDays / 7)} Weeks Ago`;
-  return d.toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  });
+  return formatAbsoluteDate(dateStr);
 }

--- a/components/lists/HoverPostRow.tsx
+++ b/components/lists/HoverPostRow.tsx
@@ -27,6 +27,8 @@ export function HoverPostRow({
   previewOnHover?: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
+  // Prefetch on hover only — viewport prefetch of every list row contends with first paint.
+  const [prefetch, setPrefetch] = useState(false);
 
   const hasHoverPreview = previewOnHover && !!previewImage;
   const showPreview = hasHoverPreview && hovered;
@@ -34,8 +36,12 @@ export function HoverPostRow({
   return (
     <Link
       href={href}
-      className="group relative flex flex-col md:flex-row gap-1.5 md:gap-4 px-4 py-3 transition-colors hover:bg-surface-1"
-      onMouseEnter={() => setHovered(true)}
+      prefetch={prefetch}
+      className="group relative flex flex-col md:flex-row gap-1.5 md:gap-4 px-4 py-3 md:min-h-[5.75rem] transition-colors hover:bg-surface-1"
+      onMouseEnter={() => {
+        setHovered(true);
+        setPrefetch(true);
+      }}
       onMouseLeave={() => setHovered(false)}
     >
       {leadingVisual ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The blog index wrapped the whole page in a Suspense fallback because `useSearchParams()` lived in the filter provider. During static render Next.js emitted a 400px pulse placeholder instead of the listing, then swapped in the real page after hydration. That is a large layout shift and a delayed first paint.

## Changes

- Keep `/blog` statically rendered with the full Highlights and All Posts HTML
- Isolate `useSearchParams()` in a nested Suspense boundary that renders nothing
- Use stable UTC dates and reserved row/date widths so hydration does not resize rows
- Prefetch post links on hover only, so the index is not competing with ~18 route prefetches
- Force-static the blog index route

Tag filters, search, and back/forward URL sync are unchanged. Filtered `?tag=` views still canonicalize to `/blog`.

## Verification

Local Chrome measurement on `/blog` after the change:

- CLS **0.002** (good is under 0.1). Remaining shift is in the marketing navbar, not the post list
- First HTML includes Highlights, All Posts, and 19 post links — no `animate-pulse` placeholder
- Category filter, search, and Load more work without a full reload

![Blog index first paint with Highlights and All Posts already in the HTML](https://cursor.com/artifacts/c/art-43b91f15-a390-4a8e-b0f3-dacf2dd80ace)
![Engineering category filter applied](https://cursor.com/artifacts/c/art-39afdf6b-d91a-49b2-9722-dedb503d556e)
<a href="https://cursor.com/agents/bc-0b0a80f9-d3fd-4b94-8f64-ad4f6db1b644/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog-index-filters-search-load-more.mp4"><img src="https://cursor.com/artifacts/c/art-c122483a-5a86-4d51-bf2e-848e7afe753c" alt="blog-index-filters-search-load-more.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b0a80f9-d3fd-4b94-8f64-ad4f6db1b644?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b0a80f9-d3fd-4b94-8f64-ad4f6db1b644&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR statically renders the complete blog index, isolates URL-tag synchronization behind a nested Suspense boundary, stabilizes list dimensions and dates, and switches shared post rows to hover-triggered prefetching.

- Removes the page-wide loading placeholder so highlights and posts appear in initial HTML.
- Preserves client-side tag, search, pagination, and URL synchronization.
- Introduces a timezone-dependent date error for slash-separated frontmatter dates.
- Applies the blog-specific prefetch optimization to non-blog consumers of the shared row component.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until blog dates are parsed consistently as UTC; the shared prefetch behavior should also be scoped to blog rows.

Slash-separated publication dates are parsed in each runtime’s local timezone and then formatted in UTC, causing incorrect dates and hydration differences for users east of UTC. The shared row change additionally removes viewport prefetching from unrelated changelog and customer links.

**Files Needing Attention:** components/blog/utils.ts, components/lists/HoverPostRow.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request["Request /blog"] --> Static["Force-static blog HTML"]
  Static --> Listing["Highlights and All Posts"]
  Static --> Provider["Hydrated BlogFilterProvider"]
  Provider --> SyncBoundary["Nested Suspense boundary"]
  SyncBoundary --> UrlSync["Read ?tag= and synchronize filter"]
  Provider --> Filters["Search, tags, and pagination"]
  Listing --> Rows["HoverPostRow links"]
  Rows --> Hover["Mouse hover enables prefetch"]
  Rows --> Touch["Touch navigation without prefetch"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/blog/utils.ts:33
**Dates Can Shift Days**

Blog frontmatter dates use `YYYY/MM/DD`, which `new Date()` parses as local time rather than a standardized UTC date. In browsers east of UTC, formatting that instant with `timeZone: "UTC"` returns the previous calendar day. Recent posts can therefore show the wrong publication date and produce a server/client hydration mismatch. Parse the date components explicitly as UTC or normalize the source to ISO `YYYY-MM-DD`.

### Issue 2
components/lists/HoverPostRow.tsx:39
**Prefetch Regression Affects Shared Rows**

Setting `prefetch={prefetch}` changes prefetching for every `HoverPostRow` consumer, not just the blog. Changelog and customer-story links now start with prefetch disabled and never enable it before navigation on touch devices, which can make those unrelated navigations slower. Make hover-only prefetch an opt-in prop or apply it only from the blog callers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blog): render the index in static HT..."](https://github.com/langfuse/langfuse-docs/commit/b91496ca7d0b60f3ccd609f1cf183dcb6867ae34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60442429)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->