### PR TITLE
docs: remove Data Platform group from Integrations menu

### DIFF
--- a/components/integrations/IntegrationIndex.tsx
+++ b/components/integrations/IntegrationIndex.tsx
@@ -1,9 +1,6 @@
 import { integrationsSource } from "@/lib/source";
 import { Cards } from "@/components/docs";
-import {
-  nativeIntegrationsMeta,
-  dataPlatformIntegrationsMeta,
-} from "@/lib/integrations-meta";
+import { nativeIntegrationsMeta } from "@/lib/integrations-meta";
 import { cn } from "@/lib/utils";
 
 function additionalLinksFromMeta(metaConfig: Record<string, any>) {
@@ -119,12 +116,6 @@ const categoryConfig: Record<
     title: "Analytics",
     description:
       "Analytics tools that can visualize Langfuse traces and metrics",
-  },
-  data: {
-    title: "Data Platform",
-    description:
-      "Use Langfuse data and metrics in your own application and data platform",
-    additionalLinks: additionalLinksFromMeta(dataPlatformIntegrationsMeta),
   },
   "developer-tools": {
     title: "Developer Tools",

--- a/content/integrations/data-platform/meta.json
+++ b/content/integrations/data-platform/meta.json
@@ -1,9 +1,0 @@
-{
-  "title": "Data Platform",
-  "pages": [
-    "[Public API](/docs/api-and-data-platform/overview)",
-    "[Metrics API](/docs/metrics/features/metrics-api)",
-    "[Prompt Webhooks](/docs/prompt-management/features/webhooks-slack-integrations)",
-    "[Export to Blob Storage (e.g., S3)](/docs/api-and-data-platform/features/export-to-blob-storage)"
-  ]
-}

--- a/content/integrations/meta.json
+++ b/content/integrations/meta.json
@@ -9,7 +9,6 @@
     "gateways",
     "no-code",
     "analytics",
-    "data-platform",
     "developer-tools",
     "other"
   ]

--- a/lib/integrations-meta.ts
+++ b/lib/integrations-meta.ts
@@ -25,4 +25,3 @@ export const nativeIntegrationsMeta: Record<string, MetaEntry> = {
     title: "API",
   },
 };
-export const dataPlatformIntegrationsMeta: Record<string, MetaEntry> = {};


### PR DESCRIPTION
## What

Removes the "Data Platform" group from the Integrations sidebar.

That group consisted entirely of cross-section link shortcuts that jumped into the `/docs/api-and-data-platform/` navigation pane:

- Public API
- Metrics API
- Prompt Webhooks
- Export to Blob Storage

These are Langfuse-internal API and export surfaces, not third-party integrations, so they don't belong under Integrations. The pane-jumping links also signalled that the separation between the two nav panes wasn't clean.

## Changes

- `content/integrations/meta.json` — drop the `data-platform` group.
- `content/integrations/data-platform/meta.json` — deleted (it only held the four link shortcuts; no real pages lived here, so no URL or redirect is lost).
- `components/integrations/IntegrationIndex.tsx` — remove the dead `data` / "Data Platform" category. It referenced the empty `dataPlatformIntegrationsMeta` and wasn't included in `index.mdx`, so it already rendered nothing.
- `lib/integrations-meta.ts` — remove the now-unused `dataPlatformIntegrationsMeta` export.

## Notes

- All four pages remain reachable from the "API & Data Platform" docs section.
- The webhooks page stays at `/docs/prompt-management/features/webhooks-slack-integrations`; only the Integrations link was removed.
- The "Native" group also has cross-section API links (`API ↗`, `MCP Server ↗`, `CLI ↗`); those are intentionally left untouched here and can be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs sidebar and index metadata only; no routes, redirects, or application logic change.
> 
> **Overview**
> Removes the **Data Platform** section from Integrations navigation because it only listed shortcuts into **API & Data Platform** docs (Public API, Metrics API, webhooks, blob export), not third-party integrations.
> 
> The `data-platform` entry is dropped from `content/integrations/meta.json`, its shortcut-only `meta.json` is deleted, and `IntegrationIndex` no longer defines a `data` category or imports `dataPlatformIntegrationsMeta` (the export is removed from `lib/integrations-meta.ts`). **Native** cross-links to API/CLI/MCP are unchanged.
> 
> Destination URLs are unchanged; those topics stay under **API & Data Platform**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0850ac063ca2ba43f099c329e2b93481e676dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62624676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because it removes only redundant navigation metadata and unused configuration while preserving all destination routes.

<details open><summary><h3>Summary</h3></summary>

- Removes the category from the Integrations sidebar metadata.
- Deletes its shortcut-only metadata file.
- Removes the unused Integration Index category and metadata export.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Remove Data Platform group from Integrat..."](https://github.com/langfuse/langfuse-docs/commit/72e2376703277018cfd03daee3c92130ee2fd54d)</sub>

<!-- /greptile_comment -->