### PR TITLE
Add Hardening for Government to handbook why page

### DIFF
--- a/content/handbook/chapters/why.mdx
+++ b/content/handbook/chapters/why.mdx
@@ -90,6 +90,7 @@ import EnterpriseCloudScale from "@/components-mdx/enterprise-cloud-scale.mdx";
 - **Certifications**: Langfuse Cloud is [SOC 2 Type II](/security/soc2) and [ISO 27001](/security/iso27001) certified.
 - **Privacy**: [GDPR](/security/gdpr) compliant with [DPA](/dpa) available. [HIPAA](/security/hipaa) aligned via a dedicated cloud region and signed Business Associate Agreement (BAA) for eligible customers.
 - **Data Regions**: Choose between US, EU, or HIPAA-ready data regions on Langfuse Cloud—or [self-host](/self-hosting) anywhere.
+- **[Hardening for Government (soon)](/self-hosting/configuration/hardening#hardening-for-government)**: FIPS-compatible deployment support, hardened images, and air-gapped operation for government and other highly regulated environments.
 - **Data Control**: [Data masking](/docs/observability/features/masking), [data retention](/docs/administration/data-retention), and [data deletion](/docs/administration/data-deletion) capabilities.
 - More details in our [Security & Privacy Center](/security).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the upcoming **Hardening for Government** capability to the Security and Compliance section of the [handbook why page](https://langfuse.com/handbook/chapters/why), matching how it already appears on the homepage and enterprise pages.

- New bullet: **Hardening for Government (soon)**, linking to `/self-hosting/configuration/hardening#hardening-for-government`
- Mentions FIPS-compatible deployment support, hardened images, and air-gapped operation — the same capabilities called out on `/enterprise` and the hardening docs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f4a4cc6-d654-47c0-8dbe-15a3b685c74b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f4a4cc6-d654-47c0-8dbe-15a3b685c74b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an upcoming “Hardening for Government” capability to the handbook’s Security and Compliance section.
- Links directly to the corresponding self-hosting hardening documentation.
- Highlights FIPS-compatible deployment support, hardened images, and air-gapped operation.
- Matches the capability wording and availability status used elsewhere in the site.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The new internal link targets an existing anchor, and the stated capabilities and upcoming status agree with the linked hardening documentation and related site content.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Hardening for Government to handbook..."](https://github.com/langfuse/langfuse-docs/commit/3dc5cb58f1870d992a7d4b53576ab09c3862f490) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60507134)</sub>

<!-- /greptile_comment -->