### PR TITLE
fix(docs): point demo trace card to tracing list

### DIFF
--- a/content/docs/demo.mdx
+++ b/content/docs/demo.mdx
@@ -32,7 +32,7 @@ The Langfuse example project is a **live, shared project** that lets you explore
   </div>
 
   <a
-    href="https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/traces/c6dd4487746b4e155f9395da828a2752?observation=300576dc5b33a15e&timestamp=2026-07-27T09:30:37.092Z&traceId=c6dd4487746b4e155f9395da828a2752"
+    href="https://cloud.langfuse.com/project/clkpwwm0m000gmm094odg11gi/traces"
     target="_blank"
     rel="noopener noreferrer"
     className="group flex min-h-[128px] flex-col justify-between rounded-[2px] border border-line-structure bg-surface-bg p-4 transition-colors hover:border-line-cta hover:bg-surface-1"
@@ -42,10 +42,10 @@ The Langfuse example project is a **live, shared project** that lets you explore
     </div>
     <div className="mt-4">
       <div className="text-base font-semibold leading-tight text-text-primary transition-colors group-hover:text-text-primary">
-        Explore your trace in Langfuse
+        Find your trace in Langfuse
       </div>
       <div className="mt-3 text-xs leading-5 text-text-tertiary">
-        Each interaction creates a trace you can inspect.
+        Open Tracing and select your latest request to inspect its trace.
       </div>
     </div>
   </a>


### PR DESCRIPTION
The demo page’s “Explore your trace” card always opened a fixed sample trace, even after a visitor submitted a new request. Point the card to the shared demo project’s tracing list and tell visitors to select their latest request.

Validation: `pnpm run format`, `pnpm run format:check`, the H1 heading check, and `git diff --check` passed. The destination returns HTTP 200. No Markdown override exists for this page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and URL change on the demo page with no application or security impact.
> 
> **Overview**
> Updates the demo page **Step 02** card so it no longer deep-links to a single sample trace. The link now goes to the shared demo project’s **Tracing** list (`/traces`), and the copy tells visitors to pick their **latest request** after they generate a trace.
> 
> Headline text shifts from “Explore your trace” to **“Find your trace in Langfuse”** to match the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a6864a3ec044f3500c91234c9a087170c62e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62671558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the demo flow provides a reliable way for visitors to identify their own trace in the shared project.

<details open><summary><h3>Summary</h3></summary>

- Removes the stale trace-specific URL.
- Directs visitors to locate their latest request in the shared trace list.
- The new selection instruction does not reliably distinguish a visitor's request from concurrent requests.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(docs): point demo trace card to trac..."](https://github.com/langfuse/langfuse-docs/commit/05a6864a3ec044f3500c91234c9a087170c62e31)</sub>

<!-- /greptile_comment -->