### PR TITLE
chore(ci): simplify link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -120,13 +120,14 @@ jobs:
           cache: true
           require-lockfile: true
 
-      - name: Run link checker unit tests
-        run: node --test scripts/check-links.test.js
+      - name: Run link and sitemap checker unit tests
+        run: pnpm run test:link-check
 
       - name: Build next.js app
         run: pnpm build
 
       - name: Start production server
+        id: server
         run: |
           pnpm start &
           echo "SERVER_PID=$!" >> "$GITHUB_ENV"
@@ -135,48 +136,28 @@ jobs:
       - name: Check markdown and source links
         run: pnpm link-check
 
-      - name: Stop production server
-        if: always()
-        run: kill "$SERVER_PID" || true
-
-  check-sitemap-links:
-    needs:
-      - pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
-        id: pnpm-install
-        with:
-          runtime: node@22
-          cache: true
-          require-lockfile: true
-
-      - name: Run sitemap checker unit tests
-        run: node --test scripts/check-sitemap-links.test.js
-
-      - name: Build next.js app
-        run: pnpm build
-
-      - name: Start production server
-        run: |
-          pnpm start &
-          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
-          timeout 30 bash -c 'until curl -sf http://127.0.0.1:3333 > /dev/null; do sleep 1; done'
-
+      # Run even if the preceding link check failed, but only with a ready server.
       - name: Check sitemap URLs
+        if: ${{ !cancelled() && steps.server.outcome == 'success' }}
         run: pnpm sitemap-check
 
       - name: Stop production server
         if: always()
         run: kill "$SERVER_PID" || true
+
+  # Preserve the existing required check name; both suites run in the job above.
+  check-sitemap-links:
+    needs:
+      - pre-job
+      - build-and-check-links
+    if: ${{ !cancelled() && needs.pre-job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify shared build and checks passed
+        env:
+          RESULT: ${{ needs.build-and-check-links.result }}
+        run: test "$RESULT" = success
 
   # Summary job that depends on all other jobs
   # This allows you to require only this single check in branch protection rules
@@ -193,10 +174,10 @@ jobs:
     if: always()
     steps:
       - name: Successful CI
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
         working-directory: .
       - name: Failing CI
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
         working-directory: .

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,16 +115,16 @@ importers:
     dependencies:
       '@ai-sdk/mcp':
         specifier: ^2.0.40
-        version: 2.0.40(zod@4.3.6)
+        version: 2.0.40(zod@4.5.4)
       '@ai-sdk/openai':
         specifier: ^4.0.51
-        version: 4.0.51(zod@4.3.6)
+        version: 4.0.51(zod@4.5.4)
       '@ai-sdk/openai-compatible':
         specifier: ^3.0.40
-        version: 3.0.40(zod@4.3.6)
+        version: 3.0.40(zod@4.5.4)
       '@ai-sdk/react':
         specifier: ^4.0.87
-        version: 4.0.87(react@19.2.8)(zod@4.3.6)
+        version: 4.0.87(react@19.2.8)(zod@4.5.4)
       '@calcom/embed-react':
         specifier: ^1.5.3
         version: 1.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -139,7 +139,7 @@ importers:
         version: 13.7.0(react@19.2.8)
       '@inkeep/cxkit-react':
         specifier: ^0.5.119
-        version: 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+        version: 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       '@langfuse/browser':
         specifier: 5.9.1
         version: 5.9.1(@opentelemetry/api@1.9.1)
@@ -160,7 +160,7 @@ importers:
         version: 5.9.1(@opentelemetry/api@1.9.1)
       '@langfuse/vercel-ai-sdk':
         specifier: 5.9.1
-        version: 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.84(zod@4.3.6))(zod@4.3.6)
+        version: 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.84(zod@4.5.4))(zod@4.5.4)
       '@modelcontextprotocol/sdk':
         specifier: ^1.13.2
         version: 1.13.2
@@ -262,7 +262,7 @@ importers:
         version: 1.12.13(@types/react@19.2.18)(react@19.2.8)
       ai:
         specifier: ^7.0.84
-        version: 7.0.84(zod@4.3.6)
+        version: 7.0.84(zod@4.5.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -277,13 +277,13 @@ importers:
         version: 11.15.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       fumadocs-core:
         specifier: ^16.15.4
-        version: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+        version: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       fumadocs-mdx:
         specifier: ^15.4.0
-        version: 15.4.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 15.4.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       fumadocs-ui:
         specifier: ^16.15.4
-        version: 16.15.4(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.2.0)
+        version: 16.15.4(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.2.0)
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -298,7 +298,7 @@ importers:
         version: 2.3.6
       katex:
         specifier: ^0.16.22
-        version: 0.16.46
+        version: 0.16.47
       langfuse:
         specifier: ^3.38.20
         version: 3.38.20
@@ -334,7 +334,7 @@ importers:
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       openai:
         specifier: ^6.22.0
-        version: 6.22.0(ws@8.18.3)(zod@4.3.6)
+        version: 6.22.0(ws@8.18.3)(zod@4.5.4)
       openai-edge:
         specifier: ^1.2.3
         version: 1.2.3
@@ -412,7 +412,7 @@ importers:
         version: 1.1.6(react@19.2.8)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.5.4
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^16.3.4
@@ -4815,10 +4815,6 @@ packages:
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
-  katex@0.16.46:
-    resolution: {integrity: sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==}
-    hasBin: true
-
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -6109,10 +6105,6 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -6468,9 +6460,6 @@ packages:
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
@@ -6512,64 +6501,64 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@4.0.2(zod@4.3.6)':
+  '@ai-sdk/gateway@4.0.2(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@4.3.6)
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.5.4)
       '@vercel/oidc': 3.2.0
