### PR TITLE
Give the homepage a descriptive SEO title

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 // Keep this on the homepage: a layout canonical would be inherited by children.
 export const metadata: Metadata = {
   title: {
-    absolute: "Langfuse: Open-source LLM observability and evaluation",
+    absolute: "Langfuse: Open Source Agent Evals & Observability",
   },
   alternates: { canonical: "https://langfuse.com/" },
 };

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -3,6 +3,9 @@ import type { Metadata } from "next";
 
 // Keep this on the homepage: a layout canonical would be inherited by children.
 export const metadata: Metadata = {
+  title: {
+    absolute: "Langfuse: Open-source LLM observability and evaluation",
+  },
   alternates: { canonical: "https://langfuse.com/" },
 };
 

--- a/md-override/index.md
+++ b/md-override/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Langfuse: Open-source LLM observability and evaluation"
+title: "Langfuse: Open Source Agent Evals & Observability"
 canonical: https://langfuse.com/
 description: Trace, evaluate, and improve AI agents with one open platform. Use production data to understand behavior, collaborate on fixes, and ship better quality at lower cost and latency.
 ---

--- a/md-override/index.md
+++ b/md-override/index.md
@@ -1,5 +1,5 @@
 ---
-title: Langfuse
+title: "Langfuse: Open-source LLM observability and evaluation"
 canonical: https://langfuse.com/
 description: Trace, evaluate, and improve AI agents with one open platform. Use production data to understand behavior, collaborate on fixes, and ship better quality at lower cost and latency.
 ---


### PR DESCRIPTION
The homepage currently uses only “Langfuse” as its search title. Set it to “Langfuse: Open-source LLM observability and evaluation” and synchronize the Markdown homepage metadata.

Use page-level `title.absolute` so the root title template does not append a second “Langfuse.” Other pages retain their existing titles.

Validation: formatting, the three existing SEO regression tests, Markdown generation, and the Markdown-override H1 check pass. Verified the installed Next.js title resolver produces the exact title and the generated homepage Markdown matches. No full production build was needed for this metadata-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes on the homepage with no auth, data, or runtime logic impact.
> 
> **Overview**
> Updates the homepage **document title** from the generic default **Langfuse** to **Langfuse: Open Source Agent Evals & Observability** for clearer SEO and SERP messaging.
> 
> The homepage metadata now uses **`title.absolute`** so the root layout’s **`%s - Langfuse`** template does not append a second suffix; other routes keep their existing title behavior. The **`md-override/index.md`** frontmatter **title** is updated to the same string so the rendered site and Markdown homepage stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d35b4bc181546d2c750d2f03f4a87c25e2478c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62653662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the rendered and Markdown homepage titles synchronized as intended.

<details open><summary><h3>Summary</h3></summary>

- Uses page-level `title.absolute` to avoid the root layout’s title suffix.
- Synchronizes the corresponding Markdown override metadata.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Give the homepage a descriptive SEO titl..."](https://github.com/langfuse/langfuse-docs/commit/499949c15db08b8138a41dc9e5d7b8375f5a5781)</sub>

<!-- /greptile_comment -->