### PR TITLE
docs: page-level FAQ tags — export-data + per-vendor integration breakup

### DIFF
--- a/components/faq/FaqIndex.tsx
+++ b/components/faq/FaqIndex.tsx
@@ -12,6 +12,7 @@ const wordCasing: Record<string, string> = {
   api: "API",
   openai: "OpenAI",
   langchain: "LangChain",
+  opentelemetry: "OpenTelemetry",
 };
 
 export const formatTag = (tag: string) =>

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -44,6 +44,19 @@ Schedule exports to Amazon S3, S3-compatible storage, Google Cloud Storage, or A
 | Schedule            | Every 20 minutes, hourly, daily, or weekly. Each run exports one time window.                                                                                                                                                                               |
 | Export Mode         | **Full history** starts at the project's earliest data; **From setup date** starts when the integration is enabled; **From custom date** starts at a selected date. Changing this setting resets the sync position and re-scans from that point.            |
 
+<span id="monitor-and-reconfigure" /><span id="export-status" />
+
+The integration settings page shows a status badge:
+
+| Badge        | Meaning                                                   |
+| ------------ | --------------------------------------------------------- |
+| **Active**   | Enabled and synced; the next run is scheduled.            |
+| **Running**  | A run is in progress.                                     |
+| **Queued**   | A run is due and waiting.                                 |
+| **Pending**  | Enabled but has not run yet.                              |
+| **Disabled** | Turned off.                                               |
+| **Error**    | The last run failed; the message and timestamp are shown. |
+
 <span id="file-formats" />
 
 **Parquet notes**
@@ -160,25 +173,6 @@ If your S3-compatible provider has no object-created events, poll the manifest p
 
 Make manifest processing idempotent. Provider events can be delivered more than once, and a catch-up can create several manifests close together.
 
-## Troubleshooting [#monitor-and-reconfigure]
-
-The integration settings page shows a status badge:
-
-| Badge        | Meaning                                                   |
-| ------------ | --------------------------------------------------------- |
-| **Active**   | Enabled and synced; the next run is scheduled.            |
-| **Running**  | A run is in progress.                                     |
-| **Queued**   | A run is due and waiting.                                 |
-| **Pending**  | Enabled but has not run yet.                              |
-| **Disabled** | Turned off.                                               |
-| **Error**    | The last run failed; the message and timestamp are shown. |
-
-import { FaqPreview } from "@/components/faq/FaqPreview";
-
-<span id="how-exports-run" /><span id="empty-files" /><span id="export-status" /><span id="re-exporting" />
-
-<FaqPreview tags={["blob-storage"]} />
-
 ## Upgrade a legacy export [#legacy-export-sources]
 
 <Callout type="warning">
@@ -232,3 +226,11 @@ Do not load both observation layouts into the same production dataset. Check the
 - **All deployments:** `traces/` and `observations/` stop receiving files after the switch, including empty files. Use `manifests/` as the run-completion signal.
 - **Langfuse Cloud:** Ignore `DEPRECATION_NOTICE.txt` when processing exports; it is not part of a run.
 - **Self-hosted Langfuse v4:** `dual` is the only write mode in which both layouts are selectable, so the optional dual-layout validation above requires it.
+
+## FAQ
+
+import { FaqPreview } from "@/components/faq/FaqPreview";
+
+<span id="how-exports-run" /><span id="empty-files" /><span id="re-exporting" />
+
+<FaqPreview tags={["blob-storage"]} />

--- a/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
+++ b/content/docs/api-and-data-platform/features/export-to-blob-storage.mdx
@@ -173,9 +173,11 @@ The integration settings page shows a status badge:
 | **Disabled** | Turned off.                                               |
 | **Error**    | The last run failed; the message and timestamp are shown. |
 
-- <span id="how-exports-run" />[Export timing, backfills, and retries](/faq/all/blob-storage-export-timing-and-retries) — Understand delays, catch-up bursts, failed runs, and retry behavior.
-- <span id="empty-files" />[Empty export files](/faq/all/blob-storage-empty-files) — Learn why files can be empty and how pipelines should handle them.
-- <span id="export-status" /><span id="re-exporting" />[Configuration changes, errors, and re-exporting](/faq/all/blob-storage-config-changes-and-errors) — Validate changes, clear sticky errors, or export historic data again.
+import { FaqPreview } from "@/components/faq/FaqPreview";
+
+<span id="how-exports-run" /><span id="empty-files" /><span id="export-status" /><span id="re-exporting" />
+
+<FaqPreview tags={["blob-storage"]} />
 
 ## Upgrade a legacy export [#legacy-export-sources]
 