-      zod: 4.3.6
+      zod: 4.5.4
 
-  '@ai-sdk/gateway@4.0.68(zod@4.3.6)':
+  '@ai-sdk/gateway@4.0.68(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
       '@vercel/oidc': 3.2.0
-      zod: 4.3.6
+      zod: 4.5.4
 
-  '@ai-sdk/mcp@2.0.40(zod@4.3.6)':
+  '@ai-sdk/mcp@2.0.40(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
       cross-spawn: 7.0.6
       pkce-challenge: 5.0.1
-      zod: 4.3.6
+      zod: 4.5.4
 
-  '@ai-sdk/openai-compatible@3.0.40(zod@4.3.6)':
+  '@ai-sdk/openai-compatible@3.0.40(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
+      zod: 4.5.4
 
-  '@ai-sdk/openai@4.0.51(zod@4.3.6)':
+  '@ai-sdk/openai@4.0.51(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
+      zod: 4.5.4
 
-  '@ai-sdk/otel@1.0.2(zod@4.3.6)':
+  '@ai-sdk/otel@1.0.2(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.0
       '@opentelemetry/api': 1.9.1
-      ai: 7.0.2(zod@4.3.6)
+      ai: 7.0.2(zod@4.5.4)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/provider-utils@5.0.0(zod@4.3.6)':
+  '@ai-sdk/provider-utils@5.0.0(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.1
-      zod: 4.3.6
+      zod: 4.5.4
 
-  '@ai-sdk/provider-utils@5.0.33(zod@4.3.6)':
+  '@ai-sdk/provider-utils@5.0.33(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.8
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.1
       undici: 7.29.1
-      zod: 4.3.6
+      zod: 4.5.4
 
   '@ai-sdk/provider@4.0.0':
     dependencies:
@@ -6579,12 +6568,12 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@4.0.87(react@19.2.8)(zod@4.3.6)':
+  '@ai-sdk/react@4.0.87(react@19.2.8)(zod@4.5.4)':
     dependencies:
-      '@ai-sdk/mcp': 2.0.40(zod@4.3.6)
+      '@ai-sdk/mcp': 2.0.40(zod@4.5.4)
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
-      ai: 7.0.84(zod@4.3.6)
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
+      ai: 7.0.84(zod@4.5.4)
       react: 19.2.8
       swr: 2.5.1(react@19.2.8)
       throttleit: 2.1.0
@@ -6596,7 +6585,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.2
+      tinyexec: 1.3.0
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -7157,7 +7146,7 @@ snapshots:
 
   '@inkeep/cxkit-color-mode@0.5.119': {}
 
-  '@inkeep/cxkit-primitives@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
+  '@inkeep/cxkit-primitives@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)':
     dependencies:
       '@inkeep/cxkit-color-mode': 0.5.119
       '@inkeep/cxkit-theme': 0.5.119
@@ -7198,7 +7187,7 @@ snapshots:
       lucide-react: 0.503.0(react@19.2.8)
       marked: 15.0.12
       merge-anything: 5.1.7
