### PR TITLE
docs(handbook): Linear ticket updates are proposals first

### DIFF
--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,13 +93,13 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session’s results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
 
 - `linear-agent-writes` — what an agent may write, when it must ask first, and how each write must be marked. Read this one before your first agentic write.
 - `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
 - `linear-context-handover` — recovering the history behind a piece of work, and proposing the reasoning for the issue when you finish.
 
-Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
+Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct — org defaults for agent behaviour live in those skills; personal overrides stay local. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
 
 ## Setup Linear
 

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,13 +93,11 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents are allowed to write to Linear directly — there is no longer a rule that one must stop and ask a human first. They comment, append their reasoning to an issue description, and create issues.
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
 
-They do have to follow rules, and **the rules are not repeated here.** They live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
-
-- `linear-agent-writes` — what an agent may write and how each write must be marked. Read this one before your first agentic write.
+- `linear-agent-writes` — what an agent may write, when it must ask first, and how each write must be marked. Read this one before your first agentic write.
 - `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
-- `linear-context-handover` — recovering the history behind a piece of work, and leaving your reasoning on the issue when you finish.
+- `linear-context-handover` — recovering the history behind a piece of work, and proposing the reasoning for the issue when you finish.
 
 Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Handbook: Linear ticket updates from agents are **proposals first**. Productive sessions should ask whether to preserve results on tickets; org agent defaults live in the langfuse skills.

## Companion

https://github.com/langfuse/langfuse/pull/17176

## Verification

- `pnpm run format` on the edited MDX
- Skipped full `pnpm build` / link-check (copy-only handbook edit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08062-272e-711b-8c64-fe6e0f154bbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08062-272e-711b-8c64-fe6e0f154bbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the handbook policy for agent writes to Linear:
- Updates to existing tickets must be proposed and approved before writing.
- Creating a subticket does not require that approval gate.
- Related skill descriptions now reflect the proposal-first workflow.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge, with no actionable defects identified.

The edited paragraph consistently describes the proposal-first policy and subticket exception, and no repository rule violation or contradictory local guidance was found.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(handbook): Linear ticket updates ar..."](https://github.com/langfuse/langfuse-docs/commit/b033ee7bd78ca09ad44d842f34a8f7721ead89ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61534790)</sub>

<!-- /greptile_comment -->