### PR TITLE
Move comparison pages to /compare and drop the docs sidebar

### DIFF
--- a/.agents/cursor/rules/available-internal-links.mdc
+++ b/.agents/cursor/rules/available-internal-links.mdc
@@ -20,7 +20,7 @@ Please make sure that all relative links match to what is available.
 - [Enterprise license keys](/self-hosting/license-key.md): Activation and licensing for self-hosted add-on features.
 - [Security](/security.md): Security controls, compliance, and supporting documentation.
 - [Data regions](/security/data-regions.md): Hosting locations and regional availability.
-- Comparisons: [LangSmith](/resources/engineering/langsmith-alternative.md), [Braintrust](/resources/engineering/best-braintrustdata-alternatives.md), and [Arize / Phoenix](/resources/engineering/best-phoenix-arize-alternatives.md), with dated competitor sources.
+- Comparisons: [LangSmith](/compare/langsmith.md), [Braintrust](/compare/braintrust.md), [Arize / Phoenix](/compare/arize-phoenix.md), [Galileo](/compare/galileo.md), and [Datadog](/compare/datadog.md), with dated competitor sources.
 
 ## Markdown Access
 
@@ -104,6 +104,10 @@ For the full list with links to each page, see: /llms-faq.txt
 ## Resources
 
 For the full list with links to each page, see: /llms-resources.txt
+
+## Compare
+
+For the full list with links to each page, see: /llms-compare.txt
 
 ## Security and compliance
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           require-lockfile: true
 
       - name: Run sitemap checker unit tests
-        run: node --test scripts/check-sitemap-links.test.js
+        run: node --test scripts/check-sitemap-links.test.js lib/compare-labels.test.js
 
       - name: Build next.js app
         run: pnpm build

--- a/app/compare/[[...slug]]/page.tsx
+++ b/app/compare/[[...slug]]/page.tsx
@@ -5,6 +5,8 @@ import { loadPage, buildSectionMetadata } from "@/lib/mdx-page";
 import { getMDXComponents } from "@/mdx-components";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { PostArticleHeader } from "@/components/PostArticleHeader";
