### PR TITLE
Update homepage sidebar links and recent blog posts

### DIFF
--- a/components/home/layout/HomeSidebar.tsx
+++ b/components/home/layout/HomeSidebar.tsx
@@ -1,4 +1,5 @@
 import { changelogSource } from "@/lib/source";
+import { getBlogIndexPages } from "@/lib/blog-index";
 import { getGitHubStars } from "@/lib/github-stars";
 import { getLatestGitHubReleaseDate } from "@/lib/github-releases";
 import { LinkBox } from "@/components/ui/link-box";
@@ -58,18 +59,6 @@ const communityStats: Array<{
     tooltip: "Leave a Star ⭐",
   },
   {
-    label: "Observations / month",
-    value: "90B+",
-    href: "/docs/observability/overview",
-    tooltip: "Explore observability",
-  },
-  {
-    label: "Global adopters",
-    value: "100k+",
-    href: "/users#adopters",
-    tooltip: "View global adopters",
-  },
-  {
     label: "Community Q&A threads",
     value: formatCount(qaCount),
     href: "https://github.com/orgs/langfuse/discussions/categories/support",
@@ -89,15 +78,55 @@ const selfHostingLinks = [
     label: "Kubernetes (Helm)",
     href: "/self-hosting/deployment/kubernetes-helm",
   },
-  { label: "AWS (Terraform)", href: "/self-hosting/deployment/aws" },
-  { label: "GCP (Terraform)", href: "/self-hosting/deployment/gcp" },
-  { label: "Azure (Terraform)", href: "/self-hosting/deployment/azure" },
 ];
+
+const terraformLinks = [
+  { label: "AWS", href: "/self-hosting/deployment/aws" },
+  { label: "GCP", href: "/self-hosting/deployment/gcp" },
+  { label: "Azure", href: "/self-hosting/deployment/azure" },
+];
+
+type RecentArticle = {
+  route: string;
+  title: string;
+  date: string;
+};
+
+function RecentArticleList({ items }: { items: RecentArticle[] }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {items.map((item) => (
+        <LinkBox
+          key={item.route}
+          href={item.route}
+          tooltip="Read article"
+          tooltipPlacement="bottom-right"
+          className="block px-2 w-full hover:bg-surface-bg"
+        >
+          <div className="flex flex-col gap-1.5">
+            <Text
+              size="s"
+              className="leading-snug text-left text-[13px] group-hover:text-text-primary"
+            >
+              {item.title}
+            </Text>
+            <Text
+              size="xs"
+              className="text-left no-underline group-hover:text-text-primary"
+            >
+              {formatRelativeDate(item.date)}
+            </Text>
+          </div>
+        </LinkBox>
+      ))}
+    </div>
+  );
+}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export async function HomeSidebar() {
-  const changelogItems = changelogSource
+  const changelogItems: RecentArticle[] = changelogSource
     .getPages()
     .filter((p) => p.data.title && p.data.date)
     .sort(
@@ -111,6 +140,19 @@ export async function HomeSidebar() {
       title: p.data.title as string,
       date: new Date(p.data.date as string).toISOString(),
     }));
+
+  const blogItems: RecentArticle[] = getBlogIndexPages()
+    .flatMap((p) => {
+      if (!p.title || !p.frontMatter?.date) return [];
+      return [
+        {
+          route: p.route,
+          title: p.title,
+          date: new Date(p.frontMatter.date).toISOString(),
+        },
+      ];
+    })
+    .slice(0, 3);
 
   const latestReleaseDate =
     (await getLatestGitHubReleaseDate()) ?? changelogItems[0]?.date;
@@ -203,32 +245,7 @@ export async function HomeSidebar() {
                 </Text>
               </Link>
             </div>
-            <div className="flex flex-col gap-2">
-              {changelogItems.map((item) => (
-                <LinkBox
-                  key={item.route}
-                  href={item.route}
-                  tooltip="Read article"
-                  tooltipPlacement="bottom-right"
-                  className="block px-2 w-full hover:bg-surface-bg"
-                >
-                  <div className="flex flex-col gap-1.5">
-                    <Text
-                      size="s"
-                      className="leading-snug text-left text-[13px] group-hover:text-text-primary"
-                    >
-                      {item.title}
-                    </Text>
-                    <Text
-                      size="xs"
-                      className="text-left no-underline group-hover:text-text-primary"
-                    >
-                      {formatRelativeDate(item.date)}
-                    </Text>
-                  </div>
-                </LinkBox>
-              ))}
-            </div>
+            <RecentArticleList items={changelogItems} />
           </div>
         </div>
 
@@ -256,7 +273,51 @@ export async function HomeSidebar() {
                   </Text>
                 </LinkBox>
               ))}
+              <div className="px-2 py-1.25">
+                <Text
+                  size="s"
+                  className="text-left whitespace-nowrap text-text-tertiary text-[13px]"
+                >
+                  {"Terraform ("}
+                  {terraformLinks.map((link, index) => (
+                    <span key={link.href}>
+                      {index > 0 && ", "}
+                      <Link
+                        href={link.href}
+                        variant="text"
+                        className="text-[13px]"
+                      >
+                        {link.label}
+                      </Link>
+                    </span>
+                  ))}
+                  {")"}
+                </Text>
+              </div>
             </div>