--- a/content/faq/all/blob-storage-config-changes-and-errors.mdx
+++ b/content/faq/all/blob-storage-config-changes-and-errors.mdx
@@ -2,7 +2,7 @@
 title: I changed my blob storage config — why didn't it re-export, and why do I still see an error?
 seoTitle: "Blob Storage Config Changes and Export Errors"
 description: How configuration changes apply to a Langfuse blob storage export, why a fixed misconfiguration can still show an error, and how to re-export historic data.
-tags: [platform, integration]
+tags: [platform, integration, export-data]
 ---
 
 import BlobStorageReExporting from "@/components-mdx/blob-storage-re-exporting.mdx";

--- a/content/faq/all/blob-storage-config-changes-and-errors.mdx
+++ b/content/faq/all/blob-storage-config-changes-and-errors.mdx
@@ -2,7 +2,7 @@
 title: I changed my blob storage config — why didn't it re-export, and why do I still see an error?
 seoTitle: "Blob Storage Config Changes and Export Errors"
 description: How configuration changes apply to a Langfuse blob storage export, why a fixed misconfiguration can still show an error, and how to re-export historic data.
-tags: [platform, integration, export-data]
+tags: [platform, export-data, blob-storage]
 ---
 
 import BlobStorageReExporting from "@/components-mdx/blob-storage-re-exporting.mdx";

--- a/content/faq/all/blob-storage-empty-files.mdx
+++ b/content/faq/all/blob-storage-empty-files.mdx
@@ -1,7 +1,7 @@
 ---
 title: Why do I see empty files in my blob storage export?
 description: Empty files in a Langfuse blob storage export are expected and normal — this article explains why they appear and how to handle them in downstream pipelines.
-tags: [platform, integration]
+tags: [platform, integration, export-data]
 ---
 
 import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx";

--- a/content/faq/all/blob-storage-empty-files.mdx
+++ b/content/faq/all/blob-storage-empty-files.mdx
@@ -1,7 +1,7 @@
 ---
 title: Why do I see empty files in my blob storage export?
 description: Empty files in a Langfuse blob storage export are expected and normal — this article explains why they appear and how to handle them in downstream pipelines.
-tags: [platform, integration, export-data]
+tags: [platform, export-data, blob-storage]
 ---
 
 import BlobStorageEmptyFiles from "@/components-mdx/blob-storage-empty-files.mdx";

--- a/content/faq/all/blob-storage-export-timing-and-retries.mdx
+++ b/content/faq/all/blob-storage-export-timing-and-retries.mdx
@@ -1,7 +1,7 @@
 ---
 title: How do blob storage export timing and retries work?
 description: How export delay, catch-up, backfills, and retries affect when files appear in blob storage.
-tags: [platform, integration]
+tags: [platform, integration, export-data]
 ---
 
 # How do blob storage export timing and retries work?

--- a/content/faq/all/blob-storage-export-timing-and-retries.mdx
+++ b/content/faq/all/blob-storage-export-timing-and-retries.mdx
@@ -1,7 +1,7 @@
 ---
 title: How do blob storage export timing and retries work?
 description: How export delay, catch-up, backfills, and retries affect when files appear in blob storage.
-tags: [platform, integration, export-data]
+tags: [platform, export-data, blob-storage]
 ---
 
 # How do blob storage export timing and retries work?

--- a/content/faq/all/custom-langchain-run-names.mdx
+++ b/content/faq/all/custom-langchain-run-names.mdx
@@ -2,7 +2,7 @@
 title: How to customize the names of observations within a Langchain trace?
 seoTitle: "Customize Observation Names in LangChain"
 description: "How to rename observations inside a LangChain trace by setting the run name, so Langfuse shows meaningful step names in the UI."
-tags: [integration]
+tags: [integration, langchain]
 ---
 
 # How to customize the names of a Langchain class within a trace?

