### PR TITLE
Update public SDK installs metric to 65M per month

### DIFF
--- a/components/CredibilitySentence.tsx
+++ b/components/CredibilitySentence.tsx
@@ -3,8 +3,8 @@ import {
   DOCKER_PULLS,
   FORTUNE_50_COMPANIES,
   FORTUNE_500_COMPANIES,
-  SDK_INSTALLS_PER_MONTH,
   formatCompanyCount,
+  formatSdkInstallsPerMonth,
 } from "./home/Usage";
 
 export const CredibilitySentence = ({
@@ -37,7 +37,7 @@ export const CredibilitySentence = ({
           </li>
           <li>
             <Metric className={metricClassName}>
-              {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+
+              {formatSdkInstallsPerMonth()}
             </Metric>{" "}
             SDK installs per month
           </li>
@@ -68,8 +68,7 @@ export const CredibilitySentence = ({
       </Metric>
       ,{" "}
       <Metric className={metricClassName}>
-        {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+ SDK installs per
-        month
+        {formatSdkInstallsPerMonth()} SDK installs per month
       </Metric>
       , and{" "}
       <Metric className={metricClassName}>

--- a/components/home/Enterprise.tsx
+++ b/components/home/Enterprise.tsx
@@ -7,7 +7,10 @@ import { Text } from "@/components/ui/text";
 import { FeaturedCustomers } from "./FeaturedCustomers";
 import { BulletList } from "./BulletList";
 import securityVisual from "./img/visuals/visual-security.svg";
-import { formatCompanyCount } from "@/lib/usage-stats";
+import {
+  formatCompanyCount,
+  formatSdkInstallsPerMonth,
+} from "@/lib/usage-stats";
 
 const architecture = [
   {
@@ -29,7 +32,10 @@ const architecture = [
 ];
 
 const openApis = [
-  { label: "130M+ SDK installs/month", href: "/careers#public-metrics" },
+  {
+    label: `${formatSdkInstallsPerMonth()} SDK installs/month`,
+    href: "/careers#public-metrics",
+  },
   { label: "90B+ observations processed per month" },
   {
     label: `${formatCompanyCount()} companies using Langfuse`,

--- a/components/home/Usage.tsx
+++ b/components/home/Usage.tsx
@@ -15,6 +15,7 @@ export {
   FORTUNE_500_COMPANIES,
   SDK_INSTALLS_PER_MONTH,
   formatCompanyCount,
+  formatSdkInstallsPerMonth,
 } from "@/lib/usage-stats";
 
 export const Usage = ({ noPadding = false }: { noPadding?: boolean }) => {

--- a/components/home/WhyLangfuse.tsx
+++ b/components/home/WhyLangfuse.tsx
@@ -7,7 +7,10 @@ import { HomeSection } from "./HomeSection";
 import { Heading } from "@/components/ui/heading";
 import { TextHighlight } from "@/components/ui/text-highlight";
 import { Text } from "@/components/ui/text";
-import { formatCompanyCount } from "@/lib/usage-stats";
+import {
+  formatCompanyCount,
+  formatSdkInstallsPerMonth,
+} from "@/lib/usage-stats";
 
 const reasons = [
   {
@@ -44,7 +47,7 @@ const reasons = [
   },
   {
     title: "Production-proven",
-    body: `${formatCompanyCount()} companies using Langfuse. Billions of events processed per month. 130M+ SDK installs/month. Fortune 50 deployments.`,
+    body: `${formatCompanyCount()} companies using Langfuse. Billions of events processed per month. ${formatSdkInstallsPerMonth()} SDK installs/month. Fortune 50 deployments.`,
   },
   {
     title: "Shipping velocity",

--- a/components/role-finder/role-finder-data.ts
+++ b/components/role-finder/role-finder-data.ts
@@ -15,6 +15,8 @@
  * ROLES and remove any options that point at it.
  */
 
+import { formatSdkInstallsPerMonth } from "@/lib/usage-stats";
+
 export type RoleKey =
   | "product"
   | "growth"
@@ -104,8 +106,7 @@ export const ROLES: Record<RoleKey, Role> = {
     ashbyId: "891eda0a-a9f6-45e6-8750-71874db8cc11",
     title: "Senior Software Engineer (SDK)",
     url: "https://jobs.ashbyhq.com/langfuse/891eda0a-a9f6-45e6-8750-71874db8cc11",
-    pitch:
-      "Build SDKs downloaded 130M+ times/month. Performance, versioning, and DX in code that runs in other people's production.",
+    pitch: `Build SDKs downloaded ${formatSdkInstallsPerMonth()} times/month. Performance, versioning, and DX in code that runs in other people's production.`,
     youll: [
       "Profile & minimize overhead in hot paths",
       "Think about versioning & backwards compatibility",

--- a/components/watchOrBookDemo/index.tsx
+++ b/components/watchOrBookDemo/index.tsx
@@ -3,7 +3,10 @@
 import { MarketoContactForm } from "@/components/MarketoContactForm";
 import { CheckCircle2 } from "lucide-react";
 import { getGitHubStars } from "@/lib/github-stars";
-import { SDK_INSTALLS_PER_MONTH, DOCKER_PULLS } from "@/components/home/Usage";
+import {
+  DOCKER_PULLS,
+  formatSdkInstallsPerMonth,
+} from "@/components/home/Usage";
 import Image from "next/image";
 import { HomeSection } from "@/components/home/HomeSection";
 import { EnterpriseLogoGrid } from "@/components/shared/EnterpriseLogoGrid";
@@ -82,8 +85,7 @@ function TalkToUsContent() {
         </strong>
         ,{" "}
         <strong className="font-[580]">
-          {(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+ SDK installs per
-          month
+          {formatSdkInstallsPerMonth()} SDK installs per month
         </strong>
         , and{" "}
         <strong className="font-[580]">

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -12,10 +12,10 @@ const {
   DOCKER_PULLS,
   FORTUNE_50_COMPANIES,
   FORTUNE_500_COMPANIES,
-  SDK_INSTALLS_PER_MONTH,
   formatCompanyCount,
   formatDockerPulls,
   formatObservationsPerMonth,
+  formatSdkInstallsPerMonth,
 } = require("./usage-stats.ts");
 
 const ADOPTERS_TABLE_PATH = path.join(
@@ -653,7 +653,7 @@ function renderJudgePromptExample() {
 function renderCredibilitySentence(attributes = "") {
   const companies = formatCompanyCount();
   const stars = Number(GITHUB_STARS).toLocaleString("en-US");
-  const sdkMillions = (SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0);
+  const sdkInstalls = formatSdkInstallsPerMonth();
   const dockerMillions = (DOCKER_PULLS / 1_000_000).toFixed(0);
   const styleMatch = attributes.match(/\bstyle=["'](list|paragraph)["']/);
   const style = styleMatch ? styleMatch[1] : "paragraph";
@@ -663,12 +663,12 @@ function renderCredibilitySentence(attributes = "") {
 
 - Used by **${companies}** companies
 - **${stars}** GitHub stars
-- **${sdkMillions}M+** SDK installs per month
+- **${sdkInstalls}** SDK installs per month
 - **${dockerMillions}M+** Docker pulls
 - Trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50** and **${FORTUNE_500_COMPANIES} of the Fortune 500**`;
   }
 
-  return `Langfuse is the most widely adopted LLM Engineering platform, used by **${companies} companies**, with **${stars} GitHub stars**, **${sdkMillions}M+ SDK installs per month**, and **${dockerMillions}M+ Docker pulls**. Trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50** and **${FORTUNE_500_COMPANIES} of the Fortune 500** companies.`;
+  return `Langfuse is the most widely adopted LLM Engineering platform, used by **${companies} companies**, with **${stars} GitHub stars**, **${sdkInstalls} SDK installs per month**, and **${dockerMillions}M+ Docker pulls**. Trusted by **${FORTUNE_50_COMPANIES} of the Fortune 50** and **${FORTUNE_500_COMPANIES} of the Fortune 500** companies.`;
 }
 
 // The Hex iframe has no Markdown equivalent, so link Markdown/PDF readers

--- a/lib/usage-stats.ts
+++ b/lib/usage-stats.ts
@@ -1,6 +1,6 @@
 /** Marketing usage stats. Update these when public metrics change. */
 
-export const SDK_INSTALLS_PER_MONTH = 130_000_000;
+export const SDK_INSTALLS_PER_MONTH = 65_000_000;
 export const DOCKER_PULLS = 38_000_000;
 export const OBSERVATIONS_PER_MONTH = 90_000_000_000;
 export const FORTUNE_500_COMPANIES = 129;
@@ -10,6 +10,10 @@ export const COMPANIES = 50_000;
 
 export function formatCompanyCount(): string {
   return `${COMPANIES.toLocaleString("en-US")}+`;
+}
+
+export function formatSdkInstallsPerMonth(): string {
+  return `${(SDK_INSTALLS_PER_MONTH / 1_000_000).toFixed(0)}M+`;
 }
 
 export function formatDockerPulls(): string {

--- a/md-override/index.md
+++ b/md-override/index.md
@@ -66,7 +66,7 @@ Markdown versions of any page on this site are available by appending `.md` to t
 Traditional observability handles many small spans. LLM systems run differently: every step carries rich, verbose I/O that legacy platforms cannot handle at scale. Langfuse ingests and queries LLM traces reliably at enterprise scale while following strict compliance frameworks.
 
 - **Architecture** — ClickHouse OLAP database, async ingestion via Redis queue, S3/blob storage for large payloads, and edge-cached prompts.
-- **Reliability at scale** — 130M+ SDK installs per month, 90B+ observations processed per month, 50,000+ companies using Langfuse, 99.9% uptime.
+- **Reliability at scale** — 65M+ SDK installs per month, 90B+ observations processed per month, 50,000+ companies using Langfuse, 99.9% uptime.
 - **Security and compliance** — [SOC 2 Type II & ISO 27001](/security), [EU and US data regions](/security/data-regions), a [HIPAA-ready region](/security/hipaa), [Hardening for Gov (soon)](/self-hosting/configuration/hardening#hardening-for-government), and [GDPR](/security/gdpr). See the [security overview](/security).
 
 [Enterprise](/enterprise) · [Talk to us](/talk-to-us)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The current public SDK install figure is 65M per month. This updates the shared marketing constant and routes remaining hardcoded copy through that helper so homepage, careers, role-finder, and Markdown overrides stay in sync.

Historical blog/handbook snapshots (e.g. Sep 2024, June 2025 posts) are left unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10b2d3ba-9689-4da3-bb0b-dc6a705e845e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10b2d3ba-9689-4da3-bb0b-dc6a705e845e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the public monthly SDK-install metric from 130M+ to 65M+ and centralizes its formatting across current marketing surfaces.
- Adds a shared `formatSdkInstallsPerMonth` helper.
- Routes homepage, credibility, demo, career, role-finder, and plain-Markdown copy through the shared formatter.
- Updates the static homepage Markdown override to the same value.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with all reviewed current SDK-install claims consistently updated to 65M+.

The shared formatter produces the expected 65M+ text, all changed consumers use its suffix correctly, the static Markdown override is synchronized, and no build, rendering, or rules-compliance failure remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[SDK_INSTALLS_PER_MONTH: 65M] --> B[formatSdkInstallsPerMonth]
  B --> C[Homepage marketing components]
  B --> D[Career and role-finder copy]
  B --> E[Demo and credibility copy]
  B --> F[Plain Markdown renderer]
  G[Static Markdown override] --> H[Homepage Markdown export]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update public SDK installs metric to 65M..."](https://github.com/langfuse/langfuse-docs/commit/dfc41a92090ba17d68b9988d57b955dc121fdf41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60508252)</sub>

**Context used:**

- Knowledge Base — [MDX content rendering and navigation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/mdx-content-rendering-and-navigation.md)

<!-- /greptile_comment -->