+          </div>
+        </div>
+
+        {/* ── Blog Posts ────────────────────────────────────────────────── */}
+        <div className="pb-px bg-line-structure">
+          <div className="px-2 py-4 rounded-sm bg-surface-1">
+            <div className="flex justify-between items-center px-2 mb-3">
+              <Text
+                size="s"
+                className="font-[430] text-[13px] text-left text-text-primary"
+              >
+                Blog Posts
+              </Text>
+              <Link href="/blog">
+                <Text
+                  size="xs"
+                  className="transition-colors hover:text-text-primary"
+                >
+                  View All
+                </Text>
+              </Link>
+            </div>
+            <RecentArticleList items={blogItems} />
           </div>
         </div>
 

--- a/components/home/layout/HomeSidebar.tsx
+++ b/components/home/layout/HomeSidebar.tsx
@@ -1,5 +1,6 @@
 import { changelogSource } from "@/lib/source";
 import { getBlogIndexPages } from "@/lib/blog-index";
+import { parseCalendarDate } from "@/components/blog/utils";
 import { getGitHubStars } from "@/lib/github-stars";
 import { getLatestGitHubReleaseDate } from "@/lib/github-releases";
 import { LinkBox } from "@/components/ui/link-box";
@@ -128,27 +129,29 @@ function RecentArticleList({ items }: { items: RecentArticle[] }) {
 export async function HomeSidebar() {
   const changelogItems: RecentArticle[] = changelogSource
     .getPages()
-    .filter((p) => p.data.title && p.data.date)
-    .sort(
-      (a, b) =>
-        new Date(b.data.date as string).getTime() -
-        new Date(a.data.date as string).getTime(),
-    )
-    .slice(0, 3)
-    .map((p) => ({
-      route: p.url,
-      title: p.data.title as string,
-      date: new Date(p.data.date as string).toISOString(),
-    }));
+    .flatMap((p) => {
+      const parsed = parseCalendarDate(p.data.date as string | undefined);
+      if (!p.data.title || !parsed) return [];
+      return [
+        {
+          route: p.url,
+          title: p.data.title as string,
+          date: parsed.toISOString(),
+        },
+      ];
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 3);
 
   const blogItems: RecentArticle[] = getBlogIndexPages()
     .flatMap((p) => {
-      if (!p.title || !p.frontMatter?.date) return [];
+      const parsed = parseCalendarDate(p.frontMatter?.date);
+      if (!p.title || !parsed) return [];
       return [
         {
           route: p.route,
           title: p.title,
-          date: new Date(p.frontMatter.date).toISOString(),
+          date: parsed.toISOString(),
         },
       ];
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the observations/month and global adopters stats from the homepage left sidebar, combines the AWS, GCP, and Azure Terraform guides into a single `Terraform (AWS, GCP, Azure)` line with each cloud linked to its guide, and lists the three most recent blog posts with a View All link.

## Changes
- Community stats keep GitHub stars, Q&A threads, roadmap threads, and the latest OSS release
- Self-hosting guides: Docker Compose, Kubernetes (Helm), then one Terraform row with AWS, GCP, and Azure links
- New Blog Posts section mirrors Changelog (title, relative date, View All)

## Test plan
- Load `/` at desktop width and confirm the two removed stats are gone
- Confirm Terraform is one line and AWS/GCP/Azure each open the matching self-hosting guide
- Confirm the Blog Posts section shows the three latest posts and View All goes to `/blog`
- Spot-check another marketing page that uses the same sidebar (e.g. `/pricing`)

Verified locally on the homepage and pricing page.

![Updated homepage left sidebar](https://cursor.com/artifacts/c/art-5c176da3-5626-464e-a5d7-3d447216db7a)
![Terraform AWS link hover](https://cursor.com/artifacts/c/art-9b52e709-b0b0-4b06-bceb-b41a791eb5b2)
<a href="https://cursor.com/agents/bc-9eacc23b-26ef-40d0-be02-edb9a8b2ddc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_sidebar_terraform_and_blog_links.mp4"><img src="https://cursor.com/artifacts/c/art-6a7f77f5-f448-4a06-80d5-16400668fc72" alt="homepage_sidebar_terraform_and_blog_links.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-16197](https://linear.app/clickhouse/issue/LFE-16197/update-homepage-sidebar-links-and-blog-posts)

<div><a href="https://cursor.com/agents/bc-9eacc23b-26ef-40d0-be02-edb9a8b2ddc5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eacc23b-26ef-40d0-be02-edb9a8b2ddc5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63013611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable issues identified.

<details open><summary><h3>Summary</h3></summary>

- Removes observations/month and global adopter statistics.
- Combines AWS, GCP, and Azure Terraform guides into one row with individual links.
- Reuses the changelog article-list presentation for the three latest blog posts and adds a View All link.
- No actionable issues were identified.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Update homepage sidebar stats, Terraform..."](https://github.com/langfuse/langfuse-docs/commit/cb5f32a6dafece2cecda369db8a3bb65401618d1)</sub>

<!-- /greptile_comment -->