-      openai: 4.78.1(zod@4.3.6)
+      openai: 4.78.1(zod@4.5.4)
       prism-react-renderer: 2.4.1(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -7219,9 +7208,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@inkeep/cxkit-react@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
+  '@inkeep/cxkit-react@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)':
     dependencies:
-      '@inkeep/cxkit-styled': 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      '@inkeep/cxkit-styled': 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
       lucide-react: 0.503.0(react@19.2.8)
     transitivePeerDependencies:
@@ -7233,9 +7222,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@inkeep/cxkit-styled@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
+  '@inkeep/cxkit-styled@0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)':
     dependencies:
-      '@inkeep/cxkit-primitives': 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      '@inkeep/cxkit-primitives': 0.5.119(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       merge-anything: 5.1.7
@@ -7325,12 +7314,12 @@ snapshots:
       '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/vercel-ai-sdk@5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.84(zod@4.3.6))(zod@4.3.6)':
+  '@langfuse/vercel-ai-sdk@5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.84(zod@4.5.4))(zod@4.5.4)':
     dependencies:
-      '@ai-sdk/otel': 1.0.2(zod@4.3.6)
+      '@ai-sdk/otel': 1.0.2(zod@4.5.4)
       '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
-      ai: 7.0.84(zod@4.3.6)
+      ai: 7.0.84(zod@4.5.4)
     transitivePeerDependencies:
       - zod
 
@@ -9514,19 +9503,19 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@7.0.2(zod@4.3.6):
+  ai@7.0.2(zod@4.5.4):
     dependencies:
-      '@ai-sdk/gateway': 4.0.2(zod@4.3.6)
+      '@ai-sdk/gateway': 4.0.2(zod@4.5.4)
       '@ai-sdk/provider': 4.0.0
-      '@ai-sdk/provider-utils': 5.0.0(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.5.4)
+      zod: 4.5.4
 
-  ai@7.0.84(zod@4.3.6):
+  ai@7.0.84(zod@4.5.4):
     dependencies:
-      '@ai-sdk/gateway': 4.0.68(zod@4.3.6)
+      '@ai-sdk/gateway': 4.0.68(zod@4.5.4)
       '@ai-sdk/provider': 4.0.8
-      '@ai-sdk/provider-utils': 5.0.33(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 5.0.33(zod@4.5.4)
+      zod: 4.5.4
 
   ajv@6.12.6:
     dependencies:
@@ -10440,7 +10429,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6):
+  fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4):
     dependencies:
       '@fumari/image-size': 0.1.0
       estree-util-value-to-estree: 3.5.0
@@ -10471,18 +10460,18 @@ snapshots:
       next: 16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      zod: 4.3.6
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.4.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  fumadocs-mdx@15.4.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       github-slugger: 2.0.0
       magic-string: 1.2.3
       mdast-util-mdx: 3.0.0
@@ -10506,7 +10495,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.15.4(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.2.0):
+  fumadocs-ui@16.15.4(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.2.0):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fumadocs/tailwind': 0.1.1(tailwindcss@4.2.0)
@@ -10522,7 +10511,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       cnfast: 0.1.0
-      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@0.577.0(react@19.2.8))(next@16.3.4(@opentelemetry/api@1.9.1)(@types/node@22.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.5.4)
       lucide-react: 1.39.0(react@19.2.8)
       motion: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -10949,10 +10938,6 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema@0.4.0: {}
-
-  katex@0.16.46:
-    dependencies:
-      commander: 8.3.0
 
   katex@0.16.47:
     dependencies:
@@ -11439,7 +11424,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.7
       devlop: 1.1.0
-      katex: 0.16.46
+      katex: 0.16.47
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
@@ -11768,7 +11753,7 @@ snapshots:
 
   openai-edge@1.2.3: {}
 
-  openai@4.78.1(zod@4.3.6):
+  openai@4.78.1(zod@4.5.4):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -11778,14 +11763,14 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.5.4
     transitivePeerDependencies:
       - encoding
 
-  openai@6.22.0(ws@8.18.3)(zod@4.3.6):
+  openai@6.22.0(ws@8.18.3)(zod@4.5.4):
     optionalDependencies:
       ws: 8.18.3
-      zod: 4.3.6
+      zod: 4.5.4
 
   opener@1.5.2: {}
 
@@ -12281,7 +12266,7 @@ snapshots:
       '@types/katex': 0.16.7
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
-      katex: 0.16.46
+      katex: 0.16.47
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
 
@@ -12743,8 +12728,6 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -13096,8 +13079,6 @@ snapshots:
       zod: 3.25.67
 
   zod@3.25.67: {}
-
-  zod@4.3.6: {}
 
   zod@4.5.4: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI workflow and lockfile-only changes; no application runtime logic. Lockfile zod bump is the main unrelated variable if merged as-is.
> 
> **Overview**
> **Consolidates link and sitemap CI** so one job builds the Next.js app once, runs checker unit tests via `pnpm run test:link-check`, then validates markdown/source links and sitemap URLs against the same production server. Sitemap checking still runs when the link step fails, as long as the server started successfully.
> 
> The standalone **`check-sitemap-links` job is kept only as a compatibility shim** (short timeout, asserts `build-and-check-links` succeeded) so existing required check names in branch protection stay valid. **`all-checks-pass` now fails on cancelled jobs** as well as failures.
> 
> Also refreshes **`pnpm-lock.yaml`** (notably `zod` 4.3.6→4.5.4 and minor transitive bumps), which is unrelated to the workflow refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b626393c5f38c73e75fa6b8b1bac8eceed9df80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63055576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The workflow consolidation appears safe to merge, but the unrelated production lockfile refresh should be removed or reviewed separately.

<details open><summary><h3>Summary</h3></summary>

- Runs both checker unit-test suites through the shared package script.
- Reuses one production build and server for source-link and sitemap validation.
- Propagates failed or cancelled jobs through the aggregate CI check.
- Also includes unrelated lockfile resolution updates that should be separated or reverted.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  P[pre-job] --> B[build-and-check-links]
  B --> U[Checker unit tests]
  U --> N[Build Next.js app]
  N --> S[Start production server]
  S --> L[Check markdown and source links]
  S --> M[Check sitemap URLs]
  B --> C[check-sitemap-links compatibility check]
  P --> C
  B --> A[all-checks-pass]
  C --> A
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(ci): simplify link checking"](https://github.com/langfuse/langfuse-docs/commit/720038f17bfaef97d587881cc72d71da8a3c7e60)</sub>

<!-- /greptile_comment -->