### PR TITLE
Include the full page URL in sidebar feedback issues

### DIFF
--- a/components/DocsChromePage.tsx
+++ b/components/DocsChromePage.tsx
@@ -62,9 +62,7 @@ export async function DocsChromePage({
       lastUpdate={lastModified}
       breadcrumb={{ component: <DocsBreadcrumb /> }}
       tableOfContent={{
-        footer: (
-          <DocsTocFooter pageTitle={data.title} lastModified={lastModified} />
-        ),
+        footer: <DocsTocFooter lastModified={lastModified} />,
       }}
       footer={{ component: <DocsAndPageFooter /> }}
     >

--- a/components/DocsTocFooter.tsx
+++ b/components/DocsTocFooter.tsx
@@ -10,6 +10,7 @@ import { HoverCard, HoverCardTrigger } from "@/components/ui/hover-card";
 import { ArrowUpRight } from "lucide-react";
 import TocCommunity from "@/components/TocCommunity";
 import { Text } from "@/components/ui/text";
+import { getDocsFeedbackIssueUrl } from "@/lib/docs-feedback-url";
 
 // ─── Utility functions ────────────────────────────────────────────────────────
 
@@ -34,15 +35,6 @@ const getGithubEditUrl = (path: string): string | null => {
   const slugPath = slugParts.join("/");
   const filePath = `${contentDir}/${slugPath === "" ? "index" : slugPath}.mdx`;
   return `https://github.com/langfuse/langfuse-docs/edit/main/${filePath}`;
-};
-
-const getFeedbackUrl = (pageTitle?: string): string => {
-  const title = (pageTitle ?? "this page").trim();
-  const params = new URLSearchParams({
-    title: `Feedback for "${title}"`,
-    labels: "feedback",
-  });
-  return `https://github.com/langfuse/langfuse-docs/issues/new?${params.toString()}`;
 };
 
 const getContributors = (path: string): string[] => {
@@ -180,7 +172,7 @@ export const DocsTocFooter = ({
   const currentPath = pathname.split("#")[0].split("?")[0];
   const [showAll, setShowAll] = useState(false);
   const editUrl = getGithubEditUrl(currentPath);
-  const feedbackUrl = getFeedbackUrl(pageTitle);
+  const feedbackUrl = getDocsFeedbackIssueUrl(currentPath, pageTitle);
   const lastModifiedDate = useMemo(
     () => (lastModified ? new Date(lastModified) : undefined),
     [lastModified],

--- a/components/DocsTocFooter.tsx
+++ b/components/DocsTocFooter.tsx
@@ -160,19 +160,15 @@ const processContributor = (username: string): ProcessedContributor => {
 // ─── Main component ───────────────────────────────────────────────────────────
 
 type DocsTocFooterProps = {
-  pageTitle?: string;
   lastModified?: string;
 };
 
-export const DocsTocFooter = ({
-  pageTitle,
-  lastModified,
-}: DocsTocFooterProps) => {
+export const DocsTocFooter = ({ lastModified }: DocsTocFooterProps) => {
   const pathname = usePathname() ?? "";
   const currentPath = pathname.split("#")[0].split("?")[0];
   const [showAll, setShowAll] = useState(false);
   const editUrl = getGithubEditUrl(currentPath);
-  const feedbackUrl = getDocsFeedbackIssueUrl(currentPath, pageTitle);
+  const feedbackUrl = getDocsFeedbackIssueUrl(currentPath);
   const lastModifiedDate = useMemo(
     () => (lastModified ? new Date(lastModified) : undefined),
     [lastModified],

--- a/lib/docs-feedback-url.test.ts
+++ b/lib/docs-feedback-url.test.ts
@@ -2,32 +2,18 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { getDocsFeedbackIssueUrl } from "./docs-feedback-url";
 
-test("pre-fills the GitHub issue body with the full page URL", () => {
-  const href = getDocsFeedbackIssueUrl(
-    "/docs/observability/get-started",
-    "Get Started",
-  );
+test("puts the full page URL in the GitHub issue title and leaves the body empty", () => {
+  const href = getDocsFeedbackIssueUrl("/docs/observability/get-started");
   const url = new URL(href);
 
   assert.equal(
     url.origin + url.pathname,
     "https://github.com/langfuse/langfuse-docs/issues/new",
   );
-  assert.equal(url.searchParams.get("title"), 'Feedback for "Get Started"');
-  assert.equal(url.searchParams.get("labels"), "feedback");
   assert.equal(
-    url.searchParams.get("body"),
-    "**Page:** https://langfuse.com/docs/observability/get-started\n",
+    url.searchParams.get("title"),
+    "Feedback for https://langfuse.com/docs/observability/get-started",
   );
-});
-
-test("falls back to a generic title when the page title is missing", () => {
-  const href = getDocsFeedbackIssueUrl("/self-hosting");
-  const url = new URL(href);
-
-  assert.equal(url.searchParams.get("title"), 'Feedback for "this page"');
-  assert.match(
-    url.searchParams.get("body") ?? "",
-    /https:\/\/langfuse\.com\/self-hosting/,
-  );
+  assert.equal(url.searchParams.get("labels"), "feedback");
+  assert.equal(url.searchParams.get("body"), null);
 });

--- a/lib/docs-feedback-url.test.ts
+++ b/lib/docs-feedback-url.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getDocsFeedbackIssueUrl } from "./docs-feedback-url";
+
+test("pre-fills the GitHub issue body with the full page URL", () => {
+  const href = getDocsFeedbackIssueUrl(
+    "/docs/observability/get-started",
+    "Get Started",
+  );
+  const url = new URL(href);
+
+  assert.equal(
+    url.origin + url.pathname,
+    "https://github.com/langfuse/langfuse-docs/issues/new",
+  );
+  assert.equal(url.searchParams.get("title"), 'Feedback for "Get Started"');
+  assert.equal(url.searchParams.get("labels"), "feedback");
+  assert.equal(
+    url.searchParams.get("body"),
+    "**Page:** https://langfuse.com/docs/observability/get-started\n",
+  );
+});
+
+test("falls back to a generic title when the page title is missing", () => {
+  const href = getDocsFeedbackIssueUrl("/self-hosting");
+  const url = new URL(href);
+
+  assert.equal(url.searchParams.get("title"), 'Feedback for "this page"');
+  assert.match(
+    url.searchParams.get("body") ?? "",
+    /https:\/\/langfuse\.com\/self-hosting/,
+  );
+});

--- a/lib/docs-feedback-url.ts
+++ b/lib/docs-feedback-url.ts
@@ -4,16 +4,11 @@ const FEEDBACK_ISSUE_BASE =
   "https://github.com/langfuse/langfuse-docs/issues/new";
 
 /** GitHub issue URL for the docs sidebar "Give us feedback" action. */
-export function getDocsFeedbackIssueUrl(
-  pagePath: string,
-  pageTitle?: string,
-): string {
-  const title = (pageTitle ?? "this page").trim();
+export function getDocsFeedbackIssueUrl(pagePath: string): string {
   const pageUrl = buildPageUrl(pagePath);
   const params = new URLSearchParams({
-    title: `Feedback for "${title}"`,
+    title: `Feedback for ${pageUrl}`,
     labels: "feedback",
-    body: `**Page:** ${pageUrl}\n`,
   });
   return `${FEEDBACK_ISSUE_BASE}?${params.toString()}`;
 }

--- a/lib/docs-feedback-url.ts
+++ b/lib/docs-feedback-url.ts
@@ -1,0 +1,19 @@
+import { buildPageUrl } from "./og-url";
+
+const FEEDBACK_ISSUE_BASE =
+  "https://github.com/langfuse/langfuse-docs/issues/new";
+
+/** GitHub issue URL for the docs sidebar "Give us feedback" action. */
+export function getDocsFeedbackIssueUrl(
+  pagePath: string,
+  pageTitle?: string,
+): string {
+  const title = (pageTitle ?? "this page").trim();
+  const pageUrl = buildPageUrl(pagePath);
+  const params = new URLSearchParams({
+    title: `Feedback for "${title}"`,
+    labels: "feedback",
+    body: `**Page:** ${pageUrl}\n`,
+  });
+  return `${FEEDBACK_ISSUE_BASE}?${params.toString()}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The docs sidebar **Give us feedback** link now opens a GitHub issue titled with the canonical page URL and leaves the description blank for the reporter.

Example title:

```
Feedback for https://langfuse.com/docs/observability/get-started
```

The `feedback` label is unchanged. The page title is no longer used, and the issue body is not pre-filled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65b61cc7-f0d7-4e35-bdda-00059068596f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65b61cc7-f0d7-4e35-bdda-00059068596f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61953104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/personal-org-4986/-/pull-requests/langfuse/langfuse-docs/3765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears safe to merge, with a non-blocking gap in automated execution of the newly added test.

<details><summary><h3>Summary</h3></summary>

- Preserves the existing issue title and `feedback` label.
- Uses the current documentation pathname to build the page URL.
- Adds focused unit cases, but they are not currently connected to the repository’s automated test or type-check workflows.
</details>

<!-- /greptile_comment -->