### PR TITLE
Speed up link-check CI without a Next.js build cache

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -76,9 +76,9 @@ CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commi
 
 CI runs `node scripts/check-h1-headings.js`. It fails if any `.md`/`.mdx` file contains more than one top-level `# ` heading (code-fenced examples are ignored). Use exactly one H1 per markdown file; deeper sections use `##`, `###`, etc.
 
-### 3. Build + link/sitemap checks (`build-and-check-links` job)
+### 3. Build + link/sitemap checks (`build-and-check-links`, `check-sitemap-links` jobs)
 
-This job runs `pnpm test:link-check`, then `pnpm build`, then `pnpm link-check` and `pnpm sitemap-check` against one production server. The full build is ~10 minutes locally — don't run it for routine edits. Instead, before pushing:
+These run `pnpm build` followed by `pnpm link-check` / `pnpm sitemap-check`. The full build is ~10 minutes locally — don't run it for routine edits. Instead, before pushing:
 
 - Check internal links you added/changed point to real pages or anchors.
 - For anchor links (`...#some-id`), make sure the target page defines the anchor explicitly with `[#some-id]` at the end of the heading line.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -76,9 +76,9 @@ CI runs `pnpm run format:check`. To fix locally, run `pnpm run format` and commi
 
 CI runs `node scripts/check-h1-headings.js`. It fails if any `.md`/`.mdx` file contains more than one top-level `# ` heading (code-fenced examples are ignored). Use exactly one H1 per markdown file; deeper sections use `##`, `###`, etc.
 
-### 3. Build + link/sitemap checks (`build-and-check-links`, `check-sitemap-links` jobs)
+### 3. Build + link/sitemap checks (`build-and-check-links` job)
 
-These run `pnpm build` followed by `pnpm link-check` / `pnpm sitemap-check`. The full build is ~10 minutes — don't run it locally for routine edits. Instead, before pushing:
+This job runs `pnpm test:link-check`, then `pnpm build`, then `pnpm link-check` and `pnpm sitemap-check` against one production server. The full build is ~10 minutes locally — don't run it for routine edits. Instead, before pushing:
 
 - Check internal links you added/changed point to real pages or anchors.
 - For anchor links (`...#some-id`), make sure the target page defines the anchor explicitly with `[#some-id]` at the end of the heading line.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
+          cache: pnpm
 
       - run: pnpm install
 
@@ -117,7 +118,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -129,80 +129,31 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
+          cache: pnpm
 
       - run: pnpm install
+
+      - name: Run link checker unit tests
+        run: pnpm test:link-check
 
       - name: Build next.js app
         run: pnpm build
 
-      - name: Start server and check links
+      - name: Start production server
         run: |
-          # Start the server in the background and capture its PID
-          pnpm start & SERVER_PID=$!
+          pnpm start &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:3333 > /dev/null; do sleep 1; done'
 
-          # Wait for the server to be ready (max 30 seconds)
-          timeout 30 bash -c 'until curl -s http://localhost:3333 > /dev/null; do sleep 1; done'
+      - name: Check markdown and source links
+        run: pnpm link-check
 
-          # Run the link checker
-          pnpm link-check
+      - name: Check sitemap URLs
+        run: pnpm sitemap-check
 
-          # Store the exit code
-          LINK_CHECK_EXIT=$?
-
-          # Kill the server using the captured PID
-          kill $SERVER_PID || true
-
-          # Exit with the link checker's exit code
-          exit $LINK_CHECK_EXIT
-
-  check-sitemap-links:
-    needs:
-      - pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        id: pnpm-install
-        with:
-          version: 9.5.0
-          run_install: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-
-      - run: pnpm install
-
-      - name: Build next.js app
-        run: pnpm build
-
-      - name: Start server and check sitemap links
-        run: |
-          # Start the server in the background and capture its PID
-          pnpm start & SERVER_PID=$!
-
-          # Wait for the server to be ready (max 30 seconds)
-          timeout 30 bash -c 'until curl -s http://localhost:3333 > /dev/null; do sleep 1; done'
-
-          # Run the sitemap checker
-          pnpm sitemap-check
-
-          # Store the exit code
-          SITEMAP_CHECK_EXIT=$?
-
-          # Kill the server using the captured PID
-          kill $SERVER_PID || true
-
-          # Exit with the sitemap checker's exit code
-          exit $SITEMAP_CHECK_EXIT
+      - name: Stop production server
+        if: always()
+        run: kill "$SERVER_PID" || true
 
   # Summary job that depends on all other jobs
   # This allows you to require only this single check in branch protection rules
@@ -214,7 +165,6 @@ jobs:
         format,
         # check-notebook-docs-sync,
         build-and-check-links,
-        check-sitemap-links,
       ]
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - run: pnpm install
 
       - name: Run link checker unit tests
-        run: pnpm test:link-check
+        run: node --test scripts/check-links.test.js
 
       - name: Build next.js app
         run: pnpm build
@@ -147,6 +147,48 @@ jobs:
 
       - name: Check markdown and source links
         run: pnpm link-check
+
+      - name: Stop production server
+        if: always()
+        run: kill "$SERVER_PID" || true
+
+  check-sitemap-links:
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        id: pnpm-install
+        with:
+          version: 9.5.0
+          run_install: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Run sitemap checker unit tests
+        run: node --test scripts/check-sitemap-links.test.js
+
+      - name: Build next.js app
+        run: pnpm build
+
+      - name: Start production server
+        run: |
+          pnpm start &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:3333 > /dev/null; do sleep 1; done'
 
       - name: Check sitemap URLs
         run: pnpm sitemap-check
@@ -165,6 +207,7 @@ jobs:
         format,
         # check-notebook-docs-sync,
         build-and-check-links,
+        check-sitemap-links,
       ]
     if: always()
     steps:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "workshop:sync": "node scripts/sync-workshop.mjs",
     "link-check": "node scripts/check-links.js",
     "sitemap-check": "node scripts/check-sitemap-links.js",
+    "test:link-check": "node --test scripts/check-links.test.js scripts/check-sitemap-links.test.js",
     "qa-chatbot:seed-general": "npx tsx components/qaChatbot/datasets/seed_general_qa_chatbot_dataset.ts",
     "qa-chatbot:seed-sdk-grounding": "npx tsx components/qaChatbot/datasets/seed_sdk_integration_grounding_dataset.ts",
     "qa-chatbot:setup-sdk-grounding-evaluators": "npx tsx components/qaChatbot/evaluators/setup_sdk_integration_grounding_evaluators.ts",

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -3,9 +3,8 @@
 const fs = require("fs");
 const path = require("path");
 const { promisify } = require("util");
-const https = require("https");
-const http = require("http");
 const { URL } = require("url");
+const { checkLink, mapPool } = require("./lib/check-http");
 
 const readFileAsync = promisify(fs.readFile);
 const EXCLUDED_HOSTNAMES = new Set([
@@ -16,141 +15,58 @@ const EXCLUDED_HOSTNAMES = new Set([
   "hipaa.cloud.langfuse.com",
 ]);
 
-// Configuration options
-const CONFIG = {
-  // The migrated App Router site is less tolerant of request bursts than the old setup.
-  maxFileConcurrency: 5,
-  fileBatchDelay: 25,
-  maxLinkConcurrency: 8,
-  linkBatchDelay: 25,
+const DEFAULT_SCAN_DIRS = [
+  "app",
+  "components",
+  "components-mdx",
+  "content",
+  "lib",
+  "scripts",
+];
 
-  // Link checking timeouts
+const DEFAULT_BASE_URL = "http://localhost:3333";
+
+const CONFIG = {
+  maxLinkConcurrency: 16,
   linkTimeout: 10000,
   externalLinkTimeout: 10000,
-
-  // Progress reporting
-  progressInterval: 20,
+  progressInterval: 200,
   debugLogging: false,
 };
 
-function shouldRetryWithGet(url, result) {
-  if (
-    result.statusCode === 405 || // Method Not Allowed
-    result.statusCode === 501 || // Not Implemented
-    result.statusCode === 400
-  ) {
-    // Bad Request (some servers reject HEAD)
-    return true;
-  }
-
-  if (
-    !url.includes("localhost:3333") ||
-    result.statusCode !== 0 ||
-    !result.error
-  ) {
-    return false;
-  }
-
-  return (
-    result.error === "Timeout" ||
-    result.error.includes("ECONNRESET") ||
-    result.error.includes("socket hang up")
-  );
+function getBaseUrl(baseUrl = process.env.LINK_CHECK_BASE) {
+  return (baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
 }
 
-async function checkLink(url, timeout = CONFIG.linkTimeout) {
-  // Prefer HEAD so static assets do not need to be downloaded, but fall back to GET
-  // for localhost when HEAD is rejected or hangs.
-  const headResult = await makeRequest(url, "HEAD", timeout);
-
-  if (shouldRetryWithGet(url, headResult)) {
-    return await makeRequest(url, "GET", timeout);
+function getScanDirs(scanDirs = process.env.LINK_CHECK_DIRS) {
+  if (Array.isArray(scanDirs) && scanDirs.length > 0) {
+    return scanDirs;
   }
-
-  return headResult;
+  if (typeof scanDirs === "string" && scanDirs.trim()) {
+    return scanDirs
+      .split(",")
+      .map((dir) => dir.trim())
+      .filter(Boolean);
+  }
+  return DEFAULT_SCAN_DIRS;
 }
 
-// Make HTTP request with specified method
-async function makeRequest(url, method, timeout) {
-  return new Promise((resolve) => {
-    try {
-      const urlObj = new URL(url);
-      const isHttps = urlObj.protocol === "https:";
-      const client = isHttps ? https : http;
-
-      const options = {
-        hostname: urlObj.hostname,
-        port: urlObj.port || (isHttps ? 443 : 80),
-        path: urlObj.pathname + urlObj.search,
-        method: method,
-        timeout: timeout,
-        headers: {
-          "User-Agent": "link-checker",
-          Connection: "keep-alive", // Reuse connections for better performance
-        },
-      };
-
-      const req = client.request(options, (res) => {
-        // Consider 2xx and 3xx as successful
-        const success = res.statusCode >= 200 && res.statusCode < 400;
-
-        // Always consume the response so keep-alive sockets can be reused.
-        res.resume();
-
-        resolve({
-          url: url,
-          status: success ? "alive" : "dead",
-          statusCode: res.statusCode,
-          method: method,
-        });
-      });
-
-      req.on("error", (err) => {
-        resolve({
-          url: url,
-          status: "dead",
-          statusCode: 0,
-          error: err.message,
-          method: method,
-        });
-      });
-
-      req.on("timeout", () => {
-        req.destroy();
-        resolve({
-          url: url,
-          status: "dead",
-          statusCode: 0,
-          error: "Timeout",
-          method: method,
-        });
-      });
-
-      req.end();
-    } catch (error) {
-      resolve({
-        url: url,
-        status: "dead",
-        statusCode: 0,
-        error: error.message,
-        method: method,
-      });
-    }
-  });
+function localHostnamesFromBase(baseUrl) {
+  try {
+    return new Set([new URL(baseUrl).hostname, "localhost", "127.0.0.1"]);
+  } catch {
+    return new Set(["localhost", "127.0.0.1"]);
+  }
 }
 
-// Extract markdown links: [text](url)
 function extractMarkdownLinks(content) {
   const links = [];
-
-  // Standard markdown links: [text](url)
   const markdownRegex = /\[([^\]]*)\]\(([^)]+)\)/g;
   let match;
 
   while ((match = markdownRegex.exec(content)) !== null) {
     const url = match[2].trim();
     if (url && !url.startsWith("#")) {
-      // Skip anchors
       links.push(url);
     }
   }
@@ -158,27 +74,19 @@ function extractMarkdownLinks(content) {
   return links;
 }
 
-// Extract href links from HTML/JSX attributes
 function extractHrefLinks(content) {
   const links = [];
-
-  // Match various href patterns:
-  // href="url", href='url', href={`url`}, href={"url"}
   const patterns = [
-    // Standard href with quotes
     /href=["']([^"']+)["']/g,
-    // Template literals in JSX: href={`/path`}
     /href=\{`([^`]+)`\}/g,
-    // String literals in JSX: href={"/path"}
     /href=\{"([^"]+)"\}/g,
     /href=\{'([^']+)'\}/g,
-    // Without braces but with template literals (less common)
     /href=`([^`]+)`/g,
   ];
 
   for (const regex of patterns) {
     let match;
-    regex.lastIndex = 0; // Reset regex state
+    regex.lastIndex = 0;
     while ((match = regex.exec(content)) !== null) {
       const href = match[1].trim();
       if (href && !href.startsWith("#") && !href.includes("${")) {
@@ -190,24 +98,18 @@ function extractHrefLinks(content) {
   return links;
 }
 
-// Extract Next.js Link component hrefs
 function extractNextJsLinks(content) {
   const links = [];
-
-  // Match Next.js Link components: <Link href="...">
   const patterns = [
-    // <Link href="/path">
     /<Link\s+href=["']([^"']+)["'][^>]*>/g,
-    // <Link href={"/path"}>
     /<Link\s+href=\{"([^"]+)"\}[^>]*>/g,
     /<Link\s+href=\{'([^']+)'\}[^>]*>/g,
-    // <Link href={`/path`}>
     /<Link\s+href=\{`([^`]+)`\}[^>]*>/g,
   ];
 
   for (const regex of patterns) {
     let match;
-    regex.lastIndex = 0; // Reset regex state
+    regex.lastIndex = 0;
     while ((match = regex.exec(content)) !== null) {
       const href = match[1].trim();
       if (href && !href.startsWith("#") && !href.includes("${")) {
@@ -219,25 +121,9 @@ function extractNextJsLinks(content) {
   return links;
 }
 
-// Extract object/property-style links in TS/TSX, e.g.
-//   { href: "/docs/...", url: "https://..." }
-// These are commonly used for data-driven link lists (cards, nav items, tools)
-// and are invisible to the href="..." / <Link href="..."> regexes above.
 function extractObjectPropertyLinks(content) {
   const links = [];
-
-  // Strip fenced code blocks first. In MDX, authors frequently include
-  // illustrative JSON/TS snippets containing object literals like
-  //   { "url": "https://langfuse.com/docs/integrations/langgraph" }
-  // or
-  //   input: { path: "/api/process" }
-  // which are example content, not real links. Skipping them avoids noisy
-  // false positives. This strip is safe for .tsx/.ts sources (which don't
-  // use triple-backtick fences).
   const scanContent = content.replace(/```[\s\S]*?```/g, "");
-
-  // Keys that conventionally hold a URL/path in our codebase.
-  // Keep this conservative so we don't pick up unrelated string properties.
   const patterns = [
     /\b(?:href|url|link|to|path|pathname)\s*:\s*["']([^"']+)["']/g,
     /\b(?:href|url|link|to|path|pathname)\s*:\s*`([^`]+)`/g,
@@ -251,9 +137,6 @@ function extractObjectPropertyLinks(content) {
       if (!value || value.startsWith("#") || value.includes("${")) {
         continue;
       }
-      // Only include relative paths and langfuse.com absolute URLs to
-      // avoid false positives on arbitrary string props. processLinks()
-      // filters further, but keeping this tight reduces noise.
       if (
         value.startsWith("/") ||
         value.startsWith("https://langfuse.com") ||
@@ -267,14 +150,9 @@ function extractObjectPropertyLinks(content) {
   return links;
 }
 
-// Extract all types of links from content
 function extractAllLinks(content, filePath) {
-  let allLinks = [];
+  let allLinks = extractMarkdownLinks(content);
 
-  // Always extract markdown links (works in .md, .mdx, and even in JSX comments)
-  allLinks = allLinks.concat(extractMarkdownLinks(content));
-
-  // Extract href attributes for HTML/JSX files
   if (
     filePath.endsWith(".mdx") ||
     filePath.endsWith(".tsx") ||
@@ -282,27 +160,17 @@ function extractAllLinks(content, filePath) {
   ) {
     allLinks = allLinks.concat(extractHrefLinks(content));
     allLinks = allLinks.concat(extractNextJsLinks(content));
-  }
-
-  // Extract object-property style links (e.g. `href: "/docs/..."`) in TS/TSX.
-  // MDX can contain similar object literals in export blocks, so include it too.
-  if (
-    filePath.endsWith(".mdx") ||
-    filePath.endsWith(".tsx") ||
-    filePath.endsWith(".ts")
-  ) {
     allLinks = allLinks.concat(extractObjectPropertyLinks(content));
   }
 
   return allLinks;
 }
 
-// Process and normalize links
-function processLinks(links) {
+function processLinks(links, baseUrl = getBaseUrl()) {
   const processedLinks = [];
+  const localHost = new URL(baseUrl).host;
 
   for (const link of links) {
-    // Skip empty or invalid links
     if (!link || typeof link !== "string") {
       continue;
     }
@@ -312,7 +180,6 @@ function processLinks(links) {
       continue;
     }
 
-    // Skip template literals, variables, and dynamic content
     if (
       trimmedLink.includes("${") ||
       trimmedLink.includes("{{") ||
@@ -327,9 +194,8 @@ function processLinks(links) {
       continue;
     }
 
-    // Skip obvious non-URL patterns
     if (
-      trimmedLink.match(/^[a-zA-Z0-9_-]+$/) || // Just a word/identifier
+      trimmedLink.match(/^[a-zA-Z0-9_-]+$/) ||
       trimmedLink.startsWith("javascript:") ||
       trimmedLink.startsWith("vbscript:") ||
       trimmedLink.startsWith("mailto:") ||
@@ -341,12 +207,10 @@ function processLinks(links) {
       continue;
     }
 
-    // Skip specific paths that redirect to external sites
     if (trimmedLink === "/ph") {
       continue;
     }
 
-    // Skip absolute URLs that are intentionally excluded from link checks
     if (
       trimmedLink.startsWith("http://") ||
       trimmedLink.startsWith("https://")
@@ -356,244 +220,220 @@ function processLinks(links) {
         if (EXCLUDED_HOSTNAMES.has(parsedUrl.hostname)) {
           continue;
         }
-      } catch (error) {
+      } catch {
         continue;
       }
     }
 
     let processedLink = trimmedLink;
 
-    // Convert relative paths to localhost URLs
     if (trimmedLink.startsWith("/")) {
-      processedLink = `http://localhost:3333${trimmedLink}`;
+      processedLink = `${baseUrl}${trimmedLink}`;
     } else if (trimmedLink.startsWith("https://langfuse.com")) {
-      processedLink = trimmedLink.replace(
-        "https://langfuse.com",
-        "http://localhost:3333",
-      );
+      processedLink = trimmedLink.replace("https://langfuse.com", baseUrl);
     } else if (trimmedLink.startsWith("http://langfuse.com")) {
-      processedLink = trimmedLink.replace(
-        "http://langfuse.com",
-        "http://localhost:3333",
-      );
+      processedLink = trimmedLink.replace("http://langfuse.com", baseUrl);
     } else if (
       !trimmedLink.startsWith("http://") &&
       !trimmedLink.startsWith("https://")
     ) {
-      // Skip non-HTTP links that aren't relative paths
       continue;
     } else if (
-      !trimmedLink.includes("localhost:3333") &&
+      !trimmedLink.includes(localHost) &&
       !trimmedLink.includes("langfuse.com")
     ) {
-      // Skip external links (not langfuse.com or localhost)
       continue;
     }
 
-    // Do not validate pdf download links
-    if (processedLink.startsWith("http://localhost:3333/api/md-to-pdf"))
+    if (processedLink.startsWith(`${baseUrl}/api/md-to-pdf`)) {
       continue;
+    }
 
-    // Final validation - make sure it's a valid URL format
     try {
       new URL(processedLink);
       processedLinks.push(processedLink);
-    } catch (error) {
-      // Skip invalid URLs
+    } catch {
       continue;
     }
   }
 
-  return [...new Set(processedLinks)]; // Remove duplicates
+  return [...new Set(processedLinks)];
 }
 
-async function checkFileLinks(filePath) {
-  try {
-    const content = await readFileAsync(filePath, "utf8");
+function findFiles(dir) {
+  let results = [];
+  if (!fs.existsSync(dir)) return results;
+  const files = fs.readdirSync(dir);
 
-    // Extract all types of links using the unified function
-    const allLinks = extractAllLinks(content, filePath);
-    const processedLinks = processLinks(allLinks);
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
 
-    if (processedLinks.length === 0) {
-      return { hasErrors: false, results: [] };
+    if (stat.isDirectory()) {
+      results = results.concat(findFiles(filePath));
+    } else if (
+      file.endsWith(".md") ||
+      file.endsWith(".mdx") ||
+      file.endsWith(".tsx") ||
+      file.endsWith(".ts")
+    ) {
+      results.push(filePath);
     }
-
-    // Check all links with configured concurrency
-    const results = [];
-    const maxConcurrent = CONFIG.maxLinkConcurrency;
-
-    for (let i = 0; i < processedLinks.length; i += maxConcurrent) {
-      const batch = processedLinks.slice(i, i + maxConcurrent);
-      const batchResults = await Promise.all(
-        batch.map((link) => {
-          // Use longer timeout for external links (non-localhost)
-          const timeout = link.includes("localhost:3333")
-            ? CONFIG.linkTimeout
-            : CONFIG.externalLinkTimeout;
-          return checkLink(link, timeout);
-        }),
-      );
-      results.push(...batchResults);
-
-      // Skip delay for local dev server (CONFIG.linkBatchDelay = 0)
-      if (
-        CONFIG.linkBatchDelay > 0 &&
-        i + maxConcurrent < processedLinks.length
-      ) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, CONFIG.linkBatchDelay),
-        );
-      }
-    }
-
-    const hasErrors = results.some((result) => result.status === "dead");
-
-    // Don't print errors here - they will be collected and reported at the end
-    return { hasErrors, results };
-  } catch (error) {
-    const relativePath = path.relative(process.cwd(), filePath);
-    console.warn(`Warning: Error processing ${relativePath}: ${error.message}`);
-    return { hasErrors: false, results: [] };
   }
+
+  return results;
 }
 
-async function main() {
-  const scanDirs = [
-    "app",
-    "components",
-    "components-mdx",
-    "content",
-    "lib",
-    "scripts",
-  ].map((d) => path.join(process.cwd(), d));
-  let hasErrors = false;
-  const allBrokenLinks = []; // Collect all broken links for final report
+function reportBrokenLinks(brokenLinks) {
+  console.error("\n=== LINK CHECK FAILED ===");
+  console.error(`Found ${brokenLinks.length} broken link(s):\n`);
 
-  try {
-    // Find all files to check
-    const findFiles = (dir) => {
-      let results = [];
-      if (!fs.existsSync(dir)) return results;
-      const files = fs.readdirSync(dir);
+  const linksByFile = {};
+  brokenLinks.forEach((link) => {
+    if (!linksByFile[link.file]) {
+      linksByFile[link.file] = [];
+    }
+    linksByFile[link.file].push(link);
+  });
 
-      for (const file of files) {
-        const filePath = path.join(dir, file);
-        const stat = fs.statSync(filePath);
-
-        if (stat.isDirectory()) {
-          results = results.concat(findFiles(filePath));
-        } else if (
-          file.endsWith(".md") ||
-          file.endsWith(".mdx") ||
-          file.endsWith(".tsx") ||
-          file.endsWith(".ts")
-        ) {
-          results.push(filePath);
-        }
+  Object.keys(linksByFile).forEach((file) => {
+    console.error(`📄 ${file}:`);
+    linksByFile[file].forEach((link) => {
+      const methodInfo = link.method ? ` (${link.method})` : "";
+      console.error(`  ❌ [${link.statusCode}] ${link.url}${methodInfo}`);
+      if (link.error) {
+        console.error(`     Error: ${link.error}`);
       }
+    });
+    console.error("");
+  });
+}
 
-      return results;
-    };
+async function collectFileLinks(files, baseUrl) {
+  const fileLinks = new Map();
 
-    const files = scanDirs.flatMap((dir) => findFiles(dir));
+  for (const filePath of files) {
+    try {
+      const content = await readFileAsync(filePath, "utf8");
+      const processedLinks = processLinks(
+        extractAllLinks(content, filePath),
+        baseUrl,
+      );
+      if (processedLinks.length > 0) {
+        fileLinks.set(filePath, processedLinks);
+      }
+    } catch (error) {
+      const relativePath = path.relative(process.cwd(), filePath);
+      console.warn(
+        `Warning: Error processing ${relativePath}: ${error.message}`,
+      );
+    }
+  }
+
+  return fileLinks;
+}
+
+async function runLinkCheck(options = {}) {
+  const baseUrl = getBaseUrl(options.baseUrl);
+  const scanDirs = getScanDirs(options.scanDirs).map((dir) =>
+    path.isAbsolute(dir) ? dir : path.join(process.cwd(), dir),
+  );
+  const checkLinkFn = options.checkLink || checkLink;
+  const localHostnames = localHostnamesFromBase(baseUrl);
+
+  const files = scanDirs.flatMap((dir) => findFiles(dir));
+  const fileLinks = await collectFileLinks(files, baseUrl);
+  const uniqueUrls = [
+    ...new Set([...fileLinks.values()].flatMap((links) => links)),
+  ];
+
+  if (options.silent !== true) {
     console.log(
       `Found ${files.length} files to check (.md, .mdx, .tsx, .ts)\n`,
     );
     console.log(
-      `Using ${CONFIG.maxFileConcurrency} files x ${CONFIG.maxLinkConcurrency} links, ` +
-        `${CONFIG.linkTimeout}ms localhost timeout`,
+      `Checking ${uniqueUrls.length} unique URLs ` +
+        `(${CONFIG.maxLinkConcurrency} concurrent, ${CONFIG.linkTimeout}ms localhost timeout)`,
     );
+  }
 
-    // Process files with configured concurrency
-    const maxConcurrent = CONFIG.maxFileConcurrency;
-    let completed = 0;
+  const urlResults = new Map();
+  let completed = 0;
 
-    for (let i = 0; i < files.length; i += maxConcurrent) {
-      const batch = files.slice(i, i + maxConcurrent);
-
-      const batchPromises = batch.map(async (file) => {
-        if (CONFIG.debugLogging) {
-          console.log(`Processing ${file}`);
-        }
-        try {
-          const result = await checkFileLinks(file);
-          if (result.hasErrors && result.results) {
-            // Collect broken links for final report
-            const relativePath = path.relative(process.cwd(), file);
-            const brokenLinks = result.results.filter(
-              (r) => r.status === "dead",
-            );
-            brokenLinks.forEach((link) => {
-              allBrokenLinks.push({
-                file: relativePath,
-                url: link.url,
-                statusCode: link.statusCode,
-                error: link.error,
-                method: link.method,
-              });
-            });
-          }
-          return result.hasErrors;
-        } catch (error) {
-          console.warn(`Warning: Error processing ${file}: ${error.message}`);
-          return false;
-        }
-      });
-
-      const batchResults = await Promise.all(batchPromises);
-      hasErrors = hasErrors || batchResults.some((result) => result);
-
-      completed += batch.length;
-      if (
-        completed % CONFIG.progressInterval === 0 ||
-        completed === files.length
-      ) {
-        console.log(`Processed ${completed}/${files.length} files`);
-      }
-
-      // Skip delay for local dev server (CONFIG.fileBatchDelay = 0)
-      if (CONFIG.fileBatchDelay > 0 && i + maxConcurrent < files.length) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, CONFIG.fileBatchDelay),
-        );
-      }
+  await mapPool(uniqueUrls, CONFIG.maxLinkConcurrency, async (url) => {
+    const timeout = url.startsWith(baseUrl)
+      ? CONFIG.linkTimeout
+      : CONFIG.externalLinkTimeout;
+    const result = await checkLinkFn(url, timeout, { localHostnames });
+    urlResults.set(url, result);
+    completed += 1;
+    if (
+      options.silent !== true &&
+      (completed % CONFIG.progressInterval === 0 ||
+        completed === uniqueUrls.length)
+    ) {
+      console.log(`Checked ${completed}/${uniqueUrls.length} unique URLs`);
     }
+    return result;
+  });
 
-    if (hasErrors) {
-      console.error("\n=== LINK CHECK FAILED ===");
-      console.error(`Found ${allBrokenLinks.length} broken link(s):\n`);
-
-      // Group broken links by file for better readability
-      const linksByFile = {};
-      allBrokenLinks.forEach((link) => {
-        if (!linksByFile[link.file]) {
-          linksByFile[link.file] = [];
-        }
-        linksByFile[link.file].push(link);
-      });
-
-      // Report broken links grouped by file
-      Object.keys(linksByFile).forEach((file) => {
-        console.error(`📄 ${file}:`);
-        linksByFile[file].forEach((link) => {
-          const methodInfo = link.method ? ` (${link.method})` : "";
-          console.error(`  ❌ [${link.statusCode}] ${link.url}${methodInfo}`);
-          if (link.error) {
-            console.error(`     Error: ${link.error}`);
-          }
+  const brokenLinks = [];
+  for (const [filePath, urls] of fileLinks.entries()) {
+    const relativePath = path.relative(process.cwd(), filePath);
+    for (const url of urls) {
+      const result = urlResults.get(url);
+      if (result && result.status === "dead") {
+        brokenLinks.push({
+          file: relativePath,
+          url: result.url,
+          statusCode: result.statusCode,
+          error: result.error,
+          method: result.method,
         });
-        console.error("");
-      });
-
-      process.exit(1);
-    } else {
-      console.log("\n✅ Link check passed: All valid links are working");
+      }
     }
+  }
+
+  return {
+    ok: brokenLinks.length === 0,
+    brokenLinks,
+    filesChecked: files.length,
+    uniqueUrls: uniqueUrls.length,
+  };
+}
+
+async function main() {
+  try {
+    const result = await runLinkCheck();
+
+    if (!result.ok) {
+      reportBrokenLinks(result.brokenLinks);
+      process.exit(1);
+    }
+
+    console.log("\n✅ Link check passed: All valid links are working");
   } catch (error) {
     console.error("Error:", error);
     process.exit(1);
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  CONFIG,
+  collectFileLinks,
+  extractAllLinks,
+  extractHrefLinks,
+  extractMarkdownLinks,
+  extractNextJsLinks,
+  extractObjectPropertyLinks,
+  findFiles,
+  getBaseUrl,
+  getScanDirs,
+  processLinks,
+  reportBrokenLinks,
+  runLinkCheck,
+};

--- a/scripts/check-links.test.js
+++ b/scripts/check-links.test.js
@@ -1,0 +1,212 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  extractAllLinks,
+  processLinks,
+  runLinkCheck,
+} = require("./check-links");
+
+function createFixtureTree(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "link-check-"));
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const fullPath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, contents);
+  }
+  return root;
+}
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    server,
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+  };
+}
+
+function runCli(args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test("extracts markdown, href, and object-property links", () => {
+  const content = `
+[Docs](/docs)
+<a href="/guides">Guides</a>
+<Link href="/blog">Blog</Link>
+const item = { href: "/faq", url: "https://langfuse.com/self-hosting" }
+`;
+
+  assert.deepEqual(extractAllLinks(content, "page.mdx"), [
+    "/docs",
+    "/guides",
+    "/blog",
+    "/blog",
+    "/faq",
+    "https://langfuse.com/self-hosting",
+  ]);
+});
+
+test("rewrites site links onto the local checker base URL", () => {
+  const processed = processLinks(
+    [
+      "/docs",
+      "https://langfuse.com/blog",
+      "http://langfuse.com/faq",
+      "https://example.com/skip",
+      "https://cloud.langfuse.com/project/~",
+      "/ph",
+      "/api/md-to-pdf?path=/docs",
+    ],
+    "http://127.0.0.1:3333",
+  );
+
+  assert.deepEqual(processed, [
+    "http://127.0.0.1:3333/docs",
+    "http://127.0.0.1:3333/blog",
+    "http://127.0.0.1:3333/faq",
+  ]);
+});
+
+test("passes when every extracted link is served", async () => {
+  const root = createFixtureTree({
+    "content/ok.md": "See [Docs](/docs) and [FAQ](/faq).",
+  });
+  const seen = [];
+  const { server, baseUrl } = await listen((req, res) => {
+    seen.push(`${req.method} ${req.url}`);
+    res.writeHead(200);
+    res.end("ok");
+  });
+
+  try {
+    const result = await runLinkCheck({
+      scanDirs: [path.join(root, "content")],
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.brokenLinks.length, 0);
+    assert.equal(result.uniqueUrls, 2);
+    assert.ok(seen.some((entry) => entry.startsWith("HEAD /docs")));
+  } finally {
+    server.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails when a source file introduces a 404", async () => {
+  const root = createFixtureTree({
+    "content/broken.md": "This [missing page](/does-not-exist) should fail CI.",
+  });
+  const { server, baseUrl } = await listen((req, res) => {
+    res.writeHead(req.url === "/does-not-exist" ? 404 : 200);
+    res.end(req.url === "/does-not-exist" ? "missing" : "ok");
+  });
+
+  try {
+    const result = await runLinkCheck({
+      scanDirs: [path.join(root, "content")],
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.brokenLinks.length, 1);
+    assert.equal(result.brokenLinks[0].statusCode, 404);
+    assert.match(result.brokenLinks[0].url, /\/does-not-exist$/);
+    assert.match(result.brokenLinks[0].file, /broken\.md$/);
+  } finally {
+    server.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("checks each unique URL once even when many files repeat it", async () => {
+  const files = {};
+  for (let i = 0; i < 8; i += 1) {
+    files[`content/page-${i}.md`] = "Repeat [Docs](/docs) here.";
+  }
+  const root = createFixtureTree(files);
+  let hits = 0;
+  const { server, baseUrl } = await listen((req, res) => {
+    if (req.url === "/docs") hits += 1;
+    res.writeHead(200);
+    res.end("ok");
+  });
+
+  try {
+    const result = await runLinkCheck({
+      scanDirs: [path.join(root, "content")],
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.uniqueUrls, 1);
+    assert.ok(hits <= 2, `expected at most HEAD+GET, got ${hits}`);
+  } finally {
+    server.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI exits 0 for working links and 1 when a broken link is introduced", async () => {
+  const root = createFixtureTree({
+    "content/page.md": "Working [docs](/docs).",
+  });
+  const { server, baseUrl } = await listen((req, res) => {
+    res.writeHead(req.url === "/docs" ? 200 : 404);
+    res.end();
+  });
+  const script = path.join(process.cwd(), "scripts/check-links.js");
+  const env = {
+    LINK_CHECK_BASE: baseUrl,
+    LINK_CHECK_DIRS: path.join(root, "content"),
+  };
+
+  try {
+    const passing = await runCli([script], env);
+    assert.equal(passing.code, 0, passing.stderr);
+    assert.match(passing.stdout, /Link check passed/);
+
+    fs.writeFileSync(
+      path.join(root, "content/page.md"),
+      "Broken [page](/does-not-exist).",
+    );
+
+    const failing = await runCli([script], env);
+    assert.equal(failing.code, 1);
+    assert.match(failing.stderr, /LINK CHECK FAILED/);
+    assert.match(failing.stderr, /does-not-exist/);
+  } finally {
+    server.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-sitemap-links.js
+++ b/scripts/check-sitemap-links.js
@@ -1,204 +1,175 @@
 "use strict";
 
-const https = require("https");
-const http = require("http");
 const { promisify } = require("util");
+const { URL } = require("url");
 const xml2js = require("xml2js");
+const { checkLink, fetchUrl, mapPool } = require("./lib/check-http");
 
-// Configuration
-const SITEMAP_URL = "http://langfuse.com/sitemap-0.xml";
-const LOCAL_SERVER_BASE = "http://localhost:3333";
+const DEFAULT_SITEMAP_URL = "http://langfuse.com/sitemap-0.xml";
+const DEFAULT_LOCAL_SERVER_BASE = "http://localhost:3333";
 const LANGFUSE_DOMAIN = "langfuse.com";
-const REQUEST_TIMEOUT = 10000; // 10 seconds
-const MAX_CONCURRENT_REQUESTS = 10;
+const REQUEST_TIMEOUT = 10000;
+const MAX_CONCURRENT_REQUESTS = 16;
 
-/**
- * Fetch content from a URL with timeout and redirect following
- */
-function fetchUrl(url) {
-  return new Promise((resolve, reject) => {
-    const isHttps = url.startsWith("https://");
-    const client = isHttps ? https : http;
-
-    const request = client.get(
-      url,
-      {
-        timeout: REQUEST_TIMEOUT,
-        headers: {
-          "User-Agent": "Langfuse-Sitemap-Checker/1.0",
-        },
-      },
-      (response) => {
-        // Handle redirects
-        if (
-          response.statusCode >= 300 &&
-          response.statusCode < 400 &&
-          response.headers.location
-        ) {
-          const redirectUrl = response.headers.location;
-          // Resolve relative redirects
-          const resolvedUrl = redirectUrl.startsWith("http")
-            ? redirectUrl
-            : new URL(redirectUrl, url).href;
-          fetchUrl(resolvedUrl).then(resolve).catch(reject);
-          return;
-        }
-
-        let data = "";
-        response.on("data", (chunk) => (data += chunk));
-        response.on("end", () => {
-          resolve({
-            statusCode: response.statusCode,
-            data: data,
-            url: url,
-          });
-        });
-      },
-    );
-
-    request.on("error", reject);
-    request.on("timeout", () => {
-      request.destroy();
-      reject(new Error(`Request timeout for ${url}`));
-    });
-  });
+function getSitemapUrl(sitemapUrl = process.env.SITEMAP_URL) {
+  return sitemapUrl || DEFAULT_SITEMAP_URL;
 }
 
-/**
- * Parse sitemap XML and extract URLs
- */
+function getLocalServerBase(baseUrl = process.env.SITEMAP_CHECK_BASE) {
+  return (baseUrl || DEFAULT_LOCAL_SERVER_BASE).replace(/\/$/, "");
+}
+
 async function parseSitemap(xmlContent) {
   const parser = new xml2js.Parser();
-  const parseString = promisify(parser.parseString);
+  const parseString = promisify(parser.parseString.bind(parser));
+  const result = await parseString(xmlContent);
+  const urls = [];
 
-  try {
-    const result = await parseString(xmlContent);
-    const urls = [];
-
-    if (result.urlset && result.urlset.url) {
-      for (const urlEntry of result.urlset.url) {
-        if (urlEntry.loc && urlEntry.loc[0]) {
-          urls.push(urlEntry.loc[0]);
-        }
+  if (result.urlset && result.urlset.url) {
+    for (const urlEntry of result.urlset.url) {
+      if (urlEntry.loc && urlEntry.loc[0]) {
+        urls.push(urlEntry.loc[0]);
       }
     }
-
-    return urls;
-  } catch (error) {
-    throw new Error(`Failed to parse sitemap XML: ${error.message}`);
   }
+
+  return urls;
 }
 
-/**
- * Filter URLs to only include Langfuse.com URLs and convert to local server URLs
- */
-function filterAndConvertUrls(urls) {
+function filterAndConvertUrls(urls, localServerBase = getLocalServerBase()) {
   return urls
     .filter((url) => url.includes(LANGFUSE_DOMAIN))
-    .map((url) => url.replace(`https://${LANGFUSE_DOMAIN}`, LOCAL_SERVER_BASE))
-    .map((url) => url.replace(`http://${LANGFUSE_DOMAIN}`, LOCAL_SERVER_BASE));
-}
-
-/**
- * Check a single URL
- */
-async function checkUrl(url) {
-  try {
-    const response = await fetchUrl(url);
-    const isError = response.statusCode >= 400;
-
-    return {
-      url: url,
-      statusCode: response.statusCode,
-      success: !isError,
-      error: isError ? `HTTP ${response.statusCode}` : null,
-    };
-  } catch (error) {
-    return {
-      url: url,
-      statusCode: null,
-      success: false,
-      error: error.message,
-    };
-  }
-}
-
-/**
- * Check URLs in batches to avoid overwhelming the server
- */
-async function checkUrlsBatch(urls, batchSize = MAX_CONCURRENT_REQUESTS) {
-  const results = [];
-
-  for (let i = 0; i < urls.length; i += batchSize) {
-    const batch = urls.slice(i, i + batchSize);
-    console.log(
-      `Checking batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(urls.length / batchSize)} (${batch.length} URLs)...`,
+    .map((url) =>
+      url
+        .replace(`https://${LANGFUSE_DOMAIN}`, localServerBase)
+        .replace(`http://${LANGFUSE_DOMAIN}`, localServerBase),
     );
+}
 
-    const batchResults = await Promise.all(batch.map((url) => checkUrl(url)));
-    results.push(...batchResults);
+function localHostnamesFromBase(baseUrl) {
+  try {
+    return new Set([new URL(baseUrl).hostname, "localhost", "127.0.0.1"]);
+  } catch {
+    return new Set(["localhost", "127.0.0.1"]);
+  }
+}
 
-    // Small delay between batches to be gentle on the server
-    if (i + batchSize < urls.length) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
+async function checkUrl(url, { localHostnames, checkLinkFn = checkLink } = {}) {
+  const response = await checkLinkFn(url, REQUEST_TIMEOUT, { localHostnames });
+  const isError = response.status === "dead";
+
+  return {
+    url,
+    statusCode: response.statusCode,
+    success: !isError,
+    error: isError ? response.error || `HTTP ${response.statusCode}` : null,
+    method: response.method,
+  };
+}
+
+async function runSitemapCheck(options = {}) {
+  const sitemapUrl = options.sitemapUrl || getSitemapUrl();
+  const localServerBase = getLocalServerBase(options.baseUrl);
+  const fetchSitemap = options.fetchUrl || fetchUrl;
+  const checkLinkFn = options.checkLink || checkLink;
+  const localHostnames = localHostnamesFromBase(localServerBase);
+  const silent = options.silent === true;
+
+  if (!silent) {
+    console.log(`Fetching sitemap from: ${sitemapUrl}`);
   }
 
-  return results;
+  const sitemapResponse = await fetchSitemap(sitemapUrl, REQUEST_TIMEOUT);
+  if (sitemapResponse.statusCode !== 200) {
+    throw new Error(
+      `Failed to fetch sitemap: HTTP ${sitemapResponse.statusCode}`,
+    );
+  }
+
+  if (!silent) {
+    console.log("Parsing sitemap XML...");
+  }
+  const urls = await parseSitemap(sitemapResponse.data);
+  if (!silent) {
+    console.log(`Found ${urls.length} URLs in sitemap`);
+  }
+
+  const localUrls = filterAndConvertUrls(urls, localServerBase);
+  if (!silent) {
+    console.log(
+      `Filtered to ${localUrls.length} Langfuse.com URLs to check against local server`,
+    );
+  }
+
+  if (localUrls.length === 0) {
+    if (!silent) {
+      console.log("No Langfuse.com URLs found in sitemap");
+    }
+    return {
+      ok: true,
+      failures: [],
+      successes: [],
+      urlsChecked: 0,
+    };
+  }
+
+  if (!silent) {
+    console.log(
+      `\nChecking ${localUrls.length} URLs against local server ` +
+        `(${MAX_CONCURRENT_REQUESTS} concurrent, HEAD with GET fallback)...`,
+    );
+  }
+
+  const results = await mapPool(
+    localUrls,
+    MAX_CONCURRENT_REQUESTS,
+    async (url, index) => {
+      const result = await checkUrl(url, { localHostnames, checkLinkFn });
+      if (
+        !silent &&
+        ((index + 1) % 100 === 0 || index + 1 === localUrls.length)
+      ) {
+        console.log(`Checked ${index + 1}/${localUrls.length} sitemap URLs`);
+      }
+      return result;
+    },
+  );
+
+  const failures = results.filter((result) => !result.success);
+  const successes = results.filter((result) => result.success);
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    successes,
+    urlsChecked: results.length,
+  };
+}
+
+function reportSitemapResults(result) {
+  console.log(`\n=== Results ===`);
+  console.log(`✅ Successful: ${result.successes.length}`);
+  console.log(`❌ Failed: ${result.failures.length}`);
+
+  if (result.failures.length > 0) {
+    console.log("\n=== Failed URLs ===");
+    result.failures.forEach((failure) => {
+      console.log(`❌ ${failure.url} - ${failure.error}`);
+    });
+    console.log(
+      `\n❌ Sitemap check failed: ${result.failures.length} URLs are broken`,
+    );
+  } else {
+    console.log("\n✅ All sitemap URLs are working correctly!");
+  }
 }
 
 async function main() {
   try {
-    console.log(`Fetching sitemap from: ${SITEMAP_URL}`);
-
-    // Fetch sitemap
-    const sitemapResponse = await fetchUrl(SITEMAP_URL);
-    if (sitemapResponse.statusCode !== 200) {
-      throw new Error(
-        `Failed to fetch sitemap: HTTP ${sitemapResponse.statusCode}`,
-      );
-    }
-
-    // Parse sitemap
-    console.log("Parsing sitemap XML...");
-    const urls = await parseSitemap(sitemapResponse.data);
-    console.log(`Found ${urls.length} URLs in sitemap`);
-
-    // Filter and convert URLs
-    const localUrls = filterAndConvertUrls(urls);
-    console.log(
-      `Filtered to ${localUrls.length} Langfuse.com URLs to check against local server`,
-    );
-
-    if (localUrls.length === 0) {
-      console.log("No Langfuse.com URLs found in sitemap");
-      return;
-    }
-
-    // Check URLs
-    console.log(`\nChecking ${localUrls.length} URLs against local server...`);
-    const results = await checkUrlsBatch(localUrls);
-
-    // Report results
-    const failures = results.filter((result) => !result.success);
-    const successes = results.filter((result) => result.success);
-
-    console.log(`\n=== Results ===`);
-    console.log(`✅ Successful: ${successes.length}`);
-    console.log(`❌ Failed: ${failures.length}`);
-
-    if (failures.length > 0) {
-      console.log("\n=== Failed URLs ===");
-      failures.forEach((failure) => {
-        console.log(`❌ ${failure.url} - ${failure.error}`);
-      });
-
-      console.log(
-        `\n❌ Sitemap check failed: ${failures.length} URLs are broken`,
-      );
+    const result = await runSitemapCheck();
+    reportSitemapResults(result);
+    if (!result.ok) {
       process.exit(1);
-    } else {
-      console.log("\n✅ All sitemap URLs are working correctly!");
     }
   } catch (error) {
     console.error("Error during sitemap check:", error.message);
@@ -206,4 +177,18 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  DEFAULT_SITEMAP_URL,
+  MAX_CONCURRENT_REQUESTS,
+  checkUrl,
+  filterAndConvertUrls,
+  getLocalServerBase,
+  getSitemapUrl,
+  parseSitemap,
+  reportSitemapResults,
+  runSitemapCheck,
+};

--- a/scripts/check-sitemap-links.js
+++ b/scripts/check-sitemap-links.js
@@ -55,7 +55,10 @@ function localHostnamesFromBase(baseUrl) {
 }
 
 async function checkUrl(url, { localHostnames, checkLinkFn = checkLink } = {}) {
-  const response = await checkLinkFn(url, REQUEST_TIMEOUT, { localHostnames });
+  const response = await checkLinkFn(url, REQUEST_TIMEOUT, {
+    localHostnames,
+    followRedirects: true,
+  });
   const isError = response.status === "dead";
 
   return {

--- a/scripts/check-sitemap-links.test.js
+++ b/scripts/check-sitemap-links.test.js
@@ -98,6 +98,37 @@ test("passes when every sitemap URL is served locally", async () => {
   }
 });
 
+test("fails when a sitemap URL redirects to a 404", async () => {
+  const { server, baseUrl } = await listen((req, res) => {
+    if (req.url === "/sitemap-0.xml") {
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(sitemapXml(["https://langfuse.com/old-docs"]));
+      return;
+    }
+    if (req.url === "/old-docs") {
+      res.writeHead(301, { Location: "/deleted-page" });
+      res.end();
+      return;
+    }
+    res.writeHead(req.url === "/deleted-page" ? 404 : 200);
+    res.end();
+  });
+
+  try {
+    const result = await runSitemapCheck({
+      sitemapUrl: `${baseUrl}/sitemap-0.xml`,
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.failures.length, 1);
+    assert.equal(result.failures[0].statusCode, 404);
+  } finally {
+    server.close();
+  }
+});
+
 test("fails when a sitemap URL 404s on the local server", async () => {
   const { server, baseUrl } = await listen((req, res) => {
     if (req.url === "/sitemap-0.xml") {

--- a/scripts/check-sitemap-links.test.js
+++ b/scripts/check-sitemap-links.test.js
@@ -1,0 +1,166 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const http = require("node:http");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  filterAndConvertUrls,
+  parseSitemap,
+  runSitemapCheck,
+} = require("./check-sitemap-links");
+
+function sitemapXml(paths) {
+  const urls = paths.map((loc) => `  <url><loc>${loc}</loc></url>`).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    server,
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+  };
+}
+
+function runCli(env) {
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      [path.join(process.cwd(), "scripts/check-sitemap-links.js")],
+      {
+        env: { ...process.env, ...env },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+test("parses sitemap URLs and rewrites them onto the local server", async () => {
+  const urls = await parseSitemap(
+    sitemapXml([
+      "https://langfuse.com/docs",
+      "http://langfuse.com/blog",
+      "https://example.com/skip",
+    ]),
+  );
+
+  assert.deepEqual(filterAndConvertUrls(urls, "http://127.0.0.1:3333"), [
+    "http://127.0.0.1:3333/docs",
+    "http://127.0.0.1:3333/blog",
+  ]);
+});
+
+test("passes when every sitemap URL is served locally", async () => {
+  const { server, baseUrl } = await listen((req, res) => {
+    if (req.url === "/sitemap-0.xml") {
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(
+        sitemapXml(["https://langfuse.com/docs", "https://langfuse.com/blog"]),
+      );
+      return;
+    }
+    res.writeHead(200);
+    res.end("ok");
+  });
+
+  try {
+    const result = await runSitemapCheck({
+      sitemapUrl: `${baseUrl}/sitemap-0.xml`,
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.urlsChecked, 2);
+    assert.equal(result.failures.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test("fails when a sitemap URL 404s on the local server", async () => {
+  const { server, baseUrl } = await listen((req, res) => {
+    if (req.url === "/sitemap-0.xml") {
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(
+        sitemapXml([
+          "https://langfuse.com/docs",
+          "https://langfuse.com/deleted-page",
+        ]),
+      );
+      return;
+    }
+    res.writeHead(req.url === "/deleted-page" ? 404 : 200);
+    res.end();
+  });
+
+  try {
+    const result = await runSitemapCheck({
+      sitemapUrl: `${baseUrl}/sitemap-0.xml`,
+      baseUrl,
+      silent: true,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.failures.length, 1);
+    assert.match(result.failures[0].url, /\/deleted-page$/);
+    assert.equal(result.failures[0].statusCode, 404);
+  } finally {
+    server.close();
+  }
+});
+
+test("CLI exits 0 for a healthy sitemap and 1 after a 404 is introduced", async () => {
+  const sitemapPaths = ["/docs"];
+  const livePages = new Set(["/docs"]);
+  const { server, baseUrl } = await listen((req, res) => {
+    if (req.url === "/sitemap-0.xml") {
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(
+        sitemapXml(sitemapPaths.map((page) => `https://langfuse.com${page}`)),
+      );
+      return;
+    }
+    res.writeHead(livePages.has(req.url) ? 200 : 404);
+    res.end();
+  });
+  const env = {
+    SITEMAP_URL: `${baseUrl}/sitemap-0.xml`,
+    SITEMAP_CHECK_BASE: baseUrl,
+  };
+
+  try {
+    const passing = await runCli(env);
+    assert.equal(passing.code, 0, passing.stderr);
+    assert.match(passing.stdout, /All sitemap URLs are working correctly/);
+
+    sitemapPaths.push("/broken-after-delete");
+
+    const failing = await runCli(env);
+    assert.equal(failing.code, 1);
+    assert.match(failing.stdout, /Sitemap check failed/);
+    assert.match(failing.stdout, /broken-after-delete/);
+  } finally {
+    server.close();
+  }
+});

--- a/scripts/lib/check-http.js
+++ b/scripts/lib/check-http.js
@@ -1,0 +1,201 @@
+"use strict";
+
+const http = require("http");
+const https = require("https");
+const { URL } = require("url");
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+const httpAgent = new http.Agent({
+  keepAlive: true,
+  maxSockets: 32,
+});
+const httpsAgent = new https.Agent({
+  keepAlive: true,
+  maxSockets: 32,
+});
+
+function shouldRetryWithGet(url, result, localHostnames) {
+  if (
+    result.statusCode === 405 ||
+    result.statusCode === 501 ||
+    result.statusCode === 400
+  ) {
+    return true;
+  }
+
+  if (result.statusCode !== 0 || !result.error) {
+    return false;
+  }
+
+  let hostname;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+
+  if (!localHostnames.has(hostname)) {
+    return false;
+  }
+
+  return (
+    result.error === "Timeout" ||
+    result.error.includes("ECONNRESET") ||
+    result.error.includes("socket hang up")
+  );
+}
+
+function makeRequest(url, method, timeout, { collectBody = false } = {}) {
+  return new Promise((resolve) => {
+    try {
+      const urlObj = new URL(url);
+      const isHttps = urlObj.protocol === "https:";
+      const client = isHttps ? https : http;
+
+      const options = {
+        hostname: urlObj.hostname,
+        port: urlObj.port || (isHttps ? 443 : 80),
+        path: urlObj.pathname + urlObj.search,
+        method,
+        timeout,
+        agent: isHttps ? httpsAgent : httpAgent,
+        headers: {
+          "User-Agent": "link-checker",
+          Connection: "keep-alive",
+        },
+      };
+
+      const req = client.request(options, (res) => {
+        const redirectLocation = res.headers.location;
+        const chunks = [];
+
+        res.on("data", (chunk) => {
+          if (collectBody) {
+            chunks.push(chunk);
+          }
+        });
+
+        res.on("end", () => {
+          const success = res.statusCode >= 200 && res.statusCode < 400;
+          resolve({
+            url,
+            status: success ? "alive" : "dead",
+            statusCode: res.statusCode,
+            method,
+            location: redirectLocation,
+            data: collectBody ? Buffer.concat(chunks).toString("utf8") : "",
+          });
+        });
+      });
+
+      req.on("error", (err) => {
+        resolve({
+          url,
+          status: "dead",
+          statusCode: 0,
+          error: err.message,
+          method,
+        });
+      });
+
+      req.on("timeout", () => {
+        req.destroy();
+        resolve({
+          url,
+          status: "dead",
+          statusCode: 0,
+          error: "Timeout",
+          method,
+        });
+      });
+
+      req.end();
+    } catch (error) {
+      resolve({
+        url,
+        status: "dead",
+        statusCode: 0,
+        error: error.message,
+        method,
+      });
+    }
+  });
+}
+
+async function checkLink(
+  url,
+  timeout = DEFAULT_TIMEOUT_MS,
+  { localHostnames = new Set(["localhost", "127.0.0.1"]) } = {},
+) {
+  const headResult = await makeRequest(url, "HEAD", timeout);
+
+  if (shouldRetryWithGet(url, headResult, localHostnames)) {
+    return await makeRequest(url, "GET", timeout);
+  }
+
+  return headResult;
+}
+
+async function fetchUrl(
+  url,
+  timeout = DEFAULT_TIMEOUT_MS,
+  { maxRedirects = 5 } = {},
+) {
+  let currentUrl = url;
+
+  for (let i = 0; i <= maxRedirects; i += 1) {
+    const result = await makeRequest(currentUrl, "GET", timeout, {
+      collectBody: true,
+    });
+
+    if (
+      result.statusCode >= 300 &&
+      result.statusCode < 400 &&
+      result.location
+    ) {
+      currentUrl = result.location.startsWith("http")
+        ? result.location
+        : new URL(result.location, currentUrl).href;
+      continue;
+    }
+
+    if (result.status === "dead" && result.error) {
+      throw new Error(result.error);
+    }
+
+    return {
+      statusCode: result.statusCode,
+      data: result.data,
+      url: currentUrl,
+    };
+  }
+
+  throw new Error(`Too many redirects for ${url}`);
+}
+
+async function mapPool(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runWorker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT_MS,
+  checkLink,
+  fetchUrl,
+  makeRequest,
+  mapPool,
+  shouldRetryWithGet,
+};

--- a/scripts/lib/check-http.js
+++ b/scripts/lib/check-http.js
@@ -123,11 +123,7 @@ function makeRequest(url, method, timeout, { collectBody = false } = {}) {
   });
 }
 
-async function checkLink(
-  url,
-  timeout = DEFAULT_TIMEOUT_MS,
-  { localHostnames = new Set(["localhost", "127.0.0.1"]) } = {},
-) {
+async function checkOnce(url, timeout, localHostnames) {
   const headResult = await makeRequest(url, "HEAD", timeout);
 
   if (shouldRetryWithGet(url, headResult, localHostnames)) {
@@ -135,6 +131,47 @@ async function checkLink(
   }
 
   return headResult;
+}
+
+async function checkLink(
+  url,
+  timeout = DEFAULT_TIMEOUT_MS,
+  {
+    localHostnames = new Set(["localhost", "127.0.0.1"]),
+    followRedirects = false,
+    maxRedirects = 5,
+  } = {},
+) {
+  let currentUrl = url;
+
+  for (let i = 0; i <= maxRedirects; i += 1) {
+    const result = await checkOnce(currentUrl, timeout, localHostnames);
+
+    if (
+      followRedirects &&
+      result.statusCode >= 300 &&
+      result.statusCode < 400 &&
+      result.location
+    ) {
+      currentUrl = result.location.startsWith("http")
+        ? result.location
+        : new URL(result.location, currentUrl).href;
+      continue;
+    }
+
+    return {
+      ...result,
+      url,
+    };
+  }
+
+  return {
+    url,
+    status: "dead",
+    statusCode: 0,
+    error: `Too many redirects for ${url}`,
+    method: "HEAD",
+  };
 }
 
 async function fetchUrl(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recent `build-and-check-links` / `check-sitemap-links` runs spend ~2.5 minutes each on a full `next build`, then extra time hitting the same URLs many times. This change speeds those jobs up without caching `.next` and without merging them.

- **Jobs stay separate.** `build-and-check-links` and `check-sitemap-links` still each build and start their own server, so a sitemap failure stays isolated from the source-link check.
- **Check each unique source URL once.** This repo currently extracts 6231 source links but only 1779 unique URLs. The checker used to HTTP-check the same path once per file.
- **Sitemap checks use HEAD** (GET fallback if HEAD is rejected), then follow redirects and evaluate the final status. A 3xx to a missing page still fails.
- **Shallow checkout** instead of `fetch-depth: 0` (which also fetched every branch). Accurate sitemap `<lastmod>` dates are only needed for the published Vercel build, not this CI job.
- **pnpm store cache** on install. No Next.js build cache.

The pass/fail contract is unchanged: a 404 on a source link or a production-sitemap URL still fails the job.

## Testing

`pnpm test:link-check` covers both the happy path and the bugs this CI is supposed to catch:

- Working markdown / sitemap URLs exit 0
- Introducing a 404 source link exits 1 and reports `HTTP 404`
- Introducing a sitemap URL that 404s locally exits 1 and reports `HTTP 404`
- A sitemap URL that redirects to a 404 also exits 1

An independent subagent repeated the CLI checks against its own fixtures (not the unit-test files). Healthy fixtures passed; adding a missing path or sitemap loc failed closed with status 404, not a connection error.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d632697-2d1d-4ba4-b445-6183c800c8ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d632697-2d1d-4ba4-b445-6183c800c8ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates source-link and sitemap validation around one production build, introduces shared bounded-concurrency HTTP utilities, deduplicates source URLs, adds checker tests, and enables pnpm caching. The shared HTTP path improves runtime, but sitemap route checks now stop at redirects instead of validating their destinations.

- Combines both publication checks into `build-and-check-links`.
- Adds reusable HEAD/GET, redirect-fetching, and worker-pool utilities.
- Checks each unique source URL once and maps failures back to source files.
- Adds unit and CLI coverage for successful and 404 responses.
- Uses a shallow checkout and pnpm store caching for this CI job.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until sitemap checks follow redirects and validate the final destination; the skipped sitemap diagnostics after source-link failures are also worth correcting.

A sitemap URL whose redirect target is broken now passes because the shared checker treats the intermediate 3xx response as alive, weakening a required publication gate. The remaining workflow issue affects diagnostic completeness rather than the final pass/fail result.

**Files Needing Attention:** scripts/lib/check-http.js, scripts/check-sitemap-links.js, .github/workflows/ci.yml
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Checkout[Shallow checkout] --> Install[pnpm install]
  Install --> Tests[Link-checker tests]
  Tests --> Build[Next.js production build]
  Build --> Server[Start production server]
  Server --> Source[Check unique source URLs]
  Source -->|success| Sitemap[Check production sitemap routes]
  Source -->|failure| Skip[Sitemap step skipped]
  Sitemap --> HTTP[Shared HEAD/GET helper]
  HTTP --> Redirect[3xx classified alive without following destination]
  Source --> Cleanup[Always stop server]
  Sitemap --> Cleanup
  Skip --> Cleanup
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/lib/check-http.js:80
**Redirect targets go unchecked**

Sitemap page checks now classify every 3xx response as alive and return it without following the `Location` header. If a sitemap route redirects to a missing, failing, or unreachable destination, CI therefore passes even though the final route is broken. The previous sitemap checker followed redirects before evaluating the final status.

### Issue 2
.github/workflows/ci.yml:151-152
**Link failures skip sitemap checks**

The sitemap check is now a normal step after `pnpm link-check`, so a broken source link prevents sitemap validation from running. These checks were previously independent jobs, allowing one run to report both kinds of publication failures. This does not weaken the final pass/fail result, but it hides unrelated sitemap regressions until the source links are fixed and CI runs again.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Speed up link-check CI by building once ..."](https://github.com/langfuse/langfuse-docs/commit/fc320952a0ab9a4835fcaf752b80c7e04fe39acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60513598)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Content publishing automation](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/content-publishing-automation.md)

<!-- /greptile_comment -->