### PR TITLE
Update API reference for data retention configuration

### DIFF
--- a/content/docs/administration/data-retention.mdx
+++ b/content/docs/administration/data-retention.mdx
@@ -35,7 +35,7 @@ Project owners and administrators can change the data retention setting within t
   ![Configure data retention in Langfuse](/images/docs/data-retention.png)
 </Frame>
 
-Data retention can also be configured via the [projects API](/docs/administration/scim-and-org-api).
+Data retention can also be configured via the [Organization Management API](/docs/administration/scim-and-org-api).
 
 ## Details
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no product or API behavior impact.
> 
> **Overview**
> Updates the **Data Retention** admin doc so programmatic configuration points to the **[Organization Management API](/docs/administration/scim-and-org-api)** instead of the outdated **projects API** label. The link destination is unchanged; only the display text is corrected for consistency with how that API is named elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd9d2fb3ff0146988ff972b4541ef420b3aceb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62889784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only terminology correction appears safe to merge.

<details open><summary><h3>Summary</h3></summary>

- Preserves the existing documentation destination.
- Aligns the link label with the credential scope and terminology of the relevant API surface.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Update API reference for data retention ..."](https://github.com/langfuse/langfuse-docs/commit/9fd9d2fb3ff0146988ff972b4541ef420b3aceb9)</sub>

<!-- /greptile_comment -->