+import { compareCrumbs } from "@/lib/post-crumbs";
 import { ContentColumns } from "@/components/layout";
 
 type PageProps = {
@@ -20,7 +22,8 @@ export default async function ComparePage({ params }: PageProps) {
   return (
     <ContentColumns footerClassName="xl:max-w-[680px]">
       <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
-        <MainContentWrapper>
+        <MainContentWrapper showCopyButton={false}>
+          <PostArticleHeader items={compareCrumbs(slug)} />
           <DocBodyChrome showCopyButton={false}>
             <MDX components={getMDXComponents()} />
           </DocBodyChrome>

--- a/app/compare/[[...slug]]/page.tsx
+++ b/app/compare/[[...slug]]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { compareSource } from "@/lib/source";
+import { loadPage, buildSectionMetadata } from "@/lib/mdx-page";
+import { getMDXComponents } from "@/mdx-components";
+import { DocBodyChrome } from "@/components/DocBodyChrome";
+import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { ContentColumns } from "@/components/layout";
+
+type PageProps = {
+  params: Promise<{ slug?: string[] }>;
+};
+
+export default async function ComparePage({ params }: PageProps) {
+  const { slug = [] } = await params;
+  const result = await loadPage(compareSource, slug);
+  if (!result) notFound();
+  const { MDX } = result;
+
+  return (
+    <ContentColumns footerClassName="xl:max-w-[680px]">
+      <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
+        <MainContentWrapper>
+          <DocBodyChrome showCopyButton={false}>
+            <MDX components={getMDXComponents()} />
+          </DocBodyChrome>
+        </MainContentWrapper>
+      </div>
+    </ContentColumns>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug = [] } = await params;
+  const page = compareSource.getPage(slug);
+  if (!page) return { title: "Not Found" };
+  return buildSectionMetadata(page, "compare", "Compare", slug);
+}
+
+export function generateStaticParams() {
+  return compareSource.generateParams();
+}

--- a/app/compare/[[...slug]]/page.tsx
+++ b/app/compare/[[...slug]]/page.tsx
@@ -17,13 +17,16 @@ export default async function ComparePage({ params }: PageProps) {
   const { slug = [] } = await params;
   const result = await loadPage(compareSource, slug);
   if (!result) notFound();
-  const { MDX } = result;
+  const { page, MDX } = result;
+  const currentLabel = String(
+    page.data.shortTitle ?? page.data.sidebarTitle ?? page.data.title ?? "",
+  );
 
   return (
     <ContentColumns footerClassName="xl:max-w-[680px]">
       <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
         <MainContentWrapper showCopyButton={false}>
-          <PostArticleHeader items={compareCrumbs(slug)} />
+          <PostArticleHeader items={compareCrumbs(slug, currentLabel)} />
           <DocBodyChrome showCopyButton={false}>
             <MDX components={getMDXComponents()} />
           </DocBodyChrome>

--- a/app/compare/layout.tsx
+++ b/app/compare/layout.tsx
@@ -1,0 +1,11 @@
+import { PageChrome } from "@/components/layout";
+
+// Competitive comparison pages. Styled like customer stories: marketing
+// chrome, no docs sidebar. Linked from the site footer as /compare.
+export default function CompareLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <PageChrome>{children}</PageChrome>;
+}

--- a/app/resources/[[...slug]]/page.tsx
+++ b/app/resources/[[...slug]]/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { resourcesSource } from "@/lib/source";
-import { DocsChromePage } from "@/components/DocsChromePage";
-import { buildSectionMetadata } from "@/lib/mdx-page";
+import { loadPage, buildSectionMetadata } from "@/lib/mdx-page";
+import { getMDXComponents } from "@/mdx-components";
+import { DocBodyChrome } from "@/components/DocBodyChrome";
+import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { ContentColumns } from "@/components/layout";
 
 type PageProps = {
   params: Promise<{ slug?: string[] }>;
@@ -10,9 +13,21 @@ type PageProps = {
 
 export default async function ResourcesPage({ params }: PageProps) {
   const { slug = [] } = await params;
-  const page = resourcesSource.getPage(slug);
-  if (!page) notFound();
-  return <DocsChromePage page={page} />;
+  const result = await loadPage(resourcesSource, slug);
+  if (!result) notFound();
+  const { MDX } = result;
+
+  return (
+    <ContentColumns footerClassName="xl:max-w-[680px]">
+      <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
+        <MainContentWrapper>
+          <DocBodyChrome showCopyButton={false}>
+            <MDX components={getMDXComponents()} />
+          </DocBodyChrome>
+        </MainContentWrapper>
+      </div>
+    </ContentColumns>
+  );
 }
 
 export async function generateMetadata({

--- a/app/resources/[[...slug]]/page.tsx
+++ b/app/resources/[[...slug]]/page.tsx
@@ -5,6 +5,8 @@ import { loadPage, buildSectionMetadata } from "@/lib/mdx-page";
 import { getMDXComponents } from "@/mdx-components";
 import { DocBodyChrome } from "@/components/DocBodyChrome";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
+import { PostArticleHeader } from "@/components/PostArticleHeader";
+import { resourcesCrumbs } from "@/lib/post-crumbs";
 import { ContentColumns } from "@/components/layout";
 
 type PageProps = {
@@ -15,12 +17,14 @@ export default async function ResourcesPage({ params }: PageProps) {
   const { slug = [] } = await params;
   const result = await loadPage(resourcesSource, slug);
   if (!result) notFound();
-  const { MDX } = result;
+  const { page, MDX } = result;
+  const title = String(page.data.title ?? "");
 
   return (
     <ContentColumns footerClassName="xl:max-w-[680px]">
       <div className="mx-auto w-full max-w-[680px] px-4 py-6 md:px-0">
-        <MainContentWrapper>
+        <MainContentWrapper showCopyButton={false}>
+          <PostArticleHeader items={resourcesCrumbs(slug, title)} />
           <DocBodyChrome showCopyButton={false}>
             <MDX components={getMDXComponents()} />
           </DocBodyChrome>

--- a/app/resources/layout.tsx
+++ b/app/resources/layout.tsx
@@ -1,21 +1,11 @@
-import { resourcesSource } from "@/lib/source";
-import { SharedDocsLayout } from "@/components/layout";
+import { PageChrome } from "@/components/layout";
 
-// SEO/GEO resources hub (e.g. /resources/engineering). Reachable mainly via
-// search, so it uses the compact docs chrome (no section tabs) rather than
-// appearing in the primary DocsSecondaryNav navigation.
+// SEO/GEO resources hub (e.g. /resources/engineering). Styled like customer
+// stories: marketing chrome, no docs sidebar. Reachable mainly via search.
 export default function ResourcesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <SharedDocsLayout
-      tree={resourcesSource.getPageTree()}
-      showSecondaryNav={false}
-      sectionLabel="Resources"
-    >
-      {children}
-    </SharedDocsLayout>
-  );
+  return <PageChrome>{children}</PageChrome>;
 }

--- a/components/DocsTocFooter.tsx
+++ b/components/DocsTocFooter.tsx
@@ -26,6 +26,7 @@ const getGithubEditUrl = (path: string): string | null => {
     library: "content/library",
     academy: "content/academy",
     resources: "content/resources",
+    compare: "content/compare",
   };
 
   const contentDir = sectionToDir[section];

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -47,6 +47,7 @@ const pathsWithoutFooterWidgets = [
   "/workflow-automation",
   "/events",
   "/changelog",
+  "/resources",
   "/cn",
   "/community",
   "/cookie-policy",

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -48,6 +48,7 @@ const pathsWithoutFooterWidgets = [
   "/events",
   "/changelog",
   "/resources",
+  "/compare",
   "/cn",
   "/community",
   "/cookie-policy",
@@ -74,6 +75,7 @@ const pathsWithCopyAsMarkdownButton = [
   "/coding-agents",
   "/workflow-automation",
   "/resources",
+  "/compare",
   "/academy",
 ];
 const isCustomerStory = (pathname: string) => pathname.startsWith("/users/");

--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { usePostHogClientCapture } from "@/src/usePostHogClientCapture";
 import { Button } from "./ui/button";
 import { Link } from "./ui/link";
@@ -338,15 +338,24 @@ export const CopyMarkdownButton = () => {
   );
 };
 
-export const MainContentWrapper = (props) => {
+export const MainContentWrapper = ({
+  children,
+  showCopyButton,
+}: {
+  children?: ReactNode;
+  /** Override the path-based copy button. Post pages render it in the header. */
+  showCopyButton?: boolean;
+}) => {
   const pathname = usePathname();
   const cookbook = COOKBOOK_ROUTE_MAPPING.find(
     (cookbook) => cookbook.path === pathname,
   );
 
-  const shouldShowCopyButton = pathsWithCopyAsMarkdownButton.some((prefix) =>
-    (pathname ?? "").startsWith(prefix),
-  );
+  const shouldShowCopyButton =
+    showCopyButton ??
+    pathsWithCopyAsMarkdownButton.some((prefix) =>
+      (pathname ?? "").startsWith(prefix),
+    );
 
   return (
     <>
@@ -360,7 +369,7 @@ export const MainContentWrapper = (props) => {
         <NotebookBanner src={cookbook.ipynbPath} className="mt-4 mb-4" />
       ) : null}
 
-      {props.children}
+      {children}
       {!pathsWithoutFooterWidgets.some(
         (path) => pathname === path || (pathname ?? "").startsWith(path + "/"),
       ) ? (

--- a/components/PostArticleHeader.tsx
+++ b/components/PostArticleHeader.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { CopyMarkdownButton } from "@/components/MainContentWrapper";
+import { cn } from "@/lib/utils";
+import type { PostCrumb } from "@/lib/post-crumbs";
+
+/**
+ * Docs-style breadcrumb row with the copy-page control on the right.
+ * Used by post-chrome sections (compare, resources) that have no docs sidebar.
+ */
+export function PostArticleHeader({ items }: { items: PostCrumb[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="not-prose mb-6 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+      <nav className="min-w-0 flex-1" aria-label="Breadcrumb">
+        <ol className="flex min-w-0 items-center gap-1.5 text-sm text-text-tertiary">
+          {items.map((item, index) => {
+            const isLast = index === items.length - 1;
+            return (
+              <li
+                key={`${item.label}-${index}`}
+                className="flex min-w-0 items-center gap-1.5"
+              >
+                {index !== 0 && (
+                  <ChevronRight className="size-3.5 shrink-0" aria-hidden />
+                )}
+                {item.href && !isLast ? (
+                  <Link
+                    href={item.href}
+                    className="truncate no-underline transition-colors hover:text-text-primary hover:no-underline"
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={cn(
+                      "truncate",
+                      isLast && "font-medium text-text-primary",
+                    )}
+                    aria-current={isLast ? "page" : undefined}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+      <CopyMarkdownButton />
+    </div>
+  );
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -72,6 +72,7 @@ const menuItems: {
       { name: "Roadmap", href: "/docs/roadmap" },
       { name: "Interactive Demo", href: "/docs/demo" },
       { name: "Customers", href: "/users" },
+      { name: "Compare", href: "/compare" },
       { name: "AI Engineering Library", href: "/library" },
       { name: "Workshop", href: "/workshop" },
       { name: "Guides & Cookbooks", href: "/guides" },

--- a/components/resources/ResourcesIndex.tsx
+++ b/components/resources/ResourcesIndex.tsx
@@ -9,11 +9,10 @@ type ResourcePage = ReturnType<typeof resourcesSource.getPages>[number];
  * "Articles" bucket and render last.
  */
 const CATEGORY_LABELS: Record<string, string> = {
-  comparison: "Comparisons",
   migration: "Migrations",
 };
 
-const CATEGORY_ORDER = ["comparison", "migration"];
+const CATEGORY_ORDER = ["migration"];
 const OTHER_KEY = "other";
 const OTHER_LABEL = "Articles";
 

--- a/content/blog/2024-08-what-is-langchain.mdx
+++ b/content/blog/2024-08-what-is-langchain.mdx
@@ -67,7 +67,7 @@ Langfuse has released integrations for [LangChain Python](/integrations/framewor
 
 The answer is, **[LangSmith](https://www.langchain.com/langsmith) is a developer platform for LLMs centered around observability, annotation, datasets, and prompt engineering/management.**
 
-LangSmith is a closed-source, commercial offering by the company behind the LangChain open-source framework. We have compiled more information about [LangSmith alternatives](/resources/engineering/langsmith-alternative) here.
+LangSmith is a closed-source, commercial offering by the company behind the LangChain open-source framework. We have compiled more information about [LangSmith alternatives](/compare/langsmith) here.
 
 ### What is LangGraph?
 
@@ -89,4 +89,4 @@ Using LangServe will allow you to create a scalable Python web server for your L
 
 Langfuse is used to gain insights into LLM applications built with or without LLM frameworks such as LangChain. Developers use Langfuse precisely because it is **framework-agnostic** and allows them to **pick-and-choose** and iterate on their LLM development stack. It can allow builders to avoid the abstraction and complexity that can come with LLM frameworks.
 
-In the context of LangChain, **Langfuse most closely replaces [LangSmith](/resources/engineering/langsmith-alternative)**.
+In the context of LangChain, **Langfuse most closely replaces [LangSmith](/compare/langsmith)**.

--- a/content/compare/arize-phoenix.mdx
+++ b/content/compare/arize-phoenix.mdx
@@ -248,5 +248,5 @@ No. Langfuse already ran on ClickHouse. The [announcement](/blog/joining-clickho
 Keep your OpenInference instrumentation and point it at Langfuse's OTLP endpoint, then recreate datasets, prompts, and evaluators. See [Switching from Arize](#switching-from-arize).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/blob/main/content/compare/arize-phoenix.mdx) with up-to-date information.
 </Callout>

--- a/content/compare/arize-phoenix.mdx
+++ b/content/compare/arize-phoenix.mdx
@@ -1,5 +1,6 @@
 ---
 title: Arize Alternative? Langfuse vs. Arize AX and Arize Phoenix
+shortTitle: Arize / Phoenix
 seoTitle: "Langfuse vs. Arize AX and Arize Phoenix"
 description: Langfuse is the open-source alternative to Arize AX and Phoenix. September 2026 comparison of unit vs span+GB pricing, evals, and the Dynatrace acquisition.
 tags: [comparison]

--- a/content/compare/arize-phoenix.mdx
+++ b/content/compare/arize-phoenix.mdx
@@ -247,5 +247,5 @@ No. Langfuse already ran on ClickHouse. The [announcement](/blog/joining-clickho
 Keep your OpenInference instrumentation and point it at Langfuse's OTLP endpoint, then recreate datasets, prompts, and evaluators. See [Switching from Arize](#switching-from-arize).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
 </Callout>

--- a/content/compare/braintrust.mdx
+++ b/content/compare/braintrust.mdx
@@ -1,5 +1,6 @@
 ---
 title: Braintrust Alternative? Langfuse vs. Braintrust for AI Engineering
+shortTitle: Braintrust
 seoTitle: "Braintrust Alternative: Langfuse vs. Braintrust"
 description: Langfuse is the open-source Braintrust alternative. August 2026 comparison of MIT self-hosting, ClickHouse vs Brainstore, unit vs GB pricing, and evals.
 tags: [comparison, integration]

--- a/content/compare/braintrust.mdx
+++ b/content/compare/braintrust.mdx
@@ -254,5 +254,5 @@ The meters differ: Langfuse counts traces, observations, and scores as units (Co
 Run both in parallel, swap the SDK wrappers or repoint your OpenTelemetry exporter, import datasets via API, and keep your autoevals scorers. Most teams see first traces the same day; history stays in Braintrust. Follow the [migration guide](/resources/engineering/migrate-from-braintrust) or see [Switching from Braintrust](#switching-from-braintrust).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
 </Callout>

--- a/content/compare/braintrust.mdx
+++ b/content/compare/braintrust.mdx
@@ -255,5 +255,5 @@ The meters differ: Langfuse counts traces, observations, and scores as units (Co
 Run both in parallel, swap the SDK wrappers or repoint your OpenTelemetry exporter, import datasets via API, and keep your autoevals scorers. Most teams see first traces the same day; history stays in Braintrust. Follow the [migration guide](/resources/engineering/migrate-from-braintrust) or see [Switching from Braintrust](#switching-from-braintrust).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/blob/main/content/compare/braintrust.mdx) with up-to-date information.
 </Callout>

--- a/content/compare/datadog.mdx
+++ b/content/compare/datadog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Langfuse vs. Datadog for LLM Observability & Agent Tracing
+shortTitle: Datadog
 description: Langfuse is the open-source alternative to Datadog Agent Observability. September 2026 comparison of self-hosting, unit vs LLM-span pricing, and evals.
 tags: [comparison]
 ---

--- a/content/compare/datadog.mdx
+++ b/content/compare/datadog.mdx
@@ -223,5 +223,5 @@ No. Langfuse already ran on ClickHouse. The [announcement](/blog/joining-clickho
 Point live traffic at Langfuse and recreate datasets, prompts, and evaluators. History usually stays in Datadog. See [Switching from Datadog Agent Observability](#switching-from-datadog).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
 </Callout>

--- a/content/compare/datadog.mdx
+++ b/content/compare/datadog.mdx
@@ -224,5 +224,5 @@ No. Langfuse already ran on ClickHouse. The [announcement](/blog/joining-clickho
 Point live traffic at Langfuse and recreate datasets, prompts, and evaluators. History usually stays in Datadog. See [Switching from Datadog Agent Observability](#switching-from-datadog).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/blob/main/content/compare/datadog.mdx) with up-to-date information.
 </Callout>

--- a/content/compare/datadog.mdx
+++ b/content/compare/datadog.mdx
@@ -1,13 +1,13 @@
 ---
-title: Langfuse vs. Datadog for LLM Observability & Agent Tracing
-shortTitle: Datadog
+title: Langfuse vs. Datadog Agent Observability
+shortTitle: Datadog Agent Observability
 description: Langfuse is the open-source alternative to Datadog Agent Observability. September 2026 comparison of self-hosting, unit vs LLM-span pricing, and evals.
 tags: [comparison]
 ---
 
 import { Cloud, MessageSquare } from "lucide-react";
 
-# Langfuse vs. Datadog
+# Langfuse vs. Datadog Agent Observability
 
 This guide outlines the key differences between **[Langfuse](/)** and **[Datadog Agent Observability](https://www.datadoghq.com/products/ai/agent-observability/)**. All Datadog facts were checked against public Datadog sources in September 2026.
 

--- a/content/compare/galileo.mdx
+++ b/content/compare/galileo.mdx
@@ -101,4 +101,4 @@ The following tables break down how Langfuse and Galileo AI approach the three c
 
 ## This comparison is out of date?
 
-Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up to date information.
+Please [raise a pull request](https://github.com/langfuse/langfuse-docs/blob/main/content/compare/galileo.mdx) with up to date information.

--- a/content/compare/galileo.mdx
+++ b/content/compare/galileo.mdx
@@ -1,5 +1,6 @@
 ---
 title: Galileo AI Alternatives? The best LLMOps platform?
+shortTitle: Galileo
 description: This article compares Langfuse and Galileo AI for LLM observability, analytics, evaluations, testing, and annotation.
 tags: [comparison]
 ---

--- a/content/compare/galileo.mdx
+++ b/content/compare/galileo.mdx
@@ -100,4 +100,4 @@ The following tables break down how Langfuse and Galileo AI approach the three c
 
 ## This comparison is out of date?
 
-Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up to date information.
+Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up to date information.

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -14,4 +14,4 @@ We publish these comparisons to help you make an educated choice. Each page is s
 - [Braintrust](/compare/braintrust)
 - [Arize / Phoenix](/compare/arize-phoenix)
 - [Galileo](/compare/galileo)
-- [Datadog](/compare/datadog)
+- [Datadog Agent Observability](/compare/datadog)

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Compare Langfuse
+seoTitle: "Compare Langfuse with LangSmith, Braintrust, Arize, Galileo, and Datadog"
+description: Head-to-head comparisons of Langfuse with other AI engineering and observability platforms.
+---
+
+# Compare Langfuse
+
+Open-source comparisons of Langfuse with other AI engineering platforms. Each page stays in markdown so it is easy to keep current.
+
+- [LangSmith Alternative: Langfuse vs. LangSmith](/compare/langsmith) — MIT self-hosting, ClickHouse vs SmithDB, evals, and unit pricing with no seats.
+- [Langfuse vs. Braintrust](/compare/braintrust) — open-source Braintrust alternative for AI engineering.
+- [Langfuse vs. Arize AX / Phoenix](/compare/arize-phoenix) — open-source alternative for unit vs span+GB pricing, evals, and the Dynatrace acquisition.
+- [Galileo AI Alternatives](/compare/galileo) — Langfuse compared with Galileo AI for observability, analytics, evaluations, testing, and annotation.
+- [Langfuse vs. Datadog](/compare/datadog) — open-source alternative for LLM observability and agent tracing.

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -8,7 +8,7 @@ description: Head-to-head comparisons of Langfuse with other AI engineering and 
 
 Start with [Why Langfuse?](/why) for a summary of how we position the product. For more context, see our [mission](/handbook/chapters/mission) and [roadmap](/docs/roadmap).
 
-We publish these comparisons to help you make an educated choice. Each page is sourced from public documentation and dated so you can see when we last checked the facts. We are committed to keeping them up to date — [pull requests](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) are welcome.
+We publish these comparisons to help you make an educated choice. Each page is sourced from public documentation and dated so you can see when we last checked the facts. We are committed to keeping them up to date — [pull requests](https://github.com/langfuse/langfuse-docs) are welcome.
 
 - [LangSmith](/compare/langsmith)
 - [Braintrust](/compare/braintrust)

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Compare Langfuse
-seoTitle: "Compare Langfuse with LangSmith, Braintrust, Arize, Galileo, and Datadog"
+seoTitle: "Compare Langfuse with other AI engineering platforms"
 description: Head-to-head comparisons of Langfuse with other AI engineering and observability platforms.
 ---
 

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Compare Langfuse
+title: Compare Langfuse to other solutions
 seoTitle: "Compare Langfuse with other AI engineering platforms"
 description: Head-to-head comparisons of Langfuse with other AI engineering and observability platforms.
 ---
 
-# Compare Langfuse
+# Compare Langfuse to other solutions
 
 Start with [Why Langfuse?](/why) for a summary of how we position the product. For more context, see our [mission](/handbook/chapters/mission) and [roadmap](/docs/roadmap).
 

--- a/content/compare/index.mdx
+++ b/content/compare/index.mdx
@@ -6,10 +6,12 @@ description: Head-to-head comparisons of Langfuse with other AI engineering and 
 
 # Compare Langfuse
 
-Open-source comparisons of Langfuse with other AI engineering platforms. Each page stays in markdown so it is easy to keep current.
+Start with [Why Langfuse?](/why) for a summary of how we position the product. For more context, see our [mission](/handbook/chapters/mission) and [roadmap](/docs/roadmap).
 
-- [LangSmith Alternative: Langfuse vs. LangSmith](/compare/langsmith) — MIT self-hosting, ClickHouse vs SmithDB, evals, and unit pricing with no seats.
-- [Langfuse vs. Braintrust](/compare/braintrust) — open-source Braintrust alternative for AI engineering.
-- [Langfuse vs. Arize AX / Phoenix](/compare/arize-phoenix) — open-source alternative for unit vs span+GB pricing, evals, and the Dynatrace acquisition.
-- [Galileo AI Alternatives](/compare/galileo) — Langfuse compared with Galileo AI for observability, analytics, evaluations, testing, and annotation.
-- [Langfuse vs. Datadog](/compare/datadog) — open-source alternative for LLM observability and agent tracing.
+We publish these comparisons to help you make an educated choice. Each page is sourced from public documentation and dated so you can see when we last checked the facts. We are committed to keeping them up to date — [pull requests](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) are welcome.
+
+- [LangSmith](/compare/langsmith)
+- [Braintrust](/compare/braintrust)
+- [Arize / Phoenix](/compare/arize-phoenix)
+- [Galileo](/compare/galileo)
+- [Datadog](/compare/datadog)

--- a/content/compare/langsmith.mdx
+++ b/content/compare/langsmith.mdx
@@ -282,5 +282,5 @@ Follow the [step-by-step migration guide](/resources/engineering/migrate-from-la
 SmithDB is LangSmith's proprietary trace database (May 2026), written in Rust on Apache DataFusion and Vortex, with trace data on object storage. LangChain reports up to 15× faster core experiences. Langfuse runs on open-source ClickHouse with an observations-first data model, so Cloud and self-hosted share the same architecture. See [Storage: ClickHouse vs SmithDB](#storage).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/resources/engineering) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
 </Callout>

--- a/content/compare/langsmith.mdx
+++ b/content/compare/langsmith.mdx
@@ -1,5 +1,6 @@
 ---
 title: LangSmith Alternative? Langfuse vs. LangSmith for AI Engineering
+shortTitle: LangSmith
 seoTitle: "LangSmith Alternative: Langfuse vs. LangSmith"
 description: Langfuse is the open-source LangSmith alternative. September 2026 comparison of MIT self-hosting, ClickHouse vs SmithDB, evals, and unit pricing with no seats.
 tags: [comparison, integration]

--- a/content/compare/langsmith.mdx
+++ b/content/compare/langsmith.mdx
@@ -283,5 +283,5 @@ Follow the [step-by-step migration guide](/resources/engineering/migrate-from-la
 SmithDB is LangSmith's proprietary trace database (May 2026), written in Rust on Apache DataFusion and Vortex, with trace data on object storage. LangChain reports up to 15× faster core experiences. Langfuse runs on open-source ClickHouse with an observations-first data model, so Cloud and self-hosted share the same architecture. See [Storage: ClickHouse vs SmithDB](#storage).
 
 <Callout type="info">
-  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/tree/main/content/compare) with up-to-date information.
+  This comparison is out of date? Please [raise a pull request](https://github.com/langfuse/langfuse-docs/blob/main/content/compare/langsmith.mdx) with up-to-date information.
 </Callout>

--- a/content/compare/meta.json
+++ b/content/compare/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Compare",
+  "pages": [
+    "index",
+    "langsmith",
+    "braintrust",
+    "arize-phoenix",
+    "galileo",
+    "datadog"
+  ]
+}

--- a/content/compare/meta.json
+++ b/content/compare/meta.json
@@ -1,11 +1,3 @@
 {
-  "title": "Compare",
-  "pages": [
-    "index",
-    "langsmith",
-    "braintrust",
-    "arize-phoenix",
-    "galileo",
-    "datadog"
-  ]
+  "title": "Compare"
 }

--- a/content/resources/engineering/clarifications.mdx
+++ b/content/resources/engineering/clarifications.mdx
@@ -1,7 +1,6 @@
 ---
 title: Clarifications
 description: Langfuse is an open-source AI engineering platform for tracing, prompt management, evals, and experiments. September 2026 clarifications of what Langfuse includes.
-tags: [comparison]
 ---
 
 # Clarifications

--- a/content/resources/engineering/index.mdx
+++ b/content/resources/engineering/index.mdx
@@ -6,7 +6,7 @@ description: In-depth engineering articles on LLM observability, evaluation, and
 
 # Engineering Resources
 
-In-depth, engineering-focused articles on LLM observability, evaluation, and tooling. For head-to-head platform pages, see [Compare Langfuse](/compare).
+In-depth, engineering-focused articles on LLM observability, evaluation, and tooling.
 
 import { ResourcesIndex } from "@/components/resources/ResourcesIndex";
 

--- a/content/resources/engineering/index.mdx
+++ b/content/resources/engineering/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Engineering Resources
 seoTitle: "Langfuse Engineering Resources"
-description: In-depth engineering articles on LLM observability, evaluation, and tooling — including platform comparisons and migration guides.
+description: In-depth engineering articles on LLM observability, evaluation, and tooling — including migration guides.
 ---
 
 # Engineering Resources
 
-In-depth, engineering-focused articles on LLM observability, evaluation, and tooling. These guides compare Langfuse with other platforms and walk through migrations so you can choose the right setup for your stack.
+In-depth, engineering-focused articles on LLM observability, evaluation, and tooling. For head-to-head platform pages, see [Compare Langfuse](/compare).
 
 import { ResourcesIndex } from "@/components/resources/ResourcesIndex";
 

--- a/content/resources/engineering/meta.json
+++ b/content/resources/engineering/meta.json
@@ -2,11 +2,6 @@
   "title": "Engineering",
   "pages": [
     "index",
-    "langsmith-alternative",
-    "best-phoenix-arize-alternatives",
-    "best-galileo-ai-alternatives",
-    "best-braintrustdata-alternatives",
-    "langfuse-vs-datadog",
     "migrate-from-langsmith",
     "migrate-from-helicone",
     "migrate-from-braintrust",

--- a/content/resources/engineering/migrate-from-arize-ax.mdx
+++ b/content/resources/engineering/migrate-from-arize-ax.mdx
@@ -17,7 +17,7 @@ Dynatrace [announced a definitive agreement to acquire Arize](https://www.dynatr
 Arize AX and Phoenix continue to operate as they do today. This guide is for teams on
 **Arize AX**. If you self-host Phoenix, use [Migrate from Arize Phoenix](/resources/engineering/migrate-from-phoenix)
 instead. For a product comparison, see
-[Langfuse vs. Arize AX / Phoenix](/resources/engineering/best-phoenix-arize-alternatives).
+[Langfuse vs. Arize AX / Phoenix](/compare/arize-phoenix).
 
 **TL;DR:**
 

--- a/content/resources/engineering/migrate-from-braintrust.mdx
+++ b/content/resources/engineering/migrate-from-braintrust.mdx
@@ -46,7 +46,7 @@ Teams tend to evaluate a Braintrust-to-Langfuse move for a few recurring reasons
 Braintrust remains a polished platform with a tight evaluation loop, a capable playground,
 and a managed hybrid deployment, and if it serves your team well there is no urgency to
 move. This guide is for teams that have decided to consolidate on Langfuse. For a
-feature-by-feature comparison, see [Langfuse vs. Braintrust](/resources/engineering/best-braintrustdata-alternatives).
+feature-by-feature comparison, see [Langfuse vs. Braintrust](/compare/braintrust).
 
 ## Concept mapping
 

--- a/content/resources/engineering/migrate-from-langsmith.mdx
+++ b/content/resources/engineering/migrate-from-langsmith.mdx
@@ -11,7 +11,7 @@ import { Details, Summary } from "@/components/Details";
 
 This guide walks through migrating AI observability from [LangSmith](https://www.langchain.com/langsmith) to [Langfuse](/): live tracing first (usually a same-day change), then datasets, prompts, experiments, and evaluators, and optionally historical traces.
 
-The [Langfuse vs. LangSmith comparison](/resources/engineering/langsmith-alternative) covers how the two products differ; this guide covers the move.
+The [Langfuse vs. LangSmith comparison](/compare/langsmith) covers how the two products differ; this guide covers the move.
 
 **TL;DR:**
 

--- a/content/resources/engineering/migrate-from-phoenix.mdx
+++ b/content/resources/engineering/migrate-from-phoenix.mdx
@@ -17,7 +17,7 @@ Dynatrace [announced a definitive agreement to acquire Arize](https://www.dynatr
 Arize AX and Phoenix continue to operate as they do today. This guide is for teams that have
 already decided to move to Langfuse from **Phoenix**. If you are on Arize AX (spaces,
 `arize.otel.register()`), use [Migrate from Arize AX](/resources/engineering/migrate-from-arize-ax). For a product comparison, see
-[Langfuse vs. Arize AX / Phoenix](/resources/engineering/best-phoenix-arize-alternatives).
+[Langfuse vs. Arize AX / Phoenix](/compare/arize-phoenix).
 
 **TL;DR:** Keep your OpenInference instrumentors. Replace `phoenix.otel.register()` with the
 Langfuse client, then call `.instrument()` on the same OpenInference package. Datasets, prompts, and evaluators are

--- a/lib/compare-labels.js
+++ b/lib/compare-labels.js
@@ -1,0 +1,91 @@
+/**
+ * Short display names for /compare/[competitor] pages. Used by breadcrumbs
+ * and by llms.txt so a new compare page is picked up without editing a
+ * hardcoded list. Unknown slugs fall back to title case.
+ */
+"use strict";
+
+const COMPARE_LABELS = {
+  langsmith: "LangSmith",
+  braintrust: "Braintrust",
+  "arize-phoenix": "Arize / Phoenix",
+  galileo: "Galileo",
+  datadog: "Datadog",
+};
+
+function titleCaseSlug(segment) {
+  return segment
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function comparePageLabel(slug) {
+  if (!slug) return "";
+  return COMPARE_LABELS[slug] ?? titleCaseSlug(slug);
+}
+
+/** Competitor slug from a /compare URL or pathname, or null for the section index. */
+function comparePathnameSlug(pathname) {
+  let path = String(pathname || "");
+  try {
+    if (/^https?:\/\//.test(path)) path = new URL(path).pathname;
+  } catch {
+    return null;
+  }
+  const parts = path.replace(/\/$/, "").split("/").filter(Boolean);
+  if (parts[0] !== "compare" || parts.length < 2) return null;
+  return parts[1];
+}
+
+function joinWithAnd(items) {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+const KNOWN_SLUG_ORDER = Object.keys(COMPARE_LABELS);
+
+/**
+ * Build the llms.txt comparisons bullet from sitemap entries so the list
+ * tracks whatever /compare pages exist.
+ */
+function formatCompareIndexLine(entries) {
+  const knownOrder = new Map(KNOWN_SLUG_ORDER.map((slug, i) => [slug, i]));
+  const links = [];
+
+  for (const entry of entries || []) {
+    if (!entry || !entry.url) continue;
+    let pathname;
+    try {
+      pathname = new URL(entry.url).pathname;
+    } catch {
+      continue;
+    }
+    const slug = comparePathnameSlug(pathname);
+    if (!slug) continue;
+    const href = entry.url.endsWith(".md") ? entry.url : `${entry.url}.md`;
+    links.push({
+      slug,
+      markdown: `[${comparePageLabel(slug)}](${href})`,
+    });
+  }
+
+  links.sort((a, b) => {
+    const ai = knownOrder.has(a.slug) ? knownOrder.get(a.slug) : Infinity;
+    const bi = knownOrder.has(b.slug) ? knownOrder.get(b.slug) : Infinity;
+    if (ai !== bi) return ai - bi;
+    return a.slug.localeCompare(b.slug);
+  });
+
+  if (links.length === 0) return "";
+  return `- Comparisons: ${joinWithAnd(links.map((l) => l.markdown))}, with dated competitor sources.\n\n`;
+}
+
+module.exports = {
+  COMPARE_LABELS,
+  comparePageLabel,
+  comparePathnameSlug,
+  formatCompareIndexLine,
+};

--- a/lib/compare-labels.js
+++ b/lib/compare-labels.js
@@ -1,17 +1,9 @@
 /**
- * Short display names for /compare/[competitor] pages. Used by breadcrumbs
- * and by llms.txt so a new compare page is picked up without editing a
- * hardcoded list. Unknown slugs fall back to title case.
+ * Helpers for /compare URLs in llms.txt. The competitor list is whatever
+ * pages exist in the sitemap; short labels come from each page's
+ * `shortTitle` frontmatter when present.
  */
 "use strict";
-
-const COMPARE_LABELS = {
-  langsmith: "LangSmith",
-  braintrust: "Braintrust",
-  "arize-phoenix": "Arize / Phoenix",
-  galileo: "Galileo",
-  datadog: "Datadog",
-};
 
 function titleCaseSlug(segment) {
   return segment
@@ -20,9 +12,10 @@ function titleCaseSlug(segment) {
     .join(" ");
 }
 
-function comparePageLabel(slug) {
+function comparePageLabel(slug, shortTitle) {
+  if (shortTitle) return shortTitle;
   if (!slug) return "";
-  return COMPARE_LABELS[slug] ?? titleCaseSlug(slug);
+  return titleCaseSlug(slug);
 }
 
 /** Competitor slug from a /compare URL or pathname, or null for the section index. */
@@ -45,14 +38,11 @@ function joinWithAnd(items) {
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 }
 
-const KNOWN_SLUG_ORDER = Object.keys(COMPARE_LABELS);
-
 /**
  * Build the llms.txt comparisons bullet from sitemap entries so the list
  * tracks whatever /compare pages exist.
  */
 function formatCompareIndexLine(entries) {
-  const knownOrder = new Map(KNOWN_SLUG_ORDER.map((slug, i) => [slug, i]));
   const links = [];
 
   for (const entry of entries || []) {
@@ -66,25 +56,21 @@ function formatCompareIndexLine(entries) {
     const slug = comparePathnameSlug(pathname);
     if (!slug) continue;
     const href = entry.url.endsWith(".md") ? entry.url : `${entry.url}.md`;
+    const label = comparePageLabel(slug, entry.shortTitle);
     links.push({
       slug,
-      markdown: `[${comparePageLabel(slug)}](${href})`,
+      label,
+      markdown: `[${label}](${href})`,
     });
   }
 
-  links.sort((a, b) => {
-    const ai = knownOrder.has(a.slug) ? knownOrder.get(a.slug) : Infinity;
-    const bi = knownOrder.has(b.slug) ? knownOrder.get(b.slug) : Infinity;
-    if (ai !== bi) return ai - bi;
-    return a.slug.localeCompare(b.slug);
-  });
+  links.sort((a, b) => a.label.localeCompare(b.label));
 
   if (links.length === 0) return "";
   return `- Comparisons: ${joinWithAnd(links.map((l) => l.markdown))}, with dated competitor sources.\n\n`;
 }
 
 module.exports = {
-  COMPARE_LABELS,
   comparePageLabel,
   comparePathnameSlug,
   formatCompareIndexLine,

--- a/lib/compare-labels.test.js
+++ b/lib/compare-labels.test.js
@@ -22,16 +22,22 @@ test("comparePathnameSlug reads the competitor slug", () => {
   );
 });
 
-test("comparePageLabel uses brand names and title-cases unknown slugs", () => {
-  assert.equal(comparePageLabel("langsmith"), "LangSmith");
+test("comparePageLabel prefers shortTitle and title-cases unknown slugs", () => {
+  assert.equal(comparePageLabel("langsmith", "LangSmith"), "LangSmith");
   assert.equal(comparePageLabel("new-vendor"), "New Vendor");
 });
 
 test("formatCompareIndexLine lists only pages that exist", () => {
   const line = formatCompareIndexLine([
     { url: "https://langfuse.com/compare" },
-    { url: "https://langfuse.com/compare/langsmith" },
-    { url: "https://langfuse.com/compare/braintrust" },
+    {
+      url: "https://langfuse.com/compare/langsmith",
+      shortTitle: "LangSmith",
+    },
+    {
+      url: "https://langfuse.com/compare/braintrust",
+      shortTitle: "Braintrust",
+    },
   ]);
   assert.match(
     line,
@@ -47,7 +53,10 @@ test("formatCompareIndexLine lists only pages that exist", () => {
 
 test("formatCompareIndexLine includes a newly added compare page", () => {
   const line = formatCompareIndexLine([
-    { url: "https://langfuse.com/compare/langsmith" },
+    {
+      url: "https://langfuse.com/compare/langsmith",
+      shortTitle: "LangSmith",
+    },
     { url: "https://langfuse.com/compare/helix" },
   ]);
   assert.match(line, /\[Helix\]\(https:\/\/langfuse.com\/compare\/helix.md\)/);

--- a/lib/compare-labels.test.js
+++ b/lib/compare-labels.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  comparePageLabel,
+  comparePathnameSlug,
+  formatCompareIndexLine,
+} = require("./compare-labels");
+
+test("comparePathnameSlug ignores the section index", () => {
+  assert.equal(comparePathnameSlug("/compare"), null);
+  assert.equal(comparePathnameSlug("/compare/"), null);
+  assert.equal(comparePathnameSlug("https://langfuse.com/compare"), null);
+});
+
+test("comparePathnameSlug reads the competitor slug", () => {
+  assert.equal(comparePathnameSlug("/compare/langsmith"), "langsmith");
+  assert.equal(
+    comparePathnameSlug("https://langfuse.com/compare/arize-phoenix"),
+    "arize-phoenix",
+  );
+});
+
+test("comparePageLabel uses brand names and title-cases unknown slugs", () => {
+  assert.equal(comparePageLabel("langsmith"), "LangSmith");
+  assert.equal(comparePageLabel("new-vendor"), "New Vendor");
+});
+
+test("formatCompareIndexLine lists only pages that exist", () => {
+  const line = formatCompareIndexLine([
+    { url: "https://langfuse.com/compare" },
+    { url: "https://langfuse.com/compare/langsmith" },
+    { url: "https://langfuse.com/compare/braintrust" },
+  ]);
+  assert.match(
+    line,
+    /\[LangSmith\]\(https:\/\/langfuse.com\/compare\/langsmith.md\)/,
+  );
+  assert.match(
+    line,
+    /\[Braintrust\]\(https:\/\/langfuse.com\/compare\/braintrust.md\)/,
+  );
+  assert.doesNotMatch(line, /Galileo/);
+  assert.doesNotMatch(line, /\/compare\.md/);
+});
+
+test("formatCompareIndexLine includes a newly added compare page", () => {
+  const line = formatCompareIndexLine([
+    { url: "https://langfuse.com/compare/langsmith" },
+    { url: "https://langfuse.com/compare/helix" },
+  ]);
+  assert.match(line, /\[Helix\]\(https:\/\/langfuse.com\/compare\/helix.md\)/);
+});
+
+test("formatCompareIndexLine is empty when there are no competitor pages", () => {
+  assert.equal(
+    formatCompareIndexLine([{ url: "https://langfuse.com/compare" }]),
+    "",
+  );
+  assert.equal(formatCompareIndexLine([]), "");
+});

--- a/lib/content-dir-map.js
+++ b/lib/content-dir-map.js
@@ -23,6 +23,7 @@ const CONTENT_DIR_TO_URL_PREFIX = {
   academy: "academy",
   workshop: "workshop",
   resources: "resources",
+  compare: "compare",
   marketing: "",
 };
 

--- a/lib/post-crumbs.ts
+++ b/lib/post-crumbs.ts
@@ -1,14 +1,8 @@
+import { comparePageLabel } from "./compare-labels.js";
+
 export type PostCrumb = {
   label: string;
   href?: string;
-};
-
-const COMPARE_LABELS: Record<string, string> = {
-  langsmith: "LangSmith",
-  braintrust: "Braintrust",
-  "arize-phoenix": "Arize / Phoenix",
-  galileo: "Galileo",
-  datadog: "Datadog",
 };
 
 function titleCaseSlug(segment: string): string {
@@ -23,7 +17,7 @@ export function compareCrumbs(slug: string[]): PostCrumb[] {
   if (slug.length === 0) return [{ label: "Compare" }];
   return [
     { label: "Compare", href: "/compare" },
-    { label: COMPARE_LABELS[slug[0]] ?? titleCaseSlug(slug[0]) },
+    { label: comparePageLabel(slug[0]) },
   ];
 }
 

--- a/lib/post-crumbs.ts
+++ b/lib/post-crumbs.ts
@@ -1,5 +1,3 @@
-import { comparePageLabel } from "./compare-labels.js";
-
 export type PostCrumb = {
   label: string;
   href?: string;
@@ -13,11 +11,14 @@ function titleCaseSlug(segment: string): string {
 }
 
 /** Breadcrumbs for `/compare` and `/compare/[competitor]`. */
-export function compareCrumbs(slug: string[]): PostCrumb[] {
+export function compareCrumbs(
+  slug: string[],
+  currentLabel?: string,
+): PostCrumb[] {
   if (slug.length === 0) return [{ label: "Compare" }];
   return [
     { label: "Compare", href: "/compare" },
-    { label: comparePageLabel(slug[0]) },
+    { label: currentLabel || titleCaseSlug(slug[0]) },
   ];
 }
 

--- a/lib/post-crumbs.ts
+++ b/lib/post-crumbs.ts
@@ -1,0 +1,45 @@
+export type PostCrumb = {
+  label: string;
+  href?: string;
+};
+
+const COMPARE_LABELS: Record<string, string> = {
+  langsmith: "LangSmith",
+  braintrust: "Braintrust",
+  "arize-phoenix": "Arize / Phoenix",
+  galileo: "Galileo",
+  datadog: "Datadog",
+};
+
+function titleCaseSlug(segment: string): string {
+  return segment
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/** Breadcrumbs for `/compare` and `/compare/[competitor]`. */
+export function compareCrumbs(slug: string[]): PostCrumb[] {
+  if (slug.length === 0) return [{ label: "Compare" }];
+  return [
+    { label: "Compare", href: "/compare" },
+    { label: COMPARE_LABELS[slug[0]] ?? titleCaseSlug(slug[0]) },
+  ];
+}
+
+/** Breadcrumbs for `/resources/engineering` and nested articles. */
+export function resourcesCrumbs(slug: string[], title: string): PostCrumb[] {
+  const folder = slug[0];
+  const folderLabel = folder ? titleCaseSlug(folder) : "Resources";
+  const folderHref = folder ? `/resources/${folder}` : "/resources/engineering";
+
+  if (slug.length <= 1) {
+    return [{ label: "Resources", href: folderHref }, { label: folderLabel }];
+  }
+
+  return [
+    { label: "Resources", href: folderHref },
+    { label: folderLabel, href: folderHref },
+    { label: title },
+  ];
+}

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1558,29 +1558,52 @@ const howWeShipRename202606 = [
 ];
 
 // Comparison + migration FAQ pages moved into the new /resources/engineering
-// SEO/GEO section - June 2026
+// SEO/GEO section - June 2026. Comparison destinations were updated again in
+// 2026-09 when those pages moved to /compare/[competitor].
 const resourcesEngineeringMove202606 = [
   ["/resources", "/resources/engineering"],
-  [
-    "/faq/all/langsmith-alternative",
-    "/resources/engineering/langsmith-alternative",
-  ],
-  [
-    "/faq/all/best-phoenix-arize-alternatives",
-    "/resources/engineering/best-phoenix-arize-alternatives",
-  ],
-  [
-    "/faq/all/best-galileo-ai-alternatives",
-    "/resources/engineering/best-galileo-ai-alternatives",
-  ],
-  [
-    "/faq/all/best-braintrustdata-alternatives",
-    "/resources/engineering/best-braintrustdata-alternatives",
-  ],
+  ["/faq/all/langsmith-alternative", "/compare/langsmith"],
+  ["/faq/all/langsmith-alternative.md", "/compare/langsmith.md"],
+  ["/faq/all/best-phoenix-arize-alternatives", "/compare/arize-phoenix"],
+  ["/faq/all/best-phoenix-arize-alternatives.md", "/compare/arize-phoenix.md"],
+  ["/faq/all/best-galileo-ai-alternatives", "/compare/galileo"],
+  ["/faq/all/best-galileo-ai-alternatives.md", "/compare/galileo.md"],
+  ["/faq/all/best-braintrustdata-alternatives", "/compare/braintrust"],
+  ["/faq/all/best-braintrustdata-alternatives.md", "/compare/braintrust.md"],
   [
     "/faq/all/migrate-from-helicone",
     "/resources/engineering/migrate-from-helicone",
   ],
+];
+
+// Competitive comparison pages moved from /resources/engineering to
+// /compare/[competitor] — September 2026
+const comparePagesMove202609 = [
+  ["/resources/engineering/langsmith-alternative", "/compare/langsmith"],
+  ["/resources/engineering/langsmith-alternative.md", "/compare/langsmith.md"],
+  [
+    "/resources/engineering/best-braintrustdata-alternatives",
+    "/compare/braintrust",
+  ],
+  [
+    "/resources/engineering/best-braintrustdata-alternatives.md",
+    "/compare/braintrust.md",
+  ],
+  [
+    "/resources/engineering/best-phoenix-arize-alternatives",
+    "/compare/arize-phoenix",
+  ],
+  [
+    "/resources/engineering/best-phoenix-arize-alternatives.md",
+    "/compare/arize-phoenix.md",
+  ],
+  ["/resources/engineering/best-galileo-ai-alternatives", "/compare/galileo"],
+  [
+    "/resources/engineering/best-galileo-ai-alternatives.md",
+    "/compare/galileo.md",
+  ],
+  ["/resources/engineering/langfuse-vs-datadog", "/compare/datadog"],
+  ["/resources/engineering/langfuse-vs-datadog.md", "/compare/datadog.md"],
 ];
 
 // JS SDK cookbook example images moved into the example-js-sdk/ subfolder.
@@ -1971,6 +1994,7 @@ const permanentRedirects = [
   ...howWeShipRename202606,
   ...cookbookJsImagesMove202606,
   ...resourcesEngineeringMove202606,
+  ...comparePagesMove202609,
   ...goodTraceBestPracticesMove202607,
   ...promptMcpPageRemoval202607,
   ...brokenLinksCleanup202608,

--- a/lib/section-registry.ts
+++ b/lib/section-registry.ts
@@ -130,7 +130,7 @@ export const docSections: Record<string, SectionMeta> = {
     source: resourcesSource,
     collection: "resources",
     title: "Resources",
-    layout: "docs",
+    layout: "post",
     hasOwnRoute: true,
   },
 };

--- a/lib/section-registry.ts
+++ b/lib/section-registry.ts
@@ -14,6 +14,7 @@ import {
   academySource,
   workshopSource,
   resourcesSource,
+  compareSource,
   marketingSource,
 } from "@/lib/source";
 
@@ -130,6 +131,13 @@ export const docSections: Record<string, SectionMeta> = {
     source: resourcesSource,
     collection: "resources",
     title: "Resources",
+    layout: "post",
+    hasOwnRoute: true,
+  },
+  compare: {
+    source: compareSource,
+    collection: "compare",
+    title: "Compare",
     layout: "post",
     hasOwnRoute: true,
   },

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -17,6 +17,7 @@ import {
   academyJa,
   workshop,
   resources,
+  compare,
 } from "fumadocs-mdx:collections/server";
 import { CONTENT_DIR_TO_URL_PREFIX } from "./content-dir-map.js";
 
@@ -172,6 +173,11 @@ export const resourcesSource = loader({
   baseUrl: baseUrl("resources"),
   source: resources.toFumadocsSource(),
   pageTree: { idPrefix: "resources", transformers: [shortTitleTransformer] },
+});
+
+export const compareSource = loader({
+  baseUrl: baseUrl("compare"),
+  source: compare.toFumadocsSource(),
 });
 
 export const marketingSource = loader({

--- a/lib/use-case-analytics.ts
+++ b/lib/use-case-analytics.ts
@@ -58,7 +58,7 @@ export function destinationGroup(url: URL, origin: string): DestinationGroup {
   if (/^\/integrations(?:\/|$)/.test(path)) return "integrations";
   if (/^\/users(?:\/|$)/.test(path)) return "stories";
   if (/^\/(docs|self-hosting)(?:\/|$)/.test(path)) return "docs";
-  if (/^\/(resources|guides|academy|blog)(?:\/|$)/.test(path))
+  if (/^\/(resources|guides|academy|blog|compare)(?:\/|$)/.test(path))
     return "resources";
   if (/^\/images\//.test(path)) return "image";
   return "other";

--- a/scripts/authors/config.js
+++ b/scripts/authors/config.js
@@ -18,6 +18,7 @@ const CONFIG = {
     "handbook",
     "academy",
     "resources",
+    "compare",
   ].map((section) => ({
     name: section.replace("-", ""),
     dirPath: path.join(__dirname, `../../content/${section}`),

--- a/scripts/generate-sitemap-excludes.js
+++ b/scripts/generate-sitemap-excludes.js
@@ -204,6 +204,8 @@ for (const filePath of walkDir(contentDir)) {
     const entry = { loc: route };
     if (lastmod) entry.lastmod = lastmod;
     if (fm.title) entry.title = fm.title;
+    if (fm.shortTitle) entry.shortTitle = fm.shortTitle;
+    else if (fm.sidebarTitle) entry.shortTitle = fm.sidebarTitle;
     if (fm.description) entry.description = fm.description;
     pagesByRoute.set(route, entry);
   }

--- a/scripts/generate-sitemap-excludes.js
+++ b/scripts/generate-sitemap-excludes.js
@@ -134,6 +134,7 @@ function contentPathToRoute(filePath) {
     blog: "blog",
     customers: "users",
     resources: "resources",
+    compare: "compare",
     // marketing pages are served at the root (no section prefix)
     marketing: "",
   };

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -61,6 +61,11 @@ const SECTION_CONFIG = {
     heading: "Resources",
     subFileHeading: "Langfuse Resources",
   },
+  compare: {
+    file: "llms-compare.txt",
+    heading: "Compare",
+    subFileHeading: "Langfuse Compare",
+  },
   security: {
     file: "llms-security.txt",
     heading: "Security and compliance",
@@ -278,7 +283,7 @@ async function generateLLMsList() {
     markdownContent += `- [Enterprise license keys](https://langfuse.com/self-hosting/license-key.md): Activation and licensing for self-hosted add-on features.\n`;
     markdownContent += `- [Security](https://langfuse.com/security.md): Security controls, compliance, and supporting documentation.\n`;
     markdownContent += `- [Data regions](https://langfuse.com/security/data-regions.md): Hosting locations and regional availability.\n`;
-    markdownContent += `- Comparisons: [LangSmith](https://langfuse.com/resources/engineering/langsmith-alternative.md), [Braintrust](https://langfuse.com/resources/engineering/best-braintrustdata-alternatives.md), and [Arize / Phoenix](https://langfuse.com/resources/engineering/best-phoenix-arize-alternatives.md), with dated competitor sources.\n\n`;
+    markdownContent += `- Comparisons: [LangSmith](https://langfuse.com/compare/langsmith.md), [Braintrust](https://langfuse.com/compare/braintrust.md), [Arize / Phoenix](https://langfuse.com/compare/arize-phoenix.md), [Galileo](https://langfuse.com/compare/galileo.md), and [Datadog](https://langfuse.com/compare/datadog.md), with dated competitor sources.\n\n`;
 
     // Markdown access + search endpoint. Listed before the MCP server section
     // because these need no client setup: an agent with `curl` can use them

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -190,6 +190,7 @@ function loadPageMeta() {
         map.set(page.loc, {
           title: page.title,
           description: page.description,
+          shortTitle: page.shortTitle,
         });
       }
     }
@@ -237,6 +238,7 @@ async function generateLLMsList() {
       const entry = {
         title: meta.title || generateTitle(url),
         description: meta.description || "",
+        shortTitle: meta.shortTitle,
         url,
       };
 

--- a/scripts/generate_llms_txt.js
+++ b/scripts/generate_llms_txt.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const xml2js = require("xml2js");
 const path = require("path");
+const { formatCompareIndexLine } = require("../lib/compare-labels");
 
 // Resolve paths from the repo root so the script is CWD-independent
 // (matches scripts/generate-sitemap-excludes.js).
@@ -283,7 +284,7 @@ async function generateLLMsList() {
     markdownContent += `- [Enterprise license keys](https://langfuse.com/self-hosting/license-key.md): Activation and licensing for self-hosted add-on features.\n`;
     markdownContent += `- [Security](https://langfuse.com/security.md): Security controls, compliance, and supporting documentation.\n`;
     markdownContent += `- [Data regions](https://langfuse.com/security/data-regions.md): Hosting locations and regional availability.\n`;
-    markdownContent += `- Comparisons: [LangSmith](https://langfuse.com/compare/langsmith.md), [Braintrust](https://langfuse.com/compare/braintrust.md), [Arize / Phoenix](https://langfuse.com/compare/arize-phoenix.md), [Galileo](https://langfuse.com/compare/galileo.md), and [Datadog](https://langfuse.com/compare/datadog.md), with dated competitor sources.\n\n`;
+    markdownContent += formatCompareIndexLine(sectionEntries.compare) || "\n";
 
     // Markdown access + search endpoint. Listed before the MCP server section
     // because these need no client setup: an agent with `curl` can use them

--- a/source.config.ts
+++ b/source.config.ts
@@ -216,6 +216,13 @@ export const resources = defineDocs({
   },
 });
 
+export const compare = defineDocs({
+  dir: "content/compare",
+  docs: {
+    schema: resourcesFrontmatterSchema,
+  },
+});
+
 export const marketing = defineDocs({
   dir: "content/marketing",
   docs: { schema: marketingFrontmatterSchema },

--- a/source.config.ts
+++ b/source.config.ts
@@ -203,8 +203,7 @@ export const workshop = defineDocs({
 });
 
 // SEO/GEO resources section (e.g. /resources/engineering). Supports optional
-// tags so the index listing can group articles by category (comparisons,
-// migrations, …).
+// tags so the index listing can group articles by category.
 const resourcesFrontmatterSchema = sidebarFrontmatterSchema.extend({
   tags: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Competitive comparison pages now live at `/compare/[competitor]` with the same customer-stories chrome as `/users` (no docs sidebar). Old `/resources/engineering/*` and FAQ URLs redirect to the new paths.

Compare and resources pages have a docs-style breadcrumb row with the copy-page control on the right (`Compare > LangSmith`, `Resources > Engineering > …`).

The `/compare` index is written for visitors: it links to [Why Langfuse?](/why), the [mission](/handbook/chapters/mission), and the [roadmap](/docs/roadmap), explains that the pages exist to help people choose and stay current (PRs welcome), and lists competitors by name.

| Old URL | New URL |
| --- | --- |
| `/resources/engineering/langsmith-alternative` | `/compare/langsmith` |
| `/resources/engineering/best-braintrustdata-alternatives` | `/compare/braintrust` |
| `/resources/engineering/best-phoenix-arize-alternatives` | `/compare/arize-phoenix` |
| `/resources/engineering/best-galileo-ai-alternatives` | `/compare/galileo` |
| `/resources/engineering/langfuse-vs-datadog` | `/compare/datadog` |

The resources hub no longer uses the docs left menu. A **Compare** link is in the site footer.

## Why

Comparison pages looked like docs because they inherited the docs sidebar. Customer stories already show how markdown pages look without that menu, and a dedicated `/compare/[competitor]` path makes them linkable from the footer.

## How to verify

- Open `/compare` — intro links to Why Langfuse, mission, and roadmap; competitor list is name-only.
- Open `/compare/langsmith` — marketing chrome, breadcrumb `Compare > LangSmith`, copy button on the right, no docs article sidebar.
- Open `/resources/engineering/langsmith-alternative` — redirects to `/compare/langsmith`.
- Open `/faq/all/langsmith-alternative` — redirects to `/compare/langsmith`.
- Footer includes Compare → `/compare`.
- `/docs` still has the docs sidebar and its existing breadcrumb + copy row.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFMKT-2373](https://linear.app/clickhouse/issue/LFMKT-2373/fix-competitive-pages-layout-on-the-website)

<div><a href="https://cursor.com/agents/bc-2e8d053b-810e-46c1-ac05-b80f22f51f8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e8d053b-810e-46c1-ac05-b80f22f51f8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63297282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the resource layout now consistently mirrors the established customer-story composition without affecting documentation routes.

<details open><summary><h3>Summary</h3></summary>

- Replaces `SharedDocsLayout` with `PageChrome`.
- Renders resource MDX in a centered 680px column within `ContentColumns`.
- Prevents duplicate footer widgets while retaining resource copy and feedback controls.
- Reclassifies resources as a post-style section in the registry.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request["/resources/[[...slug]]"] --> Layout["ResourcesLayout"]
  Layout --> Chrome["PageChrome<br/>marketing navbar and search"]
  Chrome --> Columns["ContentColumns<br/>marketing side areas and footer"]
  Columns --> Center["Centered 680px article"]
  Center --> Wrapper["MainContentWrapper<br/>copy control"]
  Wrapper --> Body["DocBodyChrome<br/>prose and feedback"]
  Body --> MDX["Resource MDX"]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["style(resources): drop docs sidebar to m..."](https://github.com/langfuse/langfuse-docs/commit/74e2ba40c7f5bdc60401f3d743646cc6cf62d967)</sub>

<!-- /greptile_comment -->