### PR TITLE
docs: clarify v4 observation response contracts

### DIFF
--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -90,7 +90,6 @@ The v1 API returns complete rows with all fields (input/output, usage, metadata,
 
 If `fields` is not specified, `core` and `basic` field groups are returned by default. Fields from groups you do not request are **absent** from the response, not `null`. The following fields are an exception and are always present but only populated when the field group `model` is selected: `modelId`, `inputPrice`, `outputPrice`, and `totalPrice`. Note that `inputPrice`, `outputPrice`, and `totalPrice` are returned as **strings** (e.g. `"0.000005"`) to preserve decimal precision; cast them to a numeric type in your pipeline.
 
-
 The `metadata` group returns a flat key map. OTEL resource attributes can appear as literal dotted keys, such as `metadata["resourceAttributes.service.name"]`, rather than nested objects. Metadata values may themselves be structured; preserve the returned keys and types. For legacy usage and cost field replacements, see the [response-field mapping](/faq/all/deprecated-api-migration#observation-response-fields).
 
 **2. Cursor-Based Pagination**
@@ -146,7 +145,6 @@ curl \
 ```
 
 **Getting observations for a specific trace:**
-
 
 ```bash
 curl \
@@ -287,53 +285,6 @@ Illustrative response with all field groups requested. This generation has recor
   "meta": {
     "cursor": "eyJsYXN0U3RhcnRUaW1lVG8iOiIyMDI1LTEyLTE3VDE2OjA5OjAwLjg3NVoiLCJsYXN0VHJhY2VJZCI6InN1cHBvcnQtY2hhdC03LTk1MGRjNTNhIiwibGFzdElkIjoic3VwcG9ydC1jaGF0LTctOTUwZGM1M2EtZ2VuIn0="
   }
-}
-```
-
-A separate example with `fields=core,basic,io,metadata,usage` shows a terminal page containing a root span with no recorded usage or cost. Empty usage, null cost, and an absent field have different meanings. The empty `meta` object means pagination is complete:
-
-```json
-{
-  "data": [
-    {
-      "id": "support-request-root",
-      "traceId": "support-request",
-      "startTime": "2025-12-17T16:09:00.000Z",
-      "endTime": "2025-12-17T16:09:01.500Z",
-      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      "parentObservationId": null,
-      "type": "SPAN",
-      "name": "support-request",
-      "level": "DEFAULT",
-      "statusMessage": "",
-      "version": "",
-      "environment": "default",
-      "bookmarked": false,
-      "public": false,
-      "userId": "",
-      "sessionId": "support-chat-session",
-      "isRootObservation": true,
-      "input": "{\"query\":\"Perfect.\"}",
-      "output": "{\"answer\":\"You are all set.\"}",
-      "metadata": {
-        "resourceAttributes.service.name": "support-api"
-      },
-      "usageDetails": {},
-      "inputUsage": 0,
-      "outputUsage": 0,
-      "totalUsage": 0,
-      "costDetails": {},
-      "inputCost": null,
-      "outputCost": null,
-      "totalCost": null,
-      "usagePricingTierName": null,
-      "modelId": null,
-      "inputPrice": null,
-      "outputPrice": null,
-      "totalPrice": null
-    }
-  ],
-  "meta": {}
 }
 ```
 

--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -48,7 +48,7 @@ The v2 Observations API is a redesigned endpoint optimized for high-performance 
 
 ### Upgrade from older trace and observation reads [#upgrade-from-older-reads]
 
-The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated read endpoint (`/api/public/traces`, `/api/public/observations`, `/api/public/sessions`, ...) to its v2 replacement, with parameter mappings and before/after examples. Include `fromStartTime` and `toStartTime` for scans and known trace time ranges. For an exact trace ID without a timestamp, both bounds may be omitted; see [ID-only lookups](/faq/all/deprecated-api-migration#trace-id-only-lookups).
+The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated read endpoint (`/api/public/traces`, `/api/public/observations`, `/api/public/sessions`, ...) to its v2 replacement, with parameter mappings and before/after examples. Include `fromStartTime` and `toStartTime` for scans and known trace time ranges.
 
 The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. There is no get-by-id route on v2; for single-observation lookups, pass a URL-encoded `filter` condition on the `id` column instead. See the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
 
@@ -90,7 +90,6 @@ The v1 API returns complete rows with all fields (input/output, usage, metadata,
 
 If `fields` is not specified, `core` and `basic` field groups are returned by default. Fields from groups you do not request are **absent** from the response, not `null`. The following fields are an exception and are always present but only populated when the field group `model` is selected: `modelId`, `inputPrice`, `outputPrice`, and `totalPrice`. Note that `inputPrice`, `outputPrice`, and `totalPrice` are returned as **strings** (e.g. `"0.000005"`) to preserve decimal precision; cast them to a numeric type in your pipeline.
 
-Unknown field groups are silently ignored, so HTTP 200 does not confirm that the requested data was included. For example, `fields=core,basic,cost` omits cost fields: use `usage`, which includes both usage and costs. Check that the fields your consumer requires are present. Empty `usageDetails` and null `totalCost` can be valid when no usage or cost was recorded; verify usage/cost readers with a generation known to contain those values.
 
 The `metadata` group returns a flat key map. OTEL resource attributes can appear as literal dotted keys, such as `metadata["resourceAttributes.service.name"]`, rather than nested objects. Metadata values may themselves be structured; preserve the returned keys and types. For legacy usage and cost field replacements, see the [response-field mapping](/faq/all/deprecated-api-migration#observation-response-fields).
 
@@ -148,7 +147,6 @@ curl \
 
 **Getting observations for a specific trace:**
 
-If only the trace ID is known, omit the time bounds as below. When its time range is known, include it. In either case, follow cursor pagination; results remain subject to retention and data-access limits.
 
 ```bash
 curl \

--- a/content/docs/api-and-data-platform/features/observations-api.mdx
+++ b/content/docs/api-and-data-platform/features/observations-api.mdx
@@ -48,7 +48,7 @@ The v2 Observations API is a redesigned endpoint optimized for high-performance 
 
 ### Upgrade from older trace and observation reads [#upgrade-from-older-reads]
 
-The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated read endpoint (`/api/public/traces`, `/api/public/observations`, `/api/public/sessions`, ...) to its v2 replacement, with parameter mappings and before/after examples. Always include `fromStartTime` and `toStartTime` to keep each request bounded.
+The [migration guide](/faq/all/deprecated-api-migration) maps every deprecated read endpoint (`/api/public/traces`, `/api/public/observations`, `/api/public/sessions`, ...) to its v2 replacement, with parameter mappings and before/after examples. Include `fromStartTime` and `toStartTime` for scans and known trace time ranges. For an exact trace ID without a timestamp, both bounds may be omitted; see [ID-only lookups](/faq/all/deprecated-api-migration#trace-id-only-lookups).
 
 The v2 Observations API returns observation rows, not full trace objects. Group rows by `traceId` when you need to reconstruct trace activity, and use [Metrics API v2](/docs/metrics/features/metrics-api#v2) for aggregate reporting with trace-level dimensions such as `traceName`, `traceRelease`, or `traceVersion`. There is no get-by-id route on v2; for single-observation lookups, pass a URL-encoded `filter` condition on the `id` column instead. See the [v2 Observations API Reference](https://api.reference.langfuse.com/#tag/observations/GET/api/public/v2/observations) for the filter schema.
 
@@ -89,6 +89,10 @@ The v1 API returns complete rows with all fields (input/output, usage, metadata,
 | `trace_context` | tags, release, traceName                                                                                               |
 
 If `fields` is not specified, `core` and `basic` field groups are returned by default. Fields from groups you do not request are **absent** from the response, not `null`. The following fields are an exception and are always present but only populated when the field group `model` is selected: `modelId`, `inputPrice`, `outputPrice`, and `totalPrice`. Note that `inputPrice`, `outputPrice`, and `totalPrice` are returned as **strings** (e.g. `"0.000005"`) to preserve decimal precision; cast them to a numeric type in your pipeline.
+
+Unknown field groups are silently ignored, so HTTP 200 does not confirm that the requested data was included. For example, `fields=core,basic,cost` omits cost fields: use `usage`, which includes both usage and costs. Check that the fields your consumer requires are present. Empty `usageDetails` and null `totalCost` can be valid when no usage or cost was recorded; verify usage/cost readers with a generation known to contain those values.
+
+The `metadata` group returns a flat key map. OTEL resource attributes can appear as literal dotted keys, such as `metadata["resourceAttributes.service.name"]`, rather than nested objects. Metadata values may themselves be structured; preserve the returned keys and types. For legacy usage and cost field replacements, see the [response-field mapping](/faq/all/deprecated-api-migration#observation-response-fields).
 
 **2. Cursor-Based Pagination**
 
@@ -143,6 +147,8 @@ curl \
 ```
 
 **Getting observations for a specific trace:**
+
+If only the trace ID is known, omit the time bounds as below. When its time range is known, include it. In either case, follow cursor pagination; results remain subject to retention and data-access limits.
 
 ```bash
 curl \
@@ -210,9 +216,9 @@ The advanced `filter` parameter supports the same field with boolean `=` and `<>
 ]
 ```
 
-### Sample Response
+### Sample response [#sample-response]
 
-With all fields included
+Illustrative response with all field groups requested. This generation has recorded usage and cost, string-encoded I/O, and dotted metadata keys. A cursor indicates that more observations match; pass it unchanged with the same filters and field groups to retrieve the next page.
 
 ```json
 {
@@ -238,7 +244,10 @@ With all fields included
       "updatedAt": "2025-12-17T16:09:01.456Z",
       "input": "{\"messages\":[{\"role\":\"user\",\"content\":\"Perfect.\"}]}",
       "output": "{\"role\":\"assistant\",\"content\":\"You're all set. Have a great day!\"}",
-      "metadata": {},
+      "metadata": {
+        "resourceAttributes.service.name": "support-api",
+        "resourceAttributes.deployment.environment": "production"
+      },
       "model": "gpt-4o",
       "internalModelId": "clm1a2b3c4d5e6f7g8h9i0j1",
       "modelParameters": {
@@ -280,6 +289,53 @@ With all fields included
   "meta": {
     "cursor": "eyJsYXN0U3RhcnRUaW1lVG8iOiIyMDI1LTEyLTE3VDE2OjA5OjAwLjg3NVoiLCJsYXN0VHJhY2VJZCI6InN1cHBvcnQtY2hhdC03LTk1MGRjNTNhIiwibGFzdElkIjoic3VwcG9ydC1jaGF0LTctOTUwZGM1M2EtZ2VuIn0="
   }
+}
+```
+
+A separate example with `fields=core,basic,io,metadata,usage` shows a terminal page containing a root span with no recorded usage or cost. Empty usage, null cost, and an absent field have different meanings. The empty `meta` object means pagination is complete:
+
+```json
+{
+  "data": [
+    {
+      "id": "support-request-root",
+      "traceId": "support-request",
+      "startTime": "2025-12-17T16:09:00.000Z",
+      "endTime": "2025-12-17T16:09:01.500Z",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "parentObservationId": null,
+      "type": "SPAN",
+      "name": "support-request",
+      "level": "DEFAULT",
+      "statusMessage": "",
+      "version": "",
+      "environment": "default",
+      "bookmarked": false,
+      "public": false,
+      "userId": "",
+      "sessionId": "support-chat-session",
+      "isRootObservation": true,
+      "input": "{\"query\":\"Perfect.\"}",
+      "output": "{\"answer\":\"You are all set.\"}",
+      "metadata": {
+        "resourceAttributes.service.name": "support-api"
+      },
+      "usageDetails": {},
+      "inputUsage": 0,
+      "outputUsage": 0,
+      "totalUsage": 0,
+      "costDetails": {},
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": null,
+      "usagePricingTierName": null,
+      "modelId": null,
+      "inputPrice": null,
+      "outputPrice": null,
+      "totalPrice": null
+    }
+  ],
+  "meta": {}
 }
 ```
 

--- a/content/docs/observability/features/log-levels.mdx
+++ b/content/docs/observability/features/log-levels.mdx
@@ -162,16 +162,6 @@ When using the [LangChain Integration](/integrations/frameworks/langchain), `lev
 
 </LangTabs>
 
-## Root status and shutdown handling [#root-status-and-shutdown]
-
-When a root observation represents an application's overall result, record its outcome as well as its input/output. If downstream error triage reads the root's `level` and `statusMessage`, verify those fields on successful, failed, and interrupted runs.
-
-For custom exception or shutdown wrappers:
-
-- Preserve the application's failure classification. In Python, catching `BaseException` also catches control-flow exits: `SystemExit(0)` and `SystemExit(None)` should not become `ERROR` solely because they exit. Classify cancellation, interrupts, and SIGTERM according to whether the application completed, shut down normally, or failed.
-- When explicitly setting `level="ERROR"`, include a useful `status_message` (Python) or `statusMessage` (JS/TS). If the exception text is empty, include its type or another meaningful diagnostic.
-- Preserve more specific messages set by application handlers; generic cleanup must not replace them with an empty or less informative message. Keep exception propagation and shutdown behavior intact.
-
 ## Filter Trace by Log Level
 
 When viewing a single trace, you can filter the observations by log level.

--- a/content/docs/observability/features/log-levels.mdx
+++ b/content/docs/observability/features/log-levels.mdx
@@ -162,6 +162,16 @@ When using the [LangChain Integration](/integrations/frameworks/langchain), `lev
 
 </LangTabs>
 
+## Root status and shutdown handling [#root-status-and-shutdown]
+
+When a root observation represents an application's overall result, record its outcome as well as its input/output. If downstream error triage reads the root's `level` and `statusMessage`, verify those fields on successful, failed, and interrupted runs.
+
+For custom exception or shutdown wrappers:
+
+- Preserve the application's failure classification. In Python, catching `BaseException` also catches control-flow exits: `SystemExit(0)` and `SystemExit(None)` should not become `ERROR` solely because they exit. Classify cancellation, interrupts, and SIGTERM according to whether the application completed, shut down normally, or failed.
+- When explicitly setting `level="ERROR"`, include a useful `status_message` (Python) or `statusMessage` (JS/TS). If the exception text is empty, include its type or another meaningful diagnostic.
+- Preserve more specific messages set by application handlers; generic cleanup must not replace them with an empty or less informative message. Keep exception propagation and shutdown behavior intact.
+
 ## Filter Trace by Log Level
 
 When viewing a single trace, you can filter the observations by log level.

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -75,7 +75,7 @@ These mappings cover the latest Python SDK v4 and JS/TS SDK v5 method surfaces. 
 | JS/TS v5  | `client.api.legacy.observationsV1.get(observationId)`   | `client.api.observations.getMany({ filter: "<observation ID filter>", fromStartTime, toStartTime })`         |
 | JS/TS v5  | `client.fetchObservation(observationId)`                | `client.api.observations.getMany({ filter: "<observation ID filter>", fromStartTime, toStartTime })`         |
 
-There is no v2 single-observation getter; filter `get_many` / `getMany` by ID and take the matching row. Bound scans with a time range and follow cursor pagination. For a trace ID without a known timestamp, use the [ID-only lookup guidance](#trace-id-only-lookups). `client.fetchObservations(...)` is not listed because in JS/TS v5 it already calls Observations API v2.
+There is no v2 single-observation getter; filter `get_many` / `getMany` by ID and take the matching row. Bound scans with a time range and follow cursor pagination. `client.fetchObservations(...)` is not listed because in JS/TS v5 it already calls Observations API v2.
 
 ### Parameter mapping
 
@@ -145,11 +145,6 @@ curl \
 | JS/TS v5  | `client.fetchTrace(traceId)`     | `client.api.observations.getMany({ traceId, fromStartTime, toStartTime })`                    |
 
 These replacements return observation rows, not the legacy trace response shape. Group them by `traceId` and reconstruct trace-level fields as described below.
-
-
-For a known trace time range, include `fromStartTime` and `toStartTime` wide enough to cover the observations you need. If you only have a trace ID, for example from a trace URL, filter by that exact `traceId` and omit the unknown time bounds. Both parameters are optional on Observations API v2; an epoch-to-now range is unnecessary. In Python use `get_many(trace_id=trace_id)`; in JS/TS use `getMany({ traceId })`.
-
-Follow `meta.cursor` until no cursor is returned, keeping the same filters and field groups on each page. Omitting time bounds does not bypass project access, retention, or plan data-access limits. Continue to use bounded windows for scans across traces.
 
 ### Parameter mapping
 

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -75,24 +75,43 @@ These mappings cover the latest Python SDK v4 and JS/TS SDK v5 method surfaces. 
 | JS/TS v5  | `client.api.legacy.observationsV1.get(observationId)`   | `client.api.observations.getMany({ filter: "<observation ID filter>", fromStartTime, toStartTime })`         |
 | JS/TS v5  | `client.fetchObservation(observationId)`                | `client.api.observations.getMany({ filter: "<observation ID filter>", fromStartTime, toStartTime })`         |
 
-There is no v2 single-observation getter; filter `get_many` / `getMany` by ID and take the matching row. Always bound observation queries with a time range and follow cursor pagination. `client.fetchObservations(...)` is not listed because in JS/TS v5 it already calls Observations API v2.
+There is no v2 single-observation getter; filter `get_many` / `getMany` by ID and take the matching row. Bound scans with a time range and follow cursor pagination. For a trace ID without a known timestamp, use the [ID-only lookup guidance](#trace-id-only-lookups). `client.fetchObservations(...)` is not listed because in JS/TS v5 it already calls Observations API v2.
 
 ### Parameter mapping
 
-| Deprecated (v1)                                                                                                               | v2 equivalent                                                                        |
-| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `page`                                                                                                                        | `cursor` (from the previous response's `meta.cursor`)                                |
-| `limit` (default 50, max 100)                                                                                                 | `limit` (default 50, max 1,000)                                                      |
-| `GET /observations/{observationId}`                                                                                           | `filter` condition on the `id` column                                                |
-| `name`, `userId`, `type`, `traceId`, `level`, `parentObservationId`, `environment`, `version`, `fromStartTime`, `toStartTime` | Unchanged; always set `fromStartTime` and `toStartTime` to keep each request bounded |
-| -                                                                                                                             | `fields`: comma-separated field groups; defaults to `core,basic`                     |
+| Deprecated (v1)                                                                                                               | v2 equivalent                                                    |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `page`                                                                                                                        | `cursor` (from the previous response's `meta.cursor`)            |
+| `limit` (default 50, max 100)                                                                                                 | `limit` (default 50, max 1,000)                                  |
+| `GET /observations/{observationId}`                                                                                           | `filter` condition on the `id` column                            |
+| `name`, `userId`, `type`, `traceId`, `level`, `parentObservationId`, `environment`, `version`, `fromStartTime`, `toStartTime` | Unchanged; use time bounds for scans and known trace time ranges |
+| -                                                                                                                             | `fields`: comma-separated field groups; defaults to `core,basic` |
 
 ### Semantic differences
 
 - Responses include only the requested `fields` groups; fields from groups you did not request are **absent**, not `null`. One exception: `modelId`, `inputPrice`, `outputPrice`, and `totalPrice` are always present but `null` unless the `model` field group is requested.
+- Unknown `fields` groups are silently ignored. For example, `fields=core,basic,cost` can return HTTP 200 without cost fields; request `usage` for usage and costs.
+- Metadata keys are returned flat, including dotted keys such as `resourceAttributes.service.name`. Replace nested access such as `metadata.resourceAttributes["service.name"]` with access to the literal returned key, `metadata["resourceAttributes.service.name"]`. Values can still be structured; do not split every dotted key to reconstruct a nested object. See the [response examples](/docs/api-and-data-platform/features/observations-api#sample-response).
 - `input`/`output` are returned as raw strings; parse them in your pipeline when you need JSON (v1 parsed them automatically). The `parseIoAsJson` parameter is deprecated: omit it or set it to `false`; setting it to `true` returns a `400` error.
 - Pagination is cursor-based: pass `meta.cursor` from the previous response until no cursor is returned. Results are always sorted by `startTime` descending.
 - When the `model` group is requested, `inputPrice`, `outputPrice`, and `totalPrice` are returned as strings (e.g. `"0.000005"`) to preserve decimal precision; cast them to a numeric type in your pipeline.
+
+### Response-field mapping [#observation-response-fields]
+
+These are JSON wire names; SDKs may expose language-specific names, such as Python's `total_cost`. Update downstream readers and fixtures as well as the request method.
+
+| Deprecated v1 response field       | v2 response field                                                     | Field group |
+| ---------------------------------- | --------------------------------------------------------------------- | ----------- |
+| `usage.input`, `promptTokens`      | `inputUsage`                                                          | `usage`     |
+| `usage.output`, `completionTokens` | `outputUsage`                                                         | `usage`     |
+| `usage.total`, `totalTokens`       | `totalUsage`                                                          | `usage`     |
+| `calculatedInputCost`              | `inputCost`                                                           | `usage`     |
+| `calculatedOutputCost`             | `outputCost`                                                          | `usage`     |
+| `calculatedTotalCost`              | `totalCost`                                                           | `usage`     |
+| `usage.unit`, `unit`               | Removed; no direct replacement                                        | —           |
+| `usageDetails`, `costDetails`      | Unchanged; preserve these maps for detailed usage and cost breakdowns | `usage`     |
+
+The legacy `usage` object is absent in v2. A row with no recorded usage can have `usageDetails: {}` and zero usage totals. A row with no recorded cost can have `costDetails: {}` and `totalCost: null`. Neither is the same as a missing field because `usage` was not requested, and `null` cost does not establish that the operation was free. Test cost readers with a known priced generation so a missing field cannot silently become zero.
 
 ### Example
 
@@ -126,6 +145,12 @@ curl \
 | JS/TS v5  | `client.fetchTrace(traceId)`     | `client.api.observations.getMany({ traceId, fromStartTime, toStartTime })`                    |
 
 These replacements return observation rows, not the legacy trace response shape. Group them by `traceId` and reconstruct trace-level fields as described below.
+
+### Trace ID without a timestamp [#trace-id-only-lookups]
+
+For a known trace time range, include `fromStartTime` and `toStartTime` wide enough to cover the observations you need. If you only have a trace ID, for example from a trace URL, filter by that exact `traceId` and omit the unknown time bounds. Both parameters are optional on Observations API v2; an epoch-to-now range is unnecessary. In Python use `get_many(trace_id=trace_id)`; in JS/TS use `getMany({ traceId })`.
+
+Follow `meta.cursor` until no cursor is returned, keeping the same filters and field groups on each page. Omitting time bounds does not bypass project access, retention, or plan data-access limits. Continue to use bounded windows for scans across traces.
 
 ### Parameter mapping
 

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -146,7 +146,6 @@ curl \
 
 These replacements return observation rows, not the legacy trace response shape. Group them by `traceId` and reconstruct trace-level fields as described below.
 
-### Trace ID without a timestamp [#trace-id-only-lookups]
 
 For a known trace time range, include `fromStartTime` and `toStartTime` wide enough to cover the observations you need. If you only have a trace ID, for example from a trace URL, filter by that exact `traceId` and omit the unknown time bounds. Both parameters are optional on Observations API v2; an epoch-to-now range is unnecessary. In Python use `get_many(trace_id=trace_id)`; in JS/TS use `getMany({ traceId })`.
 


### PR DESCRIPTION
Document the v2 observation response-field mappings, literal dotted metadata keys, ignored field groups, and valid empty usage/null costs so migrations update downstream readers as well as request methods. Populate the generation example with OTEL resource attributes and clarify that scans and known trace ranges should use time bounds.

Validation: current-head CI is green, including formatting, H1 checks, production build/link checks, sitemap checks, and Vercel preview. Local validation before review included Node.js 22 formatting, MDX compilation, generated Markdown checks, and response JSON/cursor consistency. No live project reads were performed.

Publish these docs before https://github.com/langfuse/skills/pull/111, which directs agents to the response contract and examples.

Linear: https://linear.app/clickhouse/issue/LFE-16083/close-v4-migration-response-contract-and-verification-gaps
