### PR TITLE
fix(seo): collapse redirect chains and stop shared components linking through them

### DIFF
--- a/components-mdx/datasets-create-dataset-item.mdx
+++ b/components-mdx/datasets-create-dataset-item.mdx
@@ -37,7 +37,7 @@ langfuse.create_dataset_item(
 )
 ```
 
-_See [Python SDK](/docs/sdk/python/sdk-v3) docs for details on how to initialize the Python client._
+_See [Python SDK](/docs/observability/sdk/overview) docs for details on how to initialize the Python client._
 
 </Tab>
 <Tab>
@@ -86,7 +86,7 @@ await langfuse.dataset.createItem({
 });
 ```
 
-_See [JS/TS SDK](/docs/sdk/typescript/guide) docs for details on how to initialize the JS/TS client._
+_See [JS/TS SDK](/docs/observability/sdk/overview) docs for details on how to initialize the JS/TS client._
 
 </Tab>
 
@@ -120,7 +120,7 @@ _See [JS/TS SDK](/docs/sdk/typescript/guide) docs for details on how to initiali
 </Tab>
 
 <Tab>
-  Select multiple observations from the **Observations** table, then click **Actions** → **Add to dataset**. You can create a new dataset or add to an existing one, with flexible field mapping options to control how observation data maps to dataset items. See [Batch add observations to datasets](/docs/datasets#batch-add-observations-to-datasets) for details.
+  Select multiple observations from the **Observations** table, then click **Actions** → **Add to dataset**. You can create a new dataset or add to an existing one, with flexible field mapping options to control how observation data maps to dataset items. See [Batch add observations to datasets](/docs/evaluation/experiments/datasets#batch-add-observations-to-datasets) for details.
 </Tab>
 
 </Tabs>

--- a/components-mdx/datasets-create-dataset.mdx
+++ b/components-mdx/datasets-create-dataset.mdx
@@ -15,7 +15,7 @@ langfuse.create_dataset(
 )
 ```
 
-_See [Python SDK](/docs/sdk/python/sdk-v3) docs for details on how to initialize the Python client._
+_See [Python SDK](/docs/observability/sdk/overview) docs for details on how to initialize the Python client._
 
 </Tab>
 <Tab>

--- a/components-mdx/get-started/next-steps.mdx
+++ b/components-mdx/get-started/next-steps.mdx
@@ -12,32 +12,32 @@ import {
 <Cards num={2}> 
   <Cards.Card
     title="Manage prompts in Langfuse"
-    href="/docs/prompts/get-started"
+    href="/docs/prompt-management/get-started"
     icon={<FileText />}
   />
   <Cards.Card
     title="Add evaluation scores"
-    href="/docs/evaluation/features/evaluation-methods/custom-scores"
+    href="/docs/evaluation/evaluation-methods/scores-via-sdk"
     icon={<ClipboardCheck />}
   />
   <Cards.Card
     title="Run LLM-as-a-judge Evaluators"
-    href="/docs/scores/model-based-evals"
+    href="/docs/evaluation/evaluation-methods/llm-as-a-judge"
     icon={<Scale />}
   />
   <Cards.Card
     title="Create datasets"
-    href="/docs/datasets/overview"
+    href="/docs/evaluation/experiments/datasets"
     icon={<Database />}
   />
   <Cards.Card
     title="Create custom dashboards"
-    href="/docs/analytics/custom-dashboards"
+    href="/docs/metrics/features/custom-dashboards"
     icon={<LayoutDashboard />}
   />
   <Cards.Card
     title="Test queries in the Playground"
-    href="/docs/playground"
+    href="/docs/prompt-management/features/playground"
     icon={<TestTube />}
   />
 </Cards>

--- a/components-mdx/observability-core-features.mdx
+++ b/components-mdx/observability-core-features.mdx
@@ -20,32 +20,32 @@ import {
 <Cards num={2}>
   <Card
     title="Sessions"
-    href="/docs/tracing-features/sessions"
+    href="/docs/observability/features/sessions"
     icon={<MessagesSquare />}
     arrow
   />
   <Card
     title="Users"
-    href="/docs/tracing-features/users"
+    href="/docs/observability/features/users"
     icon={<Users />}
     arrow
   />
   <Card
     title="Environments"
-    href="/docs/tracing-features/environments"
+    href="/docs/observability/features/environments"
     icon={<MapPin />}
     arrow
   />
-  <Card title="Tags" href="/docs/tracing-features/tags" icon={<Tag />} arrow />
+  <Card title="Tags" href="/docs/observability/features/tags" icon={<Tag />} arrow />
   <Card
     title="Metadata"
-    href="/docs/tracing-features/metadata"
+    href="/docs/observability/features/metadata"
     icon={<Braces />}
     arrow
   />
   <Card
     title="Trace IDs"
-    href="/docs/tracing-features/trace-ids"
+    href="/docs/observability/features/trace-ids-and-distributed-tracing"
     icon={<FileDigit />}
     arrow
   />

--- a/components-mdx/prompt-linking.mdx
+++ b/components-mdx/prompt-linking.mdx
@@ -3,7 +3,7 @@
 
 For generations created with the Langfuse Python SDK, pass the prompt directly to the generation using the `prompt` keyword argument. This links the prompt only to the intended generation and is the recommended approach.
 
-You can set the prompt on a specific generation with one of the following Langfuse Python SDK methods. For more information, see the [SDK documentation](/docs/observability/sdk/python/instrumentation).
+You can set the prompt on a specific generation with one of the following Langfuse Python SDK methods. For more information, see the [SDK documentation](/docs/observability/sdk/instrumentation).
 
 **Decorators**
 
@@ -129,7 +129,7 @@ This also works with the OpenAI Agents SDK and OpenInference instrumentations ex
 
 <Tab>
 
-There are three ways to create traces with the Langfuse JS/TS SDK. For more information, see the [SDK documentation](/docs/observability/sdk/typescript/instrumentation).
+There are three ways to create traces with the Langfuse JS/TS SDK. For more information, see the [SDK documentation](/docs/observability/sdk/instrumentation).
 
 **Observe wrapper**
 

--- a/components-mdx/self-host-help-footer.mdx
+++ b/components-mdx/self-host-help-footer.mdx
@@ -3,7 +3,7 @@
 If you experience any issues when self-hosting Langfuse, please:
 
 1. Check out [Troubleshooting & FAQ](/self-hosting/troubleshooting-and-faq) page.
-2. Use [Ask AI](/ask-ai) to get instant answers to your questions.
+2. Use [Ask AI](/docs/ask-ai) to get instant answers to your questions.
 3. Ask the maintainers on [GitHub Discussions](/gh-support).
 4. Create a bug report or feature request on [GitHub](/issues).
 

--- a/components/NavLinks.tsx
+++ b/components/NavLinks.tsx
@@ -47,7 +47,7 @@ const productFeatured: FeaturedItem = {
   title: "Get Started with Tracing",
   description: "This guide walks you through ingesting your first trace.",
   cta: "Read docs",
-  href: "/docs/get-started",
+  href: "/docs/observability/get-started",
 };
 
 const resourcesFeatured: FeaturedItem = {

--- a/components/VersionTimeline.tsx
+++ b/components/VersionTimeline.tsx
@@ -50,7 +50,7 @@ const ROWS: { id: string; name: string; segments: Segment[] }[] = [
         label: "v3 + v4 preview",
         from: { year: 2026, month: 3 },
         to: { year: 2026, month: 11 },
-        href: "/docs/v4",
+        href: "/changelog/2026-08-17-langfuse-v4",
         title:
           "Since March 10, 2026: Langfuse v3 with all v4 features available in the Langfuse v4 preview",
         className: SEGMENT_STYLES.preview,
@@ -59,7 +59,7 @@ const ROWS: { id: string; name: string; segments: Segment[] }[] = [
         label: "v4",
         from: { year: 2026, month: 11 },
         to: AXIS_END,
-        href: "/docs/v4",
+        href: "/changelog/2026-08-17-langfuse-v4",
         title: `On ${V4_CUTOVER_DATE_LONG}, Langfuse Cloud switches to v4 as the only experience and legacy APIs, features, and ingestion are removed`,
         className: SEGMENT_STYLES.ga,
       },

--- a/components/home/AllTheTools.tsx
+++ b/components/home/AllTheTools.tsx
@@ -30,7 +30,7 @@ const tools: ToolEntry[] = [
     title: "Observability",
     description:
       "Hierarchical traces capture every LLM call, tool invocation, and retrieval step. Filter by user, session, cost, latency, or custom metadata.",
-    href: "/docs/tracing",
+    href: "/docs/observability/overview",
     tooltip: "Read more",
     span: "col-span-1",
     visual: observabilityVisual as StaticImageData,
@@ -39,7 +39,7 @@ const tools: ToolEntry[] = [
     title: "Evaluation",
     description:
       "LLM-as-a-judge, heuristic functions, or human review. Run evaluators on production data or during experiments.",
-    href: "/docs/scores",
+    href: "/docs/evaluation/overview",
     tooltip: "Read more",
     span: "col-span-1",
     visual: evaluationVisual,
@@ -48,7 +48,7 @@ const tools: ToolEntry[] = [
     title: "Prompt Management",
     description:
       "Separate prompts from code with one-click deployments and rollbacks. Turn improving your production prompts a team sport.",
-    href: "/docs/prompts",
+    href: "/docs/prompt-management/get-started",
     tooltip: "Read more",
     span: "col-span-1",
     visual: promptManagementVisual as StaticImageData,
@@ -57,7 +57,7 @@ const tools: ToolEntry[] = [
     title: "Playground",
     description:
       "Test prompts on real production inputs and compare models side-by-side.",
-    href: "/docs/playground",
+    href: "/docs/prompt-management/features/playground",
     tooltip: "Read more",
     span: "col-span-1",
     visual: playgroundVisual as StaticImageData,
@@ -66,7 +66,7 @@ const tools: ToolEntry[] = [
     title: "Experiments",
     description:
       "Define test cases and run experiments. Compare results side by side.",
-    href: "/docs/experimentation",
+    href: "/docs/evaluation/experiments/datasets",
     tooltip: "Read more",
     span: "col-span-1",
     visual: experimentsVisual as StaticImageData,
@@ -84,7 +84,7 @@ const tools: ToolEntry[] = [
     title: "Cost & Latency",
     description:
       "Monitor cost, latency, and quality with dashboards and automated alerts.",
-    href: "/docs/analytics",
+    href: "/docs/metrics/overview",
     tooltip: "Read more",
     span: "col-span-1",
     visual: metricsAlertsVisual as StaticImageData,

--- a/components/home/Enterprise.tsx
+++ b/components/home/Enterprise.tsx
@@ -39,7 +39,7 @@ const openApis = [
   { label: "90B+ observations processed per month" },
   {
     label: `${formatCompanyCount()} companies using Langfuse`,
-    href: "/why",
+    href: "/handbook/chapters/why",
   },
   { label: "99.9% uptime" },
 ];

--- a/components/home/FAQ.tsx
+++ b/components/home/FAQ.tsx
@@ -13,7 +13,7 @@ const faqs: FAQItem[] = [
   {
     question: "What does Langfuse help me with?",
     answer:
-      "Langfuse helps you [debug LLM applications](/docs/observability/overview) with detailed traces that capture every step of your AI pipeline, including [agent graphs](/docs/observability/features/agent-graphs). You can [manage and version your prompts](/docs/prompt-management/overview) collaboratively, run [automated evaluations](/docs/evaluation/evaluation-methods/llm-as-a-judge) (including LLM-as-a-judge and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators)), track [costs and latency](/docs/observability/features/token-and-cost-tracking) across models and providers, and run [experiments on datasets](/docs/evaluation/experiments/overview) to measure improvements before shipping. It also supports [custom dashboards](/docs/metrics/features/custom-dashboards) for team-wide visibility.",
+      "Langfuse helps you [debug LLM applications](/docs/observability/overview) with detailed traces that capture every step of your AI pipeline, including [agent graphs](/docs/observability/features/agent-graphs). You can [manage and version your prompts](/docs/prompt-management/overview) collaboratively, run [automated evaluations](/docs/evaluation/evaluation-methods/llm-as-a-judge) (including LLM-as-a-judge and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators)), track [costs and latency](/docs/observability/features/token-and-cost-tracking) across models and providers, and run [experiments on datasets](/docs/evaluation/experiments/datasets) to measure improvements before shipping. It also supports [custom dashboards](/docs/metrics/features/custom-dashboards) for team-wide visibility.",
   },
   {
     question: "Can I use just tracing without the other features?",
@@ -23,7 +23,7 @@ const faqs: FAQItem[] = [
   {
     question: "What deployment options do exist?",
     answer:
-      "Langfuse is available as a [managed cloud service](https://cloud.langfuse.com) in [US and EU regions](/security), or you can [self-host](/self-hosting) it on your own infrastructure using [Docker Compose](/self-hosting/deployment/docker-compose), [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), or Terraform templates for [AWS](/self-hosting/deployment/aws), [GCP](/self-hosting/deployment/gcp), and [Azure](/self-hosting/deployment/azure). The self-hosted version includes all product features under the [MIT license](/open-source). For teams needing additional support and compliance, there is a [self-hosted Enterprise plan](/pricing-self-host).",
+      "Langfuse is available as a [managed cloud service](https://cloud.langfuse.com) in [US and EU regions](/security), or you can [self-host](/self-hosting) it on your own infrastructure using [Docker Compose](/self-hosting/deployment/docker-compose), [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), or Terraform templates for [AWS](/self-hosting/deployment/aws), [GCP](/self-hosting/deployment/gcp), and [Azure](/self-hosting/deployment/azure). The self-hosted version includes all product features under the [MIT license](/handbook/chapters/open-source). For teams needing additional support and compliance, there is a [self-hosted Enterprise plan](/pricing-self-host).",
   },
   {
     question: "Is self-hosting actually free?",

--- a/components/home/feature-tabs/data.ts
+++ b/components/home/feature-tabs/data.ts
@@ -276,7 +276,7 @@ const result = await langfuse.experiment.run({
     title: "Collaborate on human reviews",
     subtitle: "Add manual feedback and corrections.",
     body: "Create manual annotations to provide feedback, corrections, and improvements to your LLM outputs. Use annotations to build high-quality datasets and set a baseline for automated evals.",
-    docsHref: "/docs/evaluation/evaluation-methods/annotation",
+    docsHref: "/docs/evaluation/evaluation-methods/scores-via-ui",
     image: {
       light: AnnotationPng,
       dark: AnnotationPng,

--- a/components/home/pricing/PricingFAQ.tsx
+++ b/components/home/pricing/PricingFAQ.tsx
@@ -20,7 +20,7 @@ const faqs: FAQItem[] = [
   {
     question: "What is the easiest way to try Langfuse?",
     answer:
-      "You can view the [public example project](/demo) or sign up for a [free account](/cloud) to try Langfuse with your own data. The Hobby plan is completely free and does not require a credit card.",
+      "You can view the [public example project](/docs/demo) or sign up for a [free account](/cloud) to try Langfuse with your own data. The Hobby plan is completely free and does not require a credit card.",
   },
   {
     question: "Can I self-host Langfuse for free?",

--- a/components/home/pricing/PricingTable.tsx
+++ b/components/home/pricing/PricingTable.tsx
@@ -356,7 +356,7 @@ const sections: Section[] = [
         name: "OpenTelemetry (Java, Go, custom)",
         description:
           "Use Langfuse as an OpenTelemetry backend. Thereby you can use any OpenTelemetry compatible SDKs (Java, Go, etc.) to send traces to Langfuse. This also increases compatibility with many frameworks and LLM providers.",
-        href: "/docs/opentelemetry/get-started",
+        href: "/integrations/native/opentelemetry",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -372,7 +372,7 @@ const sections: Section[] = [
       },
       {
         name: "Custom via API",
-        href: "/api-and-data-platform/features/public-api",
+        href: "/docs/api-and-data-platform/features/public-api",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -548,7 +548,7 @@ const sections: Section[] = [
       {
         name: "Prompt Experiments",
         description: "Run structured experiments on new prompt versions",
-        href: "/docs/evaluation/dataset-runs/native-run",
+        href: "/docs/evaluation/experiments/experiments-via-ui",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -588,7 +588,7 @@ const sections: Section[] = [
         name: "Datasets",
         description:
           "Create and manage datasets of inputs and expected outputs. These can be created from production traces, manually in the UI, or uploaded via the SDK/UI. Datasets are the baseline for offline evaluation.",
-        href: "/docs/evaluation/dataset-runs/datasets",
+        href: "/docs/evaluation/experiments/datasets",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -616,7 +616,7 @@ const sections: Section[] = [
       },
       {
         name: "Evaluation Scores (custom)",
-        href: "/docs/evaluation/evaluation-methods/custom-scores",
+        href: "/docs/evaluation/evaluation-methods/scores-via-sdk",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -624,7 +624,7 @@ const sections: Section[] = [
       },
       {
         name: "User Feedback Tracking",
-        href: "/faq/all/user-feedback",
+        href: "/docs/observability/features/user-feedback",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -656,7 +656,7 @@ const sections: Section[] = [
       {
         name: "Human Annotation",
         description: "Manually annotate LLM traces in Langfuse",
-        href: "/docs/scores/annotation",
+        href: "/docs/evaluation/evaluation-methods/scores-via-ui",
         tiers: {
           cloud: { Hobby: true, Core: true, Pro: true, Enterprise: true },
           selfHosted: { "Open Source": true, Enterprise: true },
@@ -665,7 +665,7 @@ const sections: Section[] = [
       {
         name: "Human Annotation Queues",
         description: "Managed human annotation workflows with queues",
-        href: "/docs/evaluation/evaluation-methods/annotation#annotation-queues",
+        href: "/docs/evaluation/evaluation-methods/annotation-queues",
         tiers: {
           cloud: {
             Hobby: "1 queue",
@@ -1088,7 +1088,7 @@ const sections: Section[] = [
   },
   {
     name: "Security",
-    href: "/docs/security",
+    href: "/docs/security-and-guardrails",
     features: [
       {
         name: "Data region",

--- a/components/integrations/IntegrationIndex.tsx
+++ b/components/integrations/IntegrationIndex.tsx
@@ -35,12 +35,12 @@ const categoryConfig: Record<
         title: "API",
       },
       {
-        route: "/docs/sdk/python/sdk-v3",
+        route: "/docs/observability/sdk/overview",
         frontMatter: { title: "Python SDK" },
         title: "Python SDK",
       },
       {
-        route: "/docs/sdk/typescript/guide",
+        route: "/docs/observability/sdk/overview",
         frontMatter: { title: "JS/TS SDK" },
         title: "JS/TS SDK",
       },

--- a/components/japan/JapanLanding.tsx
+++ b/components/japan/JapanLanding.tsx
@@ -996,7 +996,7 @@ function FAQ() {
           </h2>
           <p className="japan-body-sm mt-3.5">
             載っていないことがあれば、
-            <Link className="japan-link" href="/ask-ai">
+            <Link className="japan-link" href="/docs/ask-ai">
               AIに質問
             </Link>
             、

--- a/components/layout/Banner.tsx
+++ b/components/layout/Banner.tsx
@@ -7,7 +7,7 @@ export function Banner() {
       height="2rem"
       className="bg-black text-white [&_a]:text-white"
     >
-      <Link href="/docs/v4">
+      <Link href="/changelog/2026-08-17-langfuse-v4">
         <span className="sm:hidden">
           Langfuse v4: up to 165× faster ·{" "}
           <span className="underline underline-offset-2">Read more</span>

--- a/components/watchOrBookDemo/constants.ts
+++ b/components/watchOrBookDemo/constants.ts
@@ -26,7 +26,7 @@ export const WALKTHROUGH_TABS = [
     cta: "Any questions after watching this video? Check out the resources at the bottom of the page, or reach out to us.",
     docs: {
       title: "Observability documentation",
-      href: "/docs/observability",
+      href: "/docs/observability/overview",
     },
   },
   {
@@ -40,7 +40,7 @@ export const WALKTHROUGH_TABS = [
     cta: "Any questions after watching this video? Check out the resources at the bottom of the page, or reach out to us.",
     docs: {
       title: "Prompt Management documentation",
-      href: "/docs/prompt-management",
+      href: "/docs/prompt-management/overview",
     },
   },
   {
@@ -54,7 +54,7 @@ export const WALKTHROUGH_TABS = [
     cta: "Any questions after watching this video? Check out the resources at the bottom of the page, or reach out to us.",
     docs: {
       title: "Evaluation documentation",
-      href: "/docs/evaluation",
+      href: "/docs/evaluation/overview",
     },
   },
 ];

--- a/lib/integrations-meta.ts
+++ b/lib/integrations-meta.ts
@@ -5,11 +5,11 @@
 type MetaEntry = { href?: string; title?: string; logo?: string };
 export const nativeIntegrationsMeta: Record<string, MetaEntry> = {
   "python-sdk": {
-    href: "/docs/sdk/python/sdk-v3",
+    href: "/docs/observability/sdk/overview",
     title: "Python SDK",
   },
   "js-ts-sdk": {
-    href: "/docs/sdk/typescript/guide",
+    href: "/docs/observability/sdk/overview",
     title: "JS/TS SDK",
   },
   "mcp-server": {

--- a/lib/markdown-component-renderers.js
+++ b/lib/markdown-component-renderers.js
@@ -838,7 +838,7 @@ function renderProductUpdateSignup(attributes) {
 function renderVersionTimeline(attributes) {
   const cloudOnly = /\bdeployments=\{\["cloud"\]\}/.test(attributes);
   const lines = [
-    `- [Langfuse Cloud](/docs/v4): v3 and the v4 preview run side by side until ${V4_CUTOVER_DATE_LONG}. From then, Langfuse Cloud is v4-only and legacy APIs, features, and ingestion are removed.`,
+    `- [Langfuse Cloud](/changelog/2026-08-17-langfuse-v4): v3 and the v4 preview run side by side until ${V4_CUTOVER_DATE_LONG}. From then, Langfuse Cloud is v4-only and legacy APIs, features, and ingestion are removed.`,
   ];
 
   if (!cloudOnly) {

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -67,7 +67,7 @@ const nonPermanentRedirects = [
   ["/sticker", "https://forms.gle/Af5BHpWUMZSCT4kg8?_imcp=1"],
   ["/ask-ai", "/docs/ask-ai"],
   ["/cloud-ai", "/cloud"],
-  ["/docs/sso", "/self-hosting/authentication-and-sso"],
+  ["/docs/sso", "/self-hosting/security/authentication-and-sso"],
   ["/billing-portal", "https://billing.stripe.com/p/login/6oE9BXd4u8PR2aYaEE"],
   ["/docs/data-security-privacy", "/security"],
   ["/baa", "/security/hipaa"],
@@ -83,11 +83,11 @@ const nonPermanentRedirects = [
   ],
   ["/discussions", "https://github.com/orgs/langfuse/discussions"],
   ["/gh-discussions", "https://github.com/orgs/langfuse/discussions"],
-  ["/docs/analytics", "/docs/analytics/overview"],
+  ["/docs/analytics", "/docs/metrics/overview"],
   ["/request-trial", "https://forms.gle/cXZuQZLmzJp8yd9k7"],
   ["/request-security-docs", "https://forms.gle/o5JE7vWtX7Qk2syc8"],
   ["/event", "/events"],
-  ["/public-metrics-dashboard", "/why#public-metrics"],
+  ["/public-metrics-dashboard", "/handbook/chapters/why#public-metrics"],
   [
     "/pricing-comparison-sheet",
     "https://docs.google.com/spreadsheets/d/1uCPPGwwgNMstF743UWa5OWWD4JzEFCJOk6dt31a3gXI/edit?usp=sharing",
@@ -105,10 +105,6 @@ const nonPermanentRedirects = [
 
   // Redirect to overview pages
   ...[
-    "/docs/integrations",
-    "/docs/scores",
-    "/docs/datasets",
-    "/docs/security",
     "/docs/observability",
     "/docs/evaluation",
     "/docs/metrics",
@@ -116,93 +112,112 @@ const nonPermanentRedirects = [
     "/docs/prompt-management",
   ].map((path) => [path, path + "/overview"]),
 
+  // These four used to go through `/overview` too, but those overview pages
+  // have since moved, so they point at the current page directly.
+  ["/docs/integrations", "/integrations"],
+  ["/docs/scores", "/docs/evaluation/overview"],
+  ["/docs/datasets", "/docs/evaluation/experiments/datasets"],
+  ["/docs/security", "/docs/security-and-guardrails"],
+
   // OLD docs redirects
 
-  ["/docs/admin-api", "/docs/api#org-scoped-routes"],
-  ["/docs/reference", "https://api.reference.langfuse.com/"],
-  ["/docs/integrations/api", "/docs/api"],
-  ["/docs/integrations/sdk/typescript", "/docs/sdk/typescript"],
-  ["/docs/integrations/sdk/python", "/docs/observability/sdk/overview"],
-  ["/docs/langchain", "/docs/integrations/langchain/tracing"],
-  ["/docs/langchain/python", "/docs/integrations/langchain/tracing"],
-  ["/docs/langchain/typescript", "/docs/integrations/langchain/tracing"],
-  ["/docs/integrations/vercel", "/docs/integrations/vercel-ai-sdk"],
-  ["/docs/integrations/livekit", "/integrations/frameworks/livekit"],
-  ["/docs/integrations/langchain", "/docs/integrations/langchain/tracing"],
   [
-    "/docs/integrations/langchain/python",
-    "/docs/integrations/langchain/tracing",
+    "/docs/admin-api",
+    "/docs/api-and-data-platform/features/public-api#org-scoped-routes",
   ],
+  ["/docs/reference", "https://api.reference.langfuse.com/"],
+  ["/docs/integrations/api", "/docs/api-and-data-platform/features/public-api"],
+  ["/docs/integrations/sdk/typescript", "/docs/observability/sdk/overview"],
+  ["/docs/integrations/sdk/python", "/docs/observability/sdk/overview"],
+  ["/docs/langchain", "/integrations/frameworks/langchain"],
+  ["/docs/langchain/python", "/integrations/frameworks/langchain"],
+  ["/docs/langchain/typescript", "/integrations/frameworks/langchain"],
+  ["/docs/integrations/vercel", "/integrations/frameworks/vercel-ai-sdk"],
+  ["/docs/integrations/livekit", "/integrations/frameworks/livekit"],
+  ["/docs/integrations/langchain", "/integrations/frameworks/langchain"],
+  ["/docs/integrations/langchain/python", "/integrations/frameworks/langchain"],
   [
     "/docs/integrations/langchain/typescript",
-    "/docs/integrations/langchain/tracing",
+    "/integrations/frameworks/langchain",
   ],
   [
     "/docs/integrations/langchain/overview",
-    "/docs/integrations/langchain/tracing",
+    "/integrations/frameworks/langchain",
   ],
   [
     "/docs/integrations/langchain/get-started",
-    "/docs/integrations/langchain/tracing",
+    "/integrations/frameworks/langchain",
   ],
-  [
-    "/docs/integrations/llama-index",
-    "/docs/integrations/llama-index/get-started",
-  ],
+  ["/docs/integrations/llama-index", "/integrations/frameworks/llamaindex"],
   [
     "/docs/integrations/llama-index/overview",
-    "/docs/integrations/llama-index/get-started",
+    "/integrations/frameworks/llamaindex",
   ],
   [
     "/docs/integrations/llama-index/cookbook",
-    "/docs/integrations/llama-index/get-started",
+    "/integrations/frameworks/llamaindex",
   ],
   [
     "/docs/integrations/llama-index/example-python",
-    "/docs/integrations/llama-index/get-started",
+    "/integrations/frameworks/llamaindex",
   ],
-  ["/docs/integrations/haystack", "/docs/integrations/haystack/get-started"],
+  ["/docs/integrations/haystack", "/integrations/frameworks/haystack"],
   [
     "/docs/integrations/openai/get-started",
-    "/docs/integrations/openai/python/get-started",
+    "/integrations/model-providers/openai-py",
   ],
   [
     "/docs/integrations/openai/examples",
-    "/docs/integrations/openai/python/examples",
+    "/integrations/model-providers/openai-py",
   ],
   [
     "/docs/integrations/openai/track-errors",
-    "/docs/integrations/openai/python/track-errors",
+    "/integrations/model-providers/openai-py",
   ],
   [
     "/docs/integrations/openai/python",
-    "/docs/integrations/openai/python/get-started",
+    "/integrations/model-providers/openai-py",
   ],
-  ["/docs/integrations/openai/js", "/docs/integrations/openai/js/get-started"],
-  ["/docs/integrations/mirascope", "/docs/integrations/mirascope/tracing"],
-  ["/docs/integrations/aws-bedrock", "/docs/integrations/amazon-bedrock"],
-  ["/docs/opentelemetry/example-pydantic-ai", "/docs/integrations/pydantic-ai"],
-  ["/docs/opentelemetry", "/docs/opentelemetry/get-started"],
-  ["/docs/integrations/other/vapi", "/docs/integrations/vapi"],
-  ["/docs/integrations/other/autogen", "/docs/integrations/autogen"],
-  ["/docs/flowise", "/docs/integrations/flowise"],
-  ["/docs/litellm", "/docs/integrations/litellm/tracing"],
+  ["/docs/integrations/openai/js", "/integrations/model-providers/openai-js"],
+  ["/docs/integrations/mirascope", "/integrations/frameworks/mirascope"],
+  [
+    "/docs/integrations/aws-bedrock",
+    "/integrations/model-providers/amazon-bedrock",
+  ],
+  [
+    "/docs/opentelemetry/example-pydantic-ai",
+    "/integrations/frameworks/pydantic-ai",
+  ],
+  ["/docs/opentelemetry", "/integrations/native/opentelemetry"],
+  ["/docs/integrations/other/vapi", "/integrations/no-code/vapi"],
+  ["/docs/integrations/other/autogen", "/integrations/frameworks/autogen"],
+  ["/docs/flowise", "/integrations/no-code/flowise"],
+  ["/docs/litellm", "/integrations/gateways/litellm"],
   ["/docs/integrations/opentelemetry", "/integrations/native/opentelemetry"],
-  ["/docs/integrations/litellm", "/docs/integrations/litellm/tracing"],
-  ["/docs/langflow", "/docs/integrations/langflow"],
-  ["/docs/local", "/docs/deployment/local"],
-  ["/docs/self-host", "/docs/deployment/self-host"],
-  ["/docs/cloud", "/docs/deployment/cloud"],
-  ["/docs/guides/sdk-integration", "/docs/sdk/overview"],
-  ["/docs/sdk", "/docs/sdk/overview"],
+  ["/docs/integrations/litellm", "/integrations/gateways/litellm"],
+  ["/docs/langflow", "/integrations/no-code/langflow"],
+  ["/docs/local", "/self-hosting/deployment/docker-compose"],
+  ["/docs/self-host", "/self-hosting"],
+  ["/docs/cloud", "/security"],
+  ["/docs/guides/sdk-integration", "/docs/observability/sdk/overview"],
+  ["/docs/sdk", "/docs/observability/sdk/overview"],
   ["/docs/sdk/python", "/docs/observability/sdk/overview"],
   ["/cookbook", "/guides"],
   ["/cookbook/:path*", "/guides/cookbook/:path*"],
-  ["/docs/sdk/typescript", "/docs/sdk/typescript/guide"],
-  ["/docs/sdk/typescript-web", "/docs/sdk/typescript/guide-web"],
-  ["/docs/scores/evals", "/docs/scores/model-based-evals"],
-  ["/docs/scores/manually", "/docs/scores/annotation"],
-  ["/docs/scores/model-based-evals/overview", "/docs/scores/model-based-evals"],
+  ["/docs/sdk/typescript", "/docs/observability/sdk/overview"],
+  [
+    "/docs/sdk/typescript-web",
+    "/docs/observability/sdk/advanced-features#custom-scores-from-browser",
+  ],
+  ["/docs/scores/evals", "/docs/evaluation/evaluation-methods/llm-as-a-judge"],
+  [
+    "/docs/scores/manually",
+    "/docs/evaluation/evaluation-methods/scores-via-ui",
+  ],
+  [
+    "/docs/scores/model-based-evals/overview",
+    "/docs/evaluation/evaluation-methods/llm-as-a-judge",
+  ],
   [
     "/docs/scores/model-based-evals/ragas",
     "/resources/engineering/evaluation-of-rag-with-ragas",
@@ -211,47 +226,56 @@ const nonPermanentRedirects = [
     "/docs/scores/model-based-evals/langchain",
     "/guides/cookbook/example_external_evaluation_pipelines",
   ],
-  ["/docs/scores/getting-started", "/docs/scores/overview"],
-  ["/experimentation", "/docs/datasets/overview"],
-  ["/docs/experimentation", "/docs/datasets/overview"],
-  ["/docs/token-usage", "/docs/model-usage-and-cost"],
-  ["/docs/debugging-ui", "/docs/tracing"],
-  ["/observability", "/docs/tracing"],
-  ["/docs/openai", "/docs/integrations/openai/get-started"],
-  ["/docs/integrations/openai", "/docs/integrations/openai/get-started"],
+  ["/docs/scores/getting-started", "/docs/evaluation/overview"],
+  ["/experimentation", "/docs/evaluation/experiments/datasets"],
+  ["/docs/experimentation", "/docs/evaluation/experiments/datasets"],
+  ["/docs/token-usage", "/docs/observability/features/token-and-cost-tracking"],
+  ["/docs/debugging-ui", "/docs/observability/overview"],
+  ["/observability", "/docs/observability/overview"],
+  ["/docs/openai", "/integrations/model-providers/openai-py"],
+  ["/docs/integrations/openai", "/integrations/model-providers/openai-py"],
   ["/docs/qa-chatbot", "/docs/demo"],
-  ["/docs/user-explorer", "/docs/tracing-features/users"],
-  ["/docs/sessions", "/docs/tracing-features/sessions"],
+  ["/docs/user-explorer", "/docs/observability/features/users"],
+  ["/docs/sessions", "/docs/observability/features/sessions"],
   ["/docs/deployment/cloud", "/security"],
   ["/docs/schedule-demo", "/talk-to-us"],
   ["/schedule-demo", "/talk-to-us"],
-  ["/docs/project-sharing", "/docs/rbac"],
+  ["/docs/project-sharing", "/docs/administration/rbac"],
   // Point directly at the final destination to avoid a redirect chain
   // (/docs/prompts/get-started is itself redirected to /docs/prompt-management/get-started).
   ["/docs/prompts", "/docs/prompt-management/get-started"],
-  ["/changelog/2024-03-03-posthog-integration", "/docs/analytics/posthog"],
+  [
+    "/changelog/2024-03-03-posthog-integration",
+    "/integrations/analytics/posthog",
+  ],
   ["/guides/videos/2-min", "/guides/videos"],
-  ["/tos", "/terms"],
-  ["/docs/export-and-fine-tuning", "/docs/query-traces"],
+  [
+    "/tos",
+    "https://clickhouse.com/legal/clickhouse-general-terms-and-conditions",
+  ],
+  [
+    "/docs/export-and-fine-tuning",
+    "/docs/api-and-data-platform/features/query-via-sdk",
+  ],
   [
     "/changelog/2024-09-04-headless-initialization-or-self-hosted-deployments",
     "/changelog/2024-09-04-headless-initialization-of-self-hosted-deployments",
   ],
-  ["/docs/deployment/v3", "/docs/deployment/v3/overview"],
+  ["/docs/deployment/v3", "/self-hosting"],
   [
     "/docs/integrations/openai-agents",
-    "/docs/integrations/openaiagentssdk/openai-agents",
+    "/integrations/frameworks/openai-agents",
   ],
   [
     "/docs/integrations/amazon-bedrock",
-    "/docs/integrations/bedrock/amazon-bedrock",
+    "/integrations/model-providers/amazon-bedrock",
   ],
-  ["/docs/open-source", "/open-source"],
+  ["/docs/open-source", "/handbook/chapters/open-source"],
   ["/faq/all/cloud-data-regions", "/security/data-regions"],
-  ["/self-hosting/local", "/self-hosting/docker-compose"],
-  ["/self-hosting/docker", "/self-hosting/kubernetes-helm"],
-  ["/docs/analytics/posthog", "/docs/analytics/integrations/posthog"],
-  ["/docs/analytics/integrations", "/docs/analytics/integrations/posthog"],
+  ["/self-hosting/local", "/self-hosting/deployment/docker-compose"],
+  ["/self-hosting/docker", "/self-hosting/deployment/kubernetes-helm"],
+  ["/docs/analytics/posthog", "/integrations/analytics/posthog"],
+  ["/docs/analytics/integrations", "/integrations/analytics/posthog"],
   [
     "/docs/analytics/daily-metrics-api",
     "/faq/all/deprecated-api-migration#daily-metrics",
@@ -266,7 +290,7 @@ const nonPermanentRedirects = [
   ],
   [
     "/docs/opentelemetry/example-opentelemetry-collector",
-    "/docs/opentelemetry/get-started#export-from-opentelemetry-collector",
+    "/integrations/native/opentelemetry#export-from-opentelemetry-collector",
   ],
 ];
 
@@ -294,7 +318,7 @@ const selfHostFolders202508 = [
   ],
   [
     "/self-hosting/organization-management-api",
-    "/self-hosting/administration/organization-management-api",
+    "/self-hosting/administration/instance-management-api",
   ],
   [
     "/self-hosting/ui-customization",
@@ -376,40 +400,46 @@ const selfHostFolders202508 = [
 const newSelfHostingSection = [
   ["/docs/self-hosting", "/self-hosting"],
   ["/docs/deployment/feature-overview", "/self-hosting/license-key"],
-  ["/docs/deployment/local", "/self-hosting/local"],
+  ["/docs/deployment/local", "/self-hosting/deployment/docker-compose"],
   ["/docs/deployment/self-host", "/self-hosting"],
   ["/docs/deployment/v3/overview", "/self-hosting"],
   [
     "/docs/deployment/v3/migrate-v2-to-v3",
-    "/self-hosting/upgrade-guides/upgrade-v2-to-v3",
+    "/self-hosting/upgrade/upgrade-guides/upgrade-v2-to-v3",
   ],
-  ["/docs/deployment/v3/troubleshooting", "/self-hosting/troubleshooting"],
-  ["/docs/deployment/v3/guides/docker-compose", "/self-hosting/docker-compose"],
+  [
+    "/docs/deployment/v3/troubleshooting",
+    "/self-hosting/troubleshooting-and-faq",
+  ],
+  [
+    "/docs/deployment/v3/guides/docker-compose",
+    "/self-hosting/deployment/docker-compose",
+  ],
   [
     "/docs/deployment/v3/guides/kubernetes-helm",
-    "/self-hosting/kubernetes-helm",
+    "/self-hosting/deployment/kubernetes-helm",
   ],
   [
     "/docs/deployment/v3/components/clickhouse",
-    "/self-hosting/infrastructure/clickhouse",
+    "/self-hosting/deployment/infrastructure/clickhouse",
   ],
   [
     "/docs/deployment/v3/components/redis",
-    "/self-hosting/infrastructure/cache",
+    "/self-hosting/deployment/infrastructure/cache",
   ],
   [
     "/docs/deployment/v3/components/blobstorage",
-    "/self-hosting/infrastructure/blobstorage",
+    "/self-hosting/deployment/infrastructure/blobstorage",
   ],
 ];
 
 // Reorder Tracing section
 const reorderTracingSection = [
-  ["/docs/tracing/overview", "/docs/tracing"],
-  ["/docs/tracing-features", "/docs/tracing"],
+  ["/docs/tracing/overview", "/docs/observability/overview"],
+  ["/docs/tracing-features", "/docs/observability/overview"],
   ...["sessions", "users", "tags", "url"].map((path) => [
     `/docs/tracing/${path}`,
-    `/docs/tracing-features/${path}`,
+    `/docs/observability/features/${path}`,
   ]),
 
   ["/superagent", "/docs/integrations/superagent"],
@@ -681,15 +711,15 @@ const mainDocsReorder202507 = [
     "/docs/datasets/example-synthetic-datasets",
     "/guides/cookbook/example_synthetic_datasets",
   ],
-  ["/docs/datasets/get-started", "/docs/evaluation/dataset-runs/datasets"],
-  ["/docs/datasets/overview", "/docs/evaluation/dataset-runs/datasets"],
+  ["/docs/datasets/get-started", "/docs/evaluation/experiments/datasets"],
+  ["/docs/datasets/overview", "/docs/evaluation/experiments/datasets"],
   [
     "/docs/datasets/prompt-experiments",
-    "/docs/evaluation/dataset-runs/native-run",
+    "/docs/evaluation/experiments/experiments-via-ui",
   ],
   [
     "/docs/datasets/python-cookbook",
-    "/docs/evaluation/dataset-runs/remote-run",
+    "/docs/evaluation/experiments/experiments-via-sdk",
   ],
   ["/docs/fine-tuning", "/docs/api-and-data-platform/features/export-from-ui"],
   [
@@ -752,7 +782,10 @@ const mainDocsReorder202507 = [
     "/docs/evaluation/evaluation-methods/scores-via-ui",
   ],
   ["/docs/scores/custom", "/docs/evaluation/evaluation-methods/scores-via-sdk"],
-  ["/docs/scores/data-model", "/docs/evaluation/evaluation-methods/overview"],
+  [
+    "/docs/scores/data-model",
+    "/docs/evaluation/evaluation-methods/llm-as-a-judge",
+  ],
   [
     "/docs/scores/external-evaluation-pipelines",
     "/guides/cookbook/example_external_evaluation_pipelines",
@@ -762,14 +795,14 @@ const mainDocsReorder202507 = [
     "/docs/evaluation/evaluation-methods/llm-as-a-judge",
   ],
   ["/docs/scores/overview", "/docs/evaluation/overview"],
-  ["/docs/scores/user-feedback", "/faq/all/user-feedback"],
+  ["/docs/scores/user-feedback", "/docs/observability/features/user-feedback"],
   [
     "/docs/evaluation/features/evaluation-methods/custom",
     "/docs/evaluation/evaluation-methods/scores-via-sdk",
   ],
   [
     "/docs/evaluation/features/experiment-comparison",
-    "/docs/evaluation/dataset-runs/datasets",
+    "/docs/evaluation/experiments/datasets",
   ],
   ["/docs/sdk/overview", "/docs/observability/sdk/overview"],
   ["/docs/sdk/python/example", "/docs/observability/sdk/overview"],
@@ -842,7 +875,7 @@ const mainDocsReorder202507 = [
   ],
   [
     "/docs/evaluation/features/datasets",
-    "/docs/evaluation/dataset-runs/datasets",
+    "/docs/evaluation/experiments/datasets",
   ],
   [
     "/docs/evaluation/features/synthetic-datasets",
@@ -850,13 +883,16 @@ const mainDocsReorder202507 = [
   ],
   [
     "/docs/datasets/dataset-runs/data-model",
-    "/docs/evaluation/dataset-runs/data-model",
+    "/docs/evaluation/experiments/data-model",
   ],
-  ["/guides/cookbook/user-feedback", "/faq/all/user-feedback"],
+  [
+    "/guides/cookbook/user-feedback",
+    "/docs/observability/features/user-feedback",
+  ],
   ["/guides/cookbook/security-and-guardrails", "/docs/security-and-guardrails"],
   [
     "/docs/evaluation/features/prompt-experiments",
-    "/docs/evaluation/dataset-runs/native-run",
+    "/docs/evaluation/experiments/experiments-via-ui",
   ],
   [
     "/guides/cookbook/integration_mirascope",
@@ -876,7 +912,7 @@ const mainDocsReorder202507 = [
   ],
   [
     "/docs/evaluation/features/evaluation-methods/user-feedback",
-    "/faq/all/user-feedback",
+    "/docs/observability/features/user-feedback",
   ],
   [
     "/docs/evaluation/features/security-and-guardrails",
@@ -898,11 +934,11 @@ const oldWebhooksSection202508 = [
 const oldDatasetRunSection202508 = [
   [
     "/docs/evaluation/dataset-runs/run-via-ui",
-    "/docs/evaluation/dataset-runs/native-run",
+    "/docs/evaluation/experiments/experiments-via-ui",
   ],
   [
     "/docs/evaluation/dataset-runs/run-via-sdk",
-    "/docs/evaluation/dataset-runs/remote-run",
+    "/docs/evaluation/experiments/experiments-via-sdk",
   ],
 ];
 

--- a/md-override/index.md
+++ b/md-override/index.md
@@ -25,7 +25,7 @@ One integrated platform to trace, manage prompts, evaluate, and experiment from 
 - **[Evaluation](/docs/evaluation/overview)** — LLM-as-a-judge, heuristic functions, or human review. Run evaluators on production data or during experiments.
 - **[Prompt management](/docs/prompt-management/overview)** — separate prompts from code with one-click deployments and rollbacks.
 - **[Playground](/docs/prompt-management/features/playground)** — test prompts on real production inputs and compare models side by side.
-- **[Experiments](/docs/evaluation/experiments/overview)** — define test cases, run experiments, and compare results side by side.
+- **[Experiments](/docs/evaluation/experiments/datasets)** — define test cases, run experiments, and compare results side by side.
 - **[Human annotation](/docs/evaluation/evaluation-methods/annotation-queues)** — collaborative human-in-the-loop workflows to review traces and create golden datasets.
 - **[Cost and latency](/docs/observability/features/token-and-cost-tracking)** — monitor cost, latency, and quality with [dashboards](/docs/metrics/features/custom-dashboards) and [automated alerts](/docs/observability/features/alerts).
 
@@ -33,7 +33,7 @@ One integrated platform to trace, manage prompts, evaluate, and experiment from 
 
 Langfuse works with any language and framework supporting OpenTelemetry instrumentation. [100+ integrations](/integrations) make getting started easier, with no framework lock-in.
 
-- **Languages** — [Python](/docs/observability/sdk/python/overview) and [TypeScript](/docs/observability/sdk/typescript/overview) native SDKs, plus Go, Java, .NET, Ruby, PHP, and Swift via [OpenTelemetry](/integrations/native/opentelemetry).
+- **Languages** — [Python](/docs/observability/sdk/overview) and [TypeScript](/docs/observability/sdk/overview) native SDKs, plus Go, Java, .NET, Ruby, PHP, and Swift via [OpenTelemetry](/integrations/native/opentelemetry).
 - **Agent frameworks** — [LangChain](/integrations/frameworks/langchain), [Vercel AI SDK](/integrations/frameworks/vercel-ai-sdk), [LiteLLM](/integrations/frameworks/litellm-sdk), [Pydantic AI](/integrations/frameworks/pydantic-ai), [Google ADK](/integrations/frameworks/google-adk), [CrewAI](/integrations/frameworks/crewai), [LiveKit](/integrations/frameworks/livekit), and many more.
 - **Model providers** — [OpenAI](/integrations/model-providers/openai-py), [Anthropic](/integrations/model-providers/anthropic), [Amazon Bedrock](/integrations/model-providers/amazon-bedrock), Azure OpenAI, [Mistral AI](/integrations/model-providers/mistral-sdk), [Google Gemini](/integrations/model-providers/google-gemini), xAI, vLLM, Groq, and many more.
 - **Coding agents and tools** — [Claude Code](/integrations/developer-tools/claude-code), [Cursor](/integrations/developer-tools/cursor), [Codex](/integrations/developer-tools/codex), [OpenWebUI](/integrations/no-code/openwebui), [Dify](/integrations/no-code/dify), [n8n](/integrations/no-code/n8n), [PostHog](/integrations/analytics/posthog), and more.
@@ -44,7 +44,7 @@ Langfuse works with any language and framework supporting OpenTelemetry instrume
 
 Langfuse is built on open standards and data portability, and will not lock in your data.
 
-- **MIT license** — all product features are MIT licensed, scale to billions of monthly events, and you can fork, modify, and contribute. See [open source](/open-source).
+- **MIT license** — all product features are MIT licensed, scale to billions of monthly events, and you can fork, modify, and contribute. See [open source](/handbook/chapters/open-source).
 - **[Self-host at scale](/self-hosting)** — [Docker Compose](/self-hosting/deployment/docker-compose), [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), and Terraform for [AWS](/self-hosting/deployment/aws), [GCP](/self-hosting/deployment/gcp), and [Azure](/self-hosting/deployment/azure).
 - **APIs and exports** — [REST APIs](/docs/api-and-data-platform/features/public-api) for everything, a [query SDK](/docs/api-and-data-platform/features/query-via-sdk), and [S3 blob storage export](/docs/api-and-data-platform/features/export-to-blob-storage).
 - **Active community** — 22,000+ GitHub stars, 5,000+ Discord members, weekly releases and community hours.
@@ -108,7 +108,7 @@ Langfuse is an [open-source](https://github.com/langfuse/langfuse) AI engineerin
 
 ### What does Langfuse help me with?
 
-Langfuse helps you [debug LLM applications](/docs/observability/overview) with detailed traces that capture every step of your AI pipeline, including [agent graphs](/docs/observability/features/agent-graphs). You can [manage and version your prompts](/docs/prompt-management/overview) collaboratively, run [automated evaluations](/docs/evaluation/evaluation-methods/llm-as-a-judge) (including LLM-as-a-judge and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators)), track [costs and latency](/docs/observability/features/token-and-cost-tracking) across models and providers, and run [experiments on datasets](/docs/evaluation/experiments/overview) to measure improvements before shipping. It also supports [custom dashboards](/docs/metrics/features/custom-dashboards) for team-wide visibility.
+Langfuse helps you [debug LLM applications](/docs/observability/overview) with detailed traces that capture every step of your AI pipeline, including [agent graphs](/docs/observability/features/agent-graphs). You can [manage and version your prompts](/docs/prompt-management/overview) collaboratively, run [automated evaluations](/docs/evaluation/evaluation-methods/llm-as-a-judge) (including LLM-as-a-judge and [code evaluators](/docs/evaluation/evaluation-methods/code-evaluators)), track [costs and latency](/docs/observability/features/token-and-cost-tracking) across models and providers, and run [experiments on datasets](/docs/evaluation/experiments/datasets) to measure improvements before shipping. It also supports [custom dashboards](/docs/metrics/features/custom-dashboards) for team-wide visibility.
 
 ### Can I use just tracing without the other features?
 
@@ -116,7 +116,7 @@ Yes, you can use Langfuse purely for [tracing](/docs/observability/overview). Th
 
 ### What deployment options do exist?
 
-Langfuse is available as a [managed cloud service](https://cloud.langfuse.com) in [US and EU regions](/security), or you can [self-host](/self-hosting) it on your own infrastructure using [Docker Compose](/self-hosting/deployment/docker-compose), [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), or Terraform templates for [AWS](/self-hosting/deployment/aws), [GCP](/self-hosting/deployment/gcp), and [Azure](/self-hosting/deployment/azure). The self-hosted version includes all product features under the [MIT license](/open-source). For teams needing additional support and compliance, there is a [self-hosted Enterprise plan](/pricing-self-host).
+Langfuse is available as a [managed cloud service](https://cloud.langfuse.com) in [US and EU regions](/security), or you can [self-host](/self-hosting) it on your own infrastructure using [Docker Compose](/self-hosting/deployment/docker-compose), [Kubernetes (Helm)](/self-hosting/deployment/kubernetes-helm), or Terraform templates for [AWS](/self-hosting/deployment/aws), [GCP](/self-hosting/deployment/gcp), and [Azure](/self-hosting/deployment/azure). The self-hosted version includes all product features under the [MIT license](/handbook/chapters/open-source). For teams needing additional support and compliance, there is a [self-hosted Enterprise plan](/pricing-self-host).
 
 ### Is self-hosting actually free?
 

--- a/md-override/pricing-self-host.md
+++ b/md-override/pricing-self-host.md
@@ -51,9 +51,9 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 | [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                             | Yes                         | Yes                                        |
 | [Native framework integrations](/integrations)                                                              | Yes                         | Yes                                        |
 | [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                               | Yes                         | Yes                                        |
-| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                         | Yes                         | Yes                                        |
+| [OpenTelemetry (Java, Go, custom)](/integrations/native/opentelemetry)                                      | Yes                         | Yes                                        |
 | [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                         | Yes                         | Yes                                        |
-| [Custom via API](/api-and-data-platform/features/public-api)                                                | Yes                         | Yes                                        |
+| [Custom via API](/docs/api-and-data-platform/features/public-api)                                           | Yes                         | Yes                                        |
 | Included usage                                                                                              | Unlimited                   | Unlimited                                  |
 | [Multi-modal](/docs/observability/features/multi-modality)                                                  | Yes                         | Yes                                        |
 | **Langfuse AI**                                                                                             |                             |                                            |
@@ -65,19 +65,19 @@ Dedicated Langfuse deployment with enterprise capabilities and support. Bundled 
 | [Prompt composability](/docs/prompt-management/features/composability)                                      | Yes                         | Yes                                        |
 | [Prompt caching (server and client)](/docs/prompt-management/features/caching)                              | Yes                         | Yes                                        |
 | [Playground](/docs/prompt-management/features/playground)                                                   | Yes                         | Yes                                        |
-| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                              | Yes                         | Yes                                        |
+| [Prompt experiments](/docs/evaluation/experiments/experiments-via-ui)                                       | Yes                         | Yes                                        |
 | [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                            | Yes                         | Yes                                        |
 | [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)                  | --                          | Yes                                        |
 | **Evaluation (online and offline)**                                                                         |                             |                                            |
-| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                          | Yes                         | Yes                                        |
+| [Datasets](/docs/evaluation/experiments/datasets)                                                           | Yes                         | Yes                                        |
 | [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                                     | Yes                         | Yes                                        |
 | [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                                       | Yes                         | Yes                                        |
-| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                             | Yes                         | Yes                                        |
-| [User feedback tracking](/faq/all/user-feedback)                                                            | Yes                         | Yes                                        |
+| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/scores-via-sdk)                            | Yes                         | Yes                                        |
+| [User feedback tracking](/docs/observability/features/user-feedback)                                        | Yes                         | Yes                                        |
 | [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)                     | Yes                         | Yes                                        |
 | [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                               | Yes                         | Yes                                        |
-| [Human annotation](/docs/scores/annotation)                                                                 | Yes                         | Yes                                        |
-| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)                 | Yes                         | Yes                                        |
+| [Human annotation](/docs/evaluation/evaluation-methods/scores-via-ui)                                       | Yes                         | Yes                                        |
+| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation-queues)                            | Yes                         | Yes                                        |
 | **Metrics**                                                                                                 |                             |                                            |
 | [Custom dashboards](/docs/metrics/features/custom-dashboards)                                               | Yes                         | Yes                                        |
 | [Alerts](/docs/observability/features/alerts)                                                               | Langfuse v4+                | Langfuse v4+                               |

--- a/md-override/pricing.md
+++ b/md-override/pricing.md
@@ -93,9 +93,9 @@ Optional **Yearly Commitment**:
 | [Token and cost tracking](/docs/observability/features/token-and-cost-tracking)                     | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Native framework integrations](/integrations)                                                      | Yes                 | Yes                 | Yes                 | Yes                          |
 | [SDKs (Python, JavaScript)](/docs/observability/sdk/overview)                                       | Yes                 | Yes                 | Yes                 | Yes                          |
-| [OpenTelemetry (Java, Go, custom)](/docs/opentelemetry/get-started)                                 | Yes                 | Yes                 | Yes                 | Yes                          |
+| [OpenTelemetry (Java, Go, custom)](/integrations/native/opentelemetry)                              | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Proxy-based logging (via LiteLLM)](/integrations/gateways/litellm)                                 | Yes                 | Yes                 | Yes                 | Yes                          |
-| [Custom via API](/api-and-data-platform/features/public-api)                                        | Yes                 | Yes                 | Yes                 | Yes                          |
+| [Custom via API](/docs/api-and-data-platform/features/public-api)                                   | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Included usage](/docs/administration/billable-units)                                               | 50k units           | 100k units          | 100k units          | 100k units                   |
 | [Additional usage](/docs/administration/billable-units)                                             | --                  | $8/100k units       | $8/100k units       | $8/100k units                |
 | Custom usage pricing                                                                                | --                  | --                  | --                  | Yearly Commitment            |
@@ -112,19 +112,19 @@ Optional **Yearly Commitment**:
 | [Prompt composability](/docs/prompt-management/features/composability)                              | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Prompt caching (server and client)](/docs/prompt-management/features/caching)                      | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Playground](/docs/prompt-management/features/playground)                                           | Yes                 | Yes                 | Yes                 | Yes                          |
-| [Prompt experiments](/docs/evaluation/dataset-runs/native-run)                                      | Yes                 | Yes                 | Yes                 | Yes                          |
+| [Prompt experiments](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Webhooks & Slack](/docs/prompt-management/features/webhooks-slack-integrations)                    | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Protected deployment labels](/docs/prompt-management/get-started#protected-prompt-labels)          | --                  | --                  | Teams add-on        | Yes                          |
 | **Evaluation (online and offline)**                                                                 |                     |                     |                     |                              |
-| [Datasets](/docs/evaluation/dataset-runs/datasets)                                                  | Yes                 | Yes                 | Yes                 | Yes                          |
+| [Datasets](/docs/evaluation/experiments/datasets)                                                   | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Experiments via SDK](/docs/evaluation/experiments/experiments-via-sdk)                             | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Experiments via UI](/docs/evaluation/experiments/experiments-via-ui)                               | Yes                 | Yes                 | Yes                 | Yes                          |
-| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/custom-scores)                     | Yes                 | Yes                 | Yes                 | Yes                          |
-| [User feedback tracking](/faq/all/user-feedback)                                                    | Yes                 | Yes                 | Yes                 | Yes                          |
+| [Evaluation scores (custom)](/docs/evaluation/evaluation-methods/scores-via-sdk)                    | Yes                 | Yes                 | Yes                 | Yes                          |
+| [User feedback tracking](/docs/observability/features/user-feedback)                                | Yes                 | Yes                 | Yes                 | Yes                          |
 | [External evaluation pipelines](/guides/cookbook/example_external_evaluation_pipelines)             | Yes                 | Yes                 | Yes                 | Yes                          |
 | [LLM-as-judge evaluators](/docs/evaluation/evaluation-methods/llm-as-a-judge)                       | Yes                 | Yes                 | Yes                 | Yes                          |
-| [Human annotation](/docs/scores/annotation)                                                         | Yes                 | Yes                 | Yes                 | Yes                          |
-| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation#annotation-queues)         | 1 queue             | 3 queues            | Yes                 | Yes                          |
+| [Human annotation](/docs/evaluation/evaluation-methods/scores-via-ui)                               | Yes                 | Yes                 | Yes                 | Yes                          |
+| [Human annotation queues](/docs/evaluation/evaluation-methods/annotation-queues)                    | 1 queue             | 3 queues            | Yes                 | Yes                          |
 | **Metrics**                                                                                         |                     |                     |                     |                              |
 | [Custom dashboards](/docs/metrics/features/custom-dashboards)                                       | Yes                 | Yes                 | Yes                 | Yes                          |
 | [Alerts](/docs/observability/features/alerts)                                                       | 2 alerts            | 20 alerts           | 50 alerts           | 100 alerts                   |
@@ -250,7 +250,7 @@ A billable unit in Langfuse is any tracing data point sent to the platform -- in
 ## Frequently Asked Questions
 
 **What is the easiest way to try Langfuse?**
-You can view the [public example project](/demo) or sign up for a [free account](/cloud) to try Langfuse with your own data. The Hobby plan is completely free and does not require a credit card.
+You can view the [public example project](/docs/demo) or sign up for a [free account](/cloud) to try Langfuse with your own data. The Hobby plan is completely free and does not require a credit card.
 
 **Can I self-host Langfuse for free?**
 Yes, Langfuse is open source and you can self-host it for free. Use Docker Compose to run Langfuse locally, or use one of the templates to self-host in production on Kubernetes. See the [self-hosting documentation](/self-hosting) to learn more.


### PR DESCRIPTION
Monthly Ahrefs site-audit triage. Crawl of 2026-09-03, project "Langfuse" (10059040): health score **98**, **86** error URLs, 3,559 URLs crawled.

None of the Error-importance issues turned out to be both real and fixable in this repo (details in the sections below). The issues worth fixing were the two with by far the largest reach — 1,361 pages linking to a redirect, and 30 redirect chains — and both trace back to a handful of causes.

## What this fixes

| Audit issue | Count | Root cause | Fix |
| --- | --- | --- | --- |
| Redirect chain (Notice) | 30 | Pages were moved repeatedly; each move added a hop to the redirects already pointing at the old path. `/docs/datasets` took three round trips to reach the real page. | Every chained source in `lib/redirects.js` now names its final destination directly — **101** of them, 71 more than the audit happened to crawl. |
| Page has links to redirect (Warning) | 1,361 | Shared components link at moved paths: the site-wide banner → `/docs/v4` (1,033 pages), the navbar Get Started card → `/docs/get-started` (453), the integration index and `lib/integrations-meta.ts` → `/docs/sdk/typescript/guide` (450), plus the pricing table and several `components-mdx` partials. | **53** links repointed at the pages they resolve to, across 20 files. |
| Page has links to redirect (Notice) | 189 | Same root cause. | Same fix. |

The `md-override` mirrors of the home and pricing pages are updated to match, per the override-sync rule.

Two of the 101 chained sources came from `.map()` blocks rather than literal tuples:

- In the "redirect to overview pages" list, four paths (`/docs/integrations`, `/docs/scores`, `/docs/datasets`, `/docs/security`) had an `/overview` page that has since moved again. They are now explicit tuples; the five whose `/overview` page is still the real page stay in the `.map()`.
- `/docs/tracing/{sessions,users,tags,url}` now points at `/docs/observability/features/*` instead of hopping through `/docs/tracing-features/*`. It stays a `.map()` because the mapping is 1:1.

Two deliberate behaviours are preserved:

- **Vanity redirects are left alone.** `/terms`, `/discord`, `/dpa`, `/subprocessors`, `/issues`, `/gh-support` and `/billing-portal` exist so a third-party URL lives in exactly one place. Inlining those URLs into the footer would defeat the point, so only links whose redirect destination is internal were rewritten.
- **Fragments are carried the way a browser carries them.** `/docs/admin-api` pointed at `/docs/api#org-scoped-routes`, which redirected on to the public-api page; the fragment survived that hop in the browser, so the collapsed tuple keeps it: `…/features/public-api#org-scoped-routes`.

One incidental fix: the pricing table's "Human Annotation Queues" row pointed at `/docs/evaluation/evaluation-methods/annotation#annotation-queues`, whose fragment did not exist on the page the redirect landed on. It now points at the dedicated `/docs/evaluation/evaluation-methods/annotation-queues` page.

## Verification

```
$ node -e 'require("./lib/redirects.js")'
loads OK — exports: nonPermanentRedirects, permanentRedirects

# no chain left anywhere in the table, and no entries gained or lost
remaining chains: 0 | entries: 625
counts: 149 nonPermanent / 476 permanent   (unchanged from main)
duplicate sources: /docs/sdk/typescript/guide x2   (pre-existing on main)
patterns untouched: /cookbook/:path* -> /guides/cookbook/:path*
                    /customers/:path* -> /users/:path*

# every changed redirect destination, followed
$ curl -sL -o /dev/null -w '%{http_code}' <55 unique destinations>
non-200 destinations: 0

# every new link target, WITHOUT -L, so a remaining hop would show up
$ curl -s -o /dev/null -w '%{http_code}' <43 unique targets>
non-200: 0

# no link in components/, components-mdx/ or lib/ still points at an
# internal redirect source
remaining internal links to redirects: 0

$ node scripts/check-h1-headings.js
Success: All checked markdown/MDX files have at most one H1 heading.

$ prettier --check <24 changed files>
All matched files use Prettier code style!

$ node scripts/generate-cloudflare-redirects.js
Total redirects: 625 — generated successfully

$ npx next build
exit=0
```

Anchors were checked individually: `#public-metrics`, `#export-from-opentelemetry-collector` and `#batch-add-observations-to-datasets` all resolve to real headings on their new targets.

These 101 destinations were first derived by resolving the table programmatically, then written into the tuples by hand. The two tables were diffed entry by entry to confirm the hand-written version resolves every one of the 625 sources to exactly the same destination, with the permanent/non-permanent split unchanged — so the full `npx next build` above, which passed, exercised an identical redirect table.

## Intentionally out of scope

**Errors on subdomains this repo does not control** — 71 of the 86 error URLs:

- `js.reference.langfuse.com` — all 15 "page has links to broken page", all 7 "404 page" and all 7 "4XX page" (`/modules/LICENSE`, `/modules/packages/*`, and Cloudflare `cdn-cgi/l/email-protection` artifacts). Generated from the JS SDK repo.
- `cloud.langfuse.com`, `python.reference.langfuse.com`, `api.reference.langfuse.com`, `instance-management-api.reference.langfuse.com` — all 16 "duplicate pages without canonical", all 12 "title tag missing", all 14 "page has no outgoing links", and the single "page size exceeds 2 MB crawl limit".

**Errors on langfuse.com that need a human decision:**

- **Hreflang and HTML lang mismatch (15 URLs)** — `/japan` and `/academy/japan/**` declare `ja-JP` hreflang but serve `<html lang="en">`, because `app/layout.tsx` is a single root layout that hardcodes `lang="en"`. This is a genuine accessibility bug as well as an audit error: screen readers announce the Japanese pages with an English voice. There is no clean server-side fix without per-locale root layouts, which in Next.js means removing the shared `app/layout.tsx` and moving all 22 top-level route entries into route groups — too large and too risky to fold into an audit PR. Worth its own change.
- **Image file size too large (28 URLs)** — mostly legacy `.gif` files on old blog and changelog posts, which per the repo's own convention should be `.mp4` on `static.langfuse.com`; converting them needs asset uploads outside this repo. The four oversized customer-story PNGs (`slite-agent-*`, `ravenna-*`, 1.4–2.4 MB) are served through `next/image`, so readers never download the originals; recompressing them properly needs `pngquant`/`cwebp` rather than a lossy `sips` pass over partner screenshots. Two entries in the audit are already stale: `/images/find-us.png` was replaced by a 583 KB `.jpg` on Sep 4, and `score-analytics-full-dashboard.png` now serves 694 KB, not 3.8 MB.
- **Orphan pages (4 URLs)** — `/cn`, `/kr`, `/wrapped`, `/oss-friends` are deliberately unlinked campaign and locale landing pages.

**Deferred, not errors:** the ~30 `content/` pages that link `/docs/v4` in prose still take one hop. They are one link each rather than site-wide multipliers, and `/docs/v4` reads well as a shorthand; the redirect is now a single hop for all of them. Separately, `#org-scoped-routes` on `/docs/api-and-data-platform/features/public-api` and `#custom-scores-from-browser` on `/docs/observability/sdk/advanced-features` are fragments that no longer exist on those pages. Both were already dead before this change — the browser carried the fragment through the old chains too — so collapsing the chains does not regress them, but they are worth a look.

## One thing to keep an eye on

Because the chains are now resolved in the tuples rather than at runtime, the next time a page moves it will re-lengthen any redirect that pointed at the old path. Worth a glance at `lib/redirects.js` whenever a page moves: if the new redirect's source is already some other redirect's destination, collapse that one too.

## Note for someone with dashboard access

The audit project is **10059040**; the older `9945827` referenced in the runbook is retired. Passing `date_compared` returned `change == crawled` for every issue, meaning this project has no earlier crawl to diff against, so this run could not answer "what changed?" — the next run will be the first with a real baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to redirect rules and documentation/marketing link targets; no application runtime, auth, or data-handling logic is modified.
> 
> **Overview**
> Addresses Ahrefs crawl issues (redirect chains and widespread links to redirecting URLs) by making redirects single-hop and repointing high-traffic internal links at their final destinations.
> 
> **`lib/redirects.js`** — Many legacy paths now resolve directly to current docs (e.g. tracing → observability, scores/datasets → evaluation, old `/docs/integrations/*` → `/integrations/*`, SDK paths → `/docs/observability/sdk/overview`). Four former “overview” shortcuts (`/docs/integrations`, `/docs/scores`, `/docs/datasets`, `/docs/security`) are explicit tuples because their targets moved again. Tracing feature slugs map straight to `/docs/observability/features/*` without an intermediate hop.
> 
> **Shared UI & content** — Site-wide surfaces updated so they no longer link through redirects: v4 **Banner** and **VersionTimeline** → changelog entry; navbar **Get Started** card → `/docs/observability/get-started`; integration index/meta → unified SDK overview; home tool cards, FAQs, pricing tables, MDX partials, and `md-override` mirrors aligned with the new doc tree (metrics, experiments/datasets, scores-via-sdk/ui, handbook chapters for open-source/why, `/docs/ask-ai`, etc.). Human annotation queues link fixed to the dedicated page instead of a dead fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a482dc555317e840d518b274f137193b86ccffa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->