### PR TITLE
docs(cli): rename package

### DIFF
--- a/content/blog/2026-02-13-will-you-be-my-cli.mdx
+++ b/content/blog/2026-02-13-will-you-be-my-cli.mdx
@@ -82,10 +82,10 @@ Two core capabilities: **programmatic API access** via the Langfuse CLI, and **d
 
 ## 1. Langfuse API via CLI
 
-Use the `langfuse-cli` to interact with the full Langfuse REST API from the command line. Run via npx (no install required):
+Use the `@langfuse/cli` package to interact with the full Langfuse REST API from the command line. Run via npx (no install required):
 
 ```bash
-npx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>
 ```
 
 ### Quickstart
@@ -197,7 +197,7 @@ Check the project:
 
 Agents often work in terminal environments and Langfuse has APIs for all core features. How can we help Agents interact with Langfuse without writing HTTP requests manually?
 
-We built [`langfuse-cli`](https://github.com/langfuse/langfuse-cli), a command-line interface that wraps the entire Langfuse API, auto-generated from our OpenAPI spec with some modifications.
+We built [`@langfuse/cli`](https://github.com/langfuse/langfuse-cli), a command-line interface that wraps the entire Langfuse API, auto-generated from our OpenAPI spec with some modifications.
 
 It's a CLI tool built on [specli](https://github.com/vercel-labs/specli) that generates commands directly from the OpenAPI specification. Every API endpoint becomes a CLI command with proper flags, validation, and help text (that again helps with progressive disclosure).
 
@@ -214,10 +214,10 @@ In the main Langfuse Skill (see above) we include a reference that teaches AI ag
 ## Install
 
 ```bash
-npx langfuse-cli api <resource> <action>   ## Run directly (recommended)
-bunx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>   ## Run directly (recommended)
+bunx @langfuse/cli api <resource> <action>
 
-npm i -g langfuse-cli                      ## Or install globally
+npm i -g @langfuse/cli                      ## Or install globally
 langfuse api <resource> <action>
 ```
 
@@ -483,7 +483,7 @@ Try it out and let us know what you think. And if you build something cool with 
 ## Resources
 
 - [Agent Skills Repository](https://github.com/langfuse/skills)
-- [Langfuse CLI on npm](https://www.npmjs.com/package/langfuse-cli)
+- [Langfuse CLI on npm](https://www.npmjs.com/package/@langfuse/cli)
 - [Langfuse MCP Reference](https://mcp.reference.langfuse.com)
 - [Langfuse Docs MCP Server](https://langfuse.com/docs/docs-mcp)
 - [Langfuse Authenticated MCP Server](/docs/api-and-data-platform/features/mcp-server)

--- a/content/blog/2026-02-26-evaluate-ai-agent-skills.mdx
+++ b/content/blog/2026-02-26-evaluate-ai-agent-skills.mdx
@@ -141,7 +141,7 @@ By changing that one comment to say the host is mandatory, the agent started che
 With the server issue fixed, a second pattern stood out: the agent would invent CLI resources and actions that didn't exist.
 
 ```bash
-> npx langfuse-cli api prompts get --name summarizer
+> npx @langfuse/cli api prompts get --name summarizer
 Exit code 1
 error: unknown option '--name'
 ```

--- a/content/blog/2026-03-31-langfuse-march-update.mdx
+++ b/content/blog/2026-03-31-langfuse-march-update.mdx
@@ -47,7 +47,7 @@ The skill uses the [Langfuse CLI](/docs/api-and-data-platform/features/cli) unde
 
 Built for agents, but useful for humans too. Script your workflows, automate batch-scoring, or sync prompts across environments in CI/CD.
 
-→ [npm](https://www.npmjs.com/package/langfuse-cli)
+→ [npm](https://www.npmjs.com/package/@langfuse/cli)
 
 ## Further reading
 

--- a/content/changelog/2026-02-17-langfuse-cli.mdx
+++ b/content/changelog/2026-02-17-langfuse-cli.mdx
@@ -20,13 +20,13 @@ Read the full documentation in the dedicated [CLI GitHub Repo](https://github.co
 Get started by running:
 
 ```bash
-npx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>
 ```
 
 Or just ask your coding agent to do it for you:
 
 ```markdown
-please install langfuse-cli
+please install @langfuse/cli
 ```
 
 ## What it can do
@@ -73,7 +73,7 @@ The CLI is designed to work together with our [Agent Skills](https://github.com/
 
 ## Learn More
 
-- [npm package](https://www.npmjs.com/package/langfuse-cli)
+- [npm package](https://www.npmjs.com/package/@langfuse/cli)
 - [CLI GitHub Repo](https://github.com/langfuse/langfuse-cli)
 - [Blog: Making Agents Fall in Love with Langfuse](/blog/2026-02-13-will-you-be-my-cli)
 - [API Reference](/docs/api)

--- a/content/changelog/2026-08-21-langfuse-cli-v1.mdx
+++ b/content/changelog/2026-08-21-langfuse-cli-v1.mdx
@@ -30,13 +30,13 @@ Install or upgrade:
 
 ```bash
 # upgrade
-npm install -g langfuse-cli@latest
+npm install -g @langfuse/cli@latest
 # upgrade via bun
-bun add --global langfuse-cli@latest
+bun add --global @langfuse/cli@latest
 
 # or run directly via npx/bunx
-npx langfuse-cli api <resource> <action>
-bunx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>
+bunx @langfuse/cli api <resource> <action>
 ```
 
 What's new:

--- a/content/docs/api-and-data-platform/features/cli.mdx
+++ b/content/docs/api-and-data-platform/features/cli.mdx
@@ -19,13 +19,19 @@ Read the full documentation in the dedicated [CLI GitHub Repo](https://github.co
 Get started by running:
 
 ```bash
-npx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>
 ```
+
+<Callout type="info">
+  **Note:** The package was previously published under `langfuse-cli`. That
+  package is identical to this one and will be updated alongside it until we
+  release a new major version. We recommend using `@langfuse/cli` from now on.
+</Callout>
 
 Or just ask your coding agent to do it for you:
 
 ```markdown
-please install langfuse-cli
+please install @langfuse/cli
 ```
 
 ## Authentication [#authentication]

--- a/content/docs/api-and-data-platform/features/cli.mdx
+++ b/content/docs/api-and-data-platform/features/cli.mdx
@@ -22,17 +22,43 @@ Get started by running:
 npx @langfuse/cli api <resource> <action>
 ```
 
+Or just ask your coding agent to do it for you:
+
+```markdown
+please install @langfuse/cli
+```
+
 <Callout type="info">
   **Note:** The package was previously published under `langfuse-cli`. That
   package is identical to this one and will be updated alongside it until we
   release a new major version. We recommend using `@langfuse/cli` from now on.
 </Callout>
 
-Or just ask your coding agent to do it for you:
+## Move from `langfuse-cli` to the new `@langfuse/cli` package
 
-```markdown
-please install @langfuse/cli
+We will maintain the `langfuse-cli` until the next major version, but we recommend using `@langfuse/cli` from now on.
+
+To migrate from `langfuse-cli`, replace the package name in your command:
+
+```bash
+npx @langfuse/cli api <resource> <action>
+# or
+bunx @langfuse/cli api <resource> <action>
 ```
+
+or switch:
+
+```bash
+# npm
+npm uninstall --global langfuse-cli
+npm install --global @langfuse/cli
+
+# Bun
+bun remove --global langfuse-cli
+bun add --global @langfuse/cli
+```
+
+After migrating, continue running the CLI with the same `langfuse` command.
 
 ## Authentication [#authentication]
 

--- a/content/faq/all/deprecated-api-migration.mdx
+++ b/content/faq/all/deprecated-api-migration.mdx
@@ -41,7 +41,7 @@ All paths are relative to `/api/public`.
 `score-create` events sent to `POST /ingestion` by the current SDKs are not deprecated. They remain supported after the v4 cutover.
 
 If you access the public API from shell scripts or coding agents, the [Langfuse CLI](/docs/api-and-data-platform/features/cli) provides commands for all supported endpoints.
-Use at least langfuse-cli version `v1.1.0` to benefit from the new endpoints.
+Use at least `@langfuse/cli` version `v1.1.0` to benefit from the new endpoints.
 
 ### SDK method quick reference [#sdk-method-quick-reference]
 

--- a/content/marketing/agents.mdx
+++ b/content/marketing/agents.mdx
@@ -52,28 +52,28 @@ The skill uses progressive disclosure: only the frontmatter sits in the agent's 
 
 ## CLI [#cli]
 
-The [`langfuse-cli`](/docs/api-and-data-platform/features/cli) wraps the entire Langfuse REST API. It is generated from the OpenAPI spec, so every endpoint becomes a command with proper flags, validation, and help text. The skill uses it under the hood, and your agent can call it directly when it can run bash.
+The [`@langfuse/cli`](/docs/api-and-data-platform/features/cli) package wraps the entire Langfuse REST API. It is generated from the OpenAPI spec, so every endpoint becomes a command with proper flags, validation, and help text. The skill uses it under the hood, and your agent can call it directly when it can run bash.
 
 Run it without installing:
 
 ```bash
-npx langfuse-cli api <resource> <action>
+npx @langfuse/cli api <resource> <action>
 ```
 
 Agents discover the surface area through built-in help, which keeps token usage low:
 
 ```bash
-npx langfuse-cli api help                       # list all resources
-npx langfuse-cli api <resource> --help          # list actions for a resource
-npx langfuse-cli api <resource> <action> --help # show args for an action
-npx langfuse-cli api schema --json              # machine-readable command schema
+npx @langfuse/cli api help                       # list all resources
+npx @langfuse/cli api <resource> --help          # list actions for a resource
+npx @langfuse/cli api <resource> <action> --help # show args for an action
+npx @langfuse/cli api schema --json              # machine-readable command schema
 ```
 
 Because the CLI is generated from the spec, it stays in sync with the API automatically and covers every endpoint, including [full-text search over observations](#fast).
 
 <Cards>
   <Card title="CLI reference" href="/docs/api-and-data-platform/features/cli" />
-  <Card title="langfuse-cli on npm" href="https://www.npmjs.com/package/langfuse-cli" />
+  <Card title="@langfuse/cli on npm" href="https://www.npmjs.com/package/@langfuse/cli" />
 </Cards>
 
 ## MCP server [#mcp]
@@ -174,4 +174,4 @@ Once an agent can read and write Langfuse data, it can help you measure quality,
 - [Using agent skills to improve your prompts](/blog/2026-02-16-prompt-improvement-claude-skills)
 - [Evaluating AI agent skills](/blog/2026-02-26-evaluate-ai-agent-skills)
 - [Agent Skill docs](/docs/api-and-data-platform/features/agent-skill) · [CLI docs](/docs/api-and-data-platform/features/cli) · [MCP server docs](/docs/api-and-data-platform/features/mcp-server) · [Langfuse Assistant docs](/docs/langfuse-assistant)
-- [Skills on GitHub](https://github.com/langfuse/skills) · [langfuse-cli on npm](https://www.npmjs.com/package/langfuse-cli) · [MCP reference](https://mcp.reference.langfuse.com)
+- [Skills on GitHub](https://github.com/langfuse/skills) · [@langfuse/cli on npm](https://www.npmjs.com/package/@langfuse/cli) · [MCP reference](https://mcp.reference.langfuse.com)

--- a/lib/agent-instructions-footer.js
+++ b/lib/agent-instructions-footer.js
@@ -58,7 +58,7 @@ function buildAgentInstructionsFooter(pageUrl) {
     "- **Install the [Langfuse Agent Skill](https://langfuse.com/docs/api-and-data-platform/features/agent-skill).** It encodes Langfuse's own best practices for instrumentation, prompt management, and evaluation, and materially improves results.",
     "- **Read [What does a good trace look like?](https://langfuse.com/docs/observability/best-practices.md)** before instrumenting an application.",
     "- **Verify endpoints, parameters, and response fields** against the [API reference](https://api.reference.langfuse.com) instead of inferring them from code examples.",
-    "- **Use the [Langfuse CLI](https://langfuse.com/docs/api-and-data-platform/features/cli)** (`npx langfuse-cli api <resource> <action>`) to read or write traces, prompts, datasets, and scores from the terminal.",
+    "- **Use the [Langfuse CLI](https://langfuse.com/docs/api-and-data-platform/features/cli)** (`npx @langfuse/cli api <resource> <action>`) to read or write traces, prompts, datasets, and scores from the terminal.",
     "",
     "Found an error in these docs? Please open an issue at <https://github.com/langfuse/langfuse-docs/issues>.",
     "",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only rename with explicit backward-compatibility notes; no runtime or API behavior changes.
> 
> **Overview**
> Documentation and agent-facing copy now treat **`@langfuse/cli`** as the canonical npm package instead of **`langfuse-cli`**.
> 
> **npx/bunx/npm** examples, install prompts, and npm links are updated across blog posts, changelogs, the agents marketing page, the deprecated API migration FAQ, and the generated markdown footer in `lib/agent-instructions-footer.js`. The **CLI docs** add a callout and a short **migration section** noting that `langfuse-cli` stays in sync until the next major and that the global **`langfuse`** command is unchanged after switching packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da90beed1146ba226a84865f638b48f22780efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63105191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the package rename is applied consistently and no concrete rendering, command-format, or repository-rule failure remains.

<details open><summary><h3>Summary</h3></summary>

- Updates direct-run and global-install commands across documentation, blog posts, changelog entries, marketing content, and generated agent instructions.
- Updates npm package links to the scoped package.
- Adds migration guidance explaining continued support for the former package name.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(cli): rename package"](https://github.com/langfuse/langfuse-docs/commit/7f0171ab5d8095d08c0083b48cedee7d2469f7d8)</sub>

<!-- /greptile_comment -->