### PR TITLE
Move remaining API routes off the deprecated Edge Runtime

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -4,7 +4,7 @@ import {
   sendFeedbackToSlack,
 } from "@/lib/feedback-slack";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "@vercel/og";
 import { NextRequest } from "next/server";
 import { SITE_DEFAULT_OG_DESCRIPTION } from "@/lib/og-url";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 function wrapWords(text: string, maxChars: number): string[] {
   const words = text.split(/\s+/).filter(Boolean);
@@ -792,7 +792,7 @@ function fitDescLayout(
 function toDataUrl(buffer: ArrayBuffer, mime: string): string {
   const bytes = new Uint8Array(buffer);
   let binary = "";
-  // `fromCharCode(...subarray)` can exceed the engine's max call/spread size on Edge; use `apply` with bounded chunks.
+  // `fromCharCode(...subarray)` can exceed the engine's max call/spread size; use `apply` with bounded chunks.
   const chunk = 0x2000; // 8192, safe for apply
   for (let i = 0; i < bytes.length; i += chunk) {
     const sub = bytes.subarray(i, i + chunk);

--- a/app/api/productUpdateSignup/route.ts
+++ b/app/api/productUpdateSignup/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 const emailSchema = z.string().email();
 

--- a/lib/feedback-slack.ts
+++ b/lib/feedback-slack.ts
@@ -178,8 +178,8 @@ export async function sendFeedbackToSlack(
 
   const response = await fetch(webhookUrl, {
     method: "POST",
-    // Edge runtime only supports "follow" | "manual"; with "manual" a redirect
-    // surfaces as a non-ok response and is rejected below.
+    // Do not follow redirects: a redirect would surface as a non-ok response
+    // and is rejected below.
     redirect: "manual",
     signal: AbortSignal.timeout(FEEDBACK_SLACK_TIMEOUT_MS),
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Next.js 16 logs `The Edge Runtime is deprecated. You can use the "nodejs" runtime instead.` during `next build`. This PR removes that warning by switching the last three Edge route handlers to Node.js.

## Where Edge was used and why

Only three App Router handlers opted into Edge:

- `/api/og` — Open Graph image generation via `@vercel/og` / Satori. Edge was the original `@vercel/og` default (WASM + no Node APIs). The handler already had Edge-specific workarounds (chunked `fromCharCode` because Edge spread limits).
- `/api/feedback` — Docs page 👍/👎 + comment → Slack webhook. Edge was used as a lightweight `fetch` endpoint (and `redirect: "manual"` was chosen because Edge only allowed `follow` | `manual`).
- `/api/productUpdateSignup` — Newsletter signup → Loops API. Same lightweight-fetch rationale.

There is no `middleware.ts` / `proxy.ts`. Other API routes (`/api/md-to-pdf`, `/api/voice-agent`) already pin `runtime = "nodejs"`.

## Why Node.js is enough

None of these handlers need Edge-only APIs:

- `@vercel/og` 0.6.8 ships a Node export (`dist/index.node.js`) and Next.js 16 documents `ImageResponse` on the Node.js runtime.
- Feedback and signup are `fetch` + `process.env` secrets (`WEBSITE_FEEDBACK_WEBHOOK`, `LOOPS_API_KEY`). Node.js supports both.

## Verification

Preview: https://langfuse-docs-git-cursor-nodejs-runtime-ab1f-langfuse.vercel.app

- `GET /api/og?title=LLM%20Platform` → `200` `image/png` 1200×630 (local and preview).
- `POST /api/feedback` invalid → `400`; valid (Slack secret) → `200 {"status":"OK"}`.
- `POST /api/productUpdateSignup` invalid → `400`; valid (Loops secret) → `200 {"status":"OK"}`.
- GitHub CI `build-and-check-links` compiled successfully; build logs contain **zero** `The Edge Runtime is deprecated` matches.
- Preview `/docs` and `/changelog` load; signup and feedback widgets render.

![Preview OG image](https://cursor.com/artifacts/c/art-ec3a11a3-f0ec-490d-97c4-d0cc89086e02)
![Preview docs page with signup and feedback](https://cursor.com/artifacts/c/art-ac42075d-d224-45e4-ae56-8f1e0480cdb0)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7819ca20-839a-461e-9d6d-8c688ce7ab1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7819ca20-839a-461e-9d6d-8c688ce7ab1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the final three Edge API route handlers to the Node.js runtime to eliminate Next.js 16 deprecation warnings while preserving their existing behavior.
- Moves feedback delivery, Open Graph image generation, and product-update signup to `runtime = "nodejs"`.
- Retains manual redirect rejection for Slack webhook delivery.
- Updates Edge-specific explanatory comments to be runtime-neutral.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the affected handlers and dependencies support Node.js and no behavior-changing defects were identified.

The changes only switch runtime declarations and update comments; the handlers use Node-compatible APIs, preserve their existing contracts, and have no conflicting deployment constraints.
</details>

<sub>Reviews (1): Last reviewed commit: ["Move remaining API routes off the deprec..."](https://github.com/langfuse/langfuse-docs/commit/b05c32b198264b0e4924856843a9e0791c3d6ab9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60547585)</sub>

**Context used:**

- Knowledge Base — [Site API endpoints](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse-docs/-/docs/site-api-endpoints.md)

<!-- /greptile_comment -->