### PR TITLE
docs(handbook): drop agent identity / me.md mention

### DIFF
--- a/content/handbook/how-we-work/productivity-and-ai.mdx
+++ b/content/handbook/how-we-work/productivity-and-ai.mdx
@@ -103,6 +103,6 @@ Several non-AI tools are critical to our workflow:
 - **Where to use it**: Use Codex in terminal/IDE for direct implementation work, and **Codex Web** when you want server-side sessions that can keep running while you focus on other work.
 - **Connectors**: Connect **Linear** and **Slack** so agents can pick up context from tickets/threads and propose scoped code/documentation updates faster.
 - **Context quality**: Keep `AGENTS.md` files up to date (especially in active repos) so coding agents reliably follow current conventions, workflows, and documentation standards.
-- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions — what an agent may write to Linear, CI quirks, and similar — rather than general ones. Identity is a short note in `AGENTS.md` (`me.md` / Cloud run owner); keep large changes in small reviewable PRs.
+- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions — what an agent may write to Linear, CI quirks, and similar — rather than general ones. Keep large changes in small reviewable PRs.
 
 You can find some examples in this blog post: [How we use LLMs to scale Langfuse](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)

--- a/content/handbook/how-we-work/productivity-and-ai.mdx
+++ b/content/handbook/how-we-work/productivity-and-ai.mdx
@@ -103,6 +103,6 @@ Several non-AI tools are critical to our workflow:
 - **Where to use it**: Use Codex in terminal/IDE for direct implementation work, and **Codex Web** when you want server-side sessions that can keep running while you focus on other work.
 - **Connectors**: Connect **Linear** and **Slack** so agents can pick up context from tickets/threads and propose scoped code/documentation updates faster.
 - **Context quality**: Keep `AGENTS.md` files up to date (especially in active repos) so coding agents reliably follow current conventions, workflows, and documentation standards.
-- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions rather than general ones — how to slice a large change into reviewable pull requests, which CI checks can pass without having run, and what an agent may write to Linear. Start with `langfuse-onboarding`, which works out who you are and points you at the rest.
+- **Skills live in the repo**: `langfuse/langfuse` carries its own agent skills under `.agents/skills/`, and `pnpm install` wires them into whichever tool you use. They cover our conventions — what an agent may write to Linear, CI quirks, and similar — rather than general ones. Identity is a short note in `AGENTS.md` (`me.md` / Cloud run owner); keep large changes in small reviewable PRs.
 
 You can find some examples in this blog post: [How we use LLMs to scale Langfuse](/blog/2025-04-24-how-we-use-llms-to-scale-langfuse)

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,7 +93,7 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session’s results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules live as agent skills in `langfuse/langfuse` under `.agents/skills/` — start with `linear-agent-writes` (what may be written, when to ask, how to mark it) and `linear-context-handover` (history + wrap-up reasoning). Org defaults live there; personal overrides stay local. Changing state — assigning, moving, closing, prioritising — stays with a human.
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session's results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules live as agent skills in `langfuse/langfuse` under `.agents/skills/` — start with `linear-agent-writes` (what may be written, when to ask, how to mark it) and `linear-context-handover` (history + wrap-up reasoning). Org defaults live there; ask the person for one-off preferences. Changing state — assigning, moving, closing, prioritising — stays with a human.
 
 ## Setup Linear
 

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,13 +93,13 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session’s results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
 
 - `linear-agent-writes` — what an agent may write, when it must ask first, and how each write must be marked. Read this one before your first agentic write.
 - `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
 - `linear-context-handover` — recovering the history behind a piece of work, and proposing the reasoning for the issue when you finish.
 
-Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
+Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct — org defaults for agent behaviour live in those skills; personal overrides stay local. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
 
 ## Setup Linear
 

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,13 +93,11 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents are allowed to write to Linear directly — there is no longer a rule that one must stop and ask a human first. They comment, append their reasoning to an issue description, and create issues.
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
 
-They do have to follow rules, and **the rules are not repeated here.** They live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
-
-- `linear-agent-writes` — what an agent may write and how each write must be marked. Read this one before your first agentic write.
+- `linear-agent-writes` — what an agent may write, when it must ask first, and how each write must be marked. Read this one before your first agentic write.
 - `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
-- `linear-context-handover` — recovering the history behind a piece of work, and leaving your reasoning on the issue when you finish.
+- `linear-context-handover` — recovering the history behind a piece of work, and proposing the reasoning for the issue when you finish.
 
 Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
 

--- a/content/handbook/tools-and-processes/using-linear.mdx
+++ b/content/handbook/tools-and-processes/using-linear.mdx
@@ -93,13 +93,7 @@ Feature owners clear triage continuously and normally decide within one working 
 
 ## Agents may write to Linear [#agents]
 
-Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session’s results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules are not repeated here; they live as agent skills in the `langfuse/langfuse` repository, under `.agents/skills/`, together with the tooling that implements them:
-
-- `linear-agent-writes` — what an agent may write, when it must ask first, and how each write must be marked. Read this one before your first agentic write.
-- `linear-planning` — planning a feature as issues that map onto a stack of pull requests.
-- `linear-context-handover` — recovering the history behind a piece of work, and proposing the reasoning for the issue when you finish.
-
-Keeping them in the repo means an agent loads them where the work happens, and there is one copy to keep correct — org defaults for agent behaviour live in those skills; personal overrides stay local. The short version: every agent write is labelled and says in its own text that an agent wrote it, so you can always tell at a glance which words on an issue are a person's. Changing state — assigning, moving, closing, prioritising — stays with a human.
+Agents may write to Linear, but **updates to an existing ticket are proposals first** — show the comment or description block, get a yes, then write. Creating a subticket under an existing issue does not need that gate. At the end of a productive agent session, the agent should ask clearly whether to update the ticket(s) so the session’s results are preserved, rather than writing unsolicited or skipping the preserve step. The detailed rules live as agent skills in `langfuse/langfuse` under `.agents/skills/` — start with `linear-agent-writes` (what may be written, when to ask, how to mark it) and `linear-context-handover` (history + wrap-up reasoning). Org defaults live there; personal overrides stay local. Changing state — assigning, moving, closing, prioritising — stays with a human.
 
 ## Setup Linear
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes the handbook line that pointed at agent identity (`me.md` / Cloud run owner) now that that concept is gone from `langfuse/langfuse`.

Companion to https://github.com/langfuse/langfuse/pull/17176.

## Type of change

- [x] Documentation only

## Checklist

- [x] Self-reviewed
- [x] Matches the identity removal in the companion langfuse PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08062-272e-711b-8c64-fe6e0f154bbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08062-272e-711b-8c64-fe6e0f154bbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62955936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation changes appear safe to merge, with no concrete correctness, security, or repository-rule issues identified.

<details open><summary><h3>Summary</h3></summary>

- Removes references to identity discovery through `me.md` or the Cloud run owner.
- Retains guidance to keep large changes in small, reviewable pull requests.
- Documents proposal-first approval for updates to existing Linear tickets, the subticket exception, session handover expectations, and human-only state changes.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(handbook): drop agent identity / me..."](https://github.com/langfuse/langfuse-docs/commit/37ce51dd8b6d7d744c4485fbf87085b06c05a201)</sub>

<!-- /greptile_comment -->