### PR TITLE
docs: use gender-neutral language in code review guidelines

### DIFF
--- a/content/handbook/product-engineering/how-we-work/code-review.mdx
+++ b/content/handbook/product-engineering/how-we-work/code-review.mdx
@@ -14,7 +14,7 @@ description: Code review process and guidelines at Langfuse.
 
 ## Responsibility of the PR author
 
-- Author is responsible for the quality of the Pull Request. If something goes wrong, he has to fix it.
+- Author is responsible for the quality of the Pull Request. If something goes wrong, they have to fix it.
 - Author has to go through the comments from the reviewer but may decide to not accept a suggestion.
 
 ## Responsibility of the reviewer


### PR DESCRIPTION
Replace “he” with “they” when referring to the PR author.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no product, security, or runtime impact.
> 
> **Overview**
> Updates the **PR author responsibility** bullet in the code review handbook to use gender-neutral pronouns: **“he has to fix it”** becomes **“they have to fix it.”** Meaning and accountability are unchanged; only inclusive wording in `code-review.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8873e0a5ea2a6675cdcaf25e1ba2fcb0956f9f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62531708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details open><summary><h3>Summary</h3></summary>

- Replaces “he” with the singular “they.”
- Preserves the sentence’s meaning and grammatical correctness.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs: use gender-neutral language in cod..."](https://github.com/langfuse/langfuse-docs/commit/4730a8fd6d4254bf72488d9635cdefd392a31d8a)</sub>

<!-- /greptile_comment -->