--- a/content/faq/all/existing-otel-setup.mdx
+++ b/content/faq/all/existing-otel-setup.mdx
@@ -2,7 +2,7 @@
 title: How to integrate Langfuse with an existing OpenTelemetry setup
 seoTitle: "Add Langfuse to an Existing OpenTelemetry Setup"
 description: Learn how to add Langfuse as a backend to your existing OpenTelemetry instrumentation without changing your application code.
-tags: [observability, integration]
+tags: [observability, integration, opentelemetry]
 ---
 
 # Using Langfuse with an Existing OpenTelemetry Setup

--- a/content/faq/all/migrate-data-between-langfuse-instances.mdx
+++ b/content/faq/all/migrate-data-between-langfuse-instances.mdx
@@ -1,7 +1,7 @@
 ---
 title: How can I migrate data between Langfuse instances?
 description: Migrate traces, prompts, and datasets between self-hosted Langfuse instances and Langfuse Cloud using the Python data migration cookbook.
-tags: [self-hosting]
+tags: [self-hosting, export-data]
 ---
 
 # How can I migrate data between Langfuse instances?

--- a/content/faq/all/openai-assistant-api.mdx
+++ b/content/faq/all/openai-assistant-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to trace the OpenAI Assistants API?
 description: "The OpenAI integrations do not instrument the Assistants API automatically. How to trace Assistants API calls with the Langfuse decorator instead."
-tags: [integration]
+tags: [integration, openai]
 ---
 
 # How to trace the OpenAI Assistants API?

--- a/content/faq/all/partner-integration-v4-upgrade.mdx
+++ b/content/faq/all/partner-integration-v4-upgrade.mdx
@@ -2,7 +2,7 @@
 title: Why is my Vapi project still on the Langfuse v3 experience?
 sidebarTitle: Vapi and the v4 upgrade
 description: Projects ingesting via the Vapi integration stay on the Langfuse v3 experience until the integration is upgraded — what this means for dashboards, tables, and evaluators.
-tags: [observability, integration]
+tags: [observability, integration, vapi]
 ---
 
 import { V4CutoverDate } from "@/components/V4CutoverDate";

--- a/content/faq/all/retrieve-experiment-scores.mdx
+++ b/content/faq/all/retrieve-experiment-scores.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to retrieve experiment scores via UI or API/SDK?
 description: Learn how to export and retrieve experiment scores through the Langfuse UI or programmatically via API/SDK.
-tags: [evaluation]
+tags: [evaluation, export-data]
 ---
 
 # How to Retrieve Experiment Scores?

