### PR TITLE
Limit walkthrough screenshots and videos to complex visual changes

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -152,6 +152,7 @@ Please check the following:
 - **No env file needed**: All external integrations (OpenAI, Supabase, PostHog, etc.) degrade gracefully when keys are absent. You do not need a `.env` file for routine development.
 - **Site search is inert locally**: The `Ctrl/Cmd+K` search dialog (powered by Inkeep) opens but returns no results without Inkeep keys. This is expected; use sidebar/link navigation to reach pages when testing docs locally.
 - **postinstall runs agent shim sync**: `pnpm install` triggers `scripts/postinstall.sh`, which syncs agent config shims. This is expected and idempotent.
+- **Walkthrough screenshots and demo videos**: Create these only for complex visual changes that cannot be understood from the diff alone — for example multi-step UI interactions, layout or responsive changes, or new interactive components. Do not create screenshots or demo videos for small edits such as copy changes, docs or markdown updates, simple style tweaks, or other changes that are clear from the code diff. In those cases, the diff is sufficient evidence.
 
 <!-- BEGIN:nextjs-agent-rules -->
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tell Cursor Cloud agents to create screenshots and demo videos only for complex visual changes, not for small edits that are clear from the diff.

## Change

Adds one bullet under **Cursor Cloud specific instructions** in `.agents/AGENTS.md` (the canonical source for `AGENTS.md` / `CLAUDE.md`):

- Create walkthrough screenshots and demo videos only when the visual change cannot be understood from the diff (multi-step UI, layout/responsive work, new interactive components).
- Skip them for copy changes, docs/markdown updates, simple style tweaks, and other diffs that stand on their own.

This is a docs-only instruction change. No site pages or UI were updated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c377d33b-f574-42bf-99dc-192a363d0296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c377d33b-f574-42bf-99dc-192a363d0296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates Cursor Cloud guidance to reserve walkthrough screenshots and demo videos for complex visual changes that cannot be understood from the diff.
- Exempts copy, documentation, Markdown, and simple styling changes.
- Leaves runtime application behavior and site content unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The instruction is scoped to Cursor Cloud walkthrough artifacts, does not conflict with established content-authoring requirements, and automatically reaches the root agent instruction files through existing symlinks.
</details>

<sub>Reviews (1): Last reviewed commit: ["Limit walkthrough screenshots and videos..."](https://github.com/langfuse/langfuse-docs/commit/dcb0da1ff1278b23c4dea8bdda64b0929aeea700) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60542623)</sub>

<!-- /greptile_comment -->