### PR TITLE
Align docs chrome sticky offsets with Fumadocs layout tokens

### DIFF
--- a/components/layout/SharedDocsLayout.tsx
+++ b/components/layout/SharedDocsLayout.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { DocsLayoutWrapper } from "./DocsLayoutWrapper";
 import { NavbarDocs } from "./NavbarDocs";
@@ -17,6 +17,20 @@ import { SidebarSeparatorItem } from "@/components/docs-sidebar/SidebarSeparator
 import { Banner } from "./Banner";
 
 /**
+ * Fumadocs' docs container sets `--fd-docs-row-1` inline to
+ * `var(--fd-banner-height, 0px)` (chrome above the layout). Our primary +
+ * secondary bars also sit above `#nd-docs-layout`, so we replace that value
+ * via `containerProps` — the same API Fumadocs already spreads onto the
+ * layout root after its defaults.
+ *
+ * `--fd-nav-height` is owned by `.docs-chrome` (see `src/overrides.css`).
+ */
+const docsLayoutTokens = {
+  "--fd-docs-row-1":
+    "calc(var(--fd-nav-height) + var(--fd-banner-height, 0px))",
+} as CSSProperties;
+
+/**
  * Shared wrapper used by all sidebar-based section layouts
  * (docs, guides, integrations, self-hosting, library, handbook, security).
  * Each layout only needs to pass the correct page tree.
@@ -24,12 +38,13 @@ import { Banner } from "./Banner";
  * Renders two sticky headers by default:
  *  1. NavbarDocs        — 60px — logo + search + launch app
  *  2. DocsSecondaryNav  — 40px — section tabs
- * Total header height is `calc(var(--lf-nav-primary-height) + var(--lf-nav-docs-secondary-height))`
- * on `.docs-chrome` as `--fd-nav-height` (see `src/overrides.css`) so fumadocs sticky offsets stay correct.
+ * Total header height is `--fd-nav-height` on `.docs-chrome`, then mapped
+ * into Fumadocs as `--fd-docs-row-1` so sidebar / TOC sticky offsets match.
  *
  * Pass `showSecondaryNav={false}` for sections that aren't in the DocsSecondaryNav
  * tabs (e.g. handbook, security). The root gets a `docs-chrome-compact` modifier
- * that resets `--fd-nav-height` back to the primary bar only.
+ * that collapses `--fd-nav-height` to the primary bar on desktop. The mobile
+ * hamburger / breadcrumb bar still renders via `nav.component`.
  */
 export function SharedDocsLayout({
   tree,
@@ -50,13 +65,6 @@ export function SharedDocsLayout({
             ? "docs-chrome flex min-h-screen flex-col"
             : "docs-chrome docs-chrome-compact flex min-h-screen flex-col"
         }
-        style={
-          showSecondaryNav
-            ? ({
-                "--lf-nav-docs-secondary-height": "40px",
-              } as React.CSSProperties)
-            : undefined
-        }
       >
         <SidebarFolderDeepLinkHandler />
         <DocsPatternTracker />
@@ -67,6 +75,7 @@ export function SharedDocsLayout({
           <DocsLayout
             tree={tree}
             githubUrl="https://github.com/langfuse/langfuse-docs"
+            containerProps={{ style: docsLayoutTokens }}
             nav={{ component: <DocsSecondaryNavMobile /> }}
             sidebar={{
               enabled: true,

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -1,7 +1,10 @@
 /*
  * Nav stack heights — keep in sync with components/layout/Navbar*.tsx (60px)
  * and components/layout/DocsSecondaryNav.tsx (40px row).
- * --fd-nav-height is consumed by fumadocs (sidebar drawer, sticky rows, etc.).
+ *
+ * `--fd-nav-height` is our dual-bar total. SharedDocsLayout maps it into
+ * Fumadocs as `--fd-docs-row-1` via DocsLayout `containerProps` (Fumadocs
+ * otherwise sets that token inline to banner-only).
  */
 :root {
   --lf-nav-primary-height: 60px;
@@ -12,7 +15,6 @@
 
 /*
  * Docs chrome (SharedDocsLayout .docs-chrome): primary navbar + section tabs.
- * fumadocs uses --fd-nav-height for sidebar sticky-top, mobile drawer top/height, etc.
  */
 .docs-chrome {
   --fd-nav-height: calc(
@@ -24,18 +26,12 @@
  * Compact variant (SharedDocsLayout showSecondaryNav={false}): sections
  * that aren't in the DocsSecondaryNav tabs (e.g. handbook, security).
  * On mobile the hamburger/breadcrumb bar still needs 40px; on desktop
- * no secondary row is shown so collapse to primary only.
+ * no secondary row is shown so collapse to primary only. `--fd-nav-height`
+ * follows `--lf-nav-docs-secondary-height` via the calc on `.docs-chrome`.
  */
-.docs-chrome.docs-chrome-compact {
-  --lf-nav-docs-secondary-height: 40px;
-  --fd-nav-height: calc(
-    var(--lf-nav-primary-height) + var(--lf-nav-docs-secondary-height)
-  );
-}
 @media (min-width: 768px) {
   .docs-chrome.docs-chrome-compact {
     --lf-nav-docs-secondary-height: 0px;
-    --fd-nav-height: var(--lf-nav-primary-height);
   }
 }
 
@@ -123,13 +119,12 @@
   display: none;
 }
 
-/* Mobile sidebar drawer: push below sticky navbar + optional banner.
-   Slide from left instead of right; full width. */
+/* Mobile sidebar drawer: Fumadocs uses inset-y-0 / right-sheet defaults.
+   Offset with --fd-docs-row-1 (set from SharedDocsLayout containerProps)
+   and slide from the left at full width. */
 #nd-sidebar-mobile {
-  top: calc(var(--fd-nav-height) + var(--fd-banner-height, 0px)) !important;
-  height: calc(
-    100dvh - var(--fd-nav-height) - var(--fd-banner-height, 0px)
-  ) !important;
+  top: var(--fd-docs-row-1) !important;
+  height: calc(var(--fd-docs-height, 100dvh) - var(--fd-docs-row-1)) !important;
   /* Override fumadocs defaults: left-aligned, full width */
   inset-inline-end: unset !important;
   inset-inline-start: 0 !important;
@@ -137,15 +132,6 @@
   max-width: 100% !important;
   border-inline-start: none !important;
   --fd-sidebar-drawer-offset: -100%;
-}
-
-/* Sidebar/collapsed-trigger sticky top: nav stack + optional banner.
-   Overrides fumadocs' inline --fd-docs-row-1: var(--fd-banner-height, 0px)
-   which only accounts for the banner, not our external custom navbar. */
-#nd-docs-layout {
-  --fd-docs-row-1: calc(
-    var(--fd-nav-height) + var(--fd-banner-height, 0px)
-  ) !important;
 }
 
 /* Sidebar + TOC width: 240px to match NavbarDocs grid-cols-[240px_1fr_240px].
@@ -431,7 +417,6 @@
   margin: 0 0 1px 1px;
   border-radius: calc(var(--radius) - 4px);
   background-color: var(--line-structure) !important;
-  top: calc(var(--fd-nav-height) + var(--fd-banner-height, 0px));
 }
 
 /* Sidebar active link */
@@ -735,10 +720,8 @@
 #nd-toc {
   --text-links: var(--line-cta);
   padding: 0;
-  /* Full viewport minus docs header stack + optional banner; 1px ≈ outer chrome / rounding */
-  max-height: calc(
-    100dvh - var(--fd-nav-height) - var(--fd-banner-height, 0px) - 1px
-  );
+  /* Full viewport minus docs header stack; 1px ≈ outer chrome / rounding */
+  max-height: calc(var(--fd-docs-height, 100dvh) - var(--fd-docs-row-1) - 1px);
   border-bottom-width: 0;
   border-radius: 0 !important;
   z-index: 10;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Simplify how the docs chrome talks to Fumadocs sticky/layout tokens, without changing how the UI looks.

The dual sticky bars stay as they are: `NavbarDocs` (60px) + `DocsSecondaryNav` (40px section tabs). Compact sections (`handbook`, `security`) still hide the desktop tabs. Mobile still has the site hamburger in the top bar and the sidebar hamburger in the secondary breadcrumb bar.

## What changed

Fumadocs' docs container sets `--fd-docs-row-1` **inline** to `var(--fd-banner-height, 0px)` — chrome above the layout. Our primary + secondary bars also sit above `#nd-docs-layout`, so we previously patched that token in `src/overrides.css` with `!important`.

This PR sets `--fd-docs-row-1` from `SharedDocsLayout` via DocsLayout `containerProps`. Fumadocs already spreads `containerProps.style` onto the layout root **after** its defaults, so this is the first-class override.

`.docs-chrome` still owns `--fd-nav-height` (primary + secondary). Compact desktop only zeros `--lf-nav-docs-secondary-height`; the existing calc updates `--fd-nav-height`.

## Override CSS removed — and why it is safe

| Removed | Why safe |
| --- | --- |
| `#nd-docs-layout { --fd-docs-row-1: … !important; }` | Same value is now set on the layout root via `containerProps`. Fumadocs sidebar / TOC already read `--fd-docs-row-1` for `top` and height. |
| `#nd-docs-layout #nd-toc { top: calc(var(--fd-nav-height) + var(--fd-banner-height, 0px)); }` | Redundant once `--fd-docs-row-1` is correct. Fumadocs TOC already uses `top: var(--fd-docs-row-1)`. |
| Compact-mode duplicate `--fd-nav-height` / `--lf-nav-docs-secondary-height` re-declarations | Mobile compact still inherits the 40px secondary token; desktop compact only needs to zero `--lf-nav-docs-secondary-height`. |
| Inline `--lf-nav-docs-secondary-height: 40px` on `SharedDocsLayout` when tabs are shown | Same as the `:root` / `.docs-chrome` default. |

## Override CSS kept

- Mobile drawer `top` / `height` still use `!important`. Fumadocs drawer is `inset-y-0` and does not read `--fd-docs-row-1`. Values now reference `--fd-docs-row-1` instead of repeating the nav+banner calc.
- Left-aligned / full-width drawer rules (visual, not sticky).
- Sidebar width, pattern background, item styling, TOC chrome (including the 1px max-height tweak, now via `--fd-docs-row-1`).

## Second-pass review

Re-checked against production (`langfuse.com`) and local `pnpm dev`. No code changes from this review.

- Desktop `/docs`: production and local both 32 + 60 + 40, sidebar/TOC sticky-top 132px. Same seven tabs; Docs active.
- Desktop `/handbook` and `/security`: no tab strip; sidebar/TOC 92px on both production and local.
- Mobile `/docs` and `/handbook`: dual hamburgers, breadcrumb at 92px, drawer at 132×712 full width — local matches production.
- After scroll, sticky tops stay put.

Verdict: ship as-is. This is a small, correct token alignment — not a chrome rewrite. Remaining Fumadocs friction (drawer `inset-y-0`, bars outside the grid, `--fd-header-height: 0`) is intentional leftover, not missed cleanup.

## Intentionally not in this PR

- No change to tab items, order, icons, or labels
- No Fumadocs native root-folder tabs (this site has many collections)
- No `DocsChromePage` `footer.component` / `breadcrumb.component` → `slots` migration
- No marketing navbar / home layout work
- No `MainContentWrapper` / `mdx-components` / dependency hygiene

![Desktop docs with section tabs](https://cursor.com/artifacts/c/art-dcfbc94d-d9b9-4537-8b4c-8c4dc2b2a518)
![Desktop handbook without section tabs](https://cursor.com/artifacts/c/art-58cad7ab-6a3b-4abc-b346-515626dff998)
![Mobile docs top bar and secondary breadcrumb](https://cursor.com/artifacts/c/art-0fb42334-4876-46b0-891d-dc186c3937f0)
![Mobile sidebar drawer below dual bars](https://cursor.com/artifacts/c/art-906e8b2c-bb6a-4aa5-8fc7-c5fec71a7403)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9158a4e7-e9a7-5b6e-ada1-09b619a1c9d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9158a4e7-e9a7-5b6e-ada1-09b619a1c9d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63511001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the responsive navigation-height cascade and sticky offsets remaining internally consistent.

<details open><summary><h3>Summary</h3></summary>

- Maps the combined navigation and banner height into `--fd-docs-row-1`.
- Removes redundant sticky-position and compact-layout overrides.
- Preserves the 40px mobile secondary bar while collapsing it for compact desktop layouts.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[".docs-chrome<br/>--fd-nav-height = primary + secondary"] --> B["DocsLayout containerProps<br/>--fd-docs-row-1 = nav + banner"]
  F["Compact desktop<br/>secondary height = 0"] --> A
  B --> C["Desktop sidebar sticky offset"]
  B --> D["TOC offset and max height"]
  B --> E["Mobile drawer top and height"]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["Align docs chrome sticky offsets with Fu..."](https://github.com/langfuse/langfuse-docs/commit/9f10e70e39adda31a81136ce9788fbedba9cae86)</sub>

<!-- /greptile_comment -->