--- a/content/integrations/frameworks/langchain.mdx
+++ b/content/integrations/frameworks/langchain.mdx
@@ -889,7 +889,7 @@ await startActiveObservation("grouped-invocations", async () => {
 
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["integration"]} />
+<FaqPreview tags={["langchain"]} />
 
 ## GitHub Discussions
 

--- a/content/integrations/model-providers/openai-js.mdx
+++ b/content/integrations/model-providers/openai-js.mdx
@@ -278,7 +278,7 @@ for await (const chunk of stream) {
 
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["integration"]} />
+<FaqPreview tags={["openai"]} />
 
 ## GitHub Discussions
 

--- a/content/integrations/model-providers/openai-py.mdx
+++ b/content/integrations/model-providers/openai-py.mdx
@@ -473,7 +473,7 @@ Throws error 👆
 
 import { FaqPreview } from "@/components/faq/FaqPreview";
 
-<FaqPreview tags={["integration"]} />
+<FaqPreview tags={["openai"]} />
 
 ## GitHub Discussions
 

--- a/content/integrations/native/opentelemetry/index.mdx
+++ b/content/integrations/native/opentelemetry/index.mdx
@@ -501,3 +501,9 @@ Once spans are arriving in Langfuse, [Tracing in the Langfuse Academy](/academy/
 - If you encounter `4xx` errors while self-hosting Langfuse, please upgrade your deployment to the latest version. The OpenTelemetry endpoint was first introduced in Langfuse [v3.22.0](https://github.com/langfuse/langfuse/releases/tag/v3.22.0) and has seen significant improvements since then.
 - Langfuse supports OTLP over HTTP with both `HTTP/JSON` and `HTTP/protobuf`. `gRPC` is not supported yet.
 - If an observation's type or timestamps look wrong, Langfuse may have rewritten them on ingest. See [Ingestion transformations](#ingestion-transformations).
+
+## FAQ
+
+import { FaqPreview } from "@/components/faq/FaqPreview";
+
+<FaqPreview tags={["opentelemetry"]} />

--- a/content/integrations/no-code/vapi.mdx
+++ b/content/integrations/no-code/vapi.mdx
@@ -79,3 +79,9 @@ Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088
 To make the most out of this integration, you can now use Langfuse's [evaluation](/docs/scores/overview) and [debugging](/docs/analytics/overview) tools to analyze and improve the performance of your voice AI agents.
 
 </Steps>
+
+## FAQ
+
+import { FaqPreview } from "@/components/faq/FaqPreview";
+
+<FaqPreview tags={["vapi"]} />


### PR DESCRIPTION
## What

Introduces page-level FAQ tags so the reusable FAQ widget surfaces exactly the relevant FAQs on each feature page, and wires the widget in.

### Export data (the original ask)
- New `export-data` tag applied to the export-related FAQs (blob storage ×3, migrate data between instances, retrieve experiment scores) — serves the docs AI index and the `/faq/tag/export-data` page.
- New narrower `blob-storage` tag on the three blob storage export FAQs.
- **Blob storage export page**: the manual FAQ bullet list under Troubleshooting is replaced with `<FaqPreview tags={["blob-storage"]} />`, so the FAQs render via the widget and auto-include future entries. The existing anchor ids (`how-exports-run`, `empty-files`, `export-status`, `re-exporting`) are preserved for external deep links.
- `migrate-data` / `retrieve-experiment-scores` also surface on the self-hosting / evaluation troubleshooting pages via their existing tags.

### Breaking up the broad `integration` bucket (per-vendor, vendor-only grain)
Each vendor page now shows only its own FAQ(s):

| FAQ | New tag | Widget embedded on |
|---|---|---|
| custom-langchain-run-names | `langchain` | `integrations/frameworks/langchain` (retargeted from `integration`) |
| openai-assistant-api | `openai` | `integrations/model-providers/openai-js` + `openai-py` (retargeted) |
| existing-otel-setup | `opentelemetry` | `integrations/native/opentelemetry` (new FAQ section) |
| partner-integration-v4-upgrade | `vapi` | `integrations/no-code/vapi` (new FAQ section) |

- Added `opentelemetry` → `OpenTelemetry` to the tag label casing map.
- `integration` is retained as an umbrella/index tag on the true integration FAQs (no longer embedded on any page).

### Not placed
- `existing-sentry-setup` — no dedicated Sentry integration page exists yet, so it stays under `observability`/`integration`.
- `unwanted-http-database-spans` — cross-cutting (any auto-instrumentation), not vendor-specific; stays under `observability`.

## Notes
- Tag routes auto-generate at `/faq/tag/<tag>` via the FAQ route's `generateStaticParams`; the widget filters with OR semantics and a FAQ may carry several tags, so page-level targeting needs no routing changes.
- No `md-override` counterparts exist for the touched pages.
- Rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and FAQ tagging only; no application logic, APIs, or security-sensitive behavior changes.
> 
> **Overview**
> **Introduces narrower FAQ tags and embeds `FaqPreview` on feature/integration pages** so each doc shows only matching FAQs instead of the broad `integration` bucket.
> 
> Export-related FAQs gain `export-data` and `blob-storage` tags. The blob storage export doc **moves** the integration status badge table into configuration (with anchor ids preserved), **drops** the manual Troubleshooting FAQ bullets, and **adds** `<FaqPreview tags={["blob-storage"]} />` with the same deep-link anchors (`how-exports-run`, `empty-files`, `re-exporting`).
> 
> Vendor-specific tags (`langchain`, `openai`, `opentelemetry`, `vapi`) replace generic `integration` on the corresponding FAQ frontmatter; LangChain and OpenAI pages **retarget** their widgets to those tags, and OpenTelemetry and Vapi pages **gain new FAQ sections**. `FaqIndex` **adds** `opentelemetry` → **OpenTelemetry** display casing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225f9e802e4f165bc906def5c53efd2fa97ce798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->