### PR TITLE
Route AWS Marketplace procurement to talk-to-us

### DIFF
--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -48,6 +48,11 @@ const faqs: FAQItem[] = [
       "You can manage your subscription through the organization settings in Langfuse Cloud or by using this [Customer Portal](/billing-portal).",
   },
   {
+    question: "Can I purchase Langfuse through AWS Marketplace?",
+    answer:
+      "Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us) to request a private offer. Invoice billing is also available.",
+  },
+  {
     question: "Can I redline the contracts?",
     answer:
       "Yes, we offer customized contracts for Langfuse Enterprise customers with a yearly commitment. Please [contact sales](/talk-to-us) for more details. The default plans are affordable as they are designed to be self-serve on our standard terms.",

--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -1,6 +1,21 @@
 import { Heading } from "@/components/ui/heading";
 import { FAQAccordion, type FAQItem } from "@/components/shared/FAQAccordion";
 
+const MARKETPLACE_QUESTION = "Can I purchase Langfuse through AWS Marketplace?";
+
+const marketplaceFaqByVariant: Record<"cloud" | "selfHosted", FAQItem> = {
+  cloud: {
+    question: MARKETPLACE_QUESTION,
+    answer:
+      "Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us?deployment=cloud) to request a private offer. Invoice billing is also available.",
+  },
+  selfHosted: {
+    question: MARKETPLACE_QUESTION,
+    answer:
+      "Yes. Self-hosted Enterprise can be billed via AWS Marketplace or invoice. [Talk to us](/talk-to-us?deployment=self-hosted) to request a private offer.",
+  },
+};
+
 const faqs: FAQItem[] = [
   {
     question: "What is the easiest way to try Langfuse?",
@@ -47,11 +62,7 @@ const faqs: FAQItem[] = [
     answer:
       "You can manage your subscription through the organization settings in Langfuse Cloud or by using this [Customer Portal](/billing-portal).",
   },
-  {
-    question: "Can I purchase Langfuse through AWS Marketplace?",
-    answer:
-      "Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us) to request a private offer. Invoice billing is also available.",
-  },
+  marketplaceFaqByVariant.cloud,
   {
     question: "Can I redline the contracts?",
     answer:
@@ -69,7 +80,17 @@ const faqs: FAQItem[] = [
   },
 ];
 
-export function PricingFAQ() {
+export function PricingFAQ({
+  variant = "cloud",
+}: {
+  variant?: "cloud" | "selfHosted";
+}) {
+  const faqsForVariant = faqs.map((faq) =>
+    faq.question === MARKETPLACE_QUESTION
+      ? marketplaceFaqByVariant[variant]
+      : faq,
+  );
+
   return (
     <div id="faq">
       <div className="pt-16">
@@ -77,7 +98,7 @@ export function PricingFAQ() {
           <Heading as="h2" size="normal" className="text-left">
             FAQ
           </Heading>
-          <FAQAccordion faqs={faqs} />
+          <FAQAccordion faqs={faqsForVariant} />
         </div>
       </div>
     </div>

--- a/components/home/pricing/index.tsx
+++ b/components/home/pricing/index.tsx
@@ -126,7 +126,7 @@ export function PricingPage({
               >
                 {variant === "cloud" && <PricingCalculator />}
                 <PricingDiscounts />
-                <PricingFAQ />
+                <PricingFAQ variant={variant} />
               </div>
             </div>
           </>

--- a/content/changelog/2024-09-20-aws-marketplace.mdx
+++ b/content/changelog/2024-09-20-aws-marketplace.mdx
@@ -15,6 +15,6 @@ The **AWS Marketplace** listing makes it easier to **purchase Langfuse in the AW
 
 AWS Marketplace is a digital catalog with thousands of software listings from independent software vendors (ISVs) that makes it easy to find, test, buy, and deploy the right software for your business.
 
-You can find Langfuse on **AWS Marketplace** [here](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu).
+To purchase Langfuse via **AWS Marketplace**, [talk to us](/talk-to-us) to request a private offer.
 
-Learn more about Langfuse in the Enterprise at [langfuse.com/enterprise](/enterprise) or [contact sales](/talk-to-us).
+Learn more about Langfuse in the Enterprise at [langfuse.com/enterprise](/enterprise).

--- a/content/faq/all/fifteen-questions-langfuse-answered.mdx
+++ b/content/faq/all/fifteen-questions-langfuse-answered.mdx
@@ -109,7 +109,7 @@ The answer is yes, Langfuse is an open source alternative to Promptlayer. You ca
 
 ## 17. Can Langfuse be purchased via the AWS Marketplace?
 
-Yes, Langfuse can be purchased via the AWS Marketplace. Please contact marketplace-aws@langfuse.com to request a private offer.
+Yes, Langfuse can be purchased via the AWS Marketplace as a private offer. Please [talk to us](/talk-to-us) to request one.
 
 ## 18. Can I use the same S3 bucket for media uploads and events?
 

--- a/content/marketing/enterprise.mdx
+++ b/content/marketing/enterprise.mdx
@@ -55,7 +55,7 @@ We offer a range of packages and services to help you get started with Langfuse.
 
 More details:
 
-- Langfuse can be procured through the [AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu) or per invoice.
+- Langfuse can be procured through AWS Marketplace or per invoice. [Talk to us](/talk-to-us) to request a private Marketplace offer.
 - With an Enterprise Agreement, you get access to additional support, features to address your specific needs and compliance requirements.
 
 ## Don't take our word for it
@@ -139,6 +139,13 @@ We're here to help you find the right solution for your use case.
 
 1. Managed Cloud (cloud.langfuse.com), see [Pricing](/pricing) and [Security](/security) page for details.
 2. [Self-hosted](/self-hosting) on your own infrastructure. Contact us if you are interested in additional support.
+
+</Details>
+
+<Details>
+<Summary>Can I purchase Langfuse through AWS Marketplace?</Summary>
+
+Yes. Langfuse is available via AWS Marketplace as a private offer. [Talk to us](/talk-to-us) and we will share an offer you can accept in your AWS account. Invoice billing is also available.
 
 </Details>
 

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -141,6 +141,9 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 
 ## Frequently Asked Questions
 
+**Can I purchase Langfuse through AWS Marketplace?**
+Yes. Self-hosted Enterprise can be billed via AWS Marketplace or invoice. [Talk to us](/talk-to-us?deployment=self-hosted) to request a private offer.
+
 **Can I self-host Langfuse for free?**
 Yes, Langfuse is open source and you can self-host it for free. Use Docker Compose to run Langfuse locally, or use one of the templates to self-host in production on Kubernetes. See the [self-hosting documentation](/self-hosting) to learn more.
 

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -280,7 +280,7 @@ Yes, you can configure [spend alerts](/docs/administration/spend-alerts) to rece
 Through the organization settings in Langfuse Cloud or the [Customer Portal](/billing-portal).
 
 **Can I purchase Langfuse through AWS Marketplace?**
-Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us) to request a private offer. Invoice billing is also available.
+Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us?deployment=cloud) to request a private offer. Invoice billing is also available.
 
 **Can I redline the contracts?**
 Yes, customized contracts are available for Enterprise customers with a yearly commitment. [Contact sales](/talk-to-us) to discuss your requirements. Default plans are self-serve on standard terms.

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -279,6 +279,9 @@ Yes, you can configure [spend alerts](/docs/administration/spend-alerts) to rece
 **How can I manage my subscription?**
 Through the organization settings in Langfuse Cloud or the [Customer Portal](/billing-portal).
 
+**Can I purchase Langfuse through AWS Marketplace?**
+Yes. Enterprise customers with a yearly commitment can bill via AWS Marketplace. [Talk to us](/talk-to-us) to request a private offer. Invoice billing is also available.
+
 **Can I redline the contracts?**
 Yes, customized contracts are available for Enterprise customers with a yearly commitment. [Contact sales](/talk-to-us) to discuss your requirements. Default plans are self-serve on standard terms.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The public Langfuse AWS Marketplace listing is deprovisioned, and the new ClickHouse-managed listing stays private (no self-serve pricing). Customers should request a private offer via the sales form instead of hitting a dead Marketplace URL.

## What changed

- **Enterprise** (`/enterprise`): replaced the old seller-profile link with a [talk-to-us](/talk-to-us) CTA, and added an FAQ on Marketplace private offers.
- **Changelog** (`/changelog/2024-09-20-aws-marketplace`): the GitHub discussion still points here; swapped the dead listing link for talk-to-us.
- **FAQ** (`/faq/all/fifteen-questions-langfuse-answered`): `marketplace-aws@langfuse.com` → talk-to-us.
- **Pricing FAQ** (cloud + self-host markdown overrides): added “Can I purchase Langfuse through AWS Marketplace?” pointing to talk-to-us.

## Left unchanged on purpose

- Pricing table copy (“Billing via AWS Marketplace”) — still accurate for private offers; Enterprise CTAs already go to talk-to-us.
- ClickHouse Cloud marketplace links on the [self-hosting ClickHouse page](/self-hosting/deployment/infrastructure/clickhouse) — those list ClickHouse Cloud itself, not Langfuse.
- Cursor / Claude / Codex plugin marketplaces, Slack screenshots, Shadeform GPU marketplace, Porter add-on, McKinsey Agents-at-Scale — unrelated.

## Context

Discussion: https://github.com/orgs/langfuse/discussions/2343#discussioncomment-10720770

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61bd4d6a-52b5-4c50-a103-a753768cf8d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61bd4d6a-52b5-4c50-a103-a753768cf8d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces references to the deprovisioned public AWS Marketplace listing with sales-form links and documents private-offer procurement across enterprise, changelog, FAQ, and pricing surfaces.
- Routes AWS Marketplace prospects to `/talk-to-us`.
- Adds Marketplace private-offer guidance to enterprise and pricing FAQs.
- Keeps cloud pricing copy aligned, but leaves the rendered and Markdown self-hosted pricing FAQs inconsistent.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking pricing-content inconsistency that should be corrected so self-hosted visitors and Markdown consumers receive the same guidance.

The procurement links resolve and the intended dead-link replacement is sound, but the shared browser FAQ and self-hosted Markdown override now publish different eligibility wording and deployment context.

**Files Needing Attention:** components/home/pricing/PricingFAQ.tsx, md-override/pricing-self-host.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/home/pricing/PricingFAQ.tsx:50-53
**Self-hosted pricing copy differs**

This shared FAQ appears on both `/pricing` and `/pricing-self-host`. As a result, the self-hosted page shows generic yearly-commitment wording and a `/talk-to-us` link, while `md-override/pricing-self-host.md` gives self-host-specific guidance and links to `/talk-to-us?deployment=self-hosted`. Please make the rendered FAQ variant-aware so browser and Markdown readers receive consistent eligibility information and deployment context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Route AWS Marketplace procurement to tal..."](https://github.com/langfuse/langfuse-docs/commit/3a6d388df0eb0d194fb6055a2ddb849fa4f829c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60542440)</sub>

**Context used:**

- Knowledge Base — [Commercial and community experiences](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/commercial-and-community-experiences.md)

<!-- /greptile